### PR TITLE
[codex] Add macOS support and release CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
       - name: Validate Compose file
-        run: docker compose config --quiet
+        run: |
+          cp .env.example .env
+          docker compose config --quiet
       - uses: docker/build-push-action@v6
         with:
           context: .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     name: Test (${{ matrix.os }}, Python ${{ matrix.python-version }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test (${{ matrix.os }}, Python ${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Lint service scripts
+        run: bash -n install-service.sh docker/entrypoint.sh
+
+      - name: Initialize local app state
+        env:
+          ODYSSEUS_ADMIN_PASSWORD: ci-admin-password
+        run: python setup.py
+
+      - name: Run tests
+        run: python -m pytest -q
+
+      - name: Smoke import ASGI app
+        run: python -c "from app import app; print(app.title)"
+
+  docker-build:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Validate Compose file
+        run: docker compose config --quiet
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          tags: odysseus:ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ permissions:
   packages: write
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   IMAGE_NAME: ghcr.io/${{ github.repository }}
   RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
   RELEASE_REF: ${{ inputs.tag || github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,13 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Existing tag to publish, for example v1.0.0"
-        required: true
+        description: "Optional existing tag to publish, for example v1.0.0"
+        required: false
+      publish:
+        description: "Publish the GitHub release and GHCR image"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -17,6 +22,8 @@ permissions:
 env:
   IMAGE_NAME: ghcr.io/${{ github.repository }}
   RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+  RELEASE_REF: ${{ inputs.tag || github.ref }}
+  PUBLISH_RELEASE: ${{ github.event_name == 'push' || inputs.publish }}
 
 jobs:
   test:
@@ -25,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag || github.ref }}
+          ref: ${{ env.RELEASE_REF }}
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -56,7 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag || github.ref }}
+          ref: ${{ env.RELEASE_REF }}
 
       - name: Build source archive
         run: |
@@ -76,7 +83,7 @@ jobs:
             dist/checksums.txt
 
       - name: Publish GitHub release
-        if: startsWith(env.RELEASE_TAG, 'v')
+        if: startsWith(env.RELEASE_TAG, 'v') && env.PUBLISH_RELEASE == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -90,11 +97,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag || github.ref }}
+          ref: ${{ env.RELEASE_REF }}
 
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3
+        if: env.PUBLISH_RELEASE == 'true'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -105,13 +113,14 @@ jobs:
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=tag
+            type=ref,event=tag,enable=${{ startsWith(env.RELEASE_TAG, 'v') }}
             type=raw,value=${{ env.RELEASE_TAG }},enable=${{ startsWith(env.RELEASE_TAG, 'v') }}
-            type=raw,value=latest,enable=${{ startsWith(env.RELEASE_TAG, 'v') }}
+            type=raw,value=latest,enable=${{ startsWith(env.RELEASE_TAG, 'v') && env.PUBLISH_RELEASE == 'true' }}
+            type=raw,value=release-dry-run,enable=${{ !startsWith(env.RELEASE_TAG, 'v') }}
 
       - uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          push: ${{ env.PUBLISH_RELEASE == 'true' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
         run: |
           python setup.py
           python -m pytest -q
+          cp .env.example .env
           docker compose config --quiet
 
   source-archive:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,116 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to publish, for example v1.0.0"
+        required: true
+
+permissions:
+  contents: write
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
+  RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+
+jobs:
+  test:
+    name: Release Gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          npm ci
+      - name: Initialize and test
+        env:
+          ODYSSEUS_ADMIN_PASSWORD: ci-admin-password
+        run: |
+          python setup.py
+          python -m pytest -q
+          docker compose config --quiet
+
+  source-archive:
+    name: Source Archive
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Build source archive
+        run: |
+          mkdir -p dist
+          git archive \
+            --format=tar.gz \
+            --prefix="odysseus-${RELEASE_TAG}/" \
+            -o "dist/odysseus-${RELEASE_TAG}.tar.gz" \
+            HEAD
+          (cd dist && sha256sum *.tar.gz > checksums.txt)
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: odysseus-source
+          path: |
+            dist/*.tar.gz
+            dist/checksums.txt
+
+      - name: Publish GitHub release
+        if: startsWith(env.RELEASE_TAG, 'v')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$RELEASE_TAG" dist/*.tar.gz dist/checksums.txt --generate-notes \
+            || gh release upload "$RELEASE_TAG" dist/*.tar.gz dist/checksums.txt --clobber
+
+  docker-image:
+    name: Docker Image
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
+            type=raw,value=${{ env.RELEASE_TAG }},enable=${{ startsWith(env.RELEASE_TAG, 'v') }}
+            type=raw,value=latest,enable=${{ startsWith(env.RELEASE_TAG, 'v') }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -61,8 +61,19 @@ After generating the key, you can also install it from the host with:
 ```bash
 ssh-copy-id -i data/ssh/id_ed25519.pub user@server
 ```
+On macOS, install `ssh-copy-id` with `brew install ssh-copy-id`, or append the
+key manually:
+```bash
+cat data/ssh/id_ed25519.pub | ssh user@server 'mkdir -p ~/.ssh && cat >> ~/.ssh/authorized_keys'
+```
 Cookbook local downloads are stored in `./data/huggingface`, mounted as
 `~/.cache/huggingface` inside the Odysseus container.
+
+On macOS Docker Desktop, set host ownership in `.env` so bind-mounted files stay
+editable from Finder/Terminal:
+```bash
+printf "PUID=%s\nPGID=%s\n" "$(id -u)" "$(id -g)" >> .env
+```
 
 Useful checks:
 ```bash
@@ -82,11 +93,14 @@ The Cookbook model catalog check should print a non-zero count. If it prints
 `0`, rebuild the Odysseus image with `docker compose build --no-cache odysseus`.
 
 ### Option 2: Manual install — Linux / macOS
-**Requirements:** Python 3.11+. On Linux/Termux, Cookbook also requires `tmux`
-for background model downloads and serves.
+**Requirements:** Python 3.11+. Cookbook also requires `tmux` for background
+model downloads and serves.
 
 Install system packages first:
 ```bash
+# macOS
+brew install tmux
+
 # Debian/Ubuntu
 sudo apt install tmux
 
@@ -107,6 +121,19 @@ pip install -r requirements.txt
 python setup.py            # creates data dirs and prints an initial admin password
 uvicorn app:app --host 0.0.0.0 --port 7000
 ```
+
+For manual installs that use vector memory without Compose, run ChromaDB
+separately:
+```bash
+docker run -d --name odysseus-chroma -p 8100:8000 chromadb/chroma:latest
+```
+
+To run Odysseus as a login service on macOS after setup:
+```bash
+./install-service.sh
+```
+This creates a LaunchAgent at `~/Library/LaunchAgents/com.odysseus.ui.plist`
+and starts Odysseus on `http://127.0.0.1:7000`.
 
 ### Option 3: Manual install — Windows (PowerShell)
 ```powershell

--- a/core/constants.py
+++ b/core/constants.py
@@ -2,7 +2,7 @@
 """Application-wide constants and configuration values."""
 import os
 
-APP_VERSION = "0.9.1"
+APP_VERSION = "1.0.0"
 
 # Base paths
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__))) + "/"

--- a/install-service.sh
+++ b/install-service.sh
@@ -1,8 +1,100 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SERVICE_FILE="$SCRIPT_DIR/odysseus-ui.service"
+APP_LABEL="com.odysseus.ui"
+PORT="${PORT:-7000}"
+HOST="${HOST:-127.0.0.1}"
+
+pick_python() {
+  if [ -x "$SCRIPT_DIR/.venv/bin/python" ]; then
+    printf '%s\n' "$SCRIPT_DIR/.venv/bin/python"
+  elif [ -x "$SCRIPT_DIR/venv/bin/python" ]; then
+    printf '%s\n' "$SCRIPT_DIR/venv/bin/python"
+  else
+    command -v python3
+  fi
+}
+
+xml_escape() {
+  "$(pick_python)" - "$1" <<'PY'
+import html
+import sys
+print(html.escape(sys.argv[1], quote=False))
+PY
+}
+
+if [ "$(uname -s)" = "Darwin" ]; then
+  PYTHON_BIN="$(pick_python)"
+  PLIST_DIR="$HOME/Library/LaunchAgents"
+  PLIST_FILE="$PLIST_DIR/$APP_LABEL.plist"
+  LOG_DIR="$SCRIPT_DIR/logs"
+  mkdir -p "$PLIST_DIR" "$LOG_DIR"
+
+  PY_ESCAPED="$(xml_escape "$PYTHON_BIN")"
+  SCRIPT_ESCAPED="$(xml_escape "$SCRIPT_DIR")"
+  OUT_ESCAPED="$(xml_escape "$LOG_DIR/odysseus-ui.out.log")"
+  ERR_ESCAPED="$(xml_escape "$LOG_DIR/odysseus-ui.err.log")"
+
+  cat > "$PLIST_FILE" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>$APP_LABEL</string>
+  <key>WorkingDirectory</key>
+  <string>$SCRIPT_ESCAPED</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>$PY_ESCAPED</string>
+    <string>-m</string>
+    <string>uvicorn</string>
+    <string>app:app</string>
+    <string>--host</string>
+    <string>$HOST</string>
+    <string>--port</string>
+    <string>$PORT</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PYTHONUNBUFFERED</key>
+    <string>1</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>$OUT_ESCAPED</string>
+  <key>StandardErrorPath</key>
+  <string>$ERR_ESCAPED</string>
+</dict>
+</plist>
+EOF
+
+  launchctl bootout "gui/$UID" "$PLIST_FILE" >/dev/null 2>&1 || true
+  launchctl bootstrap "gui/$UID" "$PLIST_FILE"
+  launchctl kickstart -k "gui/$UID/$APP_LABEL" >/dev/null 2>&1 || true
+
+  echo "Installed macOS LaunchAgent: $PLIST_FILE"
+  echo "Service: $APP_LABEL"
+  echo "URL: http://$HOST:$PORT"
+  echo "Logs:"
+  echo "  $LOG_DIR/odysseus-ui.out.log"
+  echo "  $LOG_DIR/odysseus-ui.err.log"
+  echo ""
+  echo "Stop:   launchctl bootout gui/$UID $PLIST_FILE"
+  echo "Start:  launchctl bootstrap gui/$UID $PLIST_FILE"
+  exit 0
+fi
+
+if ! command -v systemctl >/dev/null 2>&1; then
+  echo "Error: this installer supports macOS launchd or Linux systemd."
+  echo "Manual start: uvicorn app:app --host 127.0.0.1 --port 7000"
+  exit 1
+fi
 
 if [ ! -f "$SERVICE_FILE" ]; then
   echo "Error: odysseus-ui.service not found in $SCRIPT_DIR"

--- a/odysseus-ui.service
+++ b/odysseus-ui.service
@@ -9,7 +9,7 @@ Type=simple
 # CHANGE THESE to match your user and install path:
 User=YOURUSER
 WorkingDirectory=/home/YOURUSER/odysseus-ui
-ExecStart=/home/YOURUSER/odysseus-ui/venv/bin/uvicorn app:app --port 8000 --host 0.0.0.0
+ExecStart=/home/YOURUSER/odysseus-ui/venv/bin/uvicorn app:app --port 7000 --host 0.0.0.0
 Restart=always
 RestartSec=3
 EnvironmentFile=-/home/YOURUSER/odysseus-ui/.env

--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -902,7 +902,8 @@ def setup_calendar_routes() -> APIRouter:
                     lines.append(f"DTSTART:{ev.dtstart.strftime('%Y%m%dT%H%M%S')}")
                     lines.append(f"DTEND:{ev.dtend.strftime('%Y%m%dT%H%M%S')}")
                 if ev.description:
-                    lines.append(f"DESCRIPTION:{ev.description.replace(chr(10), '\\n')}")
+                    description = ev.description.replace("\n", "\\n")
+                    lines.append(f"DESCRIPTION:{description}")
                 if ev.location:
                     lines.append(f"LOCATION:{ev.location}")
                 if ev.rrule:

--- a/routes/cookbook_helpers.py
+++ b/routes/cookbook_helpers.py
@@ -199,7 +199,7 @@ class ModelDownloadRequest(BaseModel):
     env_prefix: str | None = None  # e.g. "source ~/venv/bin/activate"
     remote_host: str | None = None  # e.g. "gpu-box" — run download on this host via SSH
     ssh_port: str | None = None    # e.g. "8022" for Termux
-    platform: str | None = None    # "linux", "termux", or "windows"
+    platform: str | None = None    # "linux", "termux", "macos", or "windows"
     local_dir: str | None = None   # base dir to download into (a per-model subfolder is created under it); None = default HF cache
     disable_hf_transfer: bool = False  # skip the Rust hf_transfer downloader — slower but far more reliable on large files (used by retries)
 
@@ -212,7 +212,7 @@ class ServeRequest(BaseModel):
     env_prefix: str | None = None
     hf_token: str | None = None
     gpus: str | None = None
-    platform: str | None = None    # "linux", "termux", or "windows"
+    platform: str | None = None    # "linux", "termux", "macos", or "windows"
 
 
 def _parse_serve_phase(snapshot: str, task_type: str = "serve") -> dict:

--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import os
+import platform as py_platform
 import re
 import shlex
 import shutil
@@ -285,7 +286,14 @@ def setup_cookbook_routes() -> APIRouter:
         if windows:
             check = f"powershell -NoProfile -Command \"if (Get-Command {binary} -ErrorAction SilentlyContinue) {{ exit 0 }} else {{ exit 127 }}\""
         else:
-            check = f"command -v {shlex.quote(binary)} >/dev/null 2>&1"
+            login_check = f"command -v {shlex.quote(binary)} >/dev/null 2>&1"
+            inner = (
+                'export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:'
+                '/opt/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"; '
+                f"{login_check} || "
+                f'{{ [ -n "$SHELL" ] && "$SHELL" -lc {shlex.quote(login_check)}; }}'
+            )
+            check = f"sh -lc {shlex.quote(inner)}"
         try:
             proc = await asyncio.create_subprocess_exec(
                 "ssh", "-o", "ConnectTimeout=6", "-o", "StrictHostKeyChecking=no",
@@ -441,7 +449,7 @@ def setup_cookbook_routes() -> APIRouter:
             else:
                 # Fallback: find a venv with hf CLI, or install huggingface-hub
                 runner_lines.append(
-                    'for p in ~/vllm-env ~/venv ~/.venv; do '
+                    'for p in ~/vllm-env ~/venv ~/.venv ~/.odysseus-cookbook-venv; do '
                     'if [ -f "$p/bin/activate" ]; then source "$p/bin/activate"; break; fi; '
                     'done'
                 )
@@ -768,6 +776,10 @@ def setup_cookbook_routes() -> APIRouter:
         session_id = f"serve-{uuid.uuid4().hex[:8]}"
         remote = req.remote_host
         is_windows = req.platform == "windows"
+        req_platform = (req.platform or "").lower()
+        is_macos = req_platform in {"macos", "darwin", "mac"} or (
+            not remote and py_platform.system() == "Darwin"
+        )
 
         if not is_windows and not await _binary_available("tmux", remote, req.ssh_port):
             return {
@@ -832,13 +844,13 @@ def setup_cookbook_routes() -> APIRouter:
                 f'ssh {_pf}{remote} "powershell -Command \\"{launch_ps}\\""'
             )
         else:
-            # ── Linux/Termux: bash + tmux (existing flow) ──
+            # ── POSIX local/remote: bash + tmux (Linux, Termux, macOS) ──
             runner_lines = ["#!/bin/bash"]
             runner_lines.extend(_user_shell_path_bootstrap())
             runner_lines.append("export FLASHINFER_DISABLE_VERSION_CHECK=1")
             if req.hf_token:
                 runner_lines.append(f"export HF_TOKEN='{_bash_squote(req.hf_token)}'")
-            if req.gpus:
+            if req.gpus and not is_macos:
                 runner_lines.append(f"export CUDA_VISIBLE_DEVICES='{req.gpus}'")
             if req.env_prefix:
                 runner_lines.append(_safe_env_prefix(req.env_prefix))
@@ -866,9 +878,15 @@ def setup_cookbook_routes() -> APIRouter:
                 runner_lines.append('  echo "Native llama-server not found — building from source (one-time, may take a few minutes)..."')
                 runner_lines.append('  mkdir -p ~/bin')
                 runner_lines.append('  cd ~ && [ -d llama.cpp ] || git clone --depth 1 https://github.com/ggml-org/llama.cpp')
-                # GPU build if CUDA is present; fall back to a plain (CPU) build.
-                runner_lines.append('  cd ~/llama.cpp && { cmake -B build -DGGML_CUDA=ON 2>/dev/null || cmake -B build; } \\')
-                runner_lines.append('    && cmake --build build -j"$(nproc)" --target llama-server \\')
+                runner_lines.append('  BUILD_JOBS="$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)"')
+                runner_lines.append('  BUILD_JOBS="${BUILD_JOBS%%[!0-9]*}"')
+                runner_lines.append('  [ -n "$BUILD_JOBS" ] || BUILD_JOBS=4')
+                # GPU build if the host supports it; fall back to a plain build.
+                if is_macos:
+                    runner_lines.append('  cd ~/llama.cpp && { cmake -B build -DGGML_METAL=ON 2>/dev/null || cmake -B build; } \\')
+                else:
+                    runner_lines.append('  cd ~/llama.cpp && { cmake -B build -DGGML_CUDA=ON 2>/dev/null || cmake -B build; } \\')
+                runner_lines.append('    && cmake --build build -j"$BUILD_JOBS" --target llama-server \\')
                 runner_lines.append('    && ln -sf ~/llama.cpp/build/bin/llama-server ~/bin/llama-server')
                 runner_lines.append('  # If the native build failed, fall back to the Python bindings.')
                 runner_lines.append('  if ! command -v llama-server &>/dev/null && ! python3 -c "import llama_cpp" 2>/dev/null; then')
@@ -977,7 +995,8 @@ def setup_cookbook_routes() -> APIRouter:
             raise HTTPException(400, "Invalid ssh_port")
         pf = f"-p {port} " if port and port != "22" else ""
 
-        # Detect platform: Windows first (echo %OS% → Windows_NT), then Termux, then Linux
+        # Detect platform: Windows first (echo %OS% → Windows_NT), then
+        # Termux/macOS/Linux via POSIX shell.
         detect_cmd = f'ssh {pf}{host} "echo %OS%"'
         platform = "linux"
         try:
@@ -989,8 +1008,12 @@ def setup_cookbook_routes() -> APIRouter:
             if "Windows_NT" in out:
                 platform = "windows"
             else:
-                # Check for Termux
-                detect_cmd2 = f"ssh {pf}{host} 'test -d /data/data/com.termux && echo termux || echo linux'"
+                detect_cmd2 = (
+                    f"ssh {pf}{host} "
+                    "'if test -d /data/data/com.termux; then echo termux; "
+                    "elif [ \"$(uname -s 2>/dev/null)\" = Darwin ]; then echo macos; "
+                    "else echo linux; fi'"
+                )
                 proc2 = await asyncio.create_subprocess_shell(
                     detect_cmd2, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
                 )
@@ -1018,7 +1041,22 @@ def setup_cookbook_routes() -> APIRouter:
                 "pip install -q filelock fsspec packaging pyyaml tqdm typer httpx requests 2>/dev/null; "
                 "python3 -c 'from huggingface_hub import snapshot_download; print(\"OK\")'"
             )
-            cmd = f"ssh {pf}{host} '{setup_script}'"
+            cmd = f"ssh {pf}{host} {shlex.quote(setup_script)}"
+        elif platform == "macos":
+            setup_script = (
+                "export PATH=\"$HOME/.local/bin:$HOME/.odysseus-cookbook-venv/bin:/opt/homebrew/bin:/usr/local/bin:/opt/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH\"; "
+                "if ! command -v tmux >/dev/null 2>&1; then "
+                "  if command -v brew >/dev/null 2>&1; then brew install tmux; "
+                "  else echo 'WARNING: tmux missing and Homebrew not found. Install Homebrew or tmux manually.'; fi; "
+                "fi; "
+                "command -v tmux >/dev/null 2>&1 || echo 'WARNING: tmux missing and auto-install failed.'; "
+                "python3 -c 'import huggingface_hub' 2>/dev/null || "
+                "python3 -m pip install -q --user --break-system-packages huggingface_hub hf_transfer 2>/dev/null || "
+                "(python3 -m venv \"$HOME/.odysseus-cookbook-venv\" && \"$HOME/.odysseus-cookbook-venv/bin/python\" -m pip install -q huggingface_hub hf_transfer); "
+                "(python3 -c 'from huggingface_hub import snapshot_download; print(\"OK\")' 2>/dev/null || "
+                "\"$HOME/.odysseus-cookbook-venv/bin/python\" -c 'from huggingface_hub import snapshot_download; print(\"OK\")')"
+            )
+            cmd = f"ssh {pf}{host} {shlex.quote(setup_script)}"
         else:
             # Linux: auto-install tmux (via whichever package manager is available)
             # and huggingface_hub + hf_transfer (falling back to --user/--break-system-packages
@@ -1040,7 +1078,7 @@ def setup_cookbook_routes() -> APIRouter:
                 "pip3 install --user --break-system-packages -q huggingface_hub hf_transfer 2>/dev/null; "
                 "python3 -c 'from huggingface_hub import snapshot_download; print(\"OK\")'"
             )
-            cmd = f"ssh {pf}{host} '{setup_script}'"
+            cmd = f"ssh {pf}{host} {shlex.quote(setup_script)}"
 
         try:
             proc = await asyncio.create_subprocess_shell(
@@ -1191,6 +1229,39 @@ def setup_cookbook_routes() -> APIRouter:
                 gpus[0]["busy"] = True
         return gpus
 
+    async def _probe_macos_metal(host: str | None, ssh_port: str | None) -> list[dict]:
+        out, err = await _run_gpu_shell(
+            "uname -s 2>/dev/null; sysctl -n hw.memsize 2>/dev/null; sysctl -n machdep.cpu.brand_string 2>/dev/null || true",
+            host, ssh_port, timeout=5,
+        )
+        if err is not None or not out:
+            return []
+        lines = [ln.strip() for ln in out.splitlines() if ln.strip()]
+        if not lines or lines[0] != "Darwin":
+            return []
+        total_bytes = 0
+        if len(lines) > 1:
+            try:
+                total_bytes = int(lines[1])
+            except ValueError:
+                total_bytes = 0
+        total_mb = int((total_bytes * 0.75) / (1024 * 1024)) if total_bytes else 0
+        name = lines[2] if len(lines) > 2 else "Apple Silicon"
+        return [{
+            "index": 0,
+            "name": f"{name} GPU",
+            "uuid": "metal-unified-memory",
+            "free_mb": total_mb,
+            "total_mb": total_mb,
+            "used_mb": 0,
+            "util_pct": 0,
+            "busy": False,
+            "processes": [],
+            "backend": "metal",
+            "source": "macos-sysctl",
+            "unified_memory": True,
+        }]
+
     @router.get("/api/cookbook/gpus")
     async def list_gpus(request: Request, host: str | None = None, ssh_port: str | None = None):
         """Probe GPU memory/process state locally or via SSH.
@@ -1288,6 +1359,17 @@ def setup_cookbook_routes() -> APIRouter:
                 "gpus": amd_gpus,
                 "backend": "rocm",
                 "source": "amd-sysfs",
+                "fallback_from": "nvidia-smi",
+                "nvidia_error": nvidia_error,
+            }
+
+        metal_gpus = await _probe_macos_metal(host, ssh_port)
+        if metal_gpus:
+            return {
+                "ok": True,
+                "gpus": metal_gpus,
+                "backend": "metal",
+                "source": "macos-sysctl",
                 "fallback_from": "nvidia-smi",
                 "nvidia_error": nvidia_error,
             }

--- a/routes/hwfit_routes.py
+++ b/routes/hwfit_routes.py
@@ -55,7 +55,7 @@ def setup_hwfit_routes():
         count = max(1, min(count, 16))
         vram_each = max(1.0, vram_each)
         backend = (manual_backend or system.get("backend") or "cuda").lower()
-        if backend not in {"cuda", "rocm", "cpu_x86", "cpu_arm"}:
+        if backend not in {"cuda", "rocm", "metal", "mps", "apple", "cpu_x86", "cpu_arm"}:
             backend = "cuda"
         total_vram = round(vram_each * count, 1)
         gpu_name = f"Simulated {backend.upper()} GPU" + (f" × {count}" if count > 1 else "")

--- a/routes/shell_routes.py
+++ b/routes/shell_routes.py
@@ -483,7 +483,7 @@ def setup_shell_routes() -> APIRouter:
         import importlib, shlex, json as _json
         packages = [
             # ── System ── OS binaries, not pip packages
-            {"name": "tmux", "pip": "", "desc": "Required for Linux/Termux Cookbook background downloads and serves", "category": "System", "target": "remote", "kind": "system", "install_hint": "Run Cookbook server setup, or install tmux with apt/pacman/dnf/apk/zypper."},
+            {"name": "tmux", "pip": "", "desc": "Required for Cookbook background downloads and serves", "category": "System", "target": "remote", "kind": "system", "install_hint": "Run Cookbook server setup, or install tmux with brew/apt/pacman/dnf/apk/zypper."},
             {"name": "docker", "pip": "", "desc": "Required only for Docker-backed launch commands", "category": "System", "target": "remote", "kind": "system", "install_hint": "Install Docker on the selected server and allow this user to run docker."},
             # ── LLM ── installs on GPU servers for model serving/downloading
             {"name": "hf_transfer", "pip": "hf_transfer", "desc": "Fast model downloads from HuggingFace", "category": "LLM", "target": "remote"},

--- a/services/hwfit/fit.py
+++ b/services/hwfit/fit.py
@@ -24,7 +24,15 @@ GPU_BANDWIDTH = {
 # Pre-sort keys by length descending for correct substring matching
 _BW_KEYS_SORTED = sorted(GPU_BANDWIDTH.keys(), key=len, reverse=True)
 
-FALLBACK_K = {"cuda": 220, "rocm": 180, "cpu_x86": 70, "cpu_arm": 90}
+FALLBACK_K = {
+    "cuda": 220,
+    "rocm": 180,
+    "metal": 140,
+    "mps": 140,
+    "apple": 140,
+    "cpu_x86": 70,
+    "cpu_arm": 90,
+}
 
 USE_CASE_WEIGHTS = {
     "general":    (0.45, 0.30, 0.15, 0.10),

--- a/services/hwfit/hardware.py
+++ b/services/hwfit/hardware.py
@@ -8,7 +8,7 @@ CACHE_TTL = 1800  # 30 min — hardware rarely changes; use the Rescan button to
 
 _remote_host = None  # set by detect_system(host=...)
 _remote_port = None  # set by detect_system(ssh_port=...)
-_remote_platform = None  # set by detect_system(platform=...): "windows", "linux", "termux"
+_remote_platform = None  # set by detect_system(platform=...): "windows", "linux", "macos", "termux"
 _last_gpu_error = None  # set by _detect_nvidia() when nvidia-smi errors (driver mismatch, etc.)
 
 
@@ -35,6 +35,39 @@ def _run(cmd):
     except Exception:
         pass
     return None
+
+
+def _sysctl(name):
+    """Read a local macOS sysctl value."""
+    if _remote_host:
+        return None
+    return _run(["sysctl", "-n", name])
+
+
+def _is_remote_macos():
+    return bool(_remote_host) and str(_remote_platform or "").lower() in {"macos", "darwin", "mac"}
+
+
+def _parse_vm_stat_available_gb(out):
+    """Parse macOS vm_stat free-ish pages into GiB."""
+    page_size = 4096
+    pages = 0
+    if not out:
+        return 0.0
+    for line in out.splitlines():
+        if "page size of" in line:
+            try:
+                page_size = int(line.split("page size of", 1)[1].split("bytes", 1)[0].strip())
+            except Exception:
+                pass
+        key = line.split(":", 1)[0].strip().lower()
+        if key in {"pages free", "pages inactive", "pages speculative"} and ":" in line:
+            raw = line.split(":", 1)[1].strip().rstrip(".")
+            try:
+                pages += int(raw)
+            except ValueError:
+                pass
+    return (pages * page_size) / (1024**3) if pages else 0.0
 
 
 def _group_gpus(gpus):
@@ -204,6 +237,43 @@ def _detect_amd():
         return None
 
 
+def _detect_apple_silicon(total_ram_gb=0.0):
+    """Detect Apple Silicon as a Metal/unified-memory GPU.
+
+    macOS has no /proc or /sys GPU inventory like Linux. For M-series Macs,
+    CPU/GPU share unified memory; use a conservative 75% of system RAM as the
+    fit budget so Cookbook can surface MLX/GGUF options without pretending the
+    whole machine is dedicated VRAM.
+    """
+    if _remote_host or platform.system() != "Darwin":
+        return None
+    machine = (platform.machine() or "").lower()
+    brand = (_sysctl("machdep.cpu.brand_string") or "").strip()
+    if machine not in ("arm64", "aarch64") and "apple" not in brand.lower():
+        return None
+
+    total = total_ram_gb or _get_ram_gb()
+    unified_budget = round(max(total * 0.75, 1.0), 1) if total else 0.0
+    name = brand or "Apple Silicon"
+    gpu_name = f"{name} GPU"
+    return {
+        "gpu_name": gpu_name,
+        "gpu_vram_gb": unified_budget,
+        "gpu_count": 1,
+        "gpus": [{"index": 0, "name": gpu_name, "vram_gb": unified_budget}],
+        "gpu_groups": [{
+            "name": gpu_name,
+            "vram_each": unified_budget,
+            "count": 1,
+            "indices": [0],
+            "vram_total": unified_budget,
+        }],
+        "homogeneous": True,
+        "backend": "metal",
+        "unified_memory": True,
+    }
+
+
 def _read_file(path):
     """Read a file, locally or via SSH."""
     if _remote_host:
@@ -234,6 +304,13 @@ def _parse_meminfo():
 
 
 def _get_ram_gb():
+    if not _remote_host and platform.system() == "Darwin":
+        out = _sysctl("hw.memsize")
+        if out:
+            try:
+                return int(out.strip()) / (1024**3)
+            except ValueError:
+                pass
     meminfo = _parse_meminfo()
     if "MemTotal" in meminfo:
         return meminfo["MemTotal"] / (1024**2)
@@ -250,6 +327,11 @@ def _get_ram_gb():
 
 
 def _get_available_ram_gb():
+    if not _remote_host and platform.system() == "Darwin":
+        out = _run(["vm_stat"])
+        available = _parse_vm_stat_available_gb(out)
+        if available:
+            return available
     meminfo = _parse_meminfo()
     if "MemAvailable" in meminfo:
         return meminfo["MemAvailable"] / (1024**2)
@@ -257,6 +339,8 @@ def _get_available_ram_gb():
 
 
 def _get_cpu_name():
+    if not _remote_host and platform.system() == "Darwin":
+        return _sysctl("machdep.cpu.brand_string") or platform.processor() or "unknown"
     text = _read_file("/proc/cpuinfo")
     if text:
         for line in text.split("\n"):
@@ -360,6 +444,73 @@ def _detect_windows():
         return None
 
 
+def _detect_macos():
+    """Detect remote macOS hardware via sysctl/vm_stat over SSH."""
+    total_out = _run("sysctl -n hw.memsize 2>/dev/null")
+    if not total_out:
+        return None
+    try:
+        total_ram = round(int(total_out.strip()) / (1024**3), 1)
+    except ValueError:
+        return None
+
+    available_ram = round(
+        _parse_vm_stat_available_gb(_run("vm_stat 2>/dev/null")) or (total_ram * 0.7),
+        1,
+    )
+    try:
+        cpu_cores = int((_run("sysctl -n hw.logicalcpu 2>/dev/null") or "1").strip())
+    except ValueError:
+        cpu_cores = 1
+    cpu_name = (
+        _run("sysctl -n machdep.cpu.brand_string 2>/dev/null")
+        or _run("sysctl -n hw.model 2>/dev/null")
+        or "unknown"
+    )
+    machine = (_run("uname -m 2>/dev/null") or "").strip().lower()
+    is_apple = machine in {"arm64", "aarch64"} or "apple" in cpu_name.lower()
+
+    if is_apple:
+        unified_budget = round(max(total_ram * 0.75, 1.0), 1)
+        gpu_name = f"{cpu_name or 'Apple Silicon'} GPU"
+        return {
+            "total_ram_gb": total_ram,
+            "available_ram_gb": available_ram,
+            "cpu_cores": cpu_cores,
+            "cpu_name": cpu_name,
+            "has_gpu": True,
+            "gpu_name": gpu_name,
+            "gpu_vram_gb": unified_budget,
+            "gpu_count": 1,
+            "gpus": [{"index": 0, "name": gpu_name, "vram_gb": unified_budget}],
+            "gpu_groups": [{
+                "name": gpu_name,
+                "vram_each": unified_budget,
+                "count": 1,
+                "indices": [0],
+                "vram_total": unified_budget,
+            }],
+            "homogeneous": True,
+            "backend": "metal",
+            "unified_memory": True,
+        }
+
+    return {
+        "total_ram_gb": total_ram,
+        "available_ram_gb": available_ram,
+        "cpu_cores": cpu_cores,
+        "cpu_name": cpu_name,
+        "has_gpu": False,
+        "gpu_name": None,
+        "gpu_vram_gb": None,
+        "gpu_count": 0,
+        "gpus": [],
+        "gpu_groups": [],
+        "homogeneous": True,
+        "backend": "cpu_arm" if "arm" in machine or "aarch64" in machine else "cpu_x86",
+    }
+
+
 _cache_by_host = {}  # host -> (timestamp, result)
 
 
@@ -368,7 +519,7 @@ def detect_system(host="", ssh_port="", platform="", fresh=False):
     changes, and probing a remote host over SSH is slow). Pass fresh=True to
     bypass the cache and re-probe (the "Rescan" button).
     If host is set (e.g. 'user@server'), runs detection commands over SSH.
-    platform: "windows", "linux", "termux", or "" (auto-detect).
+    platform: "windows", "linux", "macos", "termux", or "" (auto-detect).
     """
     global _remote_host, _remote_port, _remote_platform
 
@@ -398,7 +549,21 @@ def detect_system(host="", ssh_port="", platform="", fresh=False):
         _cache_by_host[cache_key] = (now, result)
         return result
 
-    # Linux/Termux: existing multi-command detection
+    if _is_remote_macos():
+        result = _detect_macos()
+        if result:
+            _remote_host = None
+            _remote_platform = None
+            _cache_by_host[cache_key] = (now, result)
+            return result
+        result = {"error": f"Cannot connect to {host}", "host": host}
+        _remote_host = None
+        _remote_platform = None
+        _cache_by_host[cache_key] = (now, result)
+        return result
+
+    # Local macOS plus Linux/Termux: multi-command detection with platform
+    # fallbacks. Remote hosts remain Linux/Termux unless platform=windows.
     total_ram = round(_get_ram_gb(), 1)
     # If remote host returns 0 RAM, connection likely failed
     if _remote_host and total_ram <= 0:
@@ -411,7 +576,7 @@ def detect_system(host="", ssh_port="", platform="", fresh=False):
     cpu_cores = _get_cpu_count()
     cpu_name = _get_cpu_name()
 
-    gpu_info = _detect_nvidia() or _detect_amd()
+    gpu_info = _detect_nvidia() or _detect_amd() or _detect_apple_silicon(total_ram)
 
     if gpu_info:
         result = {

--- a/services/shell/service.py
+++ b/services/shell/service.py
@@ -4,6 +4,8 @@
 from dataclasses import dataclass
 from typing import Optional, AsyncIterator
 import asyncio
+import os
+import shutil
 from pathlib import Path
 
 
@@ -53,12 +55,20 @@ class ShellService:
 
         proc = None
         try:
-            proc = await asyncio.create_subprocess_shell(
-                command,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                cwd=cwd,
-            )
+            if os.name == "nt":
+                proc = await asyncio.create_subprocess_shell(
+                    command,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    cwd=cwd,
+                )
+            else:
+                proc = await asyncio.create_subprocess_exec(
+                    shutil.which("bash") or "/bin/bash", "-lc", command,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    cwd=cwd,
+                )
             stdout_b, stderr_b = await asyncio.wait_for(
                 proc.communicate(), timeout=timeout
             )
@@ -101,12 +111,20 @@ class ShellService:
         proc = None
         reader_tasks = []
         try:
-            proc = await asyncio.create_subprocess_shell(
-                command,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                cwd=self.cwd,
-            )
+            if os.name == "nt":
+                proc = await asyncio.create_subprocess_shell(
+                    command,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    cwd=self.cwd,
+                )
+            else:
+                proc = await asyncio.create_subprocess_exec(
+                    shutil.which("bash") or "/bin/bash", "-lc", command,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    cwd=self.cwd,
+                )
 
             q: asyncio.Queue = asyncio.Queue()
 

--- a/setup.py
+++ b/setup.py
@@ -109,9 +109,14 @@ def check_deps():
         print("\n  [warn] tmux not found")
         print("         Cookbook uses tmux for background downloads and model serves.")
         print("         Install it with your OS package manager, for example:")
-        print("           sudo apt install tmux")
-        print("           sudo pacman -S tmux")
-        print("           sudo dnf install tmux")
+        if sys.platform == "darwin":
+            print("           brew install tmux")
+        elif os.environ.get("PREFIX", "").startswith("/data/data/com.termux"):
+            print("           pkg install tmux")
+        else:
+            print("           sudo apt install tmux")
+            print("           sudo pacman -S tmux")
+            print("           sudo dnf install tmux")
     elif os.name != "nt":
         print("  [ok] tmux installed")
 

--- a/src/builtin_mcp.py
+++ b/src/builtin_mcp.py
@@ -23,6 +23,8 @@ def _find_npx() -> str:
     for candidate in [
         os.path.expanduser("~/.npm-global/bin/npx"),
         os.path.expanduser("~/.local/bin/npx"),
+        "/opt/homebrew/bin/npx",
+        "/opt/local/bin/npx",
         "/usr/local/bin/npx",
         "/usr/bin/npx",
     ]:

--- a/src/tool_execution.py
+++ b/src/tool_execution.py
@@ -12,6 +12,7 @@ import collections
 import json
 import logging
 import os
+import shutil
 import time
 from typing import Any, Awaitable, Callable, Dict, Optional, Tuple
 
@@ -323,12 +324,21 @@ async def _direct_fallback(
 
     try:
         if tool == "bash":
-            proc = await asyncio.create_subprocess_shell(
-                content,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                env=_subproc_env,
-            )
+            if os.name == "nt":
+                proc = await asyncio.create_subprocess_shell(
+                    content,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    env=_subproc_env,
+                )
+            else:
+                bash = shutil.which("bash") or "/bin/bash"
+                proc = await asyncio.create_subprocess_exec(
+                    bash, "-lc", content,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    env=_subproc_env,
+                )
             stdout, stderr, rc, timed_out = await _run_subprocess_streaming(
                 proc,
                 timeout=DEFAULT_BASH_TIMEOUT,

--- a/src/tool_implementations.py
+++ b/src/tool_implementations.py
@@ -2796,16 +2796,63 @@ def _cookbook_apply_retry_suggestion(cmd: str, suggestion: Dict[str, Any]) -> st
 
 
 def _scan_running_model_processes() -> List[Dict[str, Any]]:
-    """Scan /proc for running model server processes. Linux-only; returns
-    [] on other platforms or if /proc isn't accessible. Each match returns
-    a dict shaped like a cookbook task so the caller can merge cleanly.
+    """Scan local process table for running model servers.
+
+    Linux uses /proc cmdline for exact args. macOS/BSD falls back to
+    `ps -axo pid=,command=` so Ollama/llama-server/vLLM launched outside
+    Cookbook still show up.
     """
     import os
-    if not os.path.isdir("/proc"):
-        return []
+    import subprocess
     out: List[Dict[str, Any]] = []
     seen_keys = set()
+
+    def _add_match(pid: int, cmdline: str):
+        lower = cmdline.lower()
+        for label, needles in _MODEL_PROCESS_PATTERNS:
+            if any(n.lower() in lower for n in needles):
+                key = (label, cmdline.split(" ")[0])
+                if key in seen_keys:
+                    return
+                seen_keys.add(key)
+                model = ""
+                for tok in cmdline.split():
+                    if "/" in tok and any(s in tok.lower() for s in (
+                        "model", "checkpoint", ".safetensors", ".gguf", ".bin", "huggingface"
+                    )):
+                        model = tok
+                        break
+                out.append({
+                    "session_id": f"pid-{pid}",
+                    "model": model or label,
+                    "phase": "running (external)",
+                    "type": "serve",
+                    "remote": "local",
+                    "pid": pid,
+                    "label": label,
+                    "cmdline_preview": cmdline[:140] + ("…" if len(cmdline) > 140 else ""),
+                    "external": True,
+                })
+                return
+
     try:
+        if not os.path.isdir("/proc"):
+            ps = subprocess.run(
+                ["ps", "-axo", "pid=,command="],
+                capture_output=True, text=True, timeout=5,
+            )
+            if ps.returncode != 0:
+                return []
+            for line in ps.stdout.splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                pid_s, _, cmdline = line.partition(" ")
+                if not pid_s.isdigit() or not cmdline.strip():
+                    continue
+                _add_match(int(pid_s), cmdline.strip())
+            return out
+
         for pid_dir in os.listdir("/proc"):
             if not pid_dir.isdigit():
                 continue
@@ -2820,35 +2867,7 @@ def _scan_running_model_processes() -> List[Dict[str, Any]]:
             cmdline = raw.replace(b"\x00", b" ").decode("utf-8", errors="replace").strip()
             if not cmdline:
                 continue
-            lower = cmdline.lower()
-            for label, needles in _MODEL_PROCESS_PATTERNS:
-                if any(n.lower() in lower for n in needles):
-                    # Dedupe by (label, first-arg) — multi-worker servers
-                    # spawn N processes; only show one row per server.
-                    key = (label, cmdline.split(" ")[0])
-                    if key in seen_keys:
-                        break
-                    seen_keys.add(key)
-                    # Try to pluck a model name out of the cmdline.
-                    model = ""
-                    for tok in cmdline.split():
-                        if "/" in tok and any(s in tok.lower() for s in (
-                            "model", "checkpoint", ".safetensors", ".gguf", ".bin", "huggingface"
-                        )):
-                            model = tok
-                            break
-                    out.append({
-                        "session_id": f"pid-{pid_dir}",
-                        "model": model or label,
-                        "phase": "running (external)",
-                        "type": "serve",
-                        "remote": "local",
-                        "pid": int(pid_dir),
-                        "label": label,
-                        "cmdline_preview": cmdline[:140] + ("…" if len(cmdline) > 140 else ""),
-                        "external": True,
-                    })
-                    break
+            _add_match(int(pid_dir), cmdline)
     except Exception as e:
         logger.debug(f"_scan_running_model_processes failed: {e}")
     return out

--- a/src/tool_schemas.py
+++ b/src/tool_schemas.py
@@ -768,7 +768,7 @@ FUNCTION_TOOL_SCHEMAS = [
                     "host": {"type": "string", "description": "Friendly Cookbook server name (e.g. 'ajax', 'gpu-box') or raw remote host (e.g. 'user@gpu-box'). Omit for local."},
                     "model_dir": {"type": "string", "description": "Comma-separated additional model directories to scan beyond ~/.cache/huggingface/hub"},
                     "ssh_port": {"type": "string", "description": "SSH port for remote host (default 22)"},
-                    "platform": {"type": "string", "enum": ["linux", "windows"], "description": "Remote platform"}
+                    "platform": {"type": "string", "enum": ["linux", "windows", "macos", "termux"], "description": "Remote platform"}
                 },
                 "required": []
             }

--- a/static/js/cookbook-hwfit.js
+++ b/static/js/cookbook-hwfit.js
@@ -965,6 +965,8 @@ export function _expandModelRow(row, modelData) {
       // schema (repo_id + cmd) — sending `command`/`model` failed Pydantic
       // validation (422), which is why Run silently did nothing.
       const _srv = (_envState.servers || []).find(s => s.host === host);
+      const _srvPlatform = (_srv && _srv.platform) || _envState.platform || '';
+      const _isAppleTarget = ['macos', 'darwin', 'mac'].includes(String(_srvPlatform || '').toLowerCase());
       const payload = {
         repo_id: modelData.name,
         cmd: cmd,
@@ -972,8 +974,8 @@ export function _expandModelRow(row, modelData) {
         ssh_port: (_srv && _srv.port) || undefined,
         env_prefix: envPrefix || undefined,
         hf_token: _envState.hfToken || undefined,
-        gpus: _envState.gpus || cudaDevices || undefined,
-        platform: _envState.platform || undefined,
+        gpus: (!_isAppleTarget && (_envState.gpus || cudaDevices)) || undefined,
+        platform: _srvPlatform || undefined,
       };
 
       try {

--- a/static/js/cookbook.js
+++ b/static/js/cookbook.js
@@ -55,10 +55,12 @@ if (typeof window !== 'undefined' && !window._tagScrollGuardWired) {
 export const _MODELDIR_CHECK_OFF = '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/></svg>';
 export const _MODELDIR_CHECK_ON = '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><polyline points="8 12 11 15 16 9"/></svg>';
 
-// Monochrome platform glyphs (currentColor) for a server's OS tag: a penguin for
-// Linux, the four-pane logo for Windows, an Android robot for Termux/Android.
+// Monochrome platform glyphs (currentColor) for a server's OS tag.
 function _platformIcon(platform) {
   const k = (platform || '').toLowerCase();
+  if (k === 'macos' || k === 'darwin' || k === 'mac') {
+    return '<svg viewBox="0 0 24 24" width="12" height="12" fill="currentColor" aria-hidden="true"><path d="M16.5 3.2c-.8.1-1.8.6-2.4 1.4-.5.7-.9 1.7-.8 2.6.9.1 1.9-.5 2.5-1.2.6-.8 1-1.8.7-2.8zM20.3 17.4c-.4.9-.6 1.3-1.1 2.1-.7 1-1.6 2.2-2.8 2.2-1 0-1.3-.7-2.8-.7s-1.8.7-2.9.7c-1.2 0-2.1-1.1-2.8-2.1-1.9-2.7-2.1-5.9-.9-7.6.9-1.2 2.2-1.9 3.5-1.9 1.4 0 2.2.7 3.3.7 1.1 0 1.8-.7 3.4-.7 1.2 0 2.5.7 3.4 1.8-3 1.6-2.5 5.8-.3 6.5z"/></svg>';
+  }
   if (k === 'windows') {
     return '<svg viewBox="0 0 24 24" width="12" height="12" fill="currentColor" aria-hidden="true"><path d="M3 4.6l8-1.2v8.1H3V4.6zm9-1.3L21 2v9.5h-9V3.3zM3 12.5h8v8.1l-8-1.2v-6.9zm9 0h9V22l-9-1.3v-8.2z"/></svg>';
   }
@@ -158,7 +160,7 @@ function _getPort(hostOrTask) {
   return srv?.port || '';
 }
 
-/** Get platform for a given host (or task object). Returns 'windows', 'termux', 'linux', or '' */
+/** Get platform for a given host (or task object). Returns 'windows', 'termux', 'macos', 'linux', or '' */
 export function _getPlatform(hostOrTask) {
   if (!hostOrTask) return _envState.platform || '';
   if (typeof hostOrTask === 'object') return hostOrTask.platform || _getPlatform(hostOrTask.remoteHost);
@@ -169,6 +171,11 @@ export function _getPlatform(hostOrTask) {
 /** Check if the current active server is Windows */
 export function _isWindows(hostOrTask) {
   return _getPlatform(hostOrTask) === 'windows';
+}
+
+/** Check if the current active server is macOS/Apple Silicon */
+export function _isApplePlatform(hostOrTask) {
+  return ['macos', 'darwin', 'mac'].includes(String(_getPlatform(hostOrTask) || '').toLowerCase());
 }
 
 /** Detect model-specific vLLM optimizations */
@@ -241,6 +248,7 @@ export function _detectBackend(model) {
   const q = (model.quant || '').toUpperCase();
   const sysBackend = String(_hwfitCache?.system?.backend || '').toLowerCase();
   const isRocm = sysBackend === 'rocm';
+  const isApple = _isApplePlatform() || ['metal', 'mps', 'apple'].includes(sysBackend);
 
   // Image gen models → diffusers
   if (model.is_image_gen || model.is_diffusion || model._tag === 'image') {
@@ -249,6 +257,12 @@ export function _detectBackend(model) {
 
   // Windows → default to llama.cpp (no vLLM support on Windows)
   if (_isWindows()) {
+    return { backend: 'llamacpp', label: 'llama.cpp' };
+  }
+
+  // macOS/Apple Silicon → llama.cpp/Metal by default. vLLM CUDA flags are
+  // wrong here, and GGUF/MLX-filtered recommendations are Apple-oriented.
+  if (isApple) {
     return { backend: 'llamacpp', label: 'llama.cpp' };
   }
 
@@ -298,7 +312,7 @@ export function _buildEnvPrefix() {
   }
   let envVars = [];
   if (_envState.hfToken) envVars.push('export HF_TOKEN=' + _shellQuote(_envState.hfToken));
-  if (_envState.gpus) envVars.push('export CUDA_VISIBLE_DEVICES=' + _shellQuote(_envState.gpus));
+  if (_envState.gpus && !_isApplePlatform()) envVars.push('export CUDA_VISIBLE_DEVICES=' + _shellQuote(_envState.gpus));
   if (envVars.length) parts.push(envVars.join(' && '));
   if (parts.length === 0) return '';
   return parts.join(' && ') + ' &&';
@@ -366,11 +380,12 @@ export function _buildServeCmd(f, modelName, backend) {
   } else if (backend === 'llamacpp') {
     const ggufPath = f._gguf_path || 'model.gguf';
     const gpuId = f.gpu_id?.trim() || '';
+    const isApple = _isApplePlatform();
     const py = _isWindows() ? 'python' : 'python3';
     const lcPrefix = (() => {
       let p = '';
-      if (f.unified_mem && !_isWindows()) p += `GGML_CUDA_ENABLE_UNIFIED_MEMORY=1 `;
-      if (gpuId && !_isWindows()) p += `CUDA_VISIBLE_DEVICES=${gpuId} `;
+      if (f.unified_mem && !_isWindows() && !isApple) p += `GGML_CUDA_ENABLE_UNIFIED_MEMORY=1 `;
+      if (gpuId && !_isWindows() && !isApple) p += `CUDA_VISIBLE_DEVICES=${gpuId} `;
       return p;
     })();
     if (f.unified_mem && _isWindows()) cmd += `$env:GGML_CUDA_ENABLE_UNIFIED_MEMORY="1"; `;
@@ -381,7 +396,7 @@ export function _buildServeCmd(f, modelName, backend) {
       cmd += `MODEL_FILE=${ggufPath} && { [ -n "$MODEL_FILE" ] && [ -f "$MODEL_FILE" ]; } || { echo "ERROR: No GGUF found on this host. Either download the model here, or switch to the server where it's cached."; exit 1; } && `;
     }
     const modelArg = _isWindows() ? `"${ggufPath}"` : `"$MODEL_FILE"`;
-    // Prefer the native llama-server binary on Linux — its minja templating
+    // Prefer the native llama-server binary on POSIX — its minja templating
     // renders modern GGUF chat templates that the Python bindings' Jinja2
     // rejects (do_tojson ensure_ascii). Fall back to llama_cpp.server.
     // Don't suppress stderr — surface real errors (missing file, lib, OOM).
@@ -1420,7 +1435,7 @@ function _renderRecipes() {
   html += '<label>GPUs<input class="hwfit-manual-gpus" type="text" inputmode="numeric" placeholder="1"></label>';
   html += '<label>VRAM per GPU<input class="hwfit-manual-vram" type="text" inputmode="decimal" placeholder="8 GB"></label>';
   html += '<label>Total RAM<input class="hwfit-manual-ram" type="text" inputmode="decimal" placeholder="32 GB"></label>';
-  html += '<select class="hwfit-manual-backend"><option value="cuda">CUDA</option><option value="rocm">ROCm</option></select>';
+  html += '<select class="hwfit-manual-backend"><option value="cuda">CUDA</option><option value="rocm">ROCm</option><option value="metal">Metal</option></select>';
   html += '<button type="button" class="hwfit-hw-manual-save">✓ Apply</button>';
   html += '<button type="button" class="hwfit-hw-manual-clear">× Clear</button>';
   html += '</div>';

--- a/static/js/cookbookRunning.js
+++ b/static/js/cookbookRunning.js
@@ -1003,6 +1003,7 @@ export async function _launchServeTask(shortName, repo, cmd, fields, hostOverrid
   const _host = (hostOverride !== undefined) ? (hostOverride || '') : (_envState.remoteHost || '');
   const _hsrv = _envState.servers.find(s => s.host === _host) || {};
   const _hplatform = _host ? (_hsrv.platform || '') : (_envState.platform || '');
+  const _isAppleTarget = ['macos', 'darwin', 'mac'].includes(String(_hplatform || '').toLowerCase());
 
   // Replace any serve already targeting this same host:port — you can't run two
   // servers on one port, so re-serving (or retrying) should stop & remove the
@@ -1036,7 +1037,7 @@ export async function _launchServeTask(shortName, repo, cmd, fields, hostOverrid
   // working config fails: no venv activation, no GPU pinning).
   const _usedEnv = _envState.env;
   const _usedEnvPath = _envState.envPath;
-  const _usedGpus = _envState.gpus || '';
+  const _usedGpus = _isAppleTarget ? '' : (_envState.gpus || '');
   let envPrefix = '';
   if (_isWindows()) {
     if (_envState.env === 'venv' && _envState.envPath) {
@@ -1060,7 +1061,7 @@ export async function _launchServeTask(shortName, repo, cmd, fields, hostOverrid
     ssh_port: _getPort(_host) || undefined,
     env_prefix: envPrefix || undefined,
     hf_token: _envState.hfToken || undefined,
-    gpus: _envState.gpus || undefined,
+    gpus: (!_isAppleTarget && _envState.gpus) || undefined,
     platform: _hplatform || undefined,
   };
 

--- a/tests/test_hwfit_macos.py
+++ b/tests/test_hwfit_macos.py
@@ -1,0 +1,28 @@
+from services.hwfit import hardware
+
+
+def test_remote_macos_detects_apple_silicon_metal(monkeypatch):
+    responses = {
+        "sysctl -n hw.memsize 2>/dev/null": str(16 * 1024**3),
+        "vm_stat 2>/dev/null": (
+            "Mach Virtual Memory Statistics: (page size of 4096 bytes)\n"
+            "Pages free: 1024.\n"
+            "Pages inactive: 2048.\n"
+            "Pages speculative: 1024.\n"
+        ),
+        "sysctl -n hw.logicalcpu 2>/dev/null": "10",
+        "sysctl -n machdep.cpu.brand_string 2>/dev/null": "Apple M3 Pro",
+        "uname -m 2>/dev/null": "arm64",
+    }
+
+    monkeypatch.setattr(hardware, "_run", lambda cmd: responses.get(cmd))
+    hardware._cache_by_host.clear()
+
+    result = hardware.detect_system(host="me@mac", platform="macos", fresh=True)
+
+    assert result["total_ram_gb"] == 16.0
+    assert result["cpu_cores"] == 10
+    assert result["backend"] == "metal"
+    assert result["has_gpu"] is True
+    assert result["gpu_vram_gb"] == 12.0
+    assert result["gpus"][0]["name"] == "Apple M3 Pro GPU"

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -6,6 +6,11 @@ from unittest.mock import MagicMock
 import httpx
 import pytest
 
+for _name in ("routes.model_routes", "src.endpoint_resolver"):
+    _mod = sys.modules.get(_name)
+    if isinstance(_mod, MagicMock) or isinstance(getattr(_mod, "_anthropic_api_root", None), MagicMock):
+        sys.modules.pop(_name, None)
+
 if "core.database" not in sys.modules:
     _core_db = types.ModuleType("core.database")
     for _name in [


### PR DESCRIPTION
## Summary
- add macOS LaunchAgent install support and docs
- add Apple Silicon / Metal hardware detection locally and over SSH
- make Cookbook macOS-safe for tmux/Homebrew paths, llama.cpp Metal builds, and CUDA-free Apple targets
- add GitHub Actions CI plus tag/manual release workflow for source archives and GHCR images

## Validation
- `.venv/bin/pytest -q` -> 263 passed, 4 warnings
- compileall for app/core/src/routes/services/scripts/setup passed
- `node --check` for Cookbook JS modules passed
- workflow YAML parse passed
- `docker compose config --quiet` passed
- `docker build --pull=false --progress=plain -t odysseus:macos-local .` passed
- container smoke from `odysseus:macos-local` on 127.0.0.1:7001 passed health/version
- local API smoke passed health/version/hwfit/cookbook GPU probes
- browser smoke verified login page and v1.0.0

## Notes
Docker Desktop initially hung while pulling public images with the default Docker config. Pulling the base image with a temporary clean `DOCKER_CONFIG` succeeded, then the normal build succeeded with `--pull=false`.
