### PR TITLE
refactor(css): make desktop/mobile paired rules discoverable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,22 @@ docker compose logs --tail=120 odysseus
 
 Mention what you ran in the pull request description. If you could not run a check, say so.
 
+### CSS: desktop/mobile paired rules
+
+`static/style.css` is one large consolidated stylesheet, and many "the CSS did
+not move" bugs are a selector that is styled at the base layer and then quietly
+re-styled inside a responsive `@media` block. Before changing a rule, check
+whether it has a responsive override:
+
+```bash
+npm run css:overrides          # report every selector overridden under @media
+npm run css:overrides:check    # CI check: fail if a breakpoint is spelled inconsistently
+```
+
+Reuse the canonical breakpoint spellings (`@media (max-width: 768px)`, etc.,
+listed at the top of `style.css`) so overrides group into one block instead of
+splitting a single breakpoint into two near-identical ones.
+
 ## Pull Requests
 
 Good pull requests usually include:

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
     "type": "git",
     "url": "https://github.com/pewdiepie-archdaemon/odysseus.git"
   },
+  "scripts": {
+    "css:overrides": "node scripts/check-css-overrides.mjs",
+    "css:overrides:check": "node scripts/check-css-overrides.mjs --check"
+  },
   "devDependencies": {
     "@antithesishq/bombadil": "^0.3.2"
   },

--- a/scripts/check-css-overrides.mjs
+++ b/scripts/check-css-overrides.mjs
@@ -1,0 +1,360 @@
+#!/usr/bin/env node
+/*
+ * check-css-overrides.mjs — make desktop/mobile paired CSS rules discoverable.
+ *
+ * `static/style.css` is one big consolidated stylesheet, and a lot of "the CSS
+ * did not move" bugs come from a selector that is styled at the top level and
+ * then quietly re-styled again inside a responsive `@media` block. When you
+ * tweak the desktop rule and nothing changes on a phone, it's almost always a
+ * mobile override you forgot existed.
+ *
+ * This tool parses the stylesheet (comments and strings stripped, braces
+ * balanced — no regex-guessing) and reports, for every selector, where it is
+ * defined at the base layer and which `@media` breakpoints override it. It also
+ * flags breakpoints written inconsistently (e.g. `max-width: 768px` vs
+ * `max-width:768px`), which silently split one logical breakpoint into two.
+ *
+ * Usage:
+ *   node scripts/check-css-overrides.mjs            # human-readable report
+ *   node scripts/check-css-overrides.mjs --json     # machine-readable JSON
+ *   node scripts/check-css-overrides.mjs --check     # exit 1 on breakpoint drift (CI)
+ *   node scripts/check-css-overrides.mjs path/to.css # analyze a specific file
+ *
+ * Exports `analyzeCss(cssText)` for tests; no third-party dependencies.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+/**
+ * Replace comment bodies and string literals with spaces, preserving overall
+ * length and every newline so reported line numbers stay accurate. Strings and
+ * comments are the two places a stray `{`, `}`, `;` or `,` can appear without
+ * being structural, so neutralizing them lets the parser stay brace-simple.
+ */
+function blankCommentsAndStrings(src) {
+  let out = '';
+  let i = 0;
+  const n = src.length;
+  while (i < n) {
+    const c = src[i];
+    const c2 = src[i + 1];
+    if (c === '/' && c2 === '*') {
+      out += '  ';
+      i += 2;
+      while (i < n && !(src[i] === '*' && src[i + 1] === '/')) {
+        out += src[i] === '\n' ? '\n' : ' ';
+        i += 1;
+      }
+      if (i < n) {
+        out += '  ';
+        i += 2;
+      }
+      continue;
+    }
+    if (c === '"' || c === "'") {
+      const quote = c;
+      out += ' ';
+      i += 1;
+      while (i < n && src[i] !== quote) {
+        if (src[i] === '\\') {
+          out += ' ';
+          out += src[i + 1] === '\n' ? '\n' : ' ';
+          i += 2;
+          continue;
+        }
+        out += src[i] === '\n' ? '\n' : ' ';
+        i += 1;
+      }
+      if (i < n) {
+        out += ' ';
+        i += 1;
+      }
+      continue;
+    }
+    out += c;
+    i += 1;
+  }
+  return out;
+}
+
+/** Split a selector list on top-level commas (ignoring commas inside () or []). */
+function splitSelectors(prelude) {
+  const out = [];
+  let depth = 0;
+  let cur = '';
+  for (const ch of prelude) {
+    if (ch === '(' || ch === '[') depth += 1;
+    else if (ch === ')' || ch === ']') depth = Math.max(0, depth - 1);
+    if (ch === ',' && depth === 0) {
+      out.push(cur);
+      cur = '';
+    } else {
+      cur += ch;
+    }
+  }
+  out.push(cur);
+  return out
+    .map((s) => s.trim().replace(/\s+/g, ' '))
+    .filter(Boolean);
+}
+
+const NORMALIZE = (q) => q.replace(/\s+/g, '').toLowerCase();
+// At-rules whose inner blocks are NOT selectors (keyframe stops, font
+// descriptors, etc.) — never record their contents as overridable selectors.
+const SUPPRESS_ATRULES = new Set([
+  'keyframes',
+  'font-face',
+  'page',
+  'property',
+  'counter-style',
+  'font-feature-values',
+  'viewport',
+]);
+
+/**
+ * Parse a stylesheet into selector → {base lines, per-breakpoint override lines}
+ * plus the raw list of `@media` blocks encountered.
+ */
+function parse(css) {
+  const clean = blankCommentsAndStrings(css);
+  const stack = []; // frames: {type:'media'|'group'|'suppress'|'decl', normKey?, rawQuery?}
+  const mediaBlocks = [];
+  const selectors = new Map(); // selector -> {base:[lines], media:Map<normKey,{rawForms:Map,lines:[]}>}
+
+  let buf = '';
+  let bufHasContent = false;
+  let bufLine = 1;
+  let line = 1;
+
+  const nearestMedia = () => {
+    for (let k = stack.length - 1; k >= 0; k -= 1) {
+      if (stack[k].type === 'media') return stack[k];
+    }
+    return null;
+  };
+  const record = (sel, mediaFrame, atLine) => {
+    let entry = selectors.get(sel);
+    if (!entry) {
+      entry = { base: [], media: new Map() };
+      selectors.set(sel, entry);
+    }
+    if (!mediaFrame) {
+      entry.base.push(atLine);
+      return;
+    }
+    let bucket = entry.media.get(mediaFrame.normKey);
+    if (!bucket) {
+      bucket = { rawForms: new Map(), lines: [] };
+      entry.media.set(mediaFrame.normKey, bucket);
+    }
+    bucket.rawForms.set(mediaFrame.rawQuery, (bucket.rawForms.get(mediaFrame.rawQuery) || 0) + 1);
+    bucket.lines.push(atLine);
+  };
+
+  for (let i = 0; i < clean.length; i += 1) {
+    const ch = clean[i];
+    if (ch === '\n') {
+      line += 1;
+      buf += ch;
+      continue;
+    }
+    if (ch === '{') {
+      const prelude = buf.trim();
+      buf = '';
+      bufHasContent = false;
+      if (prelude.startsWith('@')) {
+        const m = /^@(?:-[a-z]+-)?([a-z-]+)/i.exec(prelude);
+        const name = m ? m[1].toLowerCase() : '';
+        if (name === 'media') {
+          const rawQuery = prelude.slice(prelude.indexOf('media') + 'media'.length).trim().replace(/\s+/g, ' ');
+          const frame = { type: 'media', normKey: NORMALIZE(rawQuery), rawQuery };
+          mediaBlocks.push({ ...frame, line: bufLine });
+          stack.push(frame);
+        } else if (SUPPRESS_ATRULES.has(name)) {
+          stack.push({ type: 'suppress' });
+        } else {
+          stack.push({ type: 'group' }); // @supports / @layer / @container — transparent to media
+        }
+      } else if (prelude) {
+        if (!stack.some((f) => f.type === 'suppress')) {
+          const mediaFrame = nearestMedia();
+          for (const sel of splitSelectors(prelude)) record(sel, mediaFrame, bufLine);
+        }
+        stack.push({ type: 'decl' });
+      } else {
+        stack.push({ type: 'group' });
+      }
+      continue;
+    }
+    if (ch === '}') {
+      stack.pop();
+      buf = '';
+      bufHasContent = false;
+      continue;
+    }
+    if (ch === ';') {
+      const top = stack[stack.length - 1];
+      if (!top || top.type !== 'decl') {
+        buf = '';
+        bufHasContent = false;
+      }
+      continue;
+    }
+    if (ch !== ' ' && ch !== '\t' && ch !== '\r' && !bufHasContent) {
+      bufHasContent = true;
+      bufLine = line;
+    }
+    buf += ch;
+  }
+
+  return { mediaBlocks, selectors };
+}
+
+/** Build the JSON-serializable analysis used by both the CLI and the tests. */
+export function analyzeCss(css) {
+  const { mediaBlocks, selectors } = parse(css);
+
+  // Breakpoint catalog + inconsistent-spelling detection.
+  const byNorm = new Map(); // normKey -> {forms:Map<rawQuery,count>, count}
+  for (const b of mediaBlocks) {
+    let e = byNorm.get(b.normKey);
+    if (!e) {
+      e = { forms: new Map(), count: 0 };
+      byNorm.set(b.normKey, e);
+    }
+    e.count += 1;
+    e.forms.set(b.rawQuery, (e.forms.get(b.rawQuery) || 0) + 1);
+  }
+  const canonical = (forms) =>
+    [...forms.entries()].sort((a, b) => b[1] - a[1])[0][0];
+
+  const breakpoints = [...byNorm.entries()]
+    .map(([, e]) => ({ query: canonical(e.forms), count: e.count }))
+    .sort((a, b) => b.count - a.count);
+
+  const inconsistentBreakpoints = [...byNorm.entries()]
+    .filter(([, e]) => e.forms.size > 1)
+    .map(([normalized, e]) => ({
+      normalized,
+      forms: [...e.forms.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .map(([form, count]) => ({ form, count })),
+    }));
+
+  const paired = [];
+  const mobileOnly = [];
+  for (const [selector, entry] of selectors) {
+    if (entry.media.size === 0) continue; // base-only — nothing responsive to track
+    const overrides = [...entry.media.entries()]
+      .map(([, bucket]) => ({
+        query: canonical(bucket.rawForms),
+        lines: bucket.lines.slice().sort((a, b) => a - b),
+      }))
+      .sort((a, b) => a.lines[0] - b.lines[0]);
+    if (entry.base.length > 0) {
+      paired.push({ selector, baseLines: entry.base.slice().sort((a, b) => a - b), overrides });
+    } else {
+      mobileOnly.push({ selector, overrides });
+    }
+  }
+  // Messiest first: most override breakpoints, then most override sites.
+  const weight = (o) => o.overrides.length * 1000 + o.overrides.reduce((n, x) => n + x.lines.length, 0);
+  paired.sort((a, b) => weight(b) - weight(a) || a.selector.localeCompare(b.selector));
+  mobileOnly.sort((a, b) => a.selector.localeCompare(b.selector));
+
+  const baseSelectors = [...selectors.values()].filter((e) => e.base.length > 0).length;
+
+  return {
+    stats: {
+      mediaBlocks: mediaBlocks.length,
+      breakpoints: breakpoints.length,
+      baseSelectors,
+      overriddenSelectors: paired.length,
+      mobileOnlySelectors: mobileOnly.length,
+      inconsistentBreakpoints: inconsistentBreakpoints.length,
+    },
+    breakpoints,
+    inconsistentBreakpoints,
+    paired,
+    mobileOnly,
+  };
+}
+
+function formatReport(a, file) {
+  const L = [];
+  L.push(`CSS responsive-override report — ${file}`);
+  L.push('='.repeat(60));
+  L.push(
+    `${a.stats.mediaBlocks} @media blocks · ${a.stats.breakpoints} distinct breakpoints · ` +
+      `${a.stats.baseSelectors} base selectors`
+  );
+  L.push(
+    `${a.stats.overriddenSelectors} selectors overridden inside @media · ` +
+      `${a.stats.mobileOnlySelectors} defined only inside @media`
+  );
+  L.push('');
+
+  L.push('Breakpoints (by number of blocks):');
+  for (const b of a.breakpoints) L.push(`  ${String(b.count).padStart(4)}  @media ${b.query}`);
+  L.push('');
+
+  if (a.inconsistentBreakpoints.length) {
+    L.push('⚠ Inconsistent breakpoint spellings (one logical breakpoint, multiple forms):');
+    for (const inc of a.inconsistentBreakpoints) {
+      L.push(`  ${inc.normalized}`);
+      for (const f of inc.forms) L.push(`      ${String(f.count).padStart(3)}×  @media ${f.form}`);
+    }
+    L.push('  → Normalize these so the breakpoint groups into one block.');
+    L.push('');
+  }
+
+  L.push('Selectors styled at base AND overridden under @media:');
+  L.push('(edit one of these at base and the override may mask your change)');
+  for (const p of a.paired) {
+    const bps = p.overrides.map((o) => `@media ${o.query} L${o.lines.join(',')}`).join('  ·  ');
+    L.push(`  ${p.selector}`);
+    L.push(`      base L${p.baseLines.join(',')}  →  ${bps}`);
+  }
+  if (!a.paired.length) L.push('  (none)');
+
+  return L.join('\n');
+}
+
+function main(argv) {
+  const args = argv.slice(2);
+  const json = args.includes('--json');
+  const check = args.includes('--check');
+  const fileArg = args.find((x) => !x.startsWith('--'));
+  const file = fileArg
+    ? fileArg
+    : fileURLToPath(new URL('../static/style.css', import.meta.url));
+
+  let css;
+  try {
+    css = readFileSync(file, 'utf8');
+  } catch (err) {
+    process.stderr.write(`Could not read ${file}: ${err.message}\n`);
+    return 2;
+  }
+
+  const analysis = analyzeCss(css);
+
+  if (json) {
+    process.stdout.write(`${JSON.stringify(analysis, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${formatReport(analysis, file)}\n`);
+  }
+
+  if (check && analysis.inconsistentBreakpoints.length) {
+    process.stderr.write(
+      `\nFAIL: ${analysis.inconsistentBreakpoints.length} breakpoint(s) written inconsistently. ` +
+        `Normalize the spellings above.\n`
+    );
+    return 1;
+  }
+  return 0;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  process.exit(main(process.argv));
+}

--- a/static/style.css
+++ b/static/style.css
@@ -2,6 +2,25 @@
 /* Odysseus UI — Consolidated Stylesheet        */
 /* ============================================ */
 
+/* ── Responsive / mobile overrides ──
+ *
+ * Many selectors are styled here at the base layer and then RE-styled inside a
+ * responsive `@media` block further down. If you change a base rule and nothing
+ * moves on mobile, a `@media` override is probably masking it.
+ *
+ * To see every selector that has a responsive override (and at which lines):
+ *     npm run css:overrides
+ *
+ * Canonical breakpoints — reuse these exact spellings so overrides group into
+ * one block (a CI check, `npm run css:overrides:check`, fails on drift):
+ *     @media (max-width: 768px)   phones / narrow (primary mobile breakpoint)
+ *     @media (max-width: 820px)   small tablets
+ *     @media (max-width: 600px)   very narrow
+ *     @media (min-width: 769px)   desktop-only counterpart to 768px
+ *     @media (hover: none)        touch (no hover) tweaks
+ *     @media (prefers-reduced-motion: reduce)
+ */
+
 
 /* ── Variables ──
  *
@@ -1884,7 +1903,7 @@ body.bg-pattern-sparkles {
       max-width: 800px;
       width: 100%;
     }
-    @media (max-width:768px) {
+    @media (max-width: 768px) {
       #welcome-screen .welcome-name { font-size:1.8rem; }
       #welcome-screen .welcome-sub { font-size:0.8rem; }
       .chat-container.welcome-active .chat-input-bar {
@@ -3863,7 +3882,7 @@ body.bg-pattern-sparkles {
       height: 24px;
       padding: 0 8px;
     }
-    @media (max-width:768px){
+    @media (max-width: 768px) {
       .box { max-height:none; }
       .chat-container { padding:10px; flex:1; margin-top:0; padding-top:42px; min-height:0; }
       .scroll-nav-btn { width:44px; height:44px; font-size:14px; margin-bottom:0; }
@@ -4951,7 +4970,7 @@ body.bg-pattern-sparkles {
       display:flex; justify-content:flex-end; gap:8px; padding-top:6px;
       border-top:1px solid var(--border); margin-top:4px;
     }
-    @media (max-width:768px) {
+    @media (max-width: 768px) {
       .styled-confirm-box {
         width: 85vw;
         padding: 12px 16px;
@@ -5026,7 +5045,7 @@ body.bg-pattern-sparkles {
       border-color: var(--accent-primary, var(--red, #4a9eff));
       box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent-primary, var(--red, #4a9eff)) 25%, transparent);
     }
-    @media (max-width:768px) {
+    @media (max-width: 768px) {
       .styled-prompt-box { width: 85vw; }
       .styled-prompt-input { font-size: 0.9rem; padding: 10px 12px; }
     }

--- a/tests/test_css_overrides_js.py
+++ b/tests/test_css_overrides_js.py
@@ -1,0 +1,108 @@
+"""Pin the CSS responsive-override analyzer in scripts/check-css-overrides.mjs.
+
+Driven through `node --input-type=module` so we exercise the real parser without
+a JS test runner (same approach as test_compare_js.py / test_reply_recipients_js.py).
+Skips when `node` is not installed rather than failing.
+
+The analyzer makes desktop/mobile paired rules in static/style.css discoverable:
+which selectors are styled at the base layer and then overridden inside a
+`@media` block, plus breakpoints that are spelled inconsistently.
+"""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_SCRIPT = _REPO / "scripts" / "check-css-overrides.mjs"
+_HAS_NODE = shutil.which("node") is not None
+
+_SAMPLE = """
+/* a stray @media (max-width: 999px) inside a comment must be ignored */
+.btn { color: red; }
+.btn::after { content: "}"; }
+@media (max-width: 768px) {
+  .btn { color: blue; }
+  .mobile-only { display: block; }
+}
+@media (max-width:768px) {
+  .btn { color: green; }
+}
+@keyframes spin { from { opacity: 0; } to { opacity: 1; } }
+@media print {
+  .btn { color: black; }
+}
+"""
+
+
+def _analyze(css: str) -> dict:
+    # `as_uri()` -> file:// URL so the ESM import resolves on Windows too
+    # (a bare C:/... path raises ERR_UNSUPPORTED_ESM_URL_SCHEME).
+    js = f"""
+    import {{ analyzeCss }} from '{_SCRIPT.as_uri()}';
+    console.log(JSON.stringify(analyzeCss({json.dumps(css)})));
+    """
+    proc = subprocess.run(
+        ["node", "--input-type=module"],
+        input=js, capture_output=True, text=True, encoding="utf-8",
+        cwd=str(_REPO), timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout.strip())
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_detects_base_plus_media_override():
+    a = _analyze(_SAMPLE)
+    paired = {p["selector"]: p for p in a["paired"]}
+    assert ".btn" in paired, "selector styled at base AND under @media should be paired"
+    queries = {o["query"] for o in paired[".btn"]["overrides"]}
+    assert "(max-width: 768px)" in queries
+    assert "print" in queries
+    assert paired[".btn"]["baseLines"], "paired selector should record its base line(s)"
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_mobile_only_vs_base_only():
+    a = _analyze(_SAMPLE)
+    mobile_only = {m["selector"] for m in a["mobileOnly"]}
+    paired = {p["selector"] for p in a["paired"]}
+    # Defined only inside @media -> mobile-only, not paired.
+    assert ".mobile-only" in mobile_only
+    assert ".mobile-only" not in paired
+    # Base-only selector (with a "}" in a string value) is neither.
+    assert ".btn::after" not in mobile_only
+    assert ".btn::after" not in paired
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_flags_inconsistent_breakpoint_spelling():
+    a = _analyze(_SAMPLE)
+    assert a["stats"]["inconsistentBreakpoints"] == 1
+    inc = a["inconsistentBreakpoints"][0]
+    assert inc["normalized"] == "(max-width:768px)"
+    forms = {f["form"] for f in inc["forms"]}
+    assert forms == {"(max-width: 768px)", "(max-width:768px)"}
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_ignores_comments_and_keyframe_stops():
+    a = _analyze(_SAMPLE)
+    # The breakpoint hidden in a comment must not be parsed as real.
+    assert all("999px" not in b["query"] for b in a["breakpoints"])
+    # @keyframes stops ("from"/"to") are not selectors.
+    selectors = {p["selector"] for p in a["paired"]} | {m["selector"] for m in a["mobileOnly"]}
+    assert "from" not in selectors and "to" not in selectors
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_repo_stylesheet_has_consistent_breakpoints():
+    """The bundled stylesheet should pass the CI breakpoint-consistency check."""
+    css = (_REPO / "static" / "style.css").read_text(encoding="utf-8")
+    a = _analyze(css)
+    assert a["inconsistentBreakpoints"] == [], (
+        "static/style.css has inconsistently spelled breakpoints; "
+        "run `npm run css:overrides` and normalize them"
+    )


### PR DESCRIPTION
## What & why

`static/style.css` is one ~34k-line consolidated stylesheet with 130+ `@media` blocks. A recurring class of "the CSS did not move" bugs is a selector styled at the base layer and then quietly re-styled inside a responsive `@media` block — so you edit the desktop rule and nothing moves on a phone, because a mobile override is masking it.

This implements the **"Mobile media override discoverability"** item from `ROADMAP.md` (Refactor Targets):

> A lot of "CSS did not move" bugs are mobile `@media` overrides of the same selector; comments or linting around desktop/mobile paired rules would help.

## Changes

- **`scripts/check-css-overrides.mjs`** — zero-dependency Node script (also exports `analyzeCss` for tests). Parses the stylesheet with comments and string literals neutralized and braces balanced (no regex-guessing), then reports:
  - every selector styled at the base layer **and** overridden inside an `@media` block, grouped by breakpoint with line numbers;
  - breakpoints spelled inconsistently (e.g. `max-width: 768px` vs `max-width:768px`) that silently split one logical breakpoint into two.
- **`package.json`** — two scripts:
  - `npm run css:overrides` — human-readable report
  - `npm run css:overrides:check` — CI check, exits non-zero on breakpoint drift
- **`static/style.css`** — normalized the 4 `max-width:768px` blocks to the canonical `max-width: 768px` so the primary mobile breakpoint groups into one block; added a short convention header listing the canonical breakpoints and pointing at the tool. No rule selectors or declarations changed — only whitespace inside 4 media-query prologues plus a comment.
- **`CONTRIBUTING.md`** — a "CSS: desktop/mobile paired rules" subsection under Running Checks.
- **`tests/test_css_overrides_js.py`** — node-driven pytest (same harness as `test_compare_js.py`) pinning paired vs mobile-only detection, comment/keyframe/string handling, and breakpoint-drift detection. Imports the module via a `file://` URL so it also runs on Windows.

## Example output

```
133 @media blocks · 20 distinct breakpoints · 5634 base selectors
415 selectors overridden inside @media · 401 defined only inside @media

Selectors styled at base AND overridden under @media:
  #welcome-screen
      base L1765  →  @media (max-height: 650px) L1786  ·  @media (max-height: 500px) L1792  ·  @media (max-height: 380px) L1798  ·  @media (max-width: 768px) L1807  ·  @media print L7101  ·  @media (prefers-reduced-motion: reduce) L20530
  .modal-content
      base L4584  →  @media (max-width: 768px) L6154,6350  ·  @media (prefers-reduced-motion: reduce) L20530
  ...
```

## Testing

- `python -m pytest tests/test_css_overrides_js.py` → **5 passed**
- `node scripts/check-css-overrides.mjs --check` → exit **0** (after normalizing the 4 breakpoints)
- `node --check scripts/check-css-overrides.mjs` → OK

No runtime/behavior change — this is tooling, docs, and whitespace-only stylesheet edits.
