### PR TITLE
Add Google Calendar and Calendly sync to the calendar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,10 @@ SEARXNG_INSTANCE=http://localhost:8080
 # Enable authentication (default: true)
 # AUTH_ENABLED=true
 
+# Host port for the Odysseus web UI in Docker Compose.
+# Change this if another local service already uses 7000 (macOS AirPlay often does).
+# APP_PORT=7000
+
 # Development-only auth bypass for loopback requests.
 # Keep false for Docker, LAN, reverse proxy, and any shared deployment.
 # LOCALHOST_BYPASS=false

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ docker compose up -d --build
 ```
 Compose starts Odysseus, ChromaDB, SearXNG, and ntfy. First run does a full
 image build. Open `http://localhost:7000` after the containers are healthy.
+If port `7000` is already taken, set `APP_PORT=7001` (or another free port)
+in `.env`, recreate the container, and open `http://localhost:7001`.
 
 Cookbook remote servers use an Odysseus-owned SSH key from `./data/ssh`
 inside Docker. In **Cookbook -> Settings -> Servers**, generate/copy the

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A self-hosted AI workspace -- meant to be the self-hosted version of the UI expe
   - **Memory / Skills** -- Persistent memory and skills, your agent evolves over time as it better understands you and your tasks!<br>　<sub>ChromaDB · fastembed (ONNX) · vector + keyword retrieval · import/export</sub>
   - **Email** -- IMAP/SMTP inbox with AI triage built in: urgency reminders, auto-tag, auto-summary, auto-reply drafts, auto-spam.<br>　<sub>IMAP · SMTP · per-account routing · CalDAV-aware</sub>
   - **Notes & Tasks** -- Quick notes with reminders, a todo list, and scheduled tasks the agent can act on.<br>　<sub>note pings · checklist · cron-style tasks · ntfy / browser / email channels</sub>
-  - **Calendar** -- Local-first calendar with CalDAV sync to Radicale / Nextcloud / Apple / Fastmail.<br>　<sub>CalDAV pull · .ics import/export · per-calendar colors · agent-aware</sub>
+  - **Calendar** -- Local-first calendar with sync to CalDAV (Radicale / Nextcloud / Apple / Fastmail), Google Calendar, and Calendly.<br>　<sub>CalDAV · Google iCal feed · Calendly API · .ics import/export · per-calendar colors · agent-aware</sub>
   - **Works on mobile** -- looks and runs great on your phone, not just desktop.<br>　<sub>responsive · installable (PWA) · touch gestures</sub>
   - **Extras** -- more to explore, happy if you give it a go!<br>　<sub>image editor · theme editor · file uploads (vision + PDF) · web search · presets · sessions · 2FA</sub>
 

--- a/core/session_manager.py
+++ b/core/session_manager.py
@@ -20,6 +20,15 @@ from .models import Session, ChatMessage
 logger = logging.getLogger(__name__)
 
 
+def _message_timestamp_iso(value: Optional[datetime]) -> Optional[str]:
+    """Return a stable ISO timestamp for chat message metadata."""
+    if not value:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.isoformat().replace("+00:00", "Z")
+
+
 class SessionManager:
     """
     Manages chat sessions with database persistence.
@@ -107,6 +116,7 @@ class SessionManager:
                 meta = json.loads(db_msg.meta_data) if db_msg.meta_data else {}
                 if meta is None: meta = {}
                 meta['_db_id'] = db_msg.id
+                meta.setdefault('timestamp', _message_timestamp_iso(db_msg.timestamp))
                 history.append(ChatMessage(
                     role=db_msg.role,
                     content=db_msg.content,
@@ -121,6 +131,7 @@ class SessionManager:
                 meta = json.loads(db_msg.meta_data) if db_msg.meta_data else {}
                 if meta is None: meta = {}
                 meta['_db_id'] = db_msg.id
+                meta.setdefault('timestamp', _message_timestamp_iso(db_msg.timestamp))
                 history.append(ChatMessage(
                     role=db_msg.role,
                     content=db_msg.content,
@@ -177,12 +188,17 @@ class SessionManager:
         db = SessionLocal()
         try:
             msg_id = str(uuid.uuid4())
+            msg_time = datetime.utcnow()
+            if message.metadata is None:
+                message.metadata = {}
+            message.metadata.setdefault('timestamp', _message_timestamp_iso(msg_time))
             db_message = DbChatMessage(
                 id=msg_id,
                 session_id=session_id,
                 role=message.role,
                 content=message.content,
-                meta_data=json.dumps(message.metadata) if message.metadata else None
+                meta_data=json.dumps(message.metadata) if message.metadata else None,
+                timestamp=msg_time,
             )
             db.add(db_message)
 
@@ -199,8 +215,6 @@ class SessionManager:
             db.commit()
 
             # Store DB ID on the in-memory message for edit/delete by ID
-            if message.metadata is None:
-                message.metadata = {}
             message.metadata['_db_id'] = msg_id
 
             logger.debug(f"Persisted message to session {session_id}")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   odysseus:
     build: .
     ports:
-      - "7000:7000"
+      - "${APP_PORT:-7000}:7000"
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs

--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -1,5 +1,6 @@
 """Calendar routes — local SQLite-backed calendar CRUD."""
 
+import asyncio
 import logging
 import uuid
 from datetime import datetime, date, timedelta
@@ -387,6 +388,31 @@ def _event_to_dict(ev: CalendarEvent) -> dict:
     }
 
 
+def _aggregate_sync_results(results) -> dict:
+    """Merge the per-source dicts returned by the calendar pulls into one
+    {calendars, events, deleted, errors} summary. `results` may contain
+    Exceptions when called via `asyncio.gather(..., return_exceptions=True)`;
+    those are folded into `errors` so one failing source never sinks the rest.
+    """
+    agg = {"calendars": 0, "events": 0, "deleted": 0, "errors": []}
+    for r in results:
+        if isinstance(r, Exception):
+            agg["errors"].append(str(r)[:200])
+            continue
+        if not isinstance(r, dict):
+            continue
+        agg["calendars"] += r.get("calendars", 0) or 0
+        agg["events"] += r.get("events", 0) or 0
+        agg["deleted"] += r.get("deleted", 0) or 0
+        # Drop the benign "not configured" no-op messages — they're expected
+        # for any source the user hasn't set up and would just be noise.
+        for e in (r.get("errors") or []):
+            if "not configured" in str(e).lower():
+                continue
+            agg["errors"].append(e)
+    return agg
+
+
 # ── Routes ──
 
 def setup_calendar_routes() -> APIRouter:
@@ -493,13 +519,178 @@ def setup_calendar_routes() -> APIRouter:
             return {"ok": False, "error": str(e)[:200]}
 
     @router.post("/sync")
-    async def sync_caldav_endpoint(request: Request):
-        """Pull events from the configured CalDAV server into local DB.
-        Returns counts + any per-calendar errors. Called by the frontend
-        on calendar open and by the periodic scheduler loop."""
+    async def sync_calendars_endpoint(request: Request):
+        """Pull events from every configured remote calendar (CalDAV, Google
+        iCal feed, Calendly) into local DB and return aggregated counts +
+        errors. Called by the frontend on calendar open. Sources that aren't
+        configured no-op silently, so this is safe to call regardless of which
+        integrations the user has set up."""
         owner = _require_user(request)
         from src.caldav_sync import sync_caldav
-        return await sync_caldav(owner)
+        from src.gcal_sync import sync_gcal
+        from src.calendly_sync import sync_calendly
+
+        # Run the three pulls concurrently — they hit different remotes and
+        # write disjoint calendars, so there's no ordering dependency.
+        results = await asyncio.gather(
+            sync_caldav(owner),
+            sync_gcal(owner),
+            sync_calendly(owner),
+            return_exceptions=True,
+        )
+        return _aggregate_sync_results(results)
+
+    @router.post("/sync/{source}")
+    async def sync_single_source(request: Request, source: str):
+        """Pull a single source on demand (used by the per-integration
+        "Sync now" buttons). `source` ∈ {caldav, gcal, calendly}."""
+        owner = _require_user(request)
+        if source == "caldav":
+            from src.caldav_sync import sync_caldav
+            return await sync_caldav(owner)
+        if source == "gcal":
+            from src.gcal_sync import sync_gcal
+            return await sync_gcal(owner)
+        if source == "calendly":
+            from src.calendly_sync import sync_calendly
+            return await sync_calendly(owner)
+        raise HTTPException(404, f"Unknown sync source: {source}")
+
+    # ── Google Calendar (secret iCal feed) config ──
+
+    @router.get("/gcal/config")
+    async def get_gcal_config(request: Request):
+        owner = _require_user(request)
+        from routes.prefs_routes import _load_for_user
+        cfg = (_load_for_user(owner) or {}).get("gcal", {}) or {}
+        return {
+            "ics_url": cfg.get("ics_url", "") or "",
+            "configured": bool(cfg.get("ics_url")),
+        }
+
+    @router.post("/gcal/config")
+    async def save_gcal_config(request: Request):
+        owner = _require_user(request)
+        from routes.prefs_routes import _load_for_user, _save_for_user
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        prefs = _load_for_user(owner) or {}
+        url = (body.get("ics_url") or "").strip()
+        # Empty url => remove the integration entirely.
+        if not url:
+            prefs.pop("gcal", None)
+            _save_for_user(owner, prefs)
+            return {"ok": True, "cleared": True}
+        prefs["gcal"] = {"ics_url": url}
+        _save_for_user(owner, prefs)
+        return {"ok": True}
+
+    @router.post("/gcal/test")
+    async def test_gcal(request: Request):
+        """Fetch the iCal feed and confirm it parses as a calendar. Accepts an
+        optional {ics_url} body to test before saving; falls back to the stored
+        URL otherwise."""
+        owner = _require_user(request)
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        url = (body.get("ics_url") or "").strip()
+        if not url:
+            from routes.prefs_routes import _load_for_user
+            url = ((_load_for_user(owner) or {}).get("gcal", {}) or {}).get("ics_url", "")
+        if not url:
+            return {"ok": False, "error": "Missing iCal URL"}
+        from src.gcal_sync import fetch_feed
+        try:
+            content = await fetch_feed(url)
+        except Exception as e:
+            return {"ok": False, "error": f"Could not fetch feed: {str(e)[:180]}"}
+        try:
+            from icalendar import Calendar as iCal
+            cal = iCal.from_ical(content)
+            n = sum(1 for c in cal.walk() if c.name == "VEVENT")
+            return {"ok": True, "events": n}
+        except Exception as e:
+            return {"ok": False, "error": f"Not a valid calendar feed: {str(e)[:180]}"}
+
+    # ── Calendly (personal access token) config ──
+
+    @router.get("/calendly/config")
+    async def get_calendly_config(request: Request):
+        owner = _require_user(request)
+        from routes.prefs_routes import _load_for_user
+        cfg = (_load_for_user(owner) or {}).get("calendly", {}) or {}
+        # Never hand the token back to the client.
+        return {
+            "token": "",
+            "has_token": bool(cfg.get("token")),
+            "configured": bool(cfg.get("token")),
+        }
+
+    @router.post("/calendly/config")
+    async def save_calendly_config(request: Request):
+        owner = _require_user(request)
+        from routes.prefs_routes import _load_for_user, _save_for_user
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        prefs = _load_for_user(owner) or {}
+        token = (body.get("token") or "").strip()
+        cfg = dict(prefs.get("calendly") or {})
+        # Explicit clear flag (the "Remove" button) drops the integration even
+        # when a token is stored.
+        if body.get("clear"):
+            prefs.pop("calendly", None)
+            _save_for_user(owner, prefs)
+            return {"ok": True, "cleared": True}
+        # Empty token with no stored token => clear. An empty token when one is
+        # already stored means "keep existing" (edit form re-submitted blank).
+        if not token and not cfg.get("token"):
+            prefs.pop("calendly", None)
+            _save_for_user(owner, prefs)
+            return {"ok": True, "cleared": True}
+        if token:
+            cfg["token"] = token
+        prefs["calendly"] = cfg
+        _save_for_user(owner, prefs)
+        return {"ok": True}
+
+    @router.post("/calendly/test")
+    async def test_calendly(request: Request):
+        """Probe the Calendly API with the token (verifies it via /users/me).
+        Accepts an optional {token} body to test before saving."""
+        owner = _require_user(request)
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        token = (body.get("token") or "").strip()
+        if not token:
+            from routes.prefs_routes import _load_for_user
+            token = ((_load_for_user(owner) or {}).get("calendly", {}) or {}).get("token", "")
+        if not token:
+            return {"ok": False, "error": "Missing access token"}
+        import httpx
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as cx:
+                r = await cx.get(
+                    "https://api.calendly.com/users/me",
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+            if r.status_code == 200:
+                name = (r.json().get("resource", {}) or {}).get("name", "")
+                return {"ok": True, "name": name}
+            if r.status_code in (401, 403):
+                return {"ok": False, "error": "Invalid or unauthorized token"}
+            return {"ok": False, "error": f"HTTP {r.status_code}"}
+        except httpx.TimeoutException:
+            return {"ok": False, "error": "Connection timed out"}
+        except Exception as e:
+            return {"ok": False, "error": str(e)[:200]}
 
     @router.get("/calendars")
     async def list_calendars(request: Request):

--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -388,6 +388,28 @@ def _event_to_dict(ev: CalendarEvent) -> dict:
     }
 
 
+def _mask_feed_url(url: str) -> str:
+    """Render a secret feed URL as a non-reversible hint for display, e.g.
+    "calendar.google.com/…/basic.ics". Returns "" for an empty url. Never
+    includes the opaque secret path segment that grants read access."""
+    url = (url or "").strip()
+    if not url:
+        return ""
+    try:
+        from urllib.parse import urlparse
+        p = urlparse(url if "://" in url else "https://" + url)
+        host = p.hostname or ""
+        last = ""
+        segs = [s for s in (p.path or "").split("/") if s]
+        if segs:
+            last = segs[-1]
+        # Only the host and the trailing filename (e.g. basic.ics) — the
+        # secret token lives in the middle segments, which we omit.
+        return f"{host}/…/{last}" if last else host
+    except Exception:
+        return "configured feed"
+
+
 def _aggregate_sync_results(results) -> dict:
     """Merge the per-source dicts returned by the calendar pulls into one
     {calendars, events, deleted, errors} summary. `results` may contain
@@ -563,9 +585,15 @@ def setup_calendar_routes() -> APIRouter:
         owner = _require_user(request)
         from routes.prefs_routes import _load_for_user
         cfg = (_load_for_user(owner) or {}).get("gcal", {}) or {}
+        url = cfg.get("ics_url", "") or ""
+        # A Google "secret address in iCal format" is a bearer secret — anyone
+        # holding it can read the calendar. Never hand it back to the client;
+        # return only a masked hint (host + last URL segment) so the UI can
+        # show *which* feed is configured without leaking the credential.
         return {
-            "ics_url": cfg.get("ics_url", "") or "",
-            "configured": bool(cfg.get("ics_url")),
+            "has_url": bool(url),
+            "configured": bool(url),
+            "hint": _mask_feed_url(url),
         }
 
     @router.post("/gcal/config")
@@ -578,11 +606,21 @@ def setup_calendar_routes() -> APIRouter:
             body = {}
         prefs = _load_for_user(owner) or {}
         url = (body.get("ics_url") or "").strip()
-        # Empty url => remove the integration entirely.
-        if not url:
+        cfg = dict(prefs.get("gcal") or {})
+        # Explicit clear flag (the "Remove" button) drops the integration.
+        if body.get("clear"):
             prefs.pop("gcal", None)
             _save_for_user(owner, prefs)
             return {"ok": True, "cleared": True}
+        # Blank url with nothing stored => nothing to do / clear. Blank url when
+        # one is already stored means "keep existing" (edit form re-submitted
+        # without re-pasting the secret URL), mirroring the password/token UX.
+        if not url:
+            if not cfg.get("ics_url"):
+                prefs.pop("gcal", None)
+                _save_for_user(owner, prefs)
+                return {"ok": True, "cleared": True}
+            return {"ok": True, "unchanged": True}
         prefs["gcal"] = {"ics_url": url}
         _save_for_user(owner, prefs)
         return {"ok": True}

--- a/src/caldav_sync.py
+++ b/src/caldav_sync.py
@@ -133,6 +133,10 @@ def _sync_blocking(owner: str, url: str, username: str, password: str) -> dict:
                 from icalendar import Calendar as iCal
 
                 seen_uids = set()
+                # Track events added to the session but not yet committed so
+                # duplicate UIDs within the same batch are updated, not re-inserted
+                # (which would violate the UNIQUE constraint on commit).
+                pending: dict = {}
                 try:
                     objs = remote_cal.date_search(start=start, end=end, expand=False)
                 except Exception as e:
@@ -182,7 +186,7 @@ def _sync_blocking(owner: str, url: str, username: str, password: str) -> dict:
                             else ""
                         )
 
-                        existing = db.query(CalendarEvent).filter(
+                        existing = pending.get(uid_val) or db.query(CalendarEvent).filter(
                             CalendarEvent.uid == uid_val,
                         ).first()
                         if existing:
@@ -196,7 +200,7 @@ def _sync_blocking(owner: str, url: str, username: str, password: str) -> dict:
                             existing.is_utc = row_is_utc
                             existing.rrule = rrule
                         else:
-                            db.add(CalendarEvent(
+                            new_ev = CalendarEvent(
                                 uid=uid_val,
                                 calendar_id=local_cal.id,
                                 summary=summary,
@@ -207,7 +211,9 @@ def _sync_blocking(owner: str, url: str, username: str, password: str) -> dict:
                                 all_day=all_day,
                                 is_utc=row_is_utc,
                                 rrule=rrule,
-                            ))
+                            )
+                            db.add(new_ev)
+                            pending[uid_val] = new_ev
                         result["events"] += 1
                 db.commit()
 

--- a/src/calendar_sync_common.py
+++ b/src/calendar_sync_common.py
@@ -1,0 +1,156 @@
+"""Shared helpers for one-way calendar sync (remote → local SQLite).
+
+The CalDAV sync (`src/caldav_sync.py`) was the first pull integration and
+grew its own copies of these helpers. The Google Calendar (`src/gcal_sync.py`)
+and Calendly (`src/calendly_sync.py`) pulls follow the exact same shape — a
+remote source maps to one local `CalendarCal` row keyed by a stable hash, and
+events upsert by UID with stale local rows pruned inside the sync window — so
+that logic lives here once instead of three times.
+
+Design notes (mirrors the CalDAV module's contract so all three behave the
+same to the rest of the app):
+- Each remote source maps to one local `CalendarCal` whose `id` is a stable
+  hash of a source key (feed URL, Calendly user URI, …) so re-syncs are
+  idempotent and target the same row across restarts.
+- Events upsert by UID. Local rows for that calendar not seen in the latest
+  pull — but inside the sync window — are deleted so remote deletions
+  propagate without false-deleting far-future events outside the window.
+- Datetimes are normalised to naive-UTC and flagged `is_utc=True` so the
+  serializer adds the `Z` suffix and the frontend renders in the user's local
+  TZ. All-day events stay date-only with `is_utc=False`.
+"""
+
+import hashlib
+from datetime import date, datetime, timedelta, timezone
+
+# Pull window shared by every source: 90 days back, 1 year forward. Keeps the
+# remote query cheap and matches what the calendar UI typically renders. Far-
+# future recurring events still come through via RRULE expansion on the
+# frontend.
+LOOKBACK_DAYS = 90
+LOOKAHEAD_DAYS = 365
+
+
+def window():
+    """The (start, end) datetime pair every pull restricts itself to."""
+    now = datetime.utcnow()
+    return now - timedelta(days=LOOKBACK_DAYS), now + timedelta(days=LOOKAHEAD_DAYS)
+
+
+def stable_cal_id(prefix: str, key: str) -> str:
+    """Deterministic local id for a remote calendar — the same source key
+    always maps to the same local row across restarts and re-syncs.
+
+    `prefix` namespaces the source ("gcal", "calendly", …) so two providers
+    that happen to share a key string never collide.
+    """
+    h = hashlib.sha256(f"{prefix}:{key}".encode("utf-8")).hexdigest()[:24]
+    return f"{prefix}-{h}"
+
+
+def to_utc_naive(dt):
+    """Normalise a parsed dtstart/dtend to ``(naive_datetime, all_day)``.
+
+    Datetimes may be tz-aware (carry an offset) or naive; dates are all-day.
+    The DB column is naive, so tz-aware values convert to UTC and lose tzinfo;
+    naive values are treated as already-local. All-day dates widen to a
+    midnight datetime. Returns the value plus an all-day flag.
+    """
+    if isinstance(dt, datetime):
+        if dt.tzinfo is not None:
+            return dt.astimezone(timezone.utc).replace(tzinfo=None), False
+        return dt, False  # naive → treat as local
+    # date-only (all-day)
+    return datetime(dt.year, dt.month, dt.day), True
+
+
+def get_or_create_cal(db, owner: str, cal_id: str, display_name: str,
+                      color: str, source: str):
+    """Fetch the local `CalendarCal` for this source or create it. Refreshes
+    the display name if the user renamed it remotely; preserves any local
+    color override on an existing row."""
+    from core.database import CalendarCal
+
+    local_cal = db.query(CalendarCal).filter(
+        CalendarCal.id == cal_id,
+        CalendarCal.owner == owner,
+    ).first()
+    if not local_cal:
+        local_cal = CalendarCal(
+            id=cal_id,
+            owner=owner,
+            name=display_name,
+            color=color,
+            source=source,
+        )
+        db.add(local_cal)
+        db.commit()
+    elif local_cal.name != display_name and display_name:
+        local_cal.name = display_name
+        db.commit()
+    return local_cal
+
+
+def upsert_event(db, calendar_id: str, fields: dict):
+    """Insert or update a single event by UID within `calendar_id`.
+
+    `fields` must contain: uid, summary, description, location, dtstart,
+    dtend, all_day, is_utc, rrule. The UID is the natural key (same as the
+    CalDAV path), so an event that moves calendars or changes time updates in
+    place rather than duplicating.
+    """
+    from core.database import CalendarEvent
+
+    uid_val = fields["uid"]
+    existing = db.query(CalendarEvent).filter(
+        CalendarEvent.uid == uid_val,
+    ).first()
+    if existing:
+        existing.calendar_id = calendar_id
+        existing.summary = fields["summary"]
+        existing.description = fields["description"]
+        existing.location = fields["location"]
+        existing.dtstart = fields["dtstart"]
+        existing.dtend = fields["dtend"]
+        existing.all_day = fields["all_day"]
+        existing.is_utc = fields["is_utc"]
+        existing.rrule = fields.get("rrule", "")
+    else:
+        db.add(CalendarEvent(
+            uid=uid_val,
+            calendar_id=calendar_id,
+            summary=fields["summary"],
+            description=fields["description"],
+            location=fields["location"],
+            dtstart=fields["dtstart"],
+            dtend=fields["dtend"],
+            all_day=fields["all_day"],
+            is_utc=fields["is_utc"],
+            rrule=fields.get("rrule", ""),
+        ))
+
+
+def prune_stale(db, calendar_id: str, start, end, seen_uids) -> int:
+    """Delete locally-cached events for `calendar_id` that vanished upstream.
+
+    Only prunes within the sync window — events outside `[start, end]` aren't
+    in the latest pull, so deleting them would be a false-positive. Returns the
+    number of rows removed.
+    """
+    from core.database import CalendarEvent
+
+    stale = db.query(CalendarEvent).filter(
+        CalendarEvent.calendar_id == calendar_id,
+        CalendarEvent.dtstart >= start,
+        CalendarEvent.dtstart <= end,
+        ~CalendarEvent.uid.in_(seen_uids) if seen_uids else CalendarEvent.uid.isnot(None),
+    ).all()
+    for ev in stale:
+        db.delete(ev)
+    return len(stale)
+
+
+def empty_result(*errors) -> dict:
+    """A zero-count result dict, optionally carrying error strings. Matches the
+    shape every sync function returns: {calendars, events, deleted, errors}."""
+    return {"calendars": 0, "events": 0, "deleted": 0, "errors": list(errors)}

--- a/src/calendly_sync.py
+++ b/src/calendly_sync.py
@@ -1,0 +1,200 @@
+"""Calendly → local SQLite sync.
+
+Calendly doesn't publish a single account-wide ICS feed for your bookings, so
+unlike the Google path we go through the Calendly v2 REST API. The user pastes
+a Personal Access Token (Calendly → Integrations → API & Webhooks → personal
+access tokens); we look up their user URI and pull `scheduled_events` in the
+sync window, one-way (remote → local).
+
+Auth is a bearer token in prefs — same "credential in, read-only pull out"
+shape as the CalDAV and Google paths. No OAuth app / redirect flow needed.
+
+API reference: https://developer.calendly.com/api-docs (GET /users/me,
+GET /scheduled_events). Times come back as RFC3339 with a `Z`, which we store
+as naive-UTC with is_utc=True so the frontend renders them in local time.
+"""
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+
+from src.calendar_sync_common import (
+    empty_result, get_or_create_cal, prune_stale, stable_cal_id, upsert_event,
+    window,
+)
+
+logger = logging.getLogger(__name__)
+
+_API_BASE = "https://api.calendly.com"
+# Cap pagination so a misbehaving token/account can't loop forever. 100 events
+# per page × 20 pages = 2000 events covers any realistic 15-month window.
+_MAX_PAGES = 20
+
+
+def _parse_rfc3339(s: str):
+    """Parse a Calendly RFC3339 timestamp ("2026-01-02T15:04:05Z" or with an
+    offset) to naive-UTC. Returns None on failure."""
+    if not s:
+        return None
+    try:
+        s2 = s.replace("Z", "+00:00") if s.endswith("Z") else s
+        dt = datetime.fromisoformat(s2)
+        if dt.tzinfo is not None:
+            return dt.astimezone(timezone.utc).replace(tzinfo=None)
+        return dt
+    except ValueError:
+        return None
+
+
+def _location_str(loc) -> str:
+    """Flatten Calendly's polymorphic `location` object into a display string.
+
+    It can be a physical address, a phone number, a Zoom/Meet/Teams join URL,
+    or a custom string depending on the event type's location kind.
+    """
+    if not isinstance(loc, dict):
+        return ""
+    for key in ("location", "join_url", "data", "type"):
+        val = loc.get(key)
+        if isinstance(val, str) and val.strip():
+            return val.strip()
+    return ""
+
+
+async def _api_get(client, url: str, token: str, params=None) -> dict:
+    r = await client.get(
+        url,
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+        params=params,
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+async def _fetch_events(token: str) -> tuple:
+    """Return (display_name, [event dicts]) from the Calendly API. Raises on
+    HTTP/network error so the caller surfaces a useful message."""
+    import httpx
+
+    start, end = window()
+    min_start = start.replace(microsecond=0).isoformat() + "Z"
+    max_start = end.replace(microsecond=0).isoformat() + "Z"
+
+    async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as cx:
+        me = await _api_get(cx, f"{_API_BASE}/users/me", token)
+        resource = (me or {}).get("resource", {}) or {}
+        user_uri = resource.get("uri")
+        display_name = (resource.get("name") or "").strip() or "Calendly"
+        if not user_uri:
+            raise ValueError("Calendly /users/me returned no user URI")
+
+        events = []
+        params = {
+            "user": user_uri,
+            "min_start_time": min_start,
+            "max_start_time": max_start,
+            "count": 100,
+            "sort": "start_time:asc",
+        }
+        next_url = f"{_API_BASE}/scheduled_events"
+        pages = 0
+        while next_url and pages < _MAX_PAGES:
+            data = await _api_get(cx, next_url, token, params=params)
+            events.extend(data.get("collection", []) or [])
+            pagination = data.get("pagination", {}) or {}
+            next_url = pagination.get("next_page")
+            # next_page is a fully-qualified URL with the cursor baked in, so
+            # the original query params must NOT be re-sent on the next hop.
+            params = None
+            pages += 1
+
+    return display_name, events
+
+
+def _store_events(owner: str, display_name: str, events: list) -> dict:
+    """Upsert fetched Calendly events into local DB. Synchronous (DB work) —
+    runs in a threadpool."""
+    from core.database import SessionLocal
+
+    result = empty_result()
+    cal_id = stable_cal_id("calendly", owner)
+    start, end = window()
+
+    db = SessionLocal()
+    try:
+        get_or_create_cal(db, owner, cal_id, display_name, color="#006BFF", source="calendly")
+        result["calendars"] = 1
+
+        seen_uids = set()
+        for ev in events:
+            uri = ev.get("uri")
+            if not uri:
+                continue
+            start_dt = _parse_rfc3339(ev.get("start_time"))
+            end_dt = _parse_rfc3339(ev.get("end_time"))
+            if not start_dt:
+                continue
+            if not end_dt:
+                from datetime import timedelta
+                end_dt = start_dt + timedelta(hours=1)
+
+            # Cancelled invitees leave the slot in status "canceled"; keep the
+            # local copy in sync by letting it upsert and rely on prune for
+            # ones that fully disappear. Skip clearly out-of-window rows so the
+            # window-scoped prune stays consistent.
+            if end_dt < start or start_dt > end:
+                continue
+
+            uid_val = f"{cal_id}:{uri.rsplit('/', 1)[-1]}"
+            seen_uids.add(uid_val)
+
+            status = (ev.get("status") or "").lower()
+            summary = str(ev.get("name") or "Calendly event")
+            if status in ("canceled", "cancelled"):
+                summary = f"(Canceled) {summary}"
+
+            upsert_event(db, cal_id, {
+                "uid": uid_val,
+                "summary": summary,
+                "description": "",
+                "location": _location_str(ev.get("location")),
+                "dtstart": start_dt,
+                "dtend": end_dt,
+                "all_day": False,
+                "is_utc": True,  # Calendly always returns tz-aware instants
+                "rrule": "",
+            })
+            result["events"] += 1
+        db.commit()
+
+        result["deleted"] = prune_stale(db, cal_id, start, end, seen_uids)
+        db.commit()
+    except Exception as e:
+        logger.exception("Calendly store failed")
+        result["errors"].append(str(e)[:200])
+        db.rollback()
+    finally:
+        db.close()
+
+    return result
+
+
+async def sync_calendly(owner: str) -> dict:
+    """Pull the user's Calendly scheduled events into local DB. Returns counts +
+    errors; no-ops with a clear error if no token is configured."""
+    from routes.prefs_routes import _load_for_user
+
+    cfg = (_load_for_user(owner) or {}).get("calendly", {}) or {}
+    token = (cfg.get("token") or "").strip()
+    if not token:
+        return empty_result("Calendly is not configured")
+    try:
+        display_name, events = await _fetch_events(token)
+    except Exception as e:
+        logger.info("Calendly fetch failed: %s", e)
+        return empty_result(f"Calendly API error: {str(e)[:160]}")
+    try:
+        return await asyncio.to_thread(_store_events, owner, display_name, events)
+    except Exception as e:
+        logger.exception("Calendly sync raised")
+        return empty_result(str(e)[:200])

--- a/src/calendly_sync.py
+++ b/src/calendly_sync.py
@@ -146,6 +146,12 @@ def _store_events(owner: str, display_name: str, events: list) -> dict:
                 continue
 
             uid_val = f"{cal_id}:{uri.rsplit('/', 1)[-1]}"
+            # SessionLocal is autoflush=False, so the upsert can't see inserts
+            # still pending earlier in this loop; if a paginated response ever
+            # repeated an event the duplicate add would fail the commit. Dedupe
+            # in-memory — first occurrence wins for this pull.
+            if uid_val in seen_uids:
+                continue
             seen_uids.add(uid_val)
 
             status = (ev.get("status") or "").lower()

--- a/src/chat_handler.py
+++ b/src/chat_handler.py
@@ -223,19 +223,22 @@ class ChatHandler:
                         if os.path.exists(_vcache):
                             try:
                                 with open(_vcache) as _vf:
-                                    vl_desc = _vf.read()
+                                    cached_desc = _vf.read().strip()
+                                if cached_desc and not cached_desc.startswith("["):
+                                    vl_desc = cached_desc
                             except Exception:
                                 vl_desc = None
                         if not vl_desc:
                             vl_result = analyze_image_with_vl_result(file_info["path"])
                             vl_desc = vl_result.get("text", "")
                             vl_model = vl_result.get("model", "")
-                            try:
-                                os.makedirs(os.path.join(UPLOAD_DIR, ".vision"), exist_ok=True)
-                                with open(_vcache, "w") as _vf:
-                                    _vf.write(vl_desc or "")
-                            except Exception:
-                                pass
+                            if vl_desc and not vl_desc.startswith("["):
+                                try:
+                                    os.makedirs(os.path.join(UPLOAD_DIR, ".vision"), exist_ok=True)
+                                    with open(_vcache, "w") as _vf:
+                                        _vf.write(vl_desc)
+                                except Exception:
+                                    pass
                         enhanced_message = f"{enhanced_message}\n\n[Image: {file_info['name']}]\n{vl_desc}"
                         # Surface the description to the client live so it renders as a
                         # collapsible "image description" on the user bubble (not just

--- a/src/document_processor.py
+++ b/src/document_processor.py
@@ -230,7 +230,7 @@ def analyze_image_with_vl_result(image_path: str) -> dict:
         last_err = None
         for i, (_url, _model, _headers) in enumerate([c for c in _vl_candidates if c and c[0] and c[1]]):
             try:
-                description = llm_call(_url, _model, vl_messages, headers=_headers, timeout=30)
+                description = llm_call(_url, _model, vl_messages, headers=_headers, timeout=120)
                 logger.info("VL analysis complete with model %s", _model)
                 return {"text": description, "model": _model}
             except Exception as e:

--- a/src/gcal_sync.py
+++ b/src/gcal_sync.py
@@ -101,12 +101,20 @@ def _sync_blocking(owner: str, url: str, feed_bytes: bytes) -> dict:
             if not dtstart_p:
                 continue
 
-            uid_val = str(comp.get("uid", "")) or str(uuid.uuid4())
-            # Namespace the UID by this calendar so the same Google event UID
-            # appearing in two subscribed feeds (or a CalDAV mirror) doesn't
-            # collide on the shared CalendarEvent.uid primary key.
-            uid_val = f"{cal_id}:{uid_val}"
-            seen_uids.add(uid_val)
+            base_uid = str(comp.get("uid", "")) or str(uuid.uuid4())
+            # Recurring events appear in the feed as one master VEVENT plus a
+            # separate VEVENT per modified occurrence, all sharing the same UID
+            # and disambiguated only by RECURRENCE-ID. Fold RECURRENCE-ID into
+            # the key so those overrides become distinct rows instead of
+            # colliding on the UID primary key.
+            uid_val = f"{cal_id}:{base_uid}"
+            rid = comp.get("recurrence-id")
+            if rid is not None:
+                try:
+                    rid_key = rid.dt.isoformat() if hasattr(rid, "dt") else str(rid)
+                except Exception:
+                    rid_key = str(rid)
+                uid_val = f"{uid_val}:{rid_key}"
 
             start_dt, all_day = to_utc_naive(dtstart_p.dt)
 
@@ -121,8 +129,18 @@ def _sync_blocking(owner: str, url: str, feed_bytes: bytes) -> dict:
             # Skip events entirely outside the sync window so prune_stale's
             # window-scoped delete stays consistent with what we inserted.
             if end_dt < start or start_dt > end:
-                seen_uids.discard(uid_val)
                 continue
+
+            # SessionLocal runs with autoflush=False, so upsert_event's
+            # existing-row lookup can't see inserts still pending earlier in
+            # this same loop. A feed that lists the same key twice (true
+            # duplicate, or a recurrence row we can't otherwise disambiguate)
+            # would therefore add two rows with one UID and blow up the commit
+            # with a UNIQUE violation — taking the whole pull down with it.
+            # Dedupe in-memory: first occurrence wins for this pull.
+            if uid_val in seen_uids:
+                continue
+            seen_uids.add(uid_val)
 
             row_is_utc = (
                 not all_day

--- a/src/gcal_sync.py
+++ b/src/gcal_sync.py
@@ -1,0 +1,177 @@
+"""Google Calendar → local SQLite sync.
+
+Google exposes every calendar as a private ICS feed — the "Secret address in
+iCal format" URL under Settings → "Integrate calendar". We pull that feed over
+HTTPS and upsert its VEVENTs into the local calendar store, one-way (remote →
+local), exactly like the CalDAV path.
+
+Why the secret-iCal URL instead of OAuth:
+- It needs no Google Cloud OAuth app, client id/secret, or consent screen —
+  the user pastes one URL and sync works immediately, which matches how every
+  other pull integration in Odysseus is configured (a credential in prefs, no
+  redirect dance).
+- It's read-only by construction, so there's no risk of the sync mutating the
+  user's Google calendar. Event creation still happens against local calendars.
+
+The same code path handles any ICS-over-HTTP feed (Outlook "Publish", iCloud
+public calendars, a raw `webcal://` link), so the module is provider-agnostic
+under the hood even though the UI frames it as "Google Calendar".
+
+The `icalendar` + `httpx` deps are already required by the CalDAV path.
+"""
+
+import asyncio
+import logging
+import uuid
+from datetime import datetime, timedelta
+
+from src.calendar_sync_common import (
+    empty_result, get_or_create_cal, prune_stale, stable_cal_id, to_utc_naive,
+    upsert_event, window,
+)
+
+logger = logging.getLogger(__name__)
+
+# Google's secret-iCal links live under calendar.google.com/calendar/ical/...
+# We don't hard-require that host (the same path serves Outlook/iCloud feeds),
+# but we do reject obviously-wrong inputs early.
+_MAX_FEED_BYTES = 10 * 1024 * 1024  # 10 MB — same cap as the .ics upload path.
+
+
+def _normalize_url(url: str) -> str:
+    """webcal:// is just http(s) with a different scheme hint used by calendar
+    clients — rewrite it so httpx can fetch it."""
+    url = (url or "").strip()
+    if url.startswith("webcal://"):
+        return "https://" + url[len("webcal://"):]
+    if url.startswith("webcals://"):
+        return "https://" + url[len("webcals://"):]
+    return url
+
+
+async def fetch_feed(url: str) -> bytes:
+    """Fetch the raw ICS document. Raises on HTTP / network error so callers
+    can surface a useful message. Caps the body to avoid OOM on a hostile or
+    runaway feed."""
+    import httpx
+
+    url = _normalize_url(url)
+    async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as cx:
+        r = await cx.get(url, headers={"Accept": "text/calendar, */*"})
+        r.raise_for_status()
+        content = r.content
+        if len(content) > _MAX_FEED_BYTES:
+            raise ValueError(f"Feed too large (> {_MAX_FEED_BYTES // (1024 * 1024)} MB)")
+        return content
+
+
+def _sync_blocking(owner: str, url: str, feed_bytes: bytes) -> dict:
+    """Parse the already-fetched ICS bytes and upsert into local DB. Synchronous
+    (DB + icalendar parsing) — intended to run in a threadpool."""
+    from icalendar import Calendar as iCal
+
+    from core.database import SessionLocal
+
+    result = empty_result()
+
+    try:
+        ical = iCal.from_ical(feed_bytes)
+    except Exception as e:
+        result["errors"].append(f"Could not parse calendar feed: {e}")
+        return result
+
+    # Prefer the feed's own name (X-WR-CALNAME) for the local calendar; the
+    # secret-iCal URL itself is opaque and not user-friendly.
+    display_name = str(ical.get("X-WR-CALNAME", "") or "").strip() or "Google Calendar"
+    cal_id = stable_cal_id("gcal", url)
+    start, end = window()
+
+    db = SessionLocal()
+    try:
+        local_cal = get_or_create_cal(
+            db, owner, cal_id, display_name, color="#4285F4", source="gcal",
+        )
+        result["calendars"] = 1
+
+        seen_uids = set()
+        for comp in ical.walk():
+            if comp.name != "VEVENT":
+                continue
+            dtstart_p = comp.get("dtstart")
+            if not dtstart_p:
+                continue
+
+            uid_val = str(comp.get("uid", "")) or str(uuid.uuid4())
+            # Namespace the UID by this calendar so the same Google event UID
+            # appearing in two subscribed feeds (or a CalDAV mirror) doesn't
+            # collide on the shared CalendarEvent.uid primary key.
+            uid_val = f"{cal_id}:{uid_val}"
+            seen_uids.add(uid_val)
+
+            start_dt, all_day = to_utc_naive(dtstart_p.dt)
+
+            dtend_p = comp.get("dtend")
+            if dtend_p:
+                end_dt, _ = to_utc_naive(dtend_p.dt)
+            elif all_day:
+                end_dt = start_dt + timedelta(days=1)
+            else:
+                end_dt = start_dt + timedelta(hours=1)
+
+            # Skip events entirely outside the sync window so prune_stale's
+            # window-scoped delete stays consistent with what we inserted.
+            if end_dt < start or start_dt > end:
+                seen_uids.discard(uid_val)
+                continue
+
+            row_is_utc = (
+                not all_day
+                and isinstance(dtstart_p.dt, datetime)
+                and dtstart_p.dt.tzinfo is not None
+            )
+
+            upsert_event(db, cal_id, {
+                "uid": uid_val,
+                "summary": str(comp.get("summary", "")),
+                "description": str(comp.get("description", "")),
+                "location": str(comp.get("location", "")),
+                "dtstart": start_dt,
+                "dtend": end_dt,
+                "all_day": all_day,
+                "is_utc": row_is_utc,
+                "rrule": (comp.get("rrule").to_ical().decode() if comp.get("rrule") else ""),
+            })
+            result["events"] += 1
+        db.commit()
+
+        result["deleted"] = prune_stale(db, cal_id, start, end, seen_uids)
+        db.commit()
+    except Exception as e:
+        logger.exception("Google Calendar sync failed")
+        result["errors"].append(str(e)[:200])
+        db.rollback()
+    finally:
+        db.close()
+
+    return result
+
+
+async def sync_gcal(owner: str) -> dict:
+    """Pull the user's configured Google Calendar iCal feed into local DB.
+    Returns counts + errors; no-ops with a clear error if not configured."""
+    from routes.prefs_routes import _load_for_user
+
+    cfg = (_load_for_user(owner) or {}).get("gcal", {}) or {}
+    url = (cfg.get("ics_url") or "").strip()
+    if not url:
+        return empty_result("Google Calendar is not configured")
+    try:
+        feed_bytes = await fetch_feed(url)
+    except Exception as e:
+        logger.info("Google Calendar feed fetch failed: %s", e)
+        return empty_result(f"Could not fetch feed: {str(e)[:160]}")
+    try:
+        return await asyncio.to_thread(_sync_blocking, owner, url, feed_bytes)
+    except Exception as e:
+        logger.exception("Google Calendar sync raised")
+        return empty_result(str(e)[:200])

--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -3082,8 +3082,16 @@ function _nowClock() {
   return new Date().toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
 }
 function _fmtTime(s) {
-  // Show the time as written in the ICS file (ignore UTC offset).
   if (!s || s.length < 16) return '';
+  // Tz-aware timestamps from CalDAV/import are stored as UTC instants and
+  // serialized with Z/offset. Display them in the browser's local timezone;
+  // legacy naive timestamps keep their written wall-clock time.
+  if (/[Zz]$|[+\-]\d{2}:?\d{2}$/.test(s)) {
+    const d = new Date(s);
+    if (!isNaN(d)) {
+      return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+    }
+  }
   return s.slice(11, 16);
 }
 function _e(s) { return uiModule.esc ? uiModule.esc(s || '') : (s || '').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;'); }

--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -189,9 +189,10 @@ async function _fetchCalendars() {
   }
 }
 
-// Trigger a CalDAV pull. `interactive=true` waits for the result and
-// refreshes the UI; false fires-and-forgets (used on first open). Both
-// no-op silently if CalDAV isn't configured.
+// Trigger a remote calendar pull (CalDAV + Google iCal feed + Calendly; the
+// /sync endpoint fans out to every configured source). `interactive=true`
+// waits for the result and refreshes the UI; false fires-and-forgets (used on
+// first open). No-ops silently for any source that isn't configured.
 async function _syncCaldav(interactive) {
   try {
     const res = await fetch(`${API_BASE}/api/calendar/sync`, {

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -2978,8 +2978,8 @@ async function initUnifiedIntegrations() {
       items.push({ type: 'caldav', id: '__caldav__', name: 'Calendar (CalDAV)', detail: calRes.url, enabled: true, data: calRes });
     }
     // Google Calendar (secret iCal feed)
-    if (gcalRes.configured || gcalRes.ics_url) {
-      items.push({ type: 'gcal', id: '__gcal__', name: 'Google Calendar', detail: 'iCal feed sync', enabled: true, data: gcalRes });
+    if (gcalRes.configured || gcalRes.has_url) {
+      items.push({ type: 'gcal', id: '__gcal__', name: 'Google Calendar', detail: gcalRes.hint || 'iCal feed sync', enabled: true, data: gcalRes });
     }
     // Calendly
     if (calendlyRes.configured || calendlyRes.has_token) {
@@ -3072,7 +3072,7 @@ async function initUnifiedIntegrations() {
         try {
           if (type === 'api') await fetch(`/api/auth/integrations/${id}`, { method: 'DELETE', credentials: 'same-origin' });
           else if (type === 'caldav') await fetch('/api/calendar/config', { method: 'POST', credentials: 'same-origin', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ url: '', username: '', password: '' }) });
-          else if (type === 'gcal') await fetch('/api/calendar/gcal/config', { method: 'POST', credentials: 'same-origin', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ ics_url: '' }) });
+          else if (type === 'gcal') await fetch('/api/calendar/gcal/config', { method: 'POST', credentials: 'same-origin', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ clear: true }) });
           else if (type === 'calendly') await fetch('/api/calendar/calendly/config', { method: 'POST', credentials: 'same-origin', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ clear: true }) });
           else if (type === 'carddav') {
             await fetch('/api/contacts/config', { method: 'PUT', credentials: 'same-origin', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ carddav_url: '', carddav_username: '', carddav_password: '' }) });
@@ -3295,6 +3295,11 @@ async function initUnifiedIntegrations() {
 
   // ── Google Calendar form (secret iCal feed) ──
   async function showGCalForm() {
+    let hasUrl = false, hint = '';
+    try {
+      const r = await fetch('/api/calendar/gcal/config', { credentials: 'same-origin' });
+      const d = await r.json(); hasUrl = !!d.has_url; hint = d.hint || '';
+    } catch (_) {}
     formEl.innerHTML = `
       <div class="admin-card" style="margin-top:8px">
         <h2 style="font-size:13px">Google Calendar</h2>
@@ -3302,17 +3307,15 @@ async function initUnifiedIntegrations() {
           <div style="font-size:11px;opacity:0.6;line-height:1.4;margin-bottom:2px">
             In Google Calendar → Settings → your calendar → "Integrate calendar",
             copy the <b>Secret address in iCal format</b> and paste it below.
-            Sync is one-way (Google → Odysseus).
+            Sync is one-way (Google → Odysseus); the secret URL is stored
+            server-side and never shown again.
           </div>
-          <div class="settings-row"><label class="settings-label">iCal URL</label><input id="uf-gcal-url" class="settings-input" placeholder="https://calendar.google.com/calendar/ical/.../basic.ics"></div>
+          <div class="settings-row"><label class="settings-label">iCal URL</label><input id="uf-gcal-url" class="settings-input" placeholder="${hasUrl ? esc(hint) + ' (saved — leave blank to keep)' : 'https://calendar.google.com/calendar/ical/.../basic.ics'}"></div>
           <div class="settings-row" style="margin-top:4px"><button class="admin-btn-sm" id="uf-gcal-save">Save</button><button class="admin-btn-sm" id="uf-gcal-test" style="opacity:0.7">Test</button><button class="admin-btn-sm" id="uf-gcal-cancel" style="opacity:0.7">Cancel</button><span id="uf-gcal-msg" style="font-size:11px"></span></div>
         </div>
       </div>`;
-    try {
-      const r = await fetch('/api/calendar/gcal/config', { credentials: 'same-origin' }); const d = await r.json();
-      el('uf-gcal-url').value = d.ics_url || '';
-    } catch (_) {}
     const _msg = (text, ok) => { const m = el('uf-gcal-msg'); m.textContent = text; m.style.color = ok ? 'var(--green,#50fa7b)' : 'var(--red)'; };
+    // Empty url body => test the stored feed (server falls back to it).
     const _test = async () => {
       try {
         const r = await fetch('/api/calendar/gcal/test', {
@@ -3330,15 +3333,21 @@ async function initUnifiedIntegrations() {
       _msg(d.ok ? `Connected — ${d.events ?? 0} events` : (d.error || 'Failed'), d.ok);
     });
     el('uf-gcal-save').addEventListener('click', async () => {
-      // Pre-validate the feed before persisting, same as CalDAV's save path.
-      _msg('Testing…', true); el('uf-gcal-msg').style.color = '';
-      const d = await _test();
-      if (!d.ok) { _msg(d.error || 'Feed unreachable — not saved', false); return; }
+      const url = el('uf-gcal-url').value.trim();
+      // Only re-validate when a URL was actually entered. A blank save on an
+      // already-configured feed is a no-op "keep existing".
+      if (url) {
+        _msg('Testing…', true); el('uf-gcal-msg').style.color = '';
+        const d = await _test();
+        if (!d.ok) { _msg(d.error || 'Feed unreachable — not saved', false); return; }
+      } else if (!hasUrl) {
+        _msg('Enter an iCal URL', false); return;
+      }
       try {
         await fetch('/api/calendar/gcal/config', {
           method: 'POST', credentials: 'same-origin',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ ics_url: el('uf-gcal-url').value.trim() }),
+          body: JSON.stringify({ ics_url: url }),
         });
         _msg('Saved', true);
         formEl.style.display = 'none';

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -2932,6 +2932,8 @@ async function initIntegrations() {
 const INTG_TYPES = {
   api:     { label: 'API',     icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>' },
   caldav:  { label: 'CalDAV',  icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>' },
+  gcal:    { label: 'Google',  icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/><line x1="3" y1="10" x2="21" y2="10"/></svg>' },
+  calendly:{ label: 'Calendly', icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>' },
   carddav: { label: 'Contacts', icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>' },
   email:   { label: 'Email',   icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg>' },
   mcp:     { label: 'MCP',     icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>' },
@@ -2955,9 +2957,11 @@ async function initUnifiedIntegrations() {
   }
 
   async function fetchAll() {
-    const [apiRes, calRes, cardRes, contactsRes, emailAccountsRes, mcpRes, vaultRes] = await Promise.all([
+    const [apiRes, calRes, gcalRes, calendlyRes, cardRes, contactsRes, emailAccountsRes, mcpRes, vaultRes] = await Promise.all([
       fetch('/api/auth/integrations', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : { integrations: [] }).catch(() => ({ integrations: [] })),
       fetch('/api/calendar/config', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : {}).catch(() => ({})),
+      fetch('/api/calendar/gcal/config', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : {}).catch(() => ({})),
+      fetch('/api/calendar/calendly/config', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : {}).catch(() => ({})),
       fetch('/api/contacts/config', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : {}).catch(() => ({})),
       fetch('/api/contacts/list', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : { contacts: [], count: 0 }).catch(() => ({ contacts: [], count: 0 })),
       fetch('/api/email/accounts', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : { accounts: [] }).catch(() => ({ accounts: [] })),
@@ -2972,6 +2976,14 @@ async function initUnifiedIntegrations() {
     // CalDAV
     if (calRes.url) {
       items.push({ type: 'caldav', id: '__caldav__', name: 'Calendar (CalDAV)', detail: calRes.url, enabled: true, data: calRes });
+    }
+    // Google Calendar (secret iCal feed)
+    if (gcalRes.configured || gcalRes.ics_url) {
+      items.push({ type: 'gcal', id: '__gcal__', name: 'Google Calendar', detail: 'iCal feed sync', enabled: true, data: gcalRes });
+    }
+    // Calendly
+    if (calendlyRes.configured || calendlyRes.has_token) {
+      items.push({ type: 'calendly', id: '__calendly__', name: 'Calendly', detail: 'Scheduled events sync', enabled: true, data: calendlyRes });
     }
     // Contacts / CardDAV
     const contactCount = Number(contactsRes.count || (contactsRes.contacts || []).length || 0);
@@ -3060,6 +3072,8 @@ async function initUnifiedIntegrations() {
         try {
           if (type === 'api') await fetch(`/api/auth/integrations/${id}`, { method: 'DELETE', credentials: 'same-origin' });
           else if (type === 'caldav') await fetch('/api/calendar/config', { method: 'POST', credentials: 'same-origin', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ url: '', username: '', password: '' }) });
+          else if (type === 'gcal') await fetch('/api/calendar/gcal/config', { method: 'POST', credentials: 'same-origin', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ ics_url: '' }) });
+          else if (type === 'calendly') await fetch('/api/calendar/calendly/config', { method: 'POST', credentials: 'same-origin', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ clear: true }) });
           else if (type === 'carddav') {
             await fetch('/api/contacts/config', { method: 'PUT', credentials: 'same-origin', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ carddav_url: '', carddav_username: '', carddav_password: '' }) });
             await fetch('/api/contacts/clear', { method: 'DELETE', credentials: 'same-origin' });
@@ -3079,6 +3093,8 @@ async function initUnifiedIntegrations() {
     formEl.style.display = '';
     if (type === 'api') showApiForm(editId);
     else if (type === 'caldav') showCalDavForm();
+    else if (type === 'gcal') showGCalForm();
+    else if (type === 'calendly') showCalendlyForm();
     else if (type === 'carddav') showCardDavForm();
     else if (type === 'email') showEmailForm(editId);
     else if (type === 'mcp') showMcpForm(editId);
@@ -3274,6 +3290,123 @@ async function initUnifiedIntegrations() {
       el('uf-caldav-msg').style.color = '';
       const d = await _runCalDavTest();
       _setCalDavMsg(d.ok ? 'Connected' : (d.error || 'Failed'), d.ok);
+    });
+  }
+
+  // ── Google Calendar form (secret iCal feed) ──
+  async function showGCalForm() {
+    formEl.innerHTML = `
+      <div class="admin-card" style="margin-top:8px">
+        <h2 style="font-size:13px">Google Calendar</h2>
+        <div class="settings-col">
+          <div style="font-size:11px;opacity:0.6;line-height:1.4;margin-bottom:2px">
+            In Google Calendar → Settings → your calendar → "Integrate calendar",
+            copy the <b>Secret address in iCal format</b> and paste it below.
+            Sync is one-way (Google → Odysseus).
+          </div>
+          <div class="settings-row"><label class="settings-label">iCal URL</label><input id="uf-gcal-url" class="settings-input" placeholder="https://calendar.google.com/calendar/ical/.../basic.ics"></div>
+          <div class="settings-row" style="margin-top:4px"><button class="admin-btn-sm" id="uf-gcal-save">Save</button><button class="admin-btn-sm" id="uf-gcal-test" style="opacity:0.7">Test</button><button class="admin-btn-sm" id="uf-gcal-cancel" style="opacity:0.7">Cancel</button><span id="uf-gcal-msg" style="font-size:11px"></span></div>
+        </div>
+      </div>`;
+    try {
+      const r = await fetch('/api/calendar/gcal/config', { credentials: 'same-origin' }); const d = await r.json();
+      el('uf-gcal-url').value = d.ics_url || '';
+    } catch (_) {}
+    const _msg = (text, ok) => { const m = el('uf-gcal-msg'); m.textContent = text; m.style.color = ok ? 'var(--green,#50fa7b)' : 'var(--red)'; };
+    const _test = async () => {
+      try {
+        const r = await fetch('/api/calendar/gcal/test', {
+          method: 'POST', credentials: 'same-origin',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ics_url: el('uf-gcal-url').value.trim() }),
+        });
+        return await r.json();
+      } catch (e) { return { ok: false, error: 'Network error: ' + e.message }; }
+    };
+    el('uf-gcal-cancel').addEventListener('click', () => { formEl.style.display = 'none'; });
+    el('uf-gcal-test').addEventListener('click', async () => {
+      _msg('Testing…', true); el('uf-gcal-msg').style.color = '';
+      const d = await _test();
+      _msg(d.ok ? `Connected — ${d.events ?? 0} events` : (d.error || 'Failed'), d.ok);
+    });
+    el('uf-gcal-save').addEventListener('click', async () => {
+      // Pre-validate the feed before persisting, same as CalDAV's save path.
+      _msg('Testing…', true); el('uf-gcal-msg').style.color = '';
+      const d = await _test();
+      if (!d.ok) { _msg(d.error || 'Feed unreachable — not saved', false); return; }
+      try {
+        await fetch('/api/calendar/gcal/config', {
+          method: 'POST', credentials: 'same-origin',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ics_url: el('uf-gcal-url').value.trim() }),
+        });
+        _msg('Saved', true);
+        formEl.style.display = 'none';
+        await renderList();
+        notifyIntegrationsChanged();
+      } catch (_) { _msg('Save failed', false); }
+    });
+  }
+
+  // ── Calendly form (personal access token) ──
+  async function showCalendlyForm() {
+    let hasToken = false;
+    try {
+      const r = await fetch('/api/calendar/calendly/config', { credentials: 'same-origin' });
+      const d = await r.json(); hasToken = !!d.has_token;
+    } catch (_) {}
+    formEl.innerHTML = `
+      <div class="admin-card" style="margin-top:8px">
+        <h2 style="font-size:13px">Calendly</h2>
+        <div class="settings-col">
+          <div style="font-size:11px;opacity:0.6;line-height:1.4;margin-bottom:2px">
+            In Calendly → Integrations → API & Webhooks, create a
+            <b>Personal Access Token</b> and paste it below. Sync pulls your
+            scheduled events (one-way) into Odysseus.
+          </div>
+          <div class="settings-row"><label class="settings-label">Access Token</label><input id="uf-calendly-token" class="settings-input" type="password" placeholder="${hasToken ? '•••••••• (saved — leave blank to keep)' : 'eyJ…'}"></div>
+          <div class="settings-row" style="margin-top:4px"><button class="admin-btn-sm" id="uf-calendly-save">Save</button><button class="admin-btn-sm" id="uf-calendly-test" style="opacity:0.7">Test</button><button class="admin-btn-sm" id="uf-calendly-cancel" style="opacity:0.7">Cancel</button><span id="uf-calendly-msg" style="font-size:11px"></span></div>
+        </div>
+      </div>`;
+    const _msg = (text, ok) => { const m = el('uf-calendly-msg'); m.textContent = text; m.style.color = ok ? 'var(--green,#50fa7b)' : 'var(--red)'; };
+    const _test = async () => {
+      try {
+        const r = await fetch('/api/calendar/calendly/test', {
+          method: 'POST', credentials: 'same-origin',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ token: el('uf-calendly-token').value.trim() }),
+        });
+        return await r.json();
+      } catch (e) { return { ok: false, error: 'Network error: ' + e.message }; }
+    };
+    el('uf-calendly-cancel').addEventListener('click', () => { formEl.style.display = 'none'; });
+    el('uf-calendly-test').addEventListener('click', async () => {
+      _msg('Testing…', true); el('uf-calendly-msg').style.color = '';
+      const d = await _test();
+      _msg(d.ok ? `Connected${d.name ? ' — ' + d.name : ''}` : (d.error || 'Failed'), d.ok);
+    });
+    el('uf-calendly-save').addEventListener('click', async () => {
+      const token = el('uf-calendly-token').value.trim();
+      // Only re-validate when a token was actually entered. A blank save on an
+      // already-configured account is a no-op "keep existing".
+      if (token) {
+        _msg('Testing…', true); el('uf-calendly-msg').style.color = '';
+        const d = await _test();
+        if (!d.ok) { _msg(d.error || 'Token rejected — not saved', false); return; }
+      } else if (!hasToken) {
+        _msg('Enter an access token', false); return;
+      }
+      try {
+        await fetch('/api/calendar/calendly/config', {
+          method: 'POST', credentials: 'same-origin',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ token }),
+        });
+        _msg('Saved', true);
+        formEl.style.display = 'none';
+        await renderList();
+        notifyIntegrationsChanged();
+      } catch (_) { _msg('Save failed', false); }
     });
   }
 
@@ -4130,6 +4263,8 @@ async function initUnifiedIntegrations() {
                 <option value="">Select...</option>
                 <option value="api">API Service</option>
                 <option value="caldav">CalDAV Calendar</option>
+                <option value="gcal">Google Calendar</option>
+                <option value="calendly">Calendly</option>
                 <option value="carddav">Contacts</option>
                 <option value="email">Email (IMAP/SMTP)</option>
                 <option value="mcp">MCP Tool Server</option>

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 for mod in [
     'sqlalchemy', 'sqlalchemy.orm', 'sqlalchemy.ext', 'sqlalchemy.ext.declarative',
     'sqlalchemy.ext.hybrid', 'sqlalchemy.sql', 'sqlalchemy.sql.expression',
-    'src.database', 'src.endpoint_resolver',
+    'src.database',
     'src.agent_tools',
     'core.models', 'core.database',
 ]:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -32,10 +32,13 @@ class TestAppStructure:
         src_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "src")
         assert os.path.exists(src_path), "src directory should exist"
 
-    def test_env_file_exists(self):
-        """Test that .env file exists"""
-        env_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), ".env")
-        assert os.path.exists(env_path), ".env file should exist"
+    def test_env_file_is_optional_and_ignored(self):
+        """A fresh checkout should not require a private .env file."""
+        root = os.path.dirname(os.path.dirname(__file__))
+        gitignore_path = os.path.join(root, ".gitignore")
+        with open(gitignore_path, encoding="utf-8") as fh:
+            ignored = {line.strip() for line in fh}
+        assert ".env" in ignored, ".env should stay local and ignored"
 
     def test_env_example_exists(self):
         """Test that .env.example exists"""

--- a/tests/test_calendar_sync.py
+++ b/tests/test_calendar_sync.py
@@ -1,0 +1,192 @@
+"""Unit tests for the Google Calendar / Calendly calendar-sync helpers.
+
+These cover the pure logic (id derivation, datetime normalisation, URL/feed
+parsing, Calendly response shaping, multi-source result aggregation) without
+hitting the network or a database — the parts most likely to regress silently.
+"""
+
+from datetime import date, datetime, timezone
+
+import pytest
+
+from src import calendar_sync_common as common
+from src import calendly_sync, gcal_sync
+
+
+# ── calendar_sync_common ──
+
+def test_stable_cal_id_is_deterministic_and_namespaced():
+    a = common.stable_cal_id("gcal", "https://example.com/feed.ics")
+    b = common.stable_cal_id("gcal", "https://example.com/feed.ics")
+    assert a == b                      # same input → same id across calls
+    assert a.startswith("gcal-")
+    # Same key, different provider prefix must not collide.
+    c = common.stable_cal_id("calendly", "https://example.com/feed.ics")
+    assert c != a and c.startswith("calendly-")
+
+
+def test_to_utc_naive_tzaware_converts_to_utc():
+    dt = datetime(2026, 5, 31, 12, 0, tzinfo=timezone.utc)
+    out, all_day = common.to_utc_naive(dt)
+    assert all_day is False
+    assert out == datetime(2026, 5, 31, 12, 0)
+    assert out.tzinfo is None          # DB column is naive
+
+
+def test_to_utc_naive_naive_passthrough():
+    dt = datetime(2026, 5, 31, 9, 30)
+    out, all_day = common.to_utc_naive(dt)
+    assert out == dt and all_day is False
+
+
+def test_to_utc_naive_date_is_all_day():
+    out, all_day = common.to_utc_naive(date(2026, 5, 31))
+    assert all_day is True
+    assert out == datetime(2026, 5, 31, 0, 0)
+
+
+def test_empty_result_shape():
+    r = common.empty_result("nope")
+    assert r == {"calendars": 0, "events": 0, "deleted": 0, "errors": ["nope"]}
+
+
+# ── gcal_sync ──
+
+@pytest.mark.parametrize("raw,expected", [
+    ("webcal://host/cal.ics", "https://host/cal.ics"),
+    ("webcals://host/cal.ics", "https://host/cal.ics"),
+    ("https://host/cal.ics", "https://host/cal.ics"),
+    ("  https://host/cal.ics  ", "https://host/cal.ics"),
+])
+def test_gcal_normalize_url(raw, expected):
+    assert gcal_sync._normalize_url(raw) == expected
+
+
+def test_gcal_sync_blocking_parses_and_namespaces_uid(monkeypatch):
+    """An ICS feed with one timed event upserts one event whose UID is
+    namespaced by the calendar id (so identical UIDs across feeds don't
+    collide on the shared primary key)."""
+    captured = {}
+
+    def fake_upsert(db, cal_id, fields):
+        captured["cal_id"] = cal_id
+        captured["fields"] = fields
+
+    monkeypatch.setattr(gcal_sync, "get_or_create_cal", lambda *a, **k: None)
+    monkeypatch.setattr(gcal_sync, "prune_stale", lambda *a, **k: 0)
+    monkeypatch.setattr(gcal_sync, "upsert_event", fake_upsert)
+
+    class _FakeSession:
+        def commit(self): pass
+        def rollback(self): pass
+        def close(self): pass
+
+    import core.database as db
+    monkeypatch.setattr(db, "SessionLocal", lambda: _FakeSession())
+
+    # An event "now-ish" so it falls inside the 90d-back/365d-forward window.
+    now = datetime.utcnow()
+    dt = now.strftime("%Y%m%dT%H%M%SZ")
+    ics = (
+        "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nX-WR-CALNAME:Work\r\n"
+        "BEGIN:VEVENT\r\nUID:abc-123\r\n"
+        f"DTSTART:{dt}\r\nDTEND:{dt}\r\nSUMMARY:Standup\r\n"
+        "END:VEVENT\r\nEND:VCALENDAR\r\n"
+    ).encode()
+
+    result = gcal_sync._sync_blocking("owner@x", "https://cal/feed.ics", ics)
+
+    assert result["events"] == 1
+    assert result["calendars"] == 1
+    assert captured["fields"]["summary"] == "Standup"
+    # UID is "<cal_id>:<original-uid>"
+    assert captured["fields"]["uid"] == f"{captured['cal_id']}:abc-123"
+    assert captured["fields"]["is_utc"] is True
+
+
+def test_gcal_sync_blocking_rejects_garbage_feed():
+    result = gcal_sync._sync_blocking("owner@x", "https://cal/feed.ics", b"not a calendar")
+    assert result["events"] == 0
+    assert result["errors"]
+
+
+# ── calendly_sync ──
+
+@pytest.mark.parametrize("raw,expected", [
+    ("2026-05-31T12:00:00Z", datetime(2026, 5, 31, 12, 0)),
+    ("2026-05-31T12:00:00+00:00", datetime(2026, 5, 31, 12, 0)),
+    ("2026-05-31T14:00:00+02:00", datetime(2026, 5, 31, 12, 0)),  # → UTC
+])
+def test_calendly_parse_rfc3339(raw, expected):
+    assert calendly_sync._parse_rfc3339(raw) == expected
+
+
+def test_calendly_parse_rfc3339_bad_input():
+    assert calendly_sync._parse_rfc3339("") is None
+    assert calendly_sync._parse_rfc3339("garbage") is None
+
+
+@pytest.mark.parametrize("loc,expected", [
+    ({"type": "zoom", "join_url": "https://zoom.us/j/1"}, "https://zoom.us/j/1"),
+    ({"type": "physical", "location": "123 Main St"}, "123 Main St"),
+    ({"type": "custom"}, "custom"),
+    (None, ""),
+    ("plain string", ""),
+])
+def test_calendly_location_str(loc, expected):
+    assert calendly_sync._location_str(loc) == expected
+
+
+def test_calendly_store_events_marks_canceled_and_namespaces_uid(monkeypatch):
+    captured = []
+    monkeypatch.setattr(calendly_sync, "get_or_create_cal", lambda *a, **k: None)
+    monkeypatch.setattr(calendly_sync, "prune_stale", lambda *a, **k: 0)
+    monkeypatch.setattr(calendly_sync, "upsert_event", lambda db, cal_id, f: captured.append((cal_id, f)))
+
+    class _FakeSession:
+        def commit(self): pass
+        def rollback(self): pass
+        def close(self): pass
+
+    import core.database as db
+    monkeypatch.setattr(db, "SessionLocal", lambda: _FakeSession())
+
+    now = datetime.utcnow().replace(microsecond=0)
+    iso = now.isoformat() + "Z"
+    events = [
+        {"uri": "https://api.calendly.com/scheduled_events/E1", "name": "Intro call",
+         "status": "active", "start_time": iso, "end_time": iso,
+         "location": {"type": "zoom", "join_url": "https://zoom.us/j/9"}},
+        {"uri": "https://api.calendly.com/scheduled_events/E2", "name": "Old call",
+         "status": "canceled", "start_time": iso, "end_time": iso, "location": None},
+    ]
+    result = calendly_sync._store_events("owner@x", "Calendly", events)
+
+    assert result["events"] == 2
+    cal_id, f1 = captured[0]
+    assert f1["uid"] == f"{cal_id}:E1"
+    assert f1["location"] == "https://zoom.us/j/9"
+    assert f1["is_utc"] is True
+    _, f2 = captured[1]
+    assert f2["summary"].startswith("(Canceled)")
+
+
+# ── route aggregation ──
+
+def test_aggregate_sync_results_sums_and_filters():
+    from routes.calendar_routes import _aggregate_sync_results
+
+    results = [
+        {"calendars": 1, "events": 3, "deleted": 1, "errors": []},
+        {"calendars": 1, "events": 2, "deleted": 0, "errors": ["Calendly is not configured"]},
+        {"calendars": 0, "events": 0, "deleted": 0, "errors": ["real error"]},
+        RuntimeError("boom"),
+    ]
+    agg = _aggregate_sync_results(results)
+    assert agg["calendars"] == 2
+    assert agg["events"] == 5
+    assert agg["deleted"] == 1
+    # "not configured" is dropped as noise; real error + exception are kept.
+    assert "real error" in agg["errors"]
+    assert any("boom" in e for e in agg["errors"])
+    assert all("not configured" not in e for e in agg["errors"])

--- a/tests/test_calendar_sync.py
+++ b/tests/test_calendar_sync.py
@@ -11,7 +11,7 @@ the PR thread.
 """
 
 import asyncio
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 
@@ -108,6 +108,54 @@ def test_gcal_sync_blocking_parses_and_namespaces_uid(monkeypatch):
     # UID is "<cal_id>:<original-uid>"
     assert captured["fields"]["uid"] == f"{captured['cal_id']}:abc-123"
     assert captured["fields"]["is_utc"] is True
+
+
+def test_gcal_sync_blocking_handles_recurring_duplicate_uids(monkeypatch):
+    """A real Google feed lists recurring events as a master VEVENT plus one
+    VEVENT per modified occurrence, all sharing the same UID. Plus feeds can
+    repeat an identical UID outright. Because SessionLocal runs autoflush=False,
+    the upsert can't dedupe pending inserts mid-loop — so without care these
+    collide on the UID primary key and the whole commit fails (the bug that
+    silently stored zero events). This must NOT raise and must not emit two
+    rows for one key."""
+    added = []
+    monkeypatch.setattr(gcal_sync, "get_or_create_cal", lambda *a, **k: None)
+    monkeypatch.setattr(gcal_sync, "prune_stale", lambda *a, **k: 0)
+    monkeypatch.setattr(gcal_sync, "upsert_event", lambda db, cal_id, f: added.append(f["uid"]))
+
+    class _FakeSession:
+        def commit(self): pass
+        def rollback(self): pass
+        def close(self): pass
+
+    import core.database as db
+    monkeypatch.setattr(db, "SessionLocal", lambda: _FakeSession())
+
+    now = datetime.utcnow()
+    d1 = now.strftime("%Y%m%dT%H%M%SZ")
+    d2 = (now + timedelta(days=7)).strftime("%Y%m%dT%H%M%SZ")
+    # Master (RRULE) + an override occurrence (same UID, RECURRENCE-ID) +
+    # an exact-duplicate of the master UID.
+    ics = (
+        "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nX-WR-CALNAME:Recurring\r\n"
+        f"BEGIN:VEVENT\r\nUID:rec-1\r\nDTSTART:{d1}\r\nDTEND:{d1}\r\n"
+        "RRULE:FREQ=WEEKLY\r\nSUMMARY:Weekly standup\r\nEND:VEVENT\r\n"
+        f"BEGIN:VEVENT\r\nUID:rec-1\r\nRECURRENCE-ID:{d2}\r\nDTSTART:{d2}\r\n"
+        f"DTEND:{d2}\r\nSUMMARY:Weekly standup (moved)\r\nEND:VEVENT\r\n"
+        f"BEGIN:VEVENT\r\nUID:rec-1\r\nDTSTART:{d1}\r\nDTEND:{d1}\r\n"
+        "SUMMARY:Weekly standup DUP\r\nEND:VEVENT\r\n"
+        "END:VCALENDAR\r\n"
+    ).encode()
+
+    result = gcal_sync._sync_blocking("owner@x", "https://cal/feed.ics", ics)
+
+    assert not result["errors"]                 # no UNIQUE-violation crash
+    assert len(added) == len(set(added))         # no duplicate keys emitted
+    # Master and the RECURRENCE-ID override are distinct rows; the exact dup
+    # of the master is collapsed.
+    assert any(u.endswith(":rec-1") for u in added)
+    assert any(":rec-1:" in u for u in added)    # the override row
+    assert len(added) == 2
 
 
 def test_gcal_sync_blocking_rejects_garbage_feed():

--- a/tests/test_calendar_sync.py
+++ b/tests/test_calendar_sync.py
@@ -3,8 +3,14 @@
 These cover the pure logic (id derivation, datetime normalisation, URL/feed
 parsing, Calendly response shaping, multi-source result aggregation) without
 hitting the network or a database — the parts most likely to regress silently.
+
+The HTTP-boundary tests (Calendly pagination/read-only, secret non-leakage)
+use fakes/TestClient rather than live accounts so they run in CI; real-source
+validation against a live Google iCal feed and Calendly token is documented in
+the PR thread.
 """
 
+import asyncio
 from datetime import date, datetime, timezone
 
 import pytest
@@ -190,3 +196,136 @@ def test_aggregate_sync_results_sums_and_filters():
     assert "real error" in agg["errors"]
     assert any("boom" in e for e in agg["errors"])
     assert all("not configured" not in e for e in agg["errors"])
+
+
+# ── secret masking ──
+
+def test_mask_feed_url_omits_secret_path():
+    from routes.calendar_routes import _mask_feed_url
+    secret = (
+        "https://calendar.google.com/calendar/ical/"
+        "abc123SECRETtoken456%40group.calendar.google.com/private-DEADBEEF/basic.ics"
+    )
+    hint = _mask_feed_url(secret)
+    # Host + trailing filename are fine to show; the opaque secret segments
+    # that grant read access must not appear.
+    assert hint == "calendar.google.com/…/basic.ics"
+    assert "SECRET" not in hint
+    assert "DEADBEEF" not in hint
+
+
+def test_mask_feed_url_empty():
+    from routes.calendar_routes import _mask_feed_url
+    assert _mask_feed_url("") == ""
+    assert _mask_feed_url(None) == ""
+
+
+# ── Calendly: pagination + read-only (GET) at the HTTP boundary ──
+
+class _FakeResp:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class _FakeAsyncClient:
+    """Records every request so the test can assert the sync only ever GETs
+    (never mutates the remote) and follows pagination cursors."""
+
+    calls = []
+
+    def __init__(self, *a, **k):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def get(self, url, headers=None, params=None):
+        _FakeAsyncClient.calls.append(("GET", url, params))
+        if url.endswith("/users/me"):
+            return _FakeResp({"resource": {"uri": "https://api.calendly.com/users/U", "name": "Amish"}})
+        # First scheduled_events page carries a cursor; second ends it.
+        if params is not None:  # first hop (original params, no cursor baked in)
+            return _FakeResp({
+                "collection": [{"uri": "https://api.calendly.com/scheduled_events/E1",
+                                "name": "Call 1", "status": "active",
+                                "start_time": "2026-06-01T10:00:00Z",
+                                "end_time": "2026-06-01T10:30:00Z", "location": None}],
+                "pagination": {"next_page": "https://api.calendly.com/scheduled_events?page=2"},
+            })
+        return _FakeResp({
+            "collection": [{"uri": "https://api.calendly.com/scheduled_events/E2",
+                            "name": "Call 2", "status": "active",
+                            "start_time": "2026-06-02T10:00:00Z",
+                            "end_time": "2026-06-02T10:30:00Z", "location": None}],
+            "pagination": {"next_page": None},
+        })
+
+
+def test_calendly_fetch_events_paginates_and_is_read_only(monkeypatch):
+    import httpx
+    _FakeAsyncClient.calls = []
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeAsyncClient)
+
+    name, events = asyncio.run(calendly_sync._fetch_events("tok-123"))
+
+    assert name == "Amish"
+    assert [e["uri"].rsplit("/", 1)[-1] for e in events] == ["E1", "E2"]
+    # Every HTTP call was a GET — the sync never mutates the Calendly account.
+    assert all(method == "GET" for method, _u, _p in _FakeAsyncClient.calls)
+    # The first scheduled_events hop constrained the window; the cursor hop
+    # dropped the original params (cursor is baked into next_page URL).
+    sched = [c for c in _FakeAsyncClient.calls if "scheduled_events" in c[1]]
+    assert sched[0][2] and "min_start_time" in sched[0][2] and "max_start_time" in sched[0][2]
+    assert sched[1][2] is None
+
+
+# ── secrets are never returned to the client (config GET endpoints) ──
+
+def _calendar_client(monkeypatch, prefs):
+    """Mount the calendar router on a bare app with auth + prefs stubbed."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    import routes.calendar_routes as cr
+    from routes import prefs_routes
+
+    monkeypatch.setattr(cr, "get_current_user", lambda request: "owner@test")
+    monkeypatch.setattr(prefs_routes, "_load_for_user", lambda user=None: dict(prefs))
+    monkeypatch.setattr(prefs_routes, "_save_for_user", lambda user, p: None)
+
+    app = FastAPI()
+    app.include_router(cr.setup_calendar_routes())
+    return TestClient(app)
+
+
+def test_gcal_config_get_never_leaks_secret_url(monkeypatch):
+    secret = ("https://calendar.google.com/calendar/ical/"
+              "TOTALLYsecretTOKEN%40group.calendar.google.com/private-CAFEBABE/basic.ics")
+    client = _calendar_client(monkeypatch, {"gcal": {"ics_url": secret}})
+    r = client.get("/api/calendar/gcal/config")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["has_url"] is True and body["configured"] is True
+    # The raw secret URL / token must never appear in the response.
+    blob = r.text
+    assert "TOTALLYsecretTOKEN" not in blob
+    assert "CAFEBABE" not in blob
+    assert "ics_url" not in body  # field that used to carry the full secret
+
+
+def test_calendly_config_get_never_leaks_token(monkeypatch):
+    client = _calendar_client(monkeypatch, {"calendly": {"token": "SUPER-secret-PAT-xyz"}})
+    r = client.get("/api/calendar/calendly/config")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["has_token"] is True and body["configured"] is True
+    assert body["token"] == ""
+    assert "SUPER-secret-PAT-xyz" not in r.text

--- a/tests/test_calendar_sync.py
+++ b/tests/test_calendar_sync.py
@@ -299,7 +299,7 @@ class _FakeAsyncClient:
     async def get(self, url, headers=None, params=None):
         _FakeAsyncClient.calls.append(("GET", url, params))
         if url.endswith("/users/me"):
-            return _FakeResp({"resource": {"uri": "https://api.calendly.com/users/U", "name": "Amish"}})
+            return _FakeResp({"resource": {"uri": "https://api.calendly.com/users/U", "name": "Test User"}})
         # First scheduled_events page carries a cursor; second ends it.
         if params is not None:  # first hop (original params, no cursor baked in)
             return _FakeResp({
@@ -325,7 +325,7 @@ def test_calendly_fetch_events_paginates_and_is_read_only(monkeypatch):
 
     name, events = asyncio.run(calendly_sync._fetch_events("tok-123"))
 
-    assert name == "Amish"
+    assert name == "Test User"
     assert [e["uri"].rsplit("/", 1)[-1] for e in events] == ["E1", "E2"]
     # Every HTTP call was a GET — the sync never mutates the Calendly account.
     assert all(method == "GET" for method, _u, _p in _FakeAsyncClient.calls)

--- a/tests/test_context_compactor.py
+++ b/tests/test_context_compactor.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 for mod in [
     'sqlalchemy', 'sqlalchemy.orm', 'sqlalchemy.ext', 'sqlalchemy.ext.declarative',
     'sqlalchemy.ext.hybrid', 'sqlalchemy.sql', 'sqlalchemy.sql.expression',
-    'src.database', 'src.endpoint_resolver',
+    'src.database',
     'core.models', 'core.database',
 ]:
     if mod not in sys.modules:

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -6,6 +6,13 @@ from unittest.mock import MagicMock
 import httpx
 import pytest
 
+_endpoint_resolver = sys.modules.get("src.endpoint_resolver")
+if _endpoint_resolver is not None and not getattr(_endpoint_resolver, "__file__", None):
+    # Other tests stub this module during collection. These helper tests need
+    # the real URL normalization helpers so Anthropic /v1 handling is covered.
+    sys.modules.pop("src.endpoint_resolver", None)
+    sys.modules.pop("routes.model_routes", None)
+
 if "core.database" not in sys.modules:
     _core_db = types.ModuleType("core.database")
     for _name in [


### PR DESCRIPTION
## What

Extends the calendar so it can sync from **Google Calendar** and **Calendly** in addition to the existing **CalDAV** support — all one-way pulls (remote → local SQLite) sharing the same upsert/prune/timezone logic.

- **Google Calendar** — via the calendar's *"Secret address in iCal format"* feed (Settings → Integrate calendar). No Google Cloud OAuth app, client secret, or consent screen required — paste one URL and it works, matching how every other pull integration in Odysseus is configured. Read-only by construction. The underlying code path also handles any ICS-over-HTTP feed (`webcal://`, Outlook/iCloud published links).
- **Calendly** — via a **Personal Access Token** against the Calendly v2 REST API (`/users/me` → `/scheduled_events`), paginated within the sync window. Canceled bookings are labelled, fully-removed ones are pruned.

## How

- `src/calendar_sync_common.py` — shared `stable_cal_id` / `to_utc_naive` / `get_or_create_cal` / `upsert_event` / `prune_stale` / `window`, so CalDAV, Google, and Calendly behave identically.
- `src/gcal_sync.py`, `src/calendly_sync.py` — the two new pulls.
- `routes/calendar_routes.py` — `POST /api/calendar/sync` now fans out to **every configured source concurrently** and returns aggregated counts (`"not configured"` no-ops are filtered out). `POST /api/calendar/sync/{source}` pulls one on demand. New `gcal/` and `calendly/` config + test endpoints (tokens are never returned to the client).
- `static/js/settings.js` — new **Google Calendar** and **Calendly** cards/forms in Settings → Integrations, with Test-before-Save like the CalDAV form.
- The frontend's existing on-open sync call now transparently pulls all three sources.

## Notes / decisions

- Chose the **iCal secret URL** for Google over full OAuth because OAuth would require shipping/registering a Google Cloud app + redirect flow, which no other integration here needs and which can't work without per-deployer credentials. The secret-URL path syncs immediately and is read-only. OAuth could be layered on later behind the same prefs key.
- No new dependencies — uses `httpx` + `icalendar`, already required by the CalDAV path.

## Tests

`tests/test_calendar_sync.py` — 22 cases covering id derivation/namespacing, tz normalisation (tz-aware → UTC, naive, all-day), `webcal://` rewriting, ICS feed parsing, Calendly RFC3339 + polymorphic location flattening + cancel labelling, and multi-source result aggregation. All green; the full existing suite shows no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
