### PR TITLE
Add .gitattributes to fix Windows CRLF shebang issue in Docker entrypoint

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,42 @@
+# Normalize to LF on checkout (prevents CRLF shebang errors in Docker)
+* text=auto eol=lf
+
+# Shell scripts MUST have LF line endings (shebang breaks with CRLF)
+*.sh text eol=lf
+
+# Python files
+*.py text eol=lf
+
+# Config files
+*.yml text eol=lf
+*.yaml text eol=lf
+*.json text eol=lf
+*.cfg text eol=lf
+*.ini text eol=lf
+*.toml text eol=lf
+
+# Web
+*.html text eol=lf
+*.css text eol=lf
+*.js text eol=lf
+*.ts text eol=lf
+*.jsx text eol=lf
+*.tsx text eol=lf
+
+# Markdown / docs
+*.md text eol=lf
+
+# Docker
+Dockerfile text eol=lf
+docker-compose.yml text eol=lf
+.dockerignore text eol=lf
+
+# Binary / generated — keep as-is
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.woff2 binary
+*.otf binary
+*.ttf binary


### PR DESCRIPTION
## Problem

On Windows, Git converts \docker/entrypoint.sh\ to CRLF line endings on clone. The shebang \#!/bin/sh\\r\ causes the Linux kernel to look for \/bin/sh\\r\ (with trailing carriage return), which doesn't exist — resulting in:

`
exec /usr/local/bin/entrypoint.sh: no such file or directory
`

Every Windows user hitting this project with Docker Desktop encounters this crash.

## Fix

Adds a \.gitattributes\ file that enforces LF line endings for shell scripts (\*.sh text eol=lf\) across all platforms. Also normalizes Python, YAML, JS, CSS, HTML, and Markdown files to LF for consistency in the containerized environment.

## Testing

Verified that with this \.gitattributes\ in place:
- \git add --renormalize .\ converts working-tree files to LF
- The Docker entrypoint script runs correctly inside the container
- \docker compose up -d\ starts Odysseus without the shebang error