### PR TITLE
PR 1: Add intelligent hardware filtering for AMD GPUs and native Windows daemon & installer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "odysseus-ui",
+  "name": "odysseus",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -867,7 +867,7 @@ def setup_cookbook_routes() -> APIRouter:
                 runner_lines.append('  mkdir -p ~/bin')
                 runner_lines.append('  cd ~ && [ -d llama.cpp ] || git clone --depth 1 https://github.com/ggml-org/llama.cpp')
                 # GPU build if CUDA is present; fall back to a plain (CPU) build.
-                runner_lines.append('  cd ~/llama.cpp && { cmake -B build -DGGML_CUDA=ON 2>/dev/null || cmake -B build; } \\')
+                runner_lines.append('  cd ~/llama.cpp && { [ -f /opt/rocm/bin/hipcc ] && HIP_PATH=/opt/rocm ROCM_PATH=/opt/rocm LD_LIBRARY_PATH=/opt/rocm/lib LDFLAGS="-L/opt/rocm/lib" cmake -B build -DGGML_HIP=ON -DAMDGPU_TARGETS=gfx1030 -DCMAKE_C_COMPILER=/opt/rocm/bin/hipcc -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc 2>/dev/null || cmake -B build -DGGML_CUDA=ON 2>/dev/null || cmake -B build; } \\')
                 runner_lines.append('    && cmake --build build -j"$(nproc)" --target llama-server \\')
                 runner_lines.append('    && ln -sf ~/llama.cpp/build/bin/llama-server ~/bin/llama-server')
                 runner_lines.append('  # If the native build failed, fall back to the Python bindings.')

--- a/scripts/windows/odysseus.iss
+++ b/scripts/windows/odysseus.iss
@@ -1,0 +1,52 @@
+; Inno Setup Script for Odysseus AI Workspace
+; This script packages a portable Python environment, the Odysseus daemon, and the codebase.
+
+[Setup]
+AppName=Odysseus AI Workspace
+AppVersion=1.0
+DefaultDirName={commonpf}\Odysseus
+DefaultGroupName=Odysseus AI Workspace
+DisableProgramGroupPage=yes
+UninstallDisplayIcon={app}\python\python.exe
+Compression=lzma2
+SolidCompression=yes
+OutputDir=Output
+OutputBaseFilename=OdysseusSetup
+ArchitecturesInstallIn64BitMode=x64
+PrivilegesRequired=admin
+SetupLogging=yes
+
+[Files]
+; Portable Python environment. Assumes portable Python is in the 'python' directory at the root of the source directory.
+; Sourced from two directories up (project root) relative to the location of this .iss script.
+Source: "..\..\python\*"; DestDir: "{app}\python"; Flags: recursesubdirs createallsubdirs ignoreversion; Check: DirExists(ExpandConstant('{src}\python')) or DirExists(ExpandConstant('{src}\..\..\python'))
+
+; Odysseus repository/codebase files, excluding developer/junk directories.
+Source: "..\..\*"; DestDir: "{app}"; Flags: recursesubdirs createallsubdirs ignoreversion; Excludes: ".git\*,.pytest_cache\*,venv\*,node_modules\*,__pycache__\*,*.pid,*.db,*.log,local_config.json,scripts\windows\Output\*"
+
+[INI]
+; Create standard Windows Web URL shortcut to open the Odysseus console
+Filename: "{app}\odysseus.url"; Section: "InternetShortcut"; Key: "URL"; String: "http://localhost:8000"
+
+[Icons]
+; Startup and control shortcuts
+Name: "{group}\Start Odysseus"; Filename: "{app}\python\pythonw.exe"; Parameters: """{app}\scripts\windows\odysseus_daemon.py"" start"; WorkingDir: "{app}"
+Name: "{group}\Stop Odysseus"; Filename: "{app}\python\pythonw.exe"; Parameters: """{app}\scripts\windows\odysseus_daemon.py"" stop"; WorkingDir: "{app}"
+Name: "{group}\Odysseus Web Console"; Filename: "{app}\odysseus.url"
+Name: "{group}\Uninstall Odysseus"; Filename: "{uninstallexe}"
+Name: "{commondesktop}\Odysseus Web Console"; Filename: "{app}\odysseus.url"; Tasks: desktopicon
+
+[Tasks]
+Name: "desktopicon"; Description: "Create a &desktop shortcut"; GroupDescription: "Additional shortcuts:"; Flags: unchecked
+
+[Run]
+; Install Python packages into the portable environment.
+Filename: "{app}\python\python.exe"; Parameters: "-m pip install --upgrade pip"; StatusMsg: "Upgrading pip..."; Flags: runhidden; Check: FileExists(ExpandConstant('{app}\python\python.exe'))
+Filename: "{app}\python\python.exe"; Parameters: "-m pip install -r requirements.txt"; StatusMsg: "Installing dependencies (this may take a few minutes)..."; Flags: runhidden; Check: FileExists(ExpandConstant('{app}\python\python.exe'))
+
+; Automatically start the background daemon at the end of installation
+Filename: "{app}\python\pythonw.exe"; Parameters: """{app}\scripts\windows\odysseus_daemon.py"" start"; StatusMsg: "Starting Odysseus background service..."; Flags: runhidden; Check: FileExists(ExpandConstant('{app}\python\pythonw.exe'))
+
+[UninstallRun]
+; Stop the background daemon when uninstalling
+Filename: "{app}\python\pythonw.exe"; Parameters: """{app}\scripts\windows\odysseus_daemon.py"" stop"; Flags: runhidden; Check: FileExists(ExpandConstant('{app}\python\pythonw.exe'))

--- a/scripts/windows/odysseus_daemon.py
+++ b/scripts/windows/odysseus_daemon.py
@@ -1,0 +1,148 @@
+import os
+import sys
+import subprocess
+import time
+
+# Set root directory relative to this script
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+sys.path.insert(0, ROOT_DIR)
+os.chdir(ROOT_DIR)
+
+PID_FILE = os.path.join(ROOT_DIR, "odysseus.pid")
+
+def is_pid_running(pid):
+    """Check if a process with the given PID is running on Windows."""
+    try:
+        # Use tasklist to see if PID exists
+        out = subprocess.run(
+            ["tasklist", "/FI", f"PID eq {pid}", "/NH"],
+            capture_output=True,
+            text=True,
+            shell=True
+        )
+        return str(pid) in out.stdout
+    except Exception:
+        return False
+
+def start():
+    """Start the Odysseus server in a detached background process."""
+    if os.path.exists(PID_FILE):
+        try:
+            with open(PID_FILE, "r") as f:
+                pid = int(f.read().strip())
+            if is_pid_running(pid):
+                print(f"Odysseus is already running (PID: {pid}).")
+                return
+        except Exception:
+            pass
+
+    # Resolve pythonw.exe path
+    python_exe = sys.executable
+    if python_exe.lower().endswith("python.exe"):
+        pythonw_exe = python_exe[:-10] + "pythonw.exe"
+    elif python_exe.lower().endswith("pythonw.exe"):
+        pythonw_exe = python_exe
+    else:
+        # Fallback to PATH resolution
+        pythonw_exe = "pythonw"
+
+    daemon_script = os.path.abspath(__file__)
+    
+    print("Starting Odysseus daemon in background...")
+    
+    # 0x00000008 is DETACHED_PROCESS creation flag for Windows
+    try:
+        proc = subprocess.Popen(
+            [pythonw_exe, daemon_script, "run"],
+            creationflags=0x00000008,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            stdin=subprocess.DEVNULL,
+            cwd=ROOT_DIR
+        )
+        
+        # Save PID to file
+        with open(PID_FILE, "w") as f:
+            f.write(str(proc.pid))
+        
+        print(f"Odysseus daemon started (PID: {proc.pid}).")
+    except Exception as e:
+        print(f"Failed to start Odysseus daemon: {e}")
+
+def stop():
+    """Stop the running background process tree."""
+    if not os.path.exists(PID_FILE):
+        print("Odysseus is not running (no PID file found).")
+        return
+
+    try:
+        with open(PID_FILE, "r") as f:
+            pid = int(f.read().strip())
+    except Exception as e:
+        print(f"Error reading PID file: {e}")
+        return
+
+    if not is_pid_running(pid):
+        print(f"Odysseus PID {pid} is not running. Cleaning up stale PID file.")
+        try:
+            os.remove(PID_FILE)
+        except Exception:
+            pass
+        return
+
+    print(f"Stopping Odysseus (PID: {pid}) and its sub-processes...")
+    try:
+        # /F forces termination, /T kills process tree (important for MCP servers/subprocesses)
+        subprocess.run(["taskkill", "/F", "/T", "/PID", str(pid)], shell=True)
+        print("Odysseus stopped successfully.")
+    except Exception as e:
+        print(f"Error stopping process: {e}")
+
+    try:
+        os.remove(PID_FILE)
+    except Exception:
+        pass
+
+def status():
+    """Report the current status of the daemon."""
+    if os.path.exists(PID_FILE):
+        try:
+            with open(PID_FILE, "r") as f:
+                pid = int(f.read().strip())
+            if is_pid_running(pid):
+                print(f"Odysseus is running in background (PID: {pid}).")
+                return
+        except Exception:
+            pass
+    print("Odysseus is stopped.")
+
+def run_server():
+    """Run the uvicorn server in-process."""
+    import uvicorn
+    from dotenv import load_dotenv
+    
+    load_dotenv()
+    
+    host = os.getenv("ODYSSEUS_HOST", "0.0.0.0")
+    port = int(os.getenv("ODYSSEUS_PORT", "8000"))
+    
+    # Run uvicorn app:app server
+    uvicorn.run("app:app", host=host, port=port, log_level="info")
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python odysseus_daemon.py [start|stop|status|run]")
+        sys.exit(1)
+
+    cmd = sys.argv[1].lower()
+    if cmd == "start":
+        start()
+    elif cmd == "stop":
+        stop()
+    elif cmd == "status":
+        status()
+    elif cmd == "run":
+        run_server()
+    else:
+        print(f"Unknown command: {cmd}")
+        sys.exit(1)

--- a/services/hwfit/fit.py
+++ b/services/hwfit/fit.py
@@ -4,6 +4,7 @@ from services.hwfit.models import (
     params_b, estimate_memory_gb, infer_use_case,
     get_models, is_prequantized, _active_params_b, QUANT_BYTES_PER_PARAM,
     QUANT_SPEED_MULT, QUANT_QUALITY_PENALTY,
+    get_model_format, is_format_compatible,
 )
 
 GPU_BANDWIDTH = {
@@ -416,12 +417,18 @@ def rank_models(system, use_case=None, limit=50, search=None, sort="score", quan
     # unrunnable suggestions.
     system_backend = (system.get("backend") or "").lower()
     apple_silicon = system_backend in ("mps", "metal", "apple")
+    system_arch = (system.get("gpu_arch") or "").lower()
 
     for m in models:
         native_q = m.get("quantization", "")
 
         # Drop MLX models on non-Apple hardware
         if not apple_silicon and native_q.startswith("mlx-"):
+            continue
+
+        # Filter by platform compatibility matrix (e.g. drop AWQ/GPTQ/FP8 on AMD/gfx1030)
+        fmt = get_model_format(m)
+        if not is_format_compatible(system_backend, system_arch, fmt):
             continue
 
         # Format filter: AWQ tab → only AWQ models, FP8 tab → only FP8 models

--- a/services/hwfit/hardware.py
+++ b/services/hwfit/hardware.py
@@ -186,6 +186,23 @@ def _detect_amd():
             return None
         total_vram = sum(c["vram_gb"] for c in cards)
         groups = _group_gpus(cards)
+        
+        # Detect AMD GPU Architecture (e.g., gfx1030) using rocminfo
+        gfx_version = None
+        rocminfo_out = _run(["rocminfo"])
+        if not rocminfo_out and _remote_host:
+            # Fallback path for remote login shells
+            rocminfo_out = _run("bash -lc 'export PATH=\"$PATH:/opt/rocm/bin\"; rocminfo'")
+        if not rocminfo_out:
+            # Try absolute path
+            rocminfo_out = _run(["/opt/rocm/bin/rocminfo"])
+        
+        if rocminfo_out:
+            import re
+            m = re.search(r"Name:\s+(gfx\d+)", rocminfo_out)
+            if m:
+                gfx_version = m.group(1)
+
         # NOTE: for APUs with BIOS UMA carveout (e.g. Strix Halo), vis_vram_total
         # is the real usable GPU memory — it's physically backed but reserved
         # by BIOS so it doesn't appear in /proc/meminfo. Don't cap it at system
@@ -198,6 +215,7 @@ def _detect_amd():
             "gpu_groups": groups,
             "homogeneous": len(groups) <= 1,
             "backend": "rocm",
+            "gpu_arch": gfx_version,
             "unified_memory": is_apu,
         }
     except Exception:
@@ -427,6 +445,7 @@ def detect_system(host="", ssh_port="", platform="", fresh=False):
             "gpu_groups": gpu_info.get("gpu_groups", []),
             "homogeneous": gpu_info.get("homogeneous", True),
             "backend": gpu_info["backend"],
+            "gpu_arch": gpu_info.get("gpu_arch"),
         }
     else:
         if _remote_host:

--- a/services/hwfit/models.py
+++ b/services/hwfit/models.py
@@ -4,6 +4,61 @@ import re
 
 QUANT_HIERARCHY = ["Q8_0", "Q6_K", "Q5_K_M", "Q4_K_M", "Q3_K_M", "Q2_K"]
 
+COMPATIBILITY_MATRIX = {
+    # Backend / Architecture -> list of supported formats/quantizations.
+    # Note: GGUF represents GGUF format, AWQ, GPTQ, FP8, mlx are prequantized formats.
+    "cuda": ["GGUF", "AWQ", "GPTQ", "FP8"],
+    # Consumer AMD cards (like Navi 21, gfx1030) are not officially supported by vLLM for AWQ/GPTQ,
+    # but run GGUF models perfectly via llama.cpp and Ollama.
+    "rocm:gfx1030": ["GGUF"],
+    "rocm": ["GGUF"],  # Default ROCm fallback
+    "mps": ["GGUF", "MLX"],
+    "metal": ["GGUF", "MLX"],
+    "apple": ["GGUF", "MLX"],
+    "cpu_x86": ["GGUF"],
+    "cpu_arm": ["GGUF"],
+}
+
+def get_model_format(model):
+    """Determine the quantization format of a model."""
+    if model.get("gguf_sources"):
+        return "GGUF"
+    q = (model.get("quantization") or "").upper()
+    if q.startswith("AWQ"):
+        return "AWQ"
+    if q.startswith("GPTQ"):
+        return "GPTQ"
+    if q.startswith("MLX"):
+        return "mlx"
+    if q == "FP8":
+        return "FP8"
+    if not is_prequantized(model):
+        return "GGUF"
+    return "UNKNOWN"
+
+def is_format_compatible(backend, arch, quant_format):
+    """Check if a given format (e.g., 'GGUF', 'AWQ', 'GPTQ', 'FP8', 'mlx')
+    is compatible with the host backend and architecture.
+    """
+    backend = (backend or "cpu_x86").lower()
+    arch = (arch or "").lower()
+    
+    # MLX is strictly for Apple Silicon
+    if quant_format.lower() == "mlx" and backend not in ("mps", "metal", "apple"):
+        return False
+        
+    # Resolve lookup key
+    key = f"{backend}:{arch}"
+    if key in COMPATIBILITY_MATRIX:
+        allowed = COMPATIBILITY_MATRIX[key]
+    elif backend in COMPATIBILITY_MATRIX:
+        allowed = COMPATIBILITY_MATRIX[backend]
+    else:
+        allowed = COMPATIBILITY_MATRIX.get("cpu_x86", ["GGUF"])
+        
+    return quant_format.upper() in allowed
+
+
 QUANT_BPP = {
     "F32": 4.0, "F16": 2.0, "BF16": 2.0, "FP8": 1.0,
     "Q8_0": 1.05, "Q6_K": 0.80, "Q5_K_M": 0.68,

--- a/static/js/cookbook-hwfit.js
+++ b/static/js/cookbook-hwfit.js
@@ -488,6 +488,21 @@ export async function _hwfitFetch(fresh = false) {
     }
     _hwfitCache = data;
     _hwfitRenderHw(hw, data.system);
+
+    // Disable and hide CUDA-only options (AWQ, FP8) in quant dropdown for AMD/gfx1030 GPUs
+    const quantSel = document.getElementById('hwfit-quant');
+    if (quantSel && data.system) {
+      const isAMD = (data.system.backend === 'rocm') || (data.system.gpu_arch === 'gfx1030');
+      Array.from(quantSel.options).forEach(opt => {
+        if (opt.value === 'AWQ-4bit' || opt.value === 'FP8') {
+          opt.disabled = isAMD;
+          opt.style.display = isAMD ? 'none' : '';
+        }
+      });
+      if (isAMD && (quantSel.value === 'AWQ-4bit' || quantSel.value === 'FP8')) {
+        quantSel.value = 'Q4_K_M';
+      }
+    }
     // Sort client-side by the active column so the highest↔lowest toggle is
     // deterministic (the previous array .reverse() didn't reliably flip).
     // 1st click on a column = highest first; clicking it again = lowest first.

--- a/tests/test_hwfit_compatibility.py
+++ b/tests/test_hwfit_compatibility.py
@@ -1,0 +1,65 @@
+import pytest
+from services.hwfit.models import get_model_format, is_format_compatible
+from services.hwfit.fit import rank_models
+
+def test_get_model_format():
+    model_gguf = {"name": "Llama-3", "gguf_sources": [{"repo": "unsloth/Llama-3-GGUF"}]}
+    model_awq = {"name": "Qwen-AWQ", "quantization": "AWQ-4bit"}
+    model_gptq = {"name": "Llama-GPTQ", "quantization": "GPTQ-Int4"}
+    model_fp8 = {"name": "DeepSeek-FP8", "quantization": "FP8"}
+    model_mlx = {"name": "Phi-MLX", "quantization": "mlx-4bit"}
+    
+    assert get_model_format(model_gguf) == "GGUF"
+    assert get_model_format(model_awq) == "AWQ"
+    assert get_model_format(model_gptq) == "GPTQ"
+    assert get_model_format(model_fp8) == "FP8"
+    assert get_model_format(model_mlx) == "mlx"
+
+def test_is_format_compatible():
+    # CUDA supports everything
+    assert is_format_compatible("cuda", "", "GGUF") is True
+    assert is_format_compatible("cuda", "", "AWQ") is True
+    assert is_format_compatible("cuda", "", "FP8") is True
+    
+    # AMD gfx1030 rocm only supports GGUF
+    assert is_format_compatible("rocm", "gfx1030", "GGUF") is True
+    assert is_format_compatible("rocm", "gfx1030", "AWQ") is False
+    assert is_format_compatible("rocm", "gfx1030", "FP8") is False
+    
+    # Standard rocm only supports GGUF by default
+    assert is_format_compatible("rocm", "", "GGUF") is True
+    assert is_format_compatible("rocm", "", "AWQ") is False
+    
+    # MLX only works on Apple Silicon
+    assert is_format_compatible("mps", "", "mlx") is True
+    assert is_format_compatible("cuda", "", "mlx") is False
+
+def test_rank_models_filtering():
+    # Mock system info for rocm gfx1030
+    system_rocm = {
+        "backend": "rocm",
+        "gpu_arch": "gfx1030",
+        "gpu_vram_gb": 16.0,
+        "gpu_count": 1,
+        "available_ram_gb": 32.0,
+        "has_gpu": True
+    }
+    
+    results_rocm = rank_models(system_rocm)
+    # Ensure no AWQ/GPTQ/FP8 formats are present
+    for r in results_rocm:
+        assert r.get("quant") not in ("AWQ-4bit", "AWQ-8bit", "GPTQ-Int4", "GPTQ-Int8", "FP8")
+        
+    # Mock system info for cuda
+    system_cuda = {
+        "backend": "cuda",
+        "gpu_vram_gb": 80.0,
+        "gpu_count": 1,
+        "available_ram_gb": 128.0,
+        "has_gpu": True
+    }
+    
+    results_cuda = rank_models(system_cuda)
+    # Ensure AWQ or FP8 exists in the top scored models
+    cuda_quants = [r.get("quant") for r in results_cuda]
+    assert any(q in ("AWQ-4bit", "AWQ-8bit", "GPTQ-Int4", "GPTQ-Int8", "FP8") for q in cuda_quants)

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -17,6 +17,11 @@ if "core.database" not in sys.modules:
         setattr(_core_db, _name, MagicMock())
     sys.modules["core.database"] = _core_db
 
+# Clean up polluted sys.modules if other tests stubbed them with MagicMock
+for _mod in ["src.endpoint_resolver", "src.llm_core", "routes.model_routes"]:
+    if _mod in sys.modules and isinstance(sys.modules[_mod], MagicMock):
+        del sys.modules[_mod]
+
 import routes.model_routes as model_routes
 import src.endpoint_resolver as endpoint_resolver
 from routes.model_routes import (

--- a/tests/test_review_regressions.py
+++ b/tests/test_review_regressions.py
@@ -68,6 +68,7 @@ def _install_model_route_import_stubs(monkeypatch):
     db_mod = types.ModuleType("core.database")
     db_mod.SessionLocal = lambda: _FakeDb([])
     db_mod.ModelEndpoint = _FakeModelEndpoint
+    db_mod.Session = object
     middleware_mod = types.ModuleType("core.middleware")
     middleware_mod.require_admin = lambda request: None
     multipart_mod = types.ModuleType("python_multipart")


### PR DESCRIPTION
### Goal
Adds intelligent hardware/format filtering for AMD GPUs in the Cookbook UI and introduces a native Windows background service daemon + Inno Setup installer script.

### Changes
1. **AMD GPU Filtering**: Detects specific GPU architectures (`gfx1030` via `rocminfo`) in `hardware.py` and pins them strictly to `GGUF` model formats in a new `COMPATIBILITY_MATRIX` (`models.py`/`fit.py`).
2. **Cookbook UI Dropdown**: Dynamically disables and hides unrunnable `AWQ-4bit` and `FP8` quantization options in the quant selection dropdown when an AMD GPU is detected (`cookbook-hwfit.js`).
3. **Windows Background Daemon**: Implements `scripts/windows/odysseus_daemon.py` which runs uvicorn in a windowless background process via `pythonw.exe` and handles process tree termination cleanly via `taskkill`.
4. **Windows Installer Setup**: Provides `scripts/windows/odysseus.iss` Inno Setup script that packages portable Python, adds Start/Stop/Web Console shortcuts, and installs python dependencies post-installation.
5. **Test Coverage & Bug Fixes**: Added verification tests in `tests/test_hwfit_compatibility.py` and resolved import pollution bugs in existing tests.

### Testing
- Tested dynamic GPU format exclusions with mocked system configs.
- Verified that the full test suite runs and passes cleanly (`265 passed`).