### PR TITLE
security: Fix command injection + missing admin gate in cookbook packages endpoint

### DIFF
--- a/routes/shell_routes.py
+++ b/routes/shell_routes.py
@@ -472,15 +472,28 @@ def setup_shell_routes() -> APIRouter:
         return StreamingResponse(generate(), media_type="text/event-stream")
 
     @router.get("/api/cookbook/packages")
-    async def list_packages(host: str | None = None, ssh_port: str | None = None, venv: str | None = None):
+    async def list_packages(request: Request, host: str | None = None, ssh_port: str | None = None, venv: str | None = None):
         """Check which optional packages are installed.
 
         Local-target packages are checked in-process. Remote-target packages
         (vllm, sglang, llama_cpp, diffusers, hf_transfer) are checked on the SELECTED
         server over SSH, inside its venv — otherwise installing on a remote box
         never reflected because the check only ever looked at the local host.
+
+        Admin only: builds and runs an SSH command, so it must not be reachable
+        by regular authenticated users.
         """
+        _require_admin(request)
         import importlib, shlex, json as _json
+        # ssh_port is interpolated into the SSH command string below. Only ever
+        # allow a bare numeric port so it can't break out of the command
+        # (e.g. ssh_port="1;rm -rf /;" would otherwise inject shell commands).
+        port_arg = ""
+        if ssh_port and str(ssh_port).strip() not in ("", "22"):
+            _port = str(ssh_port).strip()
+            if not _port.isdigit():
+                raise HTTPException(400, "Invalid ssh_port")
+            port_arg = f"-p {int(_port)} "
         packages = [
             # ── System ── OS binaries, not pip packages
             {"name": "tmux", "pip": "", "desc": "Required for Linux/Termux Cookbook background downloads and serves", "category": "System", "target": "remote", "kind": "system", "install_hint": "Run Cookbook server setup, or install tmux with apt/pacman/dnf/apk/zypper."},
@@ -520,9 +533,8 @@ def setup_shell_routes() -> APIRouter:
                     # the && short-circuits and every package reads as missing).
                     src = f". {act} && "
                 inner = f"{src}python3 -c {shlex.quote(py)}"
-                pf = f"-p {ssh_port} " if ssh_port and ssh_port not in ("", "22") else ""
                 ssh_cmd = (
-                    f"ssh -o ConnectTimeout=6 -o StrictHostKeyChecking=no {pf}"
+                    f"ssh -o ConnectTimeout=6 -o StrictHostKeyChecking=no {port_arg}"
                     f"{shlex.quote(host)} {shlex.quote(inner)}"
                 )
                 proc = await asyncio.create_subprocess_shell(
@@ -545,9 +557,8 @@ def setup_shell_routes() -> APIRouter:
                     qn = shlex.quote(name)
                     checks.append(f"if command -v {qn} >/dev/null 2>&1; then echo {qn}=1; else echo {qn}=0; fi")
                 inner = " ; ".join(checks)
-                pf = f"-p {ssh_port} " if ssh_port and ssh_port not in ("", "22") else ""
                 ssh_cmd = (
-                    f"ssh -o ConnectTimeout=6 -o StrictHostKeyChecking=no {pf}"
+                    f"ssh -o ConnectTimeout=6 -o StrictHostKeyChecking=no {port_arg}"
                     f"{shlex.quote(host)} {shlex.quote(inner)}"
                 )
                 proc = await asyncio.create_subprocess_shell(


### PR DESCRIPTION

`GET /api/cookbook/packages` is vulnerable to command injection and is missing the admin-only gate its sibling shell endpoints have.

The endpoint builds an SSH command and runs it via `create_subprocess_shell`. The caller-supplied `ssh_port` was interpolated raw into that command string, no quoting, no validation:

```python
pf = f"-p {ssh_port} " if ssh_port and ssh_port not in ("", "22") else ""
ssh_cmd = f"ssh ... {pf}{shlex.quote(host)} {shlex.quote(inner)}"
proc = await asyncio.create_subprocess_shell(ssh_cmd, ...)
```

`host` and `inner` are correctly `shlex.quote`d, but `ssh_port` is not. A request such as `?host=x&ssh_port=1;<command>;` injects arbitrary shell commands that run on the host with the app's privileges (RCE).

Compounding it, this endpoint lacked the `_require_admin(request)` check present on `/api/shell/exec` and `/api/cookbook/packages/install`, so any authenticated non-admin user could reach it.

## Fix

- Add `_require_admin(request)` to the endpoint.
- Validate `ssh_port` is a bare integer (reject otherwise with HTTP 400) and reuse the sanitized value (`port_arg`) in both SSH command builders.

No behavior change for legitimate callers, a numeric port still works; non-numeric input is now rejected instead of executed.


Amazing work, Felix, love the project!