### PR TITLE
security: gate /api/embeddings/* behind require_admin

### DIFF
--- a/routes/embedding_routes.py
+++ b/routes/embedding_routes.py
@@ -6,8 +6,9 @@ import shutil
 import logging
 import asyncio
 from pathlib import Path
-from fastapi import APIRouter, HTTPException, Form
+from fastapi import APIRouter, HTTPException, Form, Depends
 from core.constants import BASE_DIR
+from core.middleware import require_admin
 
 logger = logging.getLogger(__name__)
 
@@ -99,8 +100,15 @@ def _save_custom_endpoint(data: dict):
 def setup_embedding_routes():
     router = APIRouter(prefix="/api/embeddings")
 
+    # Admin only. These endpoints manage server-wide embedding state: they
+    # download/delete cached models and repoint the global EMBEDDING_URL that
+    # every user's RAG/semantic-memory traffic flows through. A non-admin must
+    # not reach them — POST /endpoint in particular fetches an arbitrary URL
+    # (SSRF) and then routes all future embeddings to it. The frontend already
+    # treats embeddings as admin-only (static/js/admin.js); enforce it here too.
+
     @router.get("/models")
-    def list_models():
+    def list_models(_admin: None = Depends(require_admin)):
         """List all available fastembed models with download status."""
         try:
             from fastembed import TextEmbedding
@@ -137,7 +145,7 @@ def setup_embedding_routes():
         return result
 
     @router.post("/models/{model_name:path}/download")
-    async def download_model(model_name: str):
+    async def download_model(model_name: str, _admin: None = Depends(require_admin)):
         """Download a fastembed model. Returns when complete."""
         try:
             from fastembed import TextEmbedding
@@ -173,7 +181,7 @@ def setup_embedding_routes():
             _downloading.pop(model_name, None)
 
     @router.get("/models/{model_name:path}/status")
-    def download_status(model_name: str):
+    def download_status(model_name: str, _admin: None = Depends(require_admin)):
         """Check download status of a model."""
         try:
             from fastembed import TextEmbedding
@@ -194,7 +202,7 @@ def setup_embedding_routes():
         }
 
     @router.delete("/models/{model_name:path}")
-    def delete_model(model_name: str):
+    def delete_model(model_name: str, _admin: None = Depends(require_admin)):
         """Delete a cached model."""
         if model_name == _active_model():
             raise HTTPException(400, "Cannot delete the active embedding model")
@@ -224,7 +232,7 @@ def setup_embedding_routes():
         return {"deleted": True, "model": model_name}
 
     @router.get("/endpoint")
-    def get_endpoint():
+    def get_endpoint(_admin: None = Depends(require_admin)):
         """Get the current custom embedding endpoint config."""
         saved = _load_custom_endpoint()
         current_url = os.environ.get("EMBEDDING_URL", "")
@@ -235,7 +243,7 @@ def setup_embedding_routes():
         }
 
     @router.post("/endpoint")
-    def set_endpoint(url: str = Form(...), model: str = Form("")):
+    def set_endpoint(url: str = Form(...), model: str = Form(""), _admin: None = Depends(require_admin)):
         """Save a custom embedding endpoint URL."""
         url = url.strip()
         if not url:
@@ -286,7 +294,7 @@ def setup_embedding_routes():
         return {"success": True, "url": url, "model": model}
 
     @router.delete("/endpoint")
-    def clear_endpoint():
+    def clear_endpoint(_admin: None = Depends(require_admin)):
         """Clear the custom endpoint and revert to local fastembed."""
         if os.path.exists(_ENDPOINT_FILE):
             os.remove(_ENDPOINT_FILE)

--- a/tests/test_embedding_admin_gate.py
+++ b/tests/test_embedding_admin_gate.py
@@ -1,0 +1,92 @@
+"""Pin the admin gate on every /api/embeddings/* route.
+
+These endpoints manage server-wide embedding state: they download/delete
+cached models and repoint the global EMBEDDING_URL that every user's
+RAG/semantic-memory traffic flows through. POST /endpoint additionally
+fetches an arbitrary, caller-supplied URL (SSRF) before persisting it. The
+router shipped with no auth, so any authenticated non-admin could hijack the
+embedding backend for the whole instance. `require_admin` must gate all of
+them.
+
+The first test fails if a new endpoint is ever added to this router without
+the gate — which is exactly how the original hole arose.
+"""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from core.middleware import require_admin
+from routes.embedding_routes import setup_embedding_routes
+
+
+def _gate_calls(route):
+    """Direct Depends(...) callables wired onto a route."""
+    return [dep.call for dep in route.dependant.dependencies]
+
+
+def test_every_embedding_route_requires_admin():
+    router = setup_embedding_routes()
+    http_routes = [r for r in router.routes if getattr(r, "dependant", None) is not None]
+    assert http_routes, "no routes registered on the embeddings router"
+    missing = [
+        (r.path, sorted(r.methods))
+        for r in http_routes
+        if require_admin not in _gate_calls(r)
+    ]
+    assert not missing, f"embedding routes missing admin gate: {missing}"
+
+
+class _FakeAuth:
+    """Minimal stand-in for AuthManager: only "admin" is an admin."""
+
+    is_configured = True
+
+    def is_admin(self, username):
+        return username == "admin"
+
+
+def _client(monkeypatch):
+    monkeypatch.setenv("AUTH_ENABLED", "true")
+    app = FastAPI()
+
+    # Mirror the real AuthMiddleware: stamp request.state.current_user so
+    # require_admin can read it. Driven by a test header.
+    @app.middleware("http")
+    async def _attach_user(request, call_next):
+        request.state.current_user = request.headers.get("X-Test-User") or None
+        return await call_next(request)
+
+    app.state.auth_manager = _FakeAuth()
+    app.include_router(setup_embedding_routes())
+    return TestClient(app)
+
+
+def test_get_endpoint_blocks_non_admin_allows_admin(monkeypatch):
+    client = _client(monkeypatch)
+    # Authenticated non-admin is rejected...
+    assert client.get("/api/embeddings/endpoint", headers={"X-Test-User": "alice"}).status_code == 403
+    # ...anonymous too...
+    assert client.get("/api/embeddings/endpoint").status_code == 403
+    # ...but an admin passes the gate and gets the config back.
+    resp = client.get("/api/embeddings/endpoint", headers={"X-Test-User": "admin"})
+    assert resp.status_code == 200
+    assert "url" in resp.json()
+
+
+def test_set_endpoint_blocks_non_admin_before_ssrf(monkeypatch):
+    import httpx
+
+    def _must_not_call(*args, **kwargs):
+        raise AssertionError("SSRF: httpx.post must not run for a non-admin")
+
+    # If the gate were missing, set_endpoint would reach httpx.post(url) and
+    # this would turn the AssertionError into a 500 instead of a clean 403.
+    monkeypatch.setattr(httpx, "post", _must_not_call)
+
+    client = _client(monkeypatch)
+    resp = client.post(
+        "/api/embeddings/endpoint",
+        data={"url": "http://169.254.169.254/latest/meta-data/", "model": ""},
+        headers={"X-Test-User": "alice"},
+    )
+    assert resp.status_code == 403


### PR DESCRIPTION
The embedding-management router shipped with no authentication. Any authenticated non-admin could call these endpoints because the global AuthMiddleware only requires *a* valid session, and the router added no per-route admin check.

Most serious: POST /api/embeddings/endpoint takes a caller-supplied URL, issues an httpx.post() to it as a "health check" (SSRF against internal services), then writes os.environ["EMBEDDING_URL"] and resets the RAG / ChromaDB singletons process-wide. That repoints the embedding backend that ALL users' semantic-memory and document-RAG traffic flows through — so a non-admin can exfiltrate/poison everyone's embeddings. The same router also lets a non-admin download or delete cached models (disk-fill / DoS) and read the configured endpoint URL.

The frontend already treats embeddings as admin-only (static/js/admin.js), and the sibling model-config routes all call require_admin — this router was simply missed.

Fix: gate all seven endpoints with require_admin, using the same Depends(require_admin) pattern already used in contacts_routes / personal_routes / preset_routes.

Add tests/test_embedding_admin_gate.py:
  - asserts every route on the router carries the require_admin dependency (fails if a future endpoint is added ungated — how this hole arose),
  - non-admin and anonymous callers get 403 while an admin passes,
  - the SSRF in POST /endpoint is blocked before httpx.post can run.