### PR TITLE
Quiet bundled SearXNG startup

### DIFF
--- a/config/searxng/limiter.toml
+++ b/config/searxng/limiter.toml
@@ -1,0 +1,5 @@
+# Local bundled SearXNG is only used by Odysseus, not exposed as a public
+# instance. Keep bot link-token checks off while still providing the file
+# SearXNG looks for at startup.
+[botdetection.ip_limit]
+link_token = false

--- a/config/searxng/settings.yml
+++ b/config/searxng/settings.yml
@@ -1,4 +1,11 @@
-use_default_settings: true
+use_default_settings:
+  engines:
+    remove:
+      # These default engines either need Tor or initialize non-web caches.
+      # Odysseus only needs normal web/json search from the bundled instance.
+      - ahmia
+      - torch
+      - radio browser
 
 server:
   secret_key: "__SEARXNG_SECRET__"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,6 +103,7 @@ services:
     volumes:
       - searxng-data:/etc/searxng
       - ./config/searxng/settings.yml:/tmp/searxng-settings.yml.template:ro,z
+      - ./config/searxng/limiter.toml:/etc/searxng/limiter.toml:ro,z
     environment:
       - SEARXNG_BASE_URL=http://localhost:8080/
       - SEARXNG_SECRET=${SEARXNG_SECRET:-}

--- a/tests/test_searxng_startup_config.py
+++ b/tests/test_searxng_startup_config.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_searxng_removes_non_web_startup_engines():
+    config = yaml.safe_load((ROOT / "config" / "searxng" / "settings.yml").read_text())
+
+    removed = set(config["use_default_settings"]["engines"]["remove"])
+
+    assert {"ahmia", "torch", "radio browser"} <= removed
+
+
+def test_searxng_limiter_config_is_mounted():
+    compose = yaml.safe_load((ROOT / "docker-compose.yml").read_text())
+    volumes = compose["services"]["searxng"]["volumes"]
+
+    assert "./config/searxng/limiter.toml:/etc/searxng/limiter.toml:ro,z" in volumes
+    assert (ROOT / "config" / "searxng" / "limiter.toml").exists()


### PR DESCRIPTION
## Summary

This trims a few default SearXNG engines that are not useful for Odysseus' built-in web search and can be noisy or fragile during container startup. In particular, `radio browser` initializes a separate cache path and was the one showing up in the reported stack trace.

I also added a minimal `limiter.toml` mount so the bundled container no longer warns about the missing limiter config on every boot.

## Linked Issue

Fixes #563.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`, the current default branch.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I ran the app or included the existing app/visual smoke check recorded for this branch.

## How to Test

1. `python -m py_compile tests/test_searxng_startup_config.py`
2. `python -m pytest -q tests/test_searxng_startup_config.py`
3. `git diff --check`
4. `I could not run `docker compose config` locally because this machine does not have the Docker CLI installed.`

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI/render path touched.

### Screenshots / clips

N/A
