### PR TITLE
Add Proxmox deployment scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,12 @@ Help is welcome. The best entry points are fresh-install testing, provider setup
 bugs, mobile/editor polish, docs, and small focused refactors. See
 [ROADMAP.md](ROADMAP.md) for the current help-wanted list.
 
+### Proxmox Community Scripts contribution scaffold
+For Proxmox-targeted deployment work, see
+[`docs/deployment/proxmox-community-scripts.md`](docs/deployment/proxmox-community-scripts.md).
+It includes a repository-local LXC installer + model-tier helper intended to be
+ported into Community Scripts (ProxmoxVED first, then upstream).
+
 ## Configuration
 Most setup is done inside the app with `/setup` or **Settings**. Use `.env`
 for deployment-level defaults and secrets you want present before first boot.

--- a/deploy/proxmox/install-odysseus-lxc.sh
+++ b/deploy/proxmox/install-odysseus-lxc.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Odysseus LXC installer for Proxmox-oriented Debian/Ubuntu containers.
+# This script is repository-local and designed to be ported into
+# community-scripts/ProxmoxVED and then upstream.
+
+ODYSSEUS_REPO_DEFAULT="https://github.com/pewdiepie-archdaemon/odysseus.git"
+ODYSSEUS_DIR_DEFAULT="/opt/odysseus"
+ODYSSEUS_ENV_FILE_DEFAULT=".env"
+
+APP_PORT="${APP_PORT:-7000}"
+INSTALL_OLLAMA="${INSTALL_OLLAMA:-false}"        # true|false
+AUTO_PULL_MODELS="${AUTO_PULL_MODELS:-false}"    # true|false
+MODEL_TIER="${MODEL_TIER:-cpu}"                  # cpu|gpu_modest|gpu_high
+ODYSSEUS_REPO="${ODYSSEUS_REPO:-$ODYSSEUS_REPO_DEFAULT}"
+ODYSSEUS_DIR="${ODYSSEUS_DIR:-$ODYSSEUS_DIR_DEFAULT}"
+ODYSSEUS_ENV_FILE="${ODYSSEUS_ENV_FILE:-$ODYSSEUS_ENV_FILE_DEFAULT}"
+
+log() { printf '[odysseus-install] %s\n' "$*"; }
+die() { printf '[odysseus-install] ERROR: %s\n' "$*" >&2; exit 1; }
+
+require_root() {
+  if [[ "$(id -u)" -ne 0 ]]; then
+    die "Run as root."
+  fi
+}
+
+detect_os() {
+  if [[ -f /etc/os-release ]]; then
+    # shellcheck disable=SC1091
+    . /etc/os-release
+  else
+    die "/etc/os-release missing."
+  fi
+  case "${ID:-}" in
+    debian|ubuntu) ;;
+    *) die "Unsupported OS: ${ID:-unknown}. Use Debian/Ubuntu LXC." ;;
+  esac
+}
+
+install_prereqs() {
+  log "Installing prerequisites..."
+  apt-get update -y
+  apt-get install -y --no-install-recommends \
+    ca-certificates curl git gnupg lsb-release jq zstd
+}
+
+install_docker() {
+  if command -v docker >/dev/null 2>&1; then
+    log "Docker already present."
+  else
+    log "Installing Docker..."
+    install -m 0755 -d /etc/apt/keyrings
+    curl -fsSL "https://download.docker.com/linux/${ID}/gpg" | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+    chmod a+r /etc/apt/keyrings/docker.gpg
+    echo \
+      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/${ID} \
+      ${VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list
+    apt-get update -y
+    apt-get install -y --no-install-recommends docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+    systemctl enable --now docker
+  fi
+}
+
+clone_or_update_repo() {
+  if [[ -d "${ODYSSEUS_DIR}/.git" ]]; then
+    log "Updating existing repo at ${ODYSSEUS_DIR}..."
+    git -C "${ODYSSEUS_DIR}" fetch --all --tags
+    git -C "${ODYSSEUS_DIR}" pull --ff-only
+  else
+    log "Cloning Odysseus repo to ${ODYSSEUS_DIR}..."
+    git clone "${ODYSSEUS_REPO}" "${ODYSSEUS_DIR}"
+  fi
+}
+
+prepare_env() {
+  cd "${ODYSSEUS_DIR}"
+  if [[ ! -f "${ODYSSEUS_ENV_FILE}" ]]; then
+    if [[ -f .env.example ]]; then
+      cp .env.example "${ODYSSEUS_ENV_FILE}"
+      log "Copied .env.example -> ${ODYSSEUS_ENV_FILE}"
+    else
+      touch "${ODYSSEUS_ENV_FILE}"
+      log "Created ${ODYSSEUS_ENV_FILE}"
+    fi
+  fi
+  if ! grep -q '^AUTH_ENABLED=' "${ODYSSEUS_ENV_FILE}"; then
+    printf '\nAUTH_ENABLED=true\n' >> "${ODYSSEUS_ENV_FILE}"
+  fi
+}
+
+run_compose() {
+  cd "${ODYSSEUS_DIR}"
+  log "Starting Odysseus stack with Docker Compose..."
+  local compose_args=(-f docker-compose.yml)
+  if [[ "${INSTALL_OLLAMA}" == "true" ]]; then
+    cat >docker-compose.proxmox-ollama.yml <<'EOF'
+services:
+  odysseus:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+EOF
+    compose_args+=(-f docker-compose.proxmox-ollama.yml)
+  fi
+  docker compose "${compose_args[@]}" up -d --build
+}
+
+install_model_helper() {
+  local helper_src="${ODYSSEUS_DIR}/deploy/proxmox/model-profile-helper.sh"
+  local helper_dst="/usr/local/bin/odysseus-model-profile"
+  [[ -f "${helper_src}" ]] || die "Missing helper at ${helper_src}"
+  install -m 0755 "${helper_src}" "${helper_dst}"
+}
+
+install_ollama_if_requested() {
+  if [[ "${INSTALL_OLLAMA}" != "true" ]]; then
+    return 0
+  fi
+  if command -v ollama >/dev/null 2>&1; then
+    log "Ollama already installed."
+  else
+    log "Installing Ollama..."
+    curl -fsSL https://ollama.com/install.sh | sh
+  fi
+  configure_ollama_for_docker_access
+}
+
+configure_ollama_for_docker_access() {
+  log "Configuring Ollama to listen on the LXC network interface..."
+  install -d /etc/systemd/system/ollama.service.d
+  cat >/etc/systemd/system/ollama.service.d/odysseus.conf <<'EOF'
+[Service]
+Environment="OLLAMA_HOST=0.0.0.0:11434"
+EOF
+  systemctl daemon-reload
+  systemctl enable --now ollama
+  systemctl restart ollama
+  log "Ollama will be reachable from the Odysseus container at http://host.docker.internal:11434/v1"
+}
+
+run_model_profile_helper() {
+  local helper="/usr/local/bin/odysseus-model-profile"
+  local args=(--tier "${MODEL_TIER}")
+  if [[ "${AUTO_PULL_MODELS}" == "true" ]]; then
+    args+=(--pull-models)
+  fi
+  if [[ "${INSTALL_OLLAMA}" == "true" ]]; then
+    args+=(--expect-ollama)
+  fi
+  "${helper}" "${args[@]}"
+}
+
+print_post_install() {
+  local ip
+  ip="$(hostname -I | awk '{print $1}')"
+  cat <<EOF
+
+Odysseus install complete.
+
+Access:
+  http://${ip}:${APP_PORT}
+
+Stack:
+  - odysseus
+  - chromadb
+  - searxng
+  - ntfy
+
+Security defaults:
+  - AUTH_ENABLED=true in ${ODYSSEUS_DIR}/${ODYSSEUS_ENV_FILE}
+  - Keep this private-by-default behind LAN/VPN.
+  - For internet exposure, place behind HTTPS reverse proxy.
+
+Useful checks:
+  cd ${ODYSSEUS_DIR} && docker compose ps
+  cd ${ODYSSEUS_DIR} && docker compose logs --tail=120 odysseus
+
+Model profile helper:
+  odysseus-model-profile --tier ${MODEL_TIER}
+EOF
+}
+
+main() {
+  require_root
+  detect_os
+  install_prereqs
+  install_docker
+  clone_or_update_repo
+  prepare_env
+  run_compose
+  install_model_helper
+  install_ollama_if_requested
+  run_model_profile_helper
+  print_post_install
+}
+
+main "$@"

--- a/deploy/proxmox/model-profile-helper.sh
+++ b/deploy/proxmox/model-profile-helper.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+TIER="cpu"                  # cpu|gpu_modest|gpu_high
+PULL_MODELS="false"
+PULL_ALTERNATIVES="false"
+EXPECT_OLLAMA="false"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  odysseus-model-profile --tier <cpu|gpu_modest|gpu_high> [--pull-models] [--pull-alternatives] [--expect-ollama]
+
+Purpose:
+  Print Odysseus model/runtime recommendations by hardware tier.
+  Optionally pull recommended models with Ollama.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tier)
+      TIER="${2:-}"; shift 2 ;;
+    --pull-models)
+      PULL_MODELS="true"; shift ;;
+    --pull-alternatives)
+      PULL_ALTERNATIVES="true"; shift ;;
+    --expect-ollama)
+      EXPECT_OLLAMA="true"; shift ;;
+    -h|--help)
+      usage; exit 0 ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      usage
+      exit 2 ;;
+  esac
+done
+
+case "${TIER}" in
+  cpu|gpu_modest|gpu_high) ;;
+  *)
+    echo "Invalid --tier '${TIER}'. Use cpu|gpu_modest|gpu_high." >&2
+    exit 2 ;;
+esac
+
+if [[ "${EXPECT_OLLAMA}" == "true" ]] && ! command -v ollama >/dev/null 2>&1; then
+  echo "Ollama expected but not found in PATH." >&2
+  exit 1
+fi
+
+recommendations_for_tier() {
+  case "${TIER}" in
+    cpu)
+      cat <<'EOF'
+TIER: CPU-only
+Recommended local models (Ollama tags):
+  1) qwen2.5:3b-instruct-q4_K_M   (primary)
+  2) qwen2.5:1.5b-instruct-q4_K_M (fast fallback)
+  3) phi3:mini-4k-instruct-q4_K_M (alternative)
+
+Odysseus Settings (suggested):
+  - Endpoint type: OpenAI-compatible local server (Ollama)
+  - Base URL: http://host.docker.internal:11434/v1
+  - Primary model: qwen2.5:3b-instruct-q4_K_M
+  - Fallback model: qwen2.5:1.5b-instruct-q4_K_M
+EOF
+      ;;
+    gpu_modest)
+      cat <<'EOF'
+TIER: Modest GPU (6-12GB VRAM)
+Recommended local models (Ollama tags):
+  1) qwen2.5:7b-instruct-q4_K_M   (primary)
+  2) qwen2.5:3b-instruct-q4_K_M   (fast fallback)
+  3) mistral:7b-instruct-v0.3-q4_K_M (alternative)
+
+Odysseus Settings (suggested):
+  - Endpoint type: OpenAI-compatible local server (Ollama)
+  - Base URL: http://host.docker.internal:11434/v1
+  - Primary model: qwen2.5:7b-instruct-q4_K_M
+  - Fallback model: qwen2.5:3b-instruct-q4_K_M
+EOF
+      ;;
+    gpu_high)
+      cat <<'EOF'
+TIER: High GPU (16GB+ VRAM)
+Recommended local models (Ollama tags):
+  1) qwen2.5:14b-instruct-q4_K_M  (primary)
+  2) qwen2.5:7b-instruct-q4_K_M   (fallback)
+  3) mixtral:8x7b-instruct-v0.1-q4_K_M (if VRAM budget allows)
+
+Odysseus Settings (suggested):
+  - Endpoint type: OpenAI-compatible local server (Ollama)
+  - Base URL: http://host.docker.internal:11434/v1
+  - Primary model: qwen2.5:14b-instruct-q4_K_M
+  - Fallback model: qwen2.5:7b-instruct-q4_K_M
+EOF
+      ;;
+  esac
+}
+
+pull_models_for_tier() {
+  if ! command -v ollama >/dev/null 2>&1; then
+    echo "Ollama not found; skipping model pulls." >&2
+    return 0
+  fi
+  local models=()
+  local alternatives=()
+  case "${TIER}" in
+    cpu)
+      models=(qwen2.5:3b-instruct-q4_K_M qwen2.5:1.5b-instruct-q4_K_M)
+      alternatives=(phi3:mini-4k-instruct-q4_K_M)
+      ;;
+    gpu_modest)
+      models=(qwen2.5:7b-instruct-q4_K_M qwen2.5:3b-instruct-q4_K_M)
+      alternatives=(mistral:7b-instruct-v0.3-q4_K_M)
+      ;;
+    gpu_high)
+      models=(qwen2.5:14b-instruct-q4_K_M qwen2.5:7b-instruct-q4_K_M)
+      alternatives=(mixtral:8x7b-instruct-v0.1-q4_K_M)
+      ;;
+  esac
+  if [[ "${PULL_ALTERNATIVES}" == "true" ]]; then
+    models+=("${alternatives[@]}")
+  fi
+  echo "Pulling models with Ollama..."
+  for m in "${models[@]}"; do
+    echo "  - ollama pull ${m}"
+    ollama pull "${m}"
+  done
+}
+
+recommendations_for_tier
+if [[ "${PULL_MODELS}" == "true" ]]; then
+  pull_models_for_tier
+fi

--- a/deploy/proxmox/traefik-odysseus.yml
+++ b/deploy/proxmox/traefik-odysseus.yml
@@ -1,0 +1,16 @@
+http:
+  routers:
+    odysseus:
+      rule: Host(`odysseus.example.com`)
+      entryPoints:
+        - websecure
+      tls:
+        certResolver: letsencrypt
+      service: odysseus
+
+  services:
+    odysseus:
+      loadBalancer:
+        servers:
+          - url: http://192.168.2.42:7000
+        passHostHeader: true

--- a/docs/deployment/proxmox-community-scripts.md
+++ b/docs/deployment/proxmox-community-scripts.md
@@ -1,0 +1,95 @@
+# Odysseus on Proxmox Community Scripts
+
+This repository includes a Proxmox-oriented installer package intended to be
+ported into the Community Scripts workflow (ProxmoxVED first, then upstream).
+
+## What is included
+
+- `deploy/proxmox/install-odysseus-lxc.sh`
+  - LXC guest installer (Debian/Ubuntu) using Docker Compose
+  - Brings up the full Odysseus stack: `odysseus`, `chromadb`, `searxng`, `ntfy`
+  - Sets `AUTH_ENABLED=true` by default
+- `deploy/proxmox/model-profile-helper.sh`
+  - Hardware-tier model profile helper
+  - Tiers: `cpu`, `gpu_modest` (6-12GB VRAM), `gpu_high` (16GB+ VRAM)
+  - Optional Ollama primary/fallback model pulls per tier
+
+## Local test flow
+
+Run inside a fresh Debian/Ubuntu environment:
+
+```bash
+cd /opt
+git clone https://github.com/pewdiepie-archdaemon/odysseus.git
+cd odysseus
+sudo bash deploy/proxmox/install-odysseus-lxc.sh
+```
+
+Optional model auto-setup:
+
+```bash
+sudo INSTALL_OLLAMA=true AUTO_PULL_MODELS=true MODEL_TIER=cpu bash deploy/proxmox/install-odysseus-lxc.sh
+```
+
+Post-install profile helper examples:
+
+```bash
+odysseus-model-profile --tier cpu
+odysseus-model-profile --tier gpu_modest --pull-models
+odysseus-model-profile --tier gpu_high --pull-models --pull-alternatives
+```
+
+## Expected Community Scripts mapping
+
+When upstreaming:
+
+1. Keep this logic split between:
+   - host-side CT creation script (Community Scripts template style)
+   - in-guest install routine (this installer logic)
+2. Keep `Default` mode minimal and `Advanced` mode configurable.
+3. Keep security defaults private-by-default; add reverse-proxy/TLS notes.
+4. Preserve model helper output contract so users get exact Odysseus settings
+   after install.
+
+When `INSTALL_OLLAMA=true`, the installer configures host Ollama to listen on
+`0.0.0.0:11434` and adds a Docker Compose override so the Odysseus container can
+reach it at `http://host.docker.internal:11434/v1`.
+
+## Traefik example
+
+If Traefik runs outside this LXC, route only the Odysseus web UI to the LXC IP
+and keep ChromaDB, SearXNG, ntfy, and Ollama private.
+
+Example dynamic config:
+
+```yaml
+http:
+  routers:
+    odysseus:
+      rule: Host(`odysseus.example.com`)
+      entryPoints:
+        - websecure
+      tls:
+        certResolver: letsencrypt
+      service: odysseus
+
+  services:
+    odysseus:
+      loadBalancer:
+        servers:
+          - url: http://192.168.2.42:7000
+        passHostHeader: true
+```
+
+Replace `odysseus.example.com`, `letsencrypt`, and `192.168.2.42` for your
+Traefik deployment. The same example is available at
+`deploy/proxmox/traefik-odysseus.yml`.
+
+## Recommended defaults by hardware tier
+
+- `cpu`: `qwen2.5:3b-instruct-q4_K_M` + `qwen2.5:1.5b-instruct-q4_K_M`
+- `gpu_modest`: `qwen2.5:7b-instruct-q4_K_M` + `qwen2.5:3b-instruct-q4_K_M`
+- `gpu_high`: `qwen2.5:14b-instruct-q4_K_M` + `qwen2.5:7b-instruct-q4_K_M`
+
+If local inference is not desired, users can configure any external
+OpenAI-compatible endpoint inside Odysseus settings.


### PR DESCRIPTION
## Summary

Adds a Proxmox-oriented deployment scaffold for Odysseus: an LXC installer script using Docker Compose, a hardware-tier model profile helper with optional Ollama pulls, a Traefik example, and documentation for the Community Scripts contribution path. This gives reviewers a starting point for Proxmox VE deployment work and now includes runtime validation from a Debian 12 Proxmox LXC.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Closes #59

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [x] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [x] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

A reviewer can verify the scaffold locally and compare against the runtime validation below:

1. Check out this PR branch.
2. Run shell syntax validation:

   ```bash
   bash -n deploy/proxmox/install-odysseus-lxc.sh
   bash -n deploy/proxmox/model-profile-helper.sh
   ```

3. In a Debian/Ubuntu Proxmox LXC, run the installer flow and verify Docker Compose starts the stack:

   ```bash
   cd /opt/odysseus
   docker compose ps
   curl -I --max-time 10 http://localhost:7000
   odysseus-model-profile --tier cpu
   docker compose logs --tail=80 odysseus
   ```

Runtime validation completed on a Debian 12 (bookworm) Proxmox LXC:

- Branch: `proxmox-deployment-scaffold`
- Commit: `e37f3c5`
- `docker compose ps` showed `odysseus`, `chromadb`, `searxng`, and `ntfy` running
- Odysseus was reachable on port `7000` and returned `302 Found` to `/login`, confirming auth is enabled
- `odysseus-model-profile --tier cpu` printed the expected CPU-only model recommendations
- Odysseus logs showed application startup complete, ChromaDB connectivity, FastEmbed initialization, MCP route/tool initialization, and Uvicorn listening on `0.0.0.0:7000`

## Visual / UI changes — REQUIRED if you touched anything that renders

No visual/UI-rendering code was changed. This PR only touches deployment scripts, deployment docs, the Traefik example, and README deployment documentation.

### Screenshots / clips

N/A — no UI changes.
