### PR TITLE
security: warn on startup when LOCALHOST_BYPASS is enabled

### DIFF
--- a/app.py
+++ b/app.py
@@ -108,6 +108,8 @@ auth_manager = AuthManager()
 app.state.auth_manager = auth_manager
 AUTH_ENABLED = os.getenv("AUTH_ENABLED", "true").lower() != "false"
 LOCALHOST_BYPASS = os.getenv("LOCALHOST_BYPASS", "false").lower() == "true"
+if LOCALHOST_BYPASS:
+    logger.warning("LOCALHOST_BYPASS is enabled, loopback requests bypass authentication. Do not expose this instance to a network.")
 
 if AUTH_ENABLED:
     AUTH_EXEMPT_EXACT = {


### PR DESCRIPTION
When `LOCALHOST_BYPASS=true`, all loopback requests skip authentication entirely. This is silent by default - if someone accidentally enables it (or a reverse proxy forwards requests as loopback), there's no indication in the logs that auth is being bypassed.

This adds a startup warning so operators know immediately when this mode is active and are reminded not to expose the instance to a network.