### PR TITLE
fix(llm): surface upstream streaming errors instead of hanging the UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,10 @@ SEARXNG_INSTANCE=http://localhost:8080
 # Enable authentication (default: true)
 # AUTH_ENABLED=true
 
+# Host port for the Odysseus web UI in Docker Compose.
+# Change this if another local service already uses 7000 (macOS AirPlay often does).
+# APP_PORT=7000
+
 # Development-only auth bypass for loopback requests.
 # Keep false for Docker, LAN, reverse proxy, and any shared deployment.
 # LOCALHOST_BYPASS=false

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ docker compose up -d --build
 ```
 Compose starts Odysseus, ChromaDB, SearXNG, and ntfy. First run does a full
 image build. Open `http://localhost:7000` after the containers are healthy.
+If port `7000` is already taken, set `APP_PORT=7001` (or another free port)
+in `.env`, recreate the container, and open `http://localhost:7001`.
 
 Cookbook remote servers use an Odysseus-owned SSH key from `./data/ssh`
 inside Docker. In **Cookbook -> Settings -> Servers**, generate/copy the

--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ chat model picker automatically. For NVIDIA GPUs in Docker, install the NVIDIA
 Container Toolkit and add `gpus: all` to the `odysseus` service if `nvidia-smi`
 is not visible inside the container.
 
+The default Docker image is intentionally slim. For Python-based serve engines,
+use **Cookbook -> Dependencies** to install vLLM, SGLang, llama-cpp-python, or
+diffusers into the persisted `./data/local` mount. Native CUDA builds inside the
+container also require CUDA toolkit binaries such as `nvcc`; if those are not
+installed in the container, use prebuilt Python wheels or serve from a remote
+GPU host that already has the toolkit.
+
 Useful checks:
 ```bash
 docker compose ps

--- a/README.md
+++ b/README.md
@@ -67,7 +67,15 @@ After generating the key, you can also install it from the host with:
 ssh-copy-id -i data/ssh/id_ed25519.pub user@server
 ```
 Cookbook local downloads are stored in `./data/huggingface`, mounted as
-`~/.cache/huggingface` inside the Odysseus container.
+`~/.cache/huggingface` inside the Odysseus container. Cookbook-installed
+serve engines and Python CLIs are stored in `./data/local`, mounted as
+`~/.local`, so vLLM/llama.cpp installs survive container recreation.
+
+After downloading a model, open **Cookbook -> Serve**, pick the cached model,
+and launch it. When the server answers `/v1/models`, Odysseus adds it to the
+chat model picker automatically. For NVIDIA GPUs in Docker, install the NVIDIA
+Container Toolkit and add `gpus: all` to the `odysseus` service if `nvidia-smi`
+is not visible inside the container.
 
 Useful checks:
 ```bash

--- a/app.py
+++ b/app.py
@@ -926,65 +926,6 @@ async def startup_event():
                 logger.warning(f"Nightly skill audit failed: {e}")
 
     _startup_tasks.append(asyncio.create_task(_skill_audit_nightly_loop()))
-    # Auto-detect Ollama — run in background to avoid blocking startup. In Docker,
-    # localhost is the container, so also try host.docker.internal.
-    async def _detect_ollama():
-        try:
-            import httpx
-            raw_candidates = [
-                os.getenv("OLLAMA_BASE_URL", ""),
-                os.getenv("OLLAMA_URL", ""),
-                "http://localhost:11434/v1",
-                "http://host.docker.internal:11434/v1",
-            ]
-            candidates = []
-            for raw in raw_candidates:
-                base = (raw or "").strip().rstrip("/")
-                if not base:
-                    continue
-                if base.endswith("/api"):
-                    base = base[:-4].rstrip("/")
-                if not base.endswith("/v1"):
-                    base = base + "/v1"
-                if base not in candidates:
-                    candidates.append(base)
-
-            found_base = ""
-            async with httpx.AsyncClient() as client:
-                for base in candidates:
-                    try:
-                        r = await client.get(base + "/models", timeout=2)
-                        if r.status_code == 200:
-                            found_base = base
-                            break
-                    except Exception:
-                        continue
-            if not found_base:
-                return
-            from core.database import SessionLocal, ModelEndpoint
-            db = SessionLocal()
-            try:
-                existing = None
-                for base in candidates:
-                    existing = db.query(ModelEndpoint).filter(ModelEndpoint.base_url == base).first()
-                    if existing:
-                        break
-                if not existing:
-                    host = found_base.replace("http://", "").replace("https://", "").split("/")[0]
-                    ep = ModelEndpoint(
-                        id=str(uuid.uuid4())[:8],
-                        name="Ollama" if host.startswith("localhost") else f"Ollama ({host})",
-                        base_url=found_base,
-                        is_enabled=True,
-                    )
-                    db.add(ep)
-                    db.commit()
-                    logger.info(f"Auto-added Ollama endpoint ({found_base})")
-            finally:
-                db.close()
-        except Exception as e:
-            logger.debug(f"Ollama auto-detect: {e}")
-    _startup_tasks.append(asyncio.create_task(_detect_ollama()))
     logger.info("Application startup complete")
 
 @app.on_event("shutdown")

--- a/core/auth.py
+++ b/core/auth.py
@@ -210,6 +210,36 @@ class AuthManager:
         logger.info(f"Deleted user '{username}' (by {requesting_user}); revoked {revoked} active session(s)")
         return True
 
+    def rename_user(self, old_username: str, new_username: str, requesting_user: str) -> bool:
+        """Rename a user in auth config and active sessions. Admin only."""
+        old_username = old_username.strip().lower()
+        new_username = new_username.strip().lower()
+        requesting_user = (requesting_user or "").strip().lower()
+        if not old_username or not new_username:
+            return False
+        if old_username not in self.users:
+            return False
+        if new_username in self.users:
+            return False
+        if not self.users.get(requesting_user, {}).get("is_admin"):
+            return False
+        self._config.setdefault("users", {})[new_username] = self._config["users"].pop(old_username)
+        self._save()
+
+        renamed_sessions = 0
+        with self._sessions_lock:
+            for sess in self._sessions.values():
+                if (sess or {}).get("username") == old_username:
+                    sess["username"] = new_username
+                    renamed_sessions += 1
+        if renamed_sessions:
+            self._save_sessions()
+        logger.info(
+            "Renamed user '%s' -> '%s' (by %s); updated %d active session(s)",
+            old_username, new_username, requesting_user, renamed_sessions,
+        )
+        return True
+
     def is_admin(self, username: str) -> bool:
         return self.users.get(username, {}).get("is_admin", False)
 

--- a/core/session_manager.py
+++ b/core/session_manager.py
@@ -20,6 +20,15 @@ from .models import Session, ChatMessage
 logger = logging.getLogger(__name__)
 
 
+def _message_timestamp_iso(value: Optional[datetime]) -> Optional[str]:
+    """Return a stable ISO timestamp for chat message metadata."""
+    if not value:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.isoformat().replace("+00:00", "Z")
+
+
 class SessionManager:
     """
     Manages chat sessions with database persistence.
@@ -107,6 +116,7 @@ class SessionManager:
                 meta = json.loads(db_msg.meta_data) if db_msg.meta_data else {}
                 if meta is None: meta = {}
                 meta['_db_id'] = db_msg.id
+                meta.setdefault('timestamp', _message_timestamp_iso(db_msg.timestamp))
                 history.append(ChatMessage(
                     role=db_msg.role,
                     content=db_msg.content,
@@ -121,6 +131,7 @@ class SessionManager:
                 meta = json.loads(db_msg.meta_data) if db_msg.meta_data else {}
                 if meta is None: meta = {}
                 meta['_db_id'] = db_msg.id
+                meta.setdefault('timestamp', _message_timestamp_iso(db_msg.timestamp))
                 history.append(ChatMessage(
                     role=db_msg.role,
                     content=db_msg.content,
@@ -177,12 +188,17 @@ class SessionManager:
         db = SessionLocal()
         try:
             msg_id = str(uuid.uuid4())
+            msg_time = datetime.utcnow()
+            if message.metadata is None:
+                message.metadata = {}
+            message.metadata.setdefault('timestamp', _message_timestamp_iso(msg_time))
             db_message = DbChatMessage(
                 id=msg_id,
                 session_id=session_id,
                 role=message.role,
                 content=message.content,
-                meta_data=json.dumps(message.metadata) if message.metadata else None
+                meta_data=json.dumps(message.metadata) if message.metadata else None,
+                timestamp=msg_time,
             )
             db.add(db_message)
 
@@ -199,8 +215,6 @@ class SessionManager:
             db.commit()
 
             # Store DB ID on the in-memory message for edit/delete by ID
-            if message.metadata is None:
-                message.metadata = {}
             message.metadata['_db_id'] = msg_id
 
             logger.debug(f"Persisted message to session {session_id}")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   odysseus:
     build: .
     ports:
-      - "7000:7000"
+      - "${APP_PORT:-7000}:7000"
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     restart: unless-stopped
 
   chromadb:
-    image: chromadb/chroma:latest
+    image: docker.io/chromadb/chroma:latest
     ports:
       - "${CHROMADB_BIND:-127.0.0.1}:8100:8000"
     volumes:
@@ -54,7 +54,7 @@ services:
     restart: unless-stopped
 
   searxng:
-    image: searxng/searxng:latest
+    image: docker.io/searxng/searxng:latest
     entrypoint:
       - /bin/sh
       - -c
@@ -85,7 +85,7 @@ services:
     restart: unless-stopped
 
   ntfy:
-    image: binwiederhier/ntfy
+    image: docker.io/binwiederhier/ntfy
     command: serve
     ports:
       - "${NTFY_BIND:-127.0.0.1}:8091:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,10 @@ services:
       # Cookbook local model cache. Inside Docker, "Local" means the Odysseus
       # container, so persist its HuggingFace cache under ./data/huggingface.
       - ./data/huggingface:/app/.cache/huggingface
+      # Cookbook-installed Python CLIs/packages (vLLM, llama-cpp-python, etc.)
+      # land under /app/.local for the odysseus user. Persist them so a
+      # container recreate does not silently remove installed serve engines.
+      - ./data/local:/app/.local
     extra_hosts:
       # Lets the container reach local services on the Docker host, including
       # Ollama at http://host.docker.internal:11434.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,9 @@ services:
       # static/ over it so CSS/JS edits show up on a browser reload without a
       # rebuild. The served files are then always the working-tree copy.
       - ./static:/app/static
+      # Likewise mount the Python source so backend edits take effect on a
+      # container restart instead of an image rebuild.
+      - ./src:/app/src
     extra_hosts:
       # Lets the container reach local services on the Docker host, including
       # Ollama at http://host.docker.internal:11434.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,10 @@ services:
       # land under /app/.local for the odysseus user. Persist them so a
       # container recreate does not silently remove installed serve engines.
       - ./data/local:/app/.local
+      # Frontend assets are baked into the image at build time. Mount the host
+      # static/ over it so CSS/JS edits show up on a browser reload without a
+      # rebuild. The served files are then always the working-tree copy.
+      - ./static:/app/static
     extra_hosts:
       # Lets the container reach local services on the Docker host, including
       # Ollama at http://host.docker.internal:11434.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -46,6 +46,24 @@ for dir in /app /app/data /app/logs; do
     fi
 done
 
+# Cookbook installs vllm/etc. via `pip install --user`, which pulls
+# nvidia-cuda-* wheels into /app/.local but does not set CUDA_HOME or
+# symlink /usr/local/cuda. vllm 0.22+ then crashes during engine init
+# when FlashInfer tries to JIT a sampler kernel ("Could not find nvcc",
+# then "CUDA compiler and toolkit headers are incompatible" on the
+# mixed cuda-nvcc 13.3 / cuda-runtime 13.0 wheel combo).
+#
+# Auto-set CUDA_HOME if a pip-installed nvcc is present, and disable the
+# FlashInfer JIT sampler — sampler only, no impact on attention path.
+# No-op when vllm isn't installed.
+for cu in /app/.local/lib/python*/site-packages/nvidia/cu13; do
+    if [ -x "$cu/bin/nvcc" ]; then
+        export CUDA_HOME="$cu"
+        export VLLM_USE_FLASHINFER_SAMPLER="${VLLM_USE_FLASHINFER_SAMPLER:-0}"
+        break
+    fi
+done
+
 # Drop root and run the actual app. `gosu` is preferred over `su` /
 # `sudo` because it cleans up the process tree (no extra shell layer)
 # so signals (SIGTERM from `docker stop`) reach uvicorn directly.

--- a/docs/index.html
+++ b/docs/index.html
@@ -357,8 +357,16 @@
     display: inline-flex; align-items: center; gap: 14px; margin: 18px auto 8px;
     background: var(--bg2); border: 1px solid var(--border); border-radius: 10px;
     padding: 12px 16px; font-family: ui-monospace, monospace; font-size: 14px; color: var(--fg);
+    text-align: left;
   }
   .codeblock .prompt { color: var(--accent); }
+  .codeblock .copy-btn {
+    background: none; border: 1px solid var(--border); border-radius: 6px;
+    color: var(--muted); cursor: pointer; font-size: 12px; padding: 4px 10px;
+    font-family: inherit; transition: border-color .12s ease, color .12s ease;
+  }
+  .codeblock .copy-btn:hover { border-color: var(--accent); color: var(--fg); }
+  .codeblock .copy-btn.copied { border-color: var(--green); color: var(--green); }
   .pill-row { display: flex; gap: 8px; justify-content: center; flex-wrap: wrap; margin-top: 44px; }
   .pill { font-size: 12.5px; color: var(--muted); border: 1px solid var(--border); border-radius: 999px; padding: 5px 12px; background: var(--panel); }
 
@@ -369,6 +377,9 @@
     .grid { grid-template-columns: repeat(2, 1fr); }
     .shotrow { grid-template-columns: 1fr; }
     .nav-links a:not(.btn) { display: none; }
+    .codeblock { display: flex; flex-wrap: wrap; gap: 8px; align-items: flex-start; overflow-wrap: anywhere; }
+    .codeblock > span { flex: 1 1 auto; min-width: 0; }
+    .codeblock .copy-btn { margin-left: auto; }
   }
   @media (max-width: 520px) {
     .grid { grid-template-columns: 1fr; }
@@ -660,7 +671,7 @@
         <div class="eyebrow"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 17l6-5-6-5"/><path d="M12 19h8"/></svg>Get started</div>
         <h2 class="h" style="margin-bottom:6px;">Odysseus is yours.</h2>
         <p class="sub center" style="margin:0 auto;">It's open source and free. No sales team, no demo request, no Trojan horse.</p>
-        <div class="codeblock"><span class="prompt">$</span> git clone https://github.com/pewdiepie-archdaemon/odysseus.git &amp;&amp; cd odysseus</div>
+        <div class="codeblock"><span><span class="prompt">$</span> git clone https://github.com/pewdiepie-archdaemon/odysseus.git &amp;&amp; cd odysseus</span><button class="copy-btn" data-copy="git clone https://github.com/pewdiepie-archdaemon/odysseus.git && cd odysseus">Copy</button></div>
         <div>
           <a class="btn primary" href="https://github.com/pewdiepie-archdaemon/odysseus" target="_blank" style="margin-top:14px;">View on GitHub</a>
         </div>
@@ -924,6 +935,18 @@
       });
 
       show(0);
+    })();
+
+    // Copy button for the codeblock command.
+    (function () {
+      var btn = document.querySelector('.codeblock .copy-btn');
+      if (!btn) return;
+      btn.addEventListener('click', function () {
+        navigator.clipboard.writeText(btn.getAttribute('data-copy')).then(function () {
+          btn.textContent = 'Copied!'; btn.classList.add('copied');
+          setTimeout(function () { btn.textContent = 'Copy'; btn.classList.remove('copied'); }, 2000);
+        });
+      });
     })();
   </script>
 

--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -61,6 +61,10 @@ class DeleteUserRequest(BaseModel):
     username: str
 
 
+class RenameUserRequest(BaseModel):
+    username: str
+
+
 SESSION_COOKIE = "odysseus_session"
 
 
@@ -265,6 +269,64 @@ def setup_auth_routes(auth_manager: AuthManager) -> APIRouter:
         if not ok:
             raise HTTPException(404, "User not found or is admin")
         return {"ok": True, "privileges": auth_manager.get_privileges(username)}
+
+    @router.put("/users/{username}/rename")
+    async def rename_user(username: str, body: RenameUserRequest, request: Request):
+        user = _get_current_user(request)
+        if not user or not auth_manager.is_admin(user):
+            raise HTTPException(403, "Admin only")
+        old_username = (username or "").strip().lower()
+        new_username = (body.username or "").strip().lower()
+        if not new_username:
+            raise HTTPException(400, "Username required")
+        if old_username == new_username:
+            return {"ok": True, "username": new_username, "renamed_self": old_username == user}
+        if old_username not in auth_manager.users:
+            raise HTTPException(404, "User not found")
+        if new_username in auth_manager.users:
+            raise HTTPException(409, "Username already taken")
+
+        # Usernames are ownership keys for user data. Rename the common
+        # owner-scoped DB rows before changing auth so the account keeps
+        # access to its sessions, docs, email accounts, tasks, etc.
+        try:
+            from core.database import Base, SessionLocal
+            db = SessionLocal()
+            try:
+                for mapper in Base.registry.mappers:
+                    model = mapper.class_
+                    if not hasattr(model, "owner"):
+                        continue
+                    (
+                        db.query(model)
+                        .filter(model.owner == old_username)
+                        .update({"owner": new_username}, synchronize_session=False)
+                    )
+                db.commit()
+            except Exception:
+                db.rollback()
+                raise
+            finally:
+                db.close()
+        except Exception as e:
+            logger.error("Failed to rename owner references %s -> %s: %s", old_username, new_username, e)
+            raise HTTPException(500, "Failed to rename user data")
+
+        # Per-user prefs are JSON-backed, not SQL-backed.
+        try:
+            from routes.prefs_routes import _load as _load_prefs, _save as _save_prefs
+            prefs = _load_prefs()
+            users = prefs.get("_users") if isinstance(prefs, dict) else None
+            if isinstance(users, dict) and old_username in users and new_username not in users:
+                users[new_username] = users.pop(old_username)
+                _save_prefs(prefs)
+        except Exception as e:
+            logger.warning("Failed to rename user prefs %s -> %s: %s", old_username, new_username, e)
+
+        ok = auth_manager.rename_user(old_username, new_username, user)
+        if not ok:
+            raise HTTPException(400, "Cannot rename user")
+        return {"ok": True, "username": new_username, "renamed_self": old_username == user}
 
     @router.post("/signup-toggle")
     async def toggle_signup(request: Request):

--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -152,6 +152,11 @@ def setup_cookbook_routes() -> APIRouter:
                 [{"label": "install llama.cpp dependencies or llama-cpp-python[server]", "op": "dependency", "package": "llama-cpp-python[server]"}],
             ),
             (
+                r"No module named 'torch'|No module named torch|No module named 'diffusers'|No module named diffusers",
+                "Diffusion serving requires PyTorch and diffusers.",
+                [{"label": "install diffusers[torch] in Cookbook Dependencies", "op": "dependency", "package": "diffusers[torch]"}],
+            ),
+            (
                 r"403 Forbidden|401 Unauthorized|Access to model.*is restricted|gated repo|not in the authorized list|awaiting a review",
                 "Model access is gated or unauthorized.",
                 [{"label": "set HF token and request model access on HuggingFace", "op": "manual"}],
@@ -894,6 +899,12 @@ def setup_cookbook_routes() -> APIRouter:
                 runner_lines.append('export PATH="$HOME/.local/bin:$PATH"')
                 runner_lines.append('if ! python3 -c "import sglang" 2>/dev/null; then')
                 runner_lines.append('  echo "ERROR: SGLang is not installed. Open Cookbook -> Dependencies and install sglang on this server, then launch again."')
+                runner_lines.append('  exit 127')
+                runner_lines.append('fi')
+            elif "scripts/diffusion_server.py" in req.cmd or ".diffusion_server.py" in req.cmd:
+                runner_lines.append('export PATH="$HOME/.local/bin:$PATH"')
+                runner_lines.append('if ! python3 -c "import torch, diffusers" 2>/dev/null; then')
+                runner_lines.append('  echo "ERROR: Diffusion serving requires PyTorch + diffusers. Open Cookbook -> Dependencies and install diffusers on this server, then launch again."')
                 runner_lines.append('  exit 127')
                 runner_lines.append('fi')
 

--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -122,6 +122,11 @@ def setup_cookbook_routes() -> APIRouter:
                 [{"label": "retry with --trust-remote-code", "op": "append", "arg": "--trust-remote-code"}],
             ),
             (
+                r"Either a revision or a version must be specified|transformers\.integrations\.hub_kernels|kernels/layer",
+                "vLLM/Transformers kernel package mismatch.",
+                [{"label": "update vLLM, Transformers, and kernels on this server", "op": "dependency", "package": "vllm transformers kernels"}],
+            ),
+            (
                 r"Address already in use|bind.*address.*in use",
                 "Port is already in use.",
                 [{"label": "retry on port 8001", "op": "replace", "flag": "--port", "value": "8001"}],

--- a/routes/email_routes.py
+++ b/routes/email_routes.py
@@ -452,9 +452,12 @@ def setup_email_routes():
     _LIST_CACHE = {}  # key → (expires_at, response_dict)
     _LIST_TTL = 8.0
     _READ_CACHE = {}  # key → (expires_at, response_dict)
-    _READ_TTL = 60.0
+    _READ_TTL = 30 * 60.0
     _IMAP_POOL = {}   # account_id → (conn, last_used_at)
     _IMAP_IDLE_MAX = 60.0
+    _WARMING_READS = set()
+    _WARM_READ_LIMIT = 24
+    _WARM_RECENT_SECONDS = 7 * 24 * 60 * 60
     _pool_lock = _threading.Lock()
 
     def _pooled_connect(account_id, owner=""):
@@ -949,6 +952,7 @@ def setup_email_routes():
         if not cache_bust:
             cached = _list_cache_get(ck)
             if cached is not None:
+                _schedule_recent_email_warm(cached.get("emails") or [], folder, account_id, owner)
                 return cached
         result = await _asyncio.to_thread(
             _list_emails_sync, folder, limit, offset, filter, account_id, from_addr,
@@ -957,6 +961,7 @@ def setup_email_routes():
         if result and not result.get("error"):
             if offset == 0 and not from_addr and not has_attachments and filter in ("all", "unread", "unanswered", "undone"):
                 _record_email_received_events(owner, account_id, folder, result.get("emails") or [])
+                _schedule_recent_email_warm(result.get("emails") or [], folder, account_id, owner)
             _list_cache_put(ck, result)
         return result
 
@@ -1117,7 +1122,7 @@ def setup_email_routes():
             logger.error(f"Search failed: {e}")
             return {"emails": [], "total": 0, "error": "Mail operation failed"}
 
-    def _read_email_sync(uid, folder, account_id, owner):
+    def _read_email_sync(uid, folder, account_id, owner, mark_seen=True):
         """Sync IMAP read — wrapped in to_thread by the async handler.
 
         Two-phase: read body in readonly to avoid races with concurrent reads
@@ -1156,14 +1161,15 @@ def setup_email_routes():
             parsed_date = email.utils.parsedate_to_datetime(date_str) if date_str else None
             attachments = _list_attachments_from_msg(msg)
 
-            # Set \Seen in a separate readwrite session so concurrent reads
-            # of the same UID don't fight over a shared SELECT state.
-            try:
-                with _imap(account_id, owner=owner) as conn2:
-                    conn2.select(_q(folder))
-                    conn2.uid("STORE", _uid_bytes(uid), "+FLAGS", "\\Seen")
-            except Exception:
-                pass
+            if mark_seen:
+                # Set \Seen in a separate readwrite session so concurrent reads
+                # of the same UID don't fight over a shared SELECT state.
+                try:
+                    with _imap(account_id, owner=owner) as conn2:
+                        conn2.select(_q(folder))
+                        conn2.uid("STORE", _uid_bytes(uid), "+FLAGS", "\\Seen")
+                except Exception:
+                    pass
             _t_total = _t.monotonic() - _t0
             if _t_total > 2.0:
                 logger.warning(
@@ -1269,17 +1275,74 @@ def setup_email_routes():
             logger.error(f"Failed to read email {uid}: {e}")
             return {"error": "Mail operation failed"}
 
+    def _mark_email_seen_sync(uid, folder, account_id, owner):
+        try:
+            with _imap(account_id, owner=owner) as conn:
+                conn.select(_q(folder))
+                conn.uid("STORE", _uid_bytes(uid), "+FLAGS", "\\Seen")
+            _invalidate_list_cache(account_id, folder)
+        except Exception as e:
+            logger.debug(f"mark-seen after cached read failed uid={uid}: {e}")
+
     @router.get("/read/{uid}")
     async def read_email_by_uid(uid: str, folder: str = Query("INBOX"), account_id: str | None = Query(None), owner: str = Depends(require_owner)):
-        """Read email body. Cached for 60s, sync IMAP work runs in a thread."""
+        """Read email body. Cached for 30m, sync IMAP work runs in a thread."""
         ck = _read_cache_key(account_id, folder, uid, owner=owner)
         cached = _read_cache_get(ck)
         if cached is not None:
+            try:
+                _asyncio.create_task(_asyncio.to_thread(_mark_email_seen_sync, uid, folder, account_id, owner))
+            except RuntimeError:
+                pass
             return cached
         result = await _asyncio.to_thread(_read_email_sync, uid, folder, account_id, owner)
         if result and not result.get("error"):
             _read_cache_put(ck, result)
         return result
+
+    def _schedule_recent_email_warm(emails: list, folder: str, account_id: str | None, owner: str):
+        if not emails or folder == "__scheduled__":
+            return
+        now = _time.time()
+        selected = []
+        for em in emails:
+            uid = str((em or {}).get("uid") or "").strip()
+            if not uid:
+                continue
+            try:
+                epoch = float((em or {}).get("date_epoch") or 0)
+            except Exception:
+                epoch = 0
+            if epoch and now - epoch > _WARM_RECENT_SECONDS:
+                continue
+            ck = _read_cache_key(account_id, folder, uid, owner=owner)
+            if _read_cache_get(ck) is not None or ck in _WARMING_READS:
+                continue
+            selected.append((uid, ck))
+            if len(selected) >= _WARM_READ_LIMIT:
+                break
+        if not selected:
+            return
+
+        async def _warm():
+            for uid, ck in selected:
+                if _read_cache_get(ck) is not None:
+                    continue
+                _WARMING_READS.add(ck)
+                try:
+                    result = await _asyncio.to_thread(_read_email_sync, uid, folder, account_id, owner, False)
+                    if result and not result.get("error"):
+                        _read_cache_put(ck, result)
+                except Exception as e:
+                    logger.debug(f"email read warm skipped uid={uid}: {e}")
+                finally:
+                    _WARMING_READS.discard(ck)
+                    await _asyncio.sleep(0.05)
+
+        try:
+            _asyncio.create_task(_warm())
+        except RuntimeError:
+            pass
 
     @router.get("/attachments/{uid}")
     async def list_attachments(uid: str, folder: str = Query("INBOX"), account_id: str | None = Query(None), owner: str = Depends(require_owner)):

--- a/routes/email_routes.py
+++ b/routes/email_routes.py
@@ -1285,17 +1285,24 @@ def setup_email_routes():
             logger.debug(f"mark-seen after cached read failed uid={uid}: {e}")
 
     @router.get("/read/{uid}")
-    async def read_email_by_uid(uid: str, folder: str = Query("INBOX"), account_id: str | None = Query(None), owner: str = Depends(require_owner)):
+    async def read_email_by_uid(
+        uid: str,
+        folder: str = Query("INBOX"),
+        account_id: str | None = Query(None),
+        mark_seen: bool = Query(True),
+        owner: str = Depends(require_owner),
+    ):
         """Read email body. Cached for 30m, sync IMAP work runs in a thread."""
         ck = _read_cache_key(account_id, folder, uid, owner=owner)
         cached = _read_cache_get(ck)
         if cached is not None:
-            try:
-                _asyncio.create_task(_asyncio.to_thread(_mark_email_seen_sync, uid, folder, account_id, owner))
-            except RuntimeError:
-                pass
+            if mark_seen:
+                try:
+                    _asyncio.create_task(_asyncio.to_thread(_mark_email_seen_sync, uid, folder, account_id, owner))
+                except RuntimeError:
+                    pass
             return cached
-        result = await _asyncio.to_thread(_read_email_sync, uid, folder, account_id, owner)
+        result = await _asyncio.to_thread(_read_email_sync, uid, folder, account_id, owner, mark_seen)
         if result and not result.get("error"):
             _read_cache_put(ck, result)
         return result

--- a/routes/email_routes.py
+++ b/routes/email_routes.py
@@ -222,6 +222,19 @@ def _uid_exists(conn, uid: str) -> bool:
         return False
 
 
+def _imap_uid_search(conn, criteria: str):
+    return conn.uid("SEARCH", None, criteria)
+
+
+def _imap_uid_fetch(conn, uid_set: str | bytes, query: str):
+    return conn.uid("FETCH", _uid_bytes(uid_set), query)
+
+
+def _uid_from_fetch_meta(meta_b: bytes) -> str:
+    m = re.search(rb"\bUID\s+(\d+)\b", meta_b)
+    return m.group(1).decode() if m else ""
+
+
 def _smtp_ready(cfg: dict) -> bool:
     return bool(cfg.get("smtp_host") and cfg.get("smtp_user") and cfg.get("smtp_password"))
 
@@ -587,21 +600,21 @@ def setup_email_routes():
                 from_clause = f' FROM "{_safe}"'
 
             if filter_ == "unread":
-                status, data = conn.search(None, f"(UNSEEN{from_clause})")
+                status, data = _imap_uid_search(conn, f"(UNSEEN{from_clause})")
             elif filter_ == "favorites":
                 # Flagged/favorited emails (the star toggle sets the \Flagged flag).
-                status, data = conn.search(None, f"(FLAGGED{from_clause})")
+                status, data = _imap_uid_search(conn, f"(FLAGGED{from_clause})")
             elif filter_ == "unanswered":
-                status, data = conn.search(None, f"(UNSEEN UNANSWERED{from_clause})")
+                status, data = _imap_uid_search(conn, f"(UNSEEN UNANSWERED{from_clause})")
             elif filter_ == "undone":
                 # All emails NOT marked as answered/done (read or unread).
-                status, data = conn.search(None, f"(UNANSWERED{from_clause})")
+                status, data = _imap_uid_search(conn, f"(UNANSWERED{from_clause})")
             elif filter_ == "reminders":
                 # Prefer the Odysseus marker header, but include the subject
                 # fallback too. The fallback uses a distinct Odysseus prefix
                 # so ordinary emails containing "Reminder" don't get mixed in.
-                status, data = conn.search(
-                    None,
+                status, data = _imap_uid_search(
+                    conn,
                     f'(OR HEADER X-Odysseus-Kind "reminder" SUBJECT "Reminder (Odysseus):"{from_clause})',
                 )
             elif filter_ == "pending_30d":
@@ -609,13 +622,13 @@ def setup_email_routes():
                 # within the last 30 days. SINCE takes a DD-Mon-YYYY date.
                 from datetime import datetime as _dt, timedelta as _td
                 _since = (_dt.utcnow() - _td(days=30)).strftime("%d-%b-%Y")
-                status, data = conn.search(None, f'(UNANSWERED SINCE "{_since}"{from_clause})')
+                status, data = _imap_uid_search(conn, f'(UNANSWERED SINCE "{_since}"{from_clause})')
             elif filter_ == "stale_30d":
                 # "What's been sitting too long" — UNANSWERED + delivered
                 # MORE than 30 days ago. BEFORE excludes the cutoff date itself.
                 from datetime import datetime as _dt, timedelta as _td
                 _before = (_dt.utcnow() - _td(days=30)).strftime("%d-%b-%Y")
-                status, data = conn.search(None, f'(UNANSWERED BEFORE "{_before}"{from_clause})')
+                status, data = _imap_uid_search(conn, f'(UNANSWERED BEFORE "{_before}"{from_clause})')
             elif filter_ and filter_.startswith("tag:"):
                 # Tag-based filter — resolve UIDs from email_tags first, then
                 # ask IMAP for those messages by Message-ID. `tag:spam` reads
@@ -675,31 +688,30 @@ def setup_email_routes():
                 if not _tag_message_ids and not _tag_seq_fallback:
                     conn.logout()
                     return {"emails": [], "total": 0, "folder": folder}
-                # email_tags.uid historically stores the IMAP sequence number,
-                # not UID. Resolve by stable Message-ID so tag filters still
-                # work after sequence numbers shift. Fall back to old seq rows
-                # only when a row has no Message-ID.
+                # Prefer stable Message-ID rows. Older tag rows may have only
+                # numeric ids; those were sequence numbers historically, but
+                # may be real UIDs for newer rows. Treat them as UIDs only.
                 def _imap_search_quote(value: str) -> str:
                     return '"' + str(value or "").replace("\\", "\\\\").replace('"', '\\"') + '"'
-                _seqs = set()
+                _uids = set()
                 for _mid in dict.fromkeys(_tag_message_ids):
                     if not _mid:
                         continue
-                    st_m, data_m = conn.search(None, f'(HEADER Message-ID {_imap_search_quote(_mid)}{from_clause})')
+                    st_m, data_m = _imap_uid_search(conn, f'(HEADER Message-ID {_imap_search_quote(_mid)}{from_clause})')
                     if st_m == "OK" and data_m and data_m[0]:
-                        _seqs.update(data_m[0].split())
-                for _seq in _tag_seq_fallback:
-                    if _seq:
-                        _seqs.add(str(_seq).encode())
-                if not _seqs:
+                        _uids.update(data_m[0].split())
+                for _uid in _tag_seq_fallback:
+                    if _uid:
+                        _uids.add(str(_uid).encode())
+                if not _uids:
                     conn.logout()
                     return {"emails": [], "total": 0, "folder": folder}
-                data = [b" ".join(sorted(_seqs, key=lambda x: int(x) if str(x, "ascii", "ignore").isdigit() else 0))]
+                data = [b" ".join(sorted(_uids, key=lambda x: int(x) if str(x, "ascii", "ignore").isdigit() else 0))]
                 status = "OK"
             elif from_clause:
-                status, data = conn.search(None, f"({from_clause.strip()})")
+                status, data = _imap_uid_search(conn, f"({from_clause.strip()})")
             else:
-                status, data = conn.search(None, "ALL")
+                status, data = _imap_uid_search(conn, "ALL")
 
             if status != "OK" or not data[0]:
                 conn.logout()
@@ -753,7 +765,7 @@ def setup_email_routes():
             if uid_list:
                 fetch_set = b",".join(uid_list)
                 try:
-                    status, msg_data = conn.fetch(fetch_set, "(FLAGS RFC822.HEADER RFC822.SIZE)")
+                    status, msg_data = _imap_uid_fetch(conn, fetch_set, "(UID FLAGS RFC822.HEADER RFC822.SIZE)")
                 except Exception as e:
                     logger.warning(f"Batch fetch failed, falling back to per-UID: {e}")
                     status, msg_data = "NO", []
@@ -815,8 +827,9 @@ def setup_email_routes():
                 for meta_b, raw_header in grouped:
                     try:
                         meta = meta_b.decode(errors="replace")
-                        seq_m = seq_re.match(meta_b)
-                        seq_num = seq_m.group(1).decode() if seq_m else ""
+                        uid_num = _uid_from_fetch_meta(meta_b)
+                        if not uid_num:
+                            continue
                         flag_m = re.search(r'FLAGS \(([^)]*)\)', meta)
                         flags = flag_m.group(1) if flag_m else ""
                         size_m = re.search(r'RFC822\.SIZE (\d+)', meta)
@@ -848,9 +861,9 @@ def setup_email_routes():
                         is_flagged = "\\Flagged" in flags
                         ct = msg.get("Content-Type", "")
                         has_attachments = "multipart/mixed" in ct.lower() or "multipart/related" in ct.lower()
-                        tag_entry = _tag_by_message_id.get(message_id.strip()) or _tag_by_uid.get(seq_num, {})
+                        tag_entry = _tag_by_message_id.get(message_id.strip()) or _tag_by_uid.get(uid_num, {})
                         emails.append({
-                            "uid": seq_num,
+                            "uid": uid_num,
                             "message_id": message_id.strip(),
                             "subject": subject,
                             "from_name": sender_name or sender_addr,
@@ -1028,7 +1041,7 @@ def setup_email_routes():
                 q_escaped = q.replace('\\', '\\\\').replace('"', '\\"')
                 search_cmd = f'(OR FROM "{q_escaped}" TEXT "{q_escaped}")'
 
-                status, data = conn.search(None, search_cmd)
+                status, data = _imap_uid_search(conn, search_cmd)
                 if status != "OK" or not data[0]:
                     return {"emails": [], "total": 0, "query": q}
 
@@ -1039,7 +1052,7 @@ def setup_email_routes():
                 emails = []
                 for uid in uid_list:
                     try:
-                        status, msg_data = conn.fetch(uid, "(FLAGS RFC822.HEADER)")
+                        status, msg_data = _imap_uid_fetch(conn, uid, "(UID FLAGS RFC822.HEADER)")
                         if status != "OK":
                             continue
                         raw_header = None
@@ -1071,8 +1084,15 @@ def setup_email_routes():
                         ct = msg.get("Content-Type", "")
                         has_attachments = "multipart/mixed" in ct.lower() or "multipart/related" in ct.lower()
 
+                        stable_uid = ""
+                        for part in msg_data:
+                            if isinstance(part, tuple):
+                                meta_b = part[0] if isinstance(part[0], bytes) else str(part[0]).encode()
+                                stable_uid = _uid_from_fetch_meta(meta_b) or stable_uid
+                        if not stable_uid:
+                            continue
                         emails.append({
-                            "uid": uid.decode(),
+                            "uid": stable_uid,
                             "message_id": message_id.strip(),
                             "subject": subject,
                             "from_name": sender_name or sender_addr,
@@ -1113,7 +1133,7 @@ def setup_email_routes():
             with _imap(account_id, owner=owner) as conn:
                 conn.select(_q(folder), readonly=True)
                 _t_select = _t.monotonic() - _t0
-                status, msg_data = conn.fetch(uid.encode(), "(BODY.PEEK[])")
+                status, msg_data = _imap_uid_fetch(conn, uid, "(BODY.PEEK[])")
                 _t_fetch = _t.monotonic() - _t0
                 if status != "OK":
                     return {"error": f"Email UID {uid} not found"}
@@ -1141,7 +1161,7 @@ def setup_email_routes():
             try:
                 with _imap(account_id, owner=owner) as conn2:
                     conn2.select(_q(folder))
-                    conn2.store(uid.encode(), "+FLAGS", "\\Seen")
+                    conn2.uid("STORE", _uid_bytes(uid), "+FLAGS", "\\Seen")
             except Exception:
                 pass
             _t_total = _t.monotonic() - _t0
@@ -1267,7 +1287,7 @@ def setup_email_routes():
         try:
             with _imap(account_id, owner=owner) as conn:
                 conn.select(_q(folder), readonly=True)
-                status, msg_data = conn.fetch(uid.encode(), "(RFC822)")
+                status, msg_data = _imap_uid_fetch(conn, uid, "(RFC822)")
             if status != "OK":
                 return {"attachments": [], "error": "Email not found"}
             raw = msg_data[0][1]
@@ -1284,7 +1304,7 @@ def setup_email_routes():
         try:
             with _imap(account_id, owner=owner) as conn:
                 conn.select(_q(folder), readonly=True)
-                status, msg_data = conn.fetch(uid.encode(), "(RFC822)")
+                status, msg_data = _imap_uid_fetch(conn, uid, "(RFC822)")
             if status != "OK":
                 return {"error": "Email not found"}
             raw = msg_data[0][1]
@@ -1320,7 +1340,7 @@ def setup_email_routes():
         try:
             with _imap(account_id, owner=owner) as conn:
                 conn.select(_q(folder), readonly=True)
-                status, msg_data = conn.fetch(uid.encode(), "(RFC822)")
+                status, msg_data = _imap_uid_fetch(conn, uid, "(RFC822)")
             if status != "OK":
                 return {"error": "Email not found"}
             raw = msg_data[0][1]
@@ -1528,7 +1548,7 @@ def setup_email_routes():
         try:
             with _imap(account_id, owner=owner) as conn:
                 conn.select(_q(folder), readonly=True)
-                status, msg_data = conn.fetch(uid.encode(), "(RFC822)")
+                status, msg_data = _imap_uid_fetch(conn, uid, "(RFC822)")
             if status != "OK":
                 return {"error": "Email not found"}
             raw = msg_data[0][1]
@@ -2340,7 +2360,7 @@ def setup_email_routes():
                     def _fetch_atts():
                         with _imap(account_id, owner=owner) as conn:
                             conn.select(_q(folder), readonly=True)
-                            status, msg_data = conn.fetch(str(uid).encode(), "(BODY.PEEK[])")
+                            status, msg_data = _imap_uid_fetch(conn, str(uid), "(BODY.PEEK[])")
                             if status != "OK" or not msg_data or not msg_data[0]:
                                 return ""
                             raw = msg_data[0][1]

--- a/routes/shell_routes.py
+++ b/routes/shell_routes.py
@@ -14,9 +14,12 @@ from typing import Dict, Any
 try:
     import fcntl
     import pty
-except ImportError:
+except ImportError as exc:
     fcntl = None
     pty = None
+    _PTY_IMPORT_ERROR = exc
+else:
+    _PTY_IMPORT_ERROR = None
 
 from fastapi import APIRouter, Request, HTTPException
 from fastapi.responses import StreamingResponse
@@ -43,6 +46,8 @@ def _require_admin(request: Request):
 
 logger = logging.getLogger(__name__)
 
+PTY_SUPPORTED = pty is not None and fcntl is not None and hasattr(os, "setsid")
+
 
 def _find_line_break(buf):
     """Find next line terminator in buffer. Returns (index, separator_length) or (-1, 0)."""
@@ -63,6 +68,7 @@ EXEC_TIMEOUT = 30  # seconds — shorter than agent's 60s
 STREAM_TIMEOUT = 120  # default for short commands
 MAX_OUTPUT = 200_000  # truncate limit
 TMUX_LOG_DIR = Path(tempfile.gettempdir()) / "odysseus-tmux"
+PTY_UNSUPPORTED_ERROR = "pty_unsupported"
 
 
 class ShellExecRequest(BaseModel):
@@ -102,9 +108,12 @@ async def _exec_shell(command: str, timeout: int = EXEC_TIMEOUT) -> Dict[str, An
 
 async def _generate_pty(cmd: str, timeout: int, request: Request):
     """Run command in a pseudo-TTY so tqdm/progress bars work natively."""
-    if pty is None or fcntl is None:
-        yield f"data: {json.dumps({'stream': 'stderr', 'data': 'PTY streaming is not available on Windows'})}\n\n"
-        yield f"data: {json.dumps({'exit_code': -1})}\n\n"
+    if not PTY_SUPPORTED:
+        msg = "PTY streaming is not supported on this platform"
+        if _PTY_IMPORT_ERROR:
+            msg += f": {_PTY_IMPORT_ERROR}"
+        yield f"data: {json.dumps({'stream': 'stderr', 'data': msg, 'error': PTY_UNSUPPORTED_ERROR})}\n\n"
+        yield f"data: {json.dumps({'exit_code': -1, 'error': PTY_UNSUPPORTED_ERROR})}\n\n"
         return
 
     loop = asyncio.get_event_loop()

--- a/routes/shell_routes.py
+++ b/routes/shell_routes.py
@@ -491,7 +491,7 @@ def setup_shell_routes() -> APIRouter:
         return StreamingResponse(generate(), media_type="text/event-stream")
 
     @router.get("/api/cookbook/packages")
-    async def list_packages(host: str | None = None, ssh_port: str | None = None, venv: str | None = None):
+    async def list_packages(request: Request, host: str | None = None, ssh_port: str | None = None, venv: str | None = None):
         """Check which optional packages are installed.
 
         Local-target packages are checked in-process. Remote-target packages
@@ -499,7 +499,14 @@ def setup_shell_routes() -> APIRouter:
         server over SSH, inside its venv — otherwise installing on a remote box
         never reflected because the check only ever looked at the local host.
         """
+        _require_admin(request)
         import importlib, shlex, json as _json
+        port_arg = ""
+        if ssh_port and str(ssh_port).strip() not in ("", "22"):
+            _port = str(ssh_port).strip()
+            if not _port.isdigit():
+                raise HTTPException(400, "Invalid ssh_port")
+            port_arg = f"-p {int(_port)} "
         packages = [
             # ── System ── OS binaries, not pip packages
             {"name": "tmux", "pip": "", "desc": "Required for Linux/Termux Cookbook background downloads and serves", "category": "System", "target": "remote", "kind": "system", "install_hint": "Run Cookbook server setup, or install tmux with apt/pacman/dnf/apk/zypper."},
@@ -539,9 +546,8 @@ def setup_shell_routes() -> APIRouter:
                     # the && short-circuits and every package reads as missing).
                     src = f". {act} && "
                 inner = f"{src}python3 -c {shlex.quote(py)}"
-                pf = f"-p {ssh_port} " if ssh_port and ssh_port not in ("", "22") else ""
                 ssh_cmd = (
-                    f"ssh -o ConnectTimeout=6 -o StrictHostKeyChecking=no {pf}"
+                    f"ssh -o ConnectTimeout=6 -o StrictHostKeyChecking=no {port_arg}"
                     f"{shlex.quote(host)} {shlex.quote(inner)}"
                 )
                 proc = await asyncio.create_subprocess_shell(
@@ -564,9 +570,8 @@ def setup_shell_routes() -> APIRouter:
                     qn = shlex.quote(name)
                     checks.append(f"if command -v {qn} >/dev/null 2>&1; then echo {qn}=1; else echo {qn}=0; fi")
                 inner = " ; ".join(checks)
-                pf = f"-p {ssh_port} " if ssh_port and ssh_port not in ("", "22") else ""
                 ssh_cmd = (
-                    f"ssh -o ConnectTimeout=6 -o StrictHostKeyChecking=no {pf}"
+                    f"ssh -o ConnectTimeout=6 -o StrictHostKeyChecking=no {port_arg}"
                     f"{shlex.quote(host)} {shlex.quote(inner)}"
                 )
                 proc = await asyncio.create_subprocess_shell(

--- a/routes/shell_routes.py
+++ b/routes/shell_routes.py
@@ -501,7 +501,7 @@ def setup_shell_routes() -> APIRouter:
             {"name": "sglang", "pip": "sglang[all]", "desc": "Serve HF safetensors models via SGLang", "category": "LLM", "target": "remote"},
             {"name": "vllm", "pip": "vllm", "desc": "High-throughput LLM serving engine", "category": "LLM", "target": "remote"},
             # ── Image ── editor + diffusion model serving
-            {"name": "diffusers", "pip": "diffusers", "desc": "Image generation pipelines (SD, Flux)", "category": "Image", "target": "remote"},
+            {"name": "diffusers", "pip": "diffusers[torch]", "desc": "Image generation pipelines (SD, Flux) with PyTorch", "category": "Image", "target": "remote"},
             {"name": "rembg", "pip": "rembg[gpu]", "desc": "AI background removal for image editor", "category": "Image", "target": "local"},
             {"name": "realesrgan", "pip": "realesrgan", "desc": "AI denoise + upscale (Real-ESRGAN). Used by editor's Denoise and Upscale tools.", "category": "Image", "target": "local"},
             # ── Tools ──
@@ -600,7 +600,7 @@ def setup_shell_routes() -> APIRouter:
             return {"ok": False, "error": "No package specified"}
         # Validate against known packages to prevent arbitrary pip install
         known = {
-            "rembg[gpu]", "hf_transfer", "llama-cpp-python[server]", "sglang[all]", "diffusers",
+            "rembg[gpu]", "hf_transfer", "llama-cpp-python[server]", "sglang[all]", "diffusers", "diffusers[torch]",
             "TTS", "bark", "faster-whisper", "playwright", "realesrgan", "gfpgan",
             "insightface", "onnxruntime-gpu", "onnxruntime", "hdbscan",
         }

--- a/src/caldav_sync.py
+++ b/src/caldav_sync.py
@@ -133,6 +133,10 @@ def _sync_blocking(owner: str, url: str, username: str, password: str) -> dict:
                 from icalendar import Calendar as iCal
 
                 seen_uids = set()
+                # Track events added to the session but not yet committed so
+                # duplicate UIDs within the same batch are updated, not re-inserted
+                # (which would violate the UNIQUE constraint on commit).
+                pending: dict = {}
                 try:
                     objs = remote_cal.date_search(start=start, end=end, expand=False)
                 except Exception as e:
@@ -182,7 +186,7 @@ def _sync_blocking(owner: str, url: str, username: str, password: str) -> dict:
                             else ""
                         )
 
-                        existing = db.query(CalendarEvent).filter(
+                        existing = pending.get(uid_val) or db.query(CalendarEvent).filter(
                             CalendarEvent.uid == uid_val,
                         ).first()
                         if existing:
@@ -196,7 +200,7 @@ def _sync_blocking(owner: str, url: str, username: str, password: str) -> dict:
                             existing.is_utc = row_is_utc
                             existing.rrule = rrule
                         else:
-                            db.add(CalendarEvent(
+                            new_ev = CalendarEvent(
                                 uid=uid_val,
                                 calendar_id=local_cal.id,
                                 summary=summary,
@@ -207,7 +211,9 @@ def _sync_blocking(owner: str, url: str, username: str, password: str) -> dict:
                                 all_day=all_day,
                                 is_utc=row_is_utc,
                                 rrule=rrule,
-                            ))
+                            )
+                            db.add(new_ev)
+                            pending[uid_val] = new_ev
                         result["events"] += 1
                 db.commit()
 

--- a/src/chat_handler.py
+++ b/src/chat_handler.py
@@ -223,19 +223,22 @@ class ChatHandler:
                         if os.path.exists(_vcache):
                             try:
                                 with open(_vcache) as _vf:
-                                    vl_desc = _vf.read()
+                                    cached_desc = _vf.read().strip()
+                                if cached_desc and not cached_desc.startswith("["):
+                                    vl_desc = cached_desc
                             except Exception:
                                 vl_desc = None
                         if not vl_desc:
                             vl_result = analyze_image_with_vl_result(file_info["path"])
                             vl_desc = vl_result.get("text", "")
                             vl_model = vl_result.get("model", "")
-                            try:
-                                os.makedirs(os.path.join(UPLOAD_DIR, ".vision"), exist_ok=True)
-                                with open(_vcache, "w") as _vf:
-                                    _vf.write(vl_desc or "")
-                            except Exception:
-                                pass
+                            if vl_desc and not vl_desc.startswith("["):
+                                try:
+                                    os.makedirs(os.path.join(UPLOAD_DIR, ".vision"), exist_ok=True)
+                                    with open(_vcache, "w") as _vf:
+                                        _vf.write(vl_desc)
+                                except Exception:
+                                    pass
                         enhanced_message = f"{enhanced_message}\n\n[Image: {file_info['name']}]\n{vl_desc}"
                         # Surface the description to the client live so it renders as a
                         # collapsible "image description" on the user bubble (not just

--- a/src/chat_handler.py
+++ b/src/chat_handler.py
@@ -15,7 +15,7 @@ from src.constants import (
     UPLOAD_DIR,
 )
 from core.models import ChatMessage
-from src.chat_helpers import extract_urls
+from src.chat_helpers import extract_urls, is_vision_model
 from src.document_processor import build_user_content, analyze_image_with_vl_result
 from src.youtube_handler import (
     is_youtube_url,
@@ -147,17 +147,7 @@ class ChatHandler:
         # Analyze images — skip if vision disabled, or if main model is vision-capable
         from src.settings import get_setting
         vision_enabled = get_setting("vision_enabled", True)
-        VISION_KEYWORDS = [
-            "gpt-4o", "gpt-4.1", "gpt-4.5", "gpt-4-turbo", "gpt-4-vision",
-            "claude-sonnet", "claude-opus", "claude-haiku",
-            "gemini", "llava", "pixtral", "qwen2-vl", "qwen-vl", "qwen3-vl", "qwen3vl", "minicpm",
-        ]
-        main_model = (sess.model or "").lower()
-        main_is_vision = any(kw in main_model for kw in VISION_KEYWORDS)
-        # Also match models with "vl" in the name (e.g. Qwen3VL, InternVL, any *-VL-*)
-        if not main_is_vision:
-            import re
-            main_is_vision = bool(re.search(r'\dvl|vl\d|[-_]vl[-_.\d]|vl-', main_model))
+        main_is_vision = is_vision_model(sess.model or "")
 
         # Read uploads DB once and index by id (was read twice + linear-scanned per attachment)
         files_by_id: Dict[str, Dict] = {}

--- a/src/chat_helpers.py
+++ b/src/chat_helpers.py
@@ -23,6 +23,36 @@ def extract_urls(text: str) -> List[str]:
     return cleaned_urls
 
 
+# Model-name substrings that signal native image input. A missed match here
+# silently drops the image from the chat request (it gets swapped for a text
+# caption), so the model never sees it. Keep this broad, especially for local
+# models (Ollama/llama.cpp) that ship under many names. See issue #124.
+_VISION_MODEL_KEYWORDS = (
+    # hosted
+    "gpt-4o", "gpt-4.1", "gpt-4.5", "gpt-4-turbo", "gpt-4-vision",
+    "claude-sonnet", "claude-opus", "claude-haiku", "gemini",
+    # open / local
+    "vision", "llava", "bakllava", "moondream", "pixtral", "minicpm",
+    "internvl", "cogvlm", "qwen-vl", "qwen2-vl", "qwen3-vl", "qwen3vl",
+)
+# Catches the "*-VL-*" / "*VL*" family not covered by a literal keyword above
+# (e.g. Qwen2.5-VL and various tags): a standalone "vl" token, plus "vlm".
+_VISION_VL_RE = re.compile(r'(?<![a-z])vl(?![a-z])|vlm')
+
+
+def is_vision_model(model_name: str) -> bool:
+    """Best-effort check of whether a model can natively accept images.
+
+    Decides whether image attachments get passed through to the model or
+    swapped for a separate caption. Err toward True, since a false negative
+    drops the image entirely. See issue #124.
+    """
+    m = (model_name or "").lower()
+    if any(kw in m for kw in _VISION_MODEL_KEYWORDS):
+        return True
+    return bool(_VISION_VL_RE.search(m))
+
+
 def validate_message(message: str) -> str:
     """Validate message input."""
     if not message:

--- a/src/context_compactor.py
+++ b/src/context_compactor.py
@@ -6,7 +6,7 @@ Summarizes older messages via the same LLM, preserving key context.
 """
 
 import logging
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from src.model_context import get_context_length, estimate_tokens
 from src.llm_core import llm_call_async
@@ -95,6 +95,55 @@ def _sanitize_tool_messages(msgs: List[Dict]) -> List[Dict]:
     return out
 
 
+def _message_text_token_estimate(text: str) -> int:
+    return int(len(text) * 0.3) + 4
+
+
+def _truncate_text_to_token_budget(text: str, token_budget: int) -> str:
+    """Trim a too-large current user message instead of dropping it entirely."""
+    if token_budget <= 32:
+        return "[Current user message omitted: it exceeded the model context window.]"
+
+    # Match src.model_context.estimate_tokens' rough chars * 0.3 estimate.
+    max_chars = max(200, int((token_budget - 16) / 0.3))
+    if len(text) <= max_chars:
+        return text
+
+    notice = (
+        "\n\n[Notice: the pasted message was too large for this model's context "
+        "window, so Odysseus kept the beginning and end.]"
+    )
+    keep_chars = max(200, max_chars - len(notice))
+    head_len = max(100, int(keep_chars * 0.7))
+    tail_len = max(80, keep_chars - head_len)
+    return text[:head_len].rstrip() + notice + "\n\n" + text[-tail_len:].lstrip()
+
+
+def _truncate_message_to_token_budget(msg: Dict[str, Any], token_budget: int) -> Dict[str, Any]:
+    """Return a copy of msg whose text content fits inside token_budget."""
+    out = dict(msg)
+    content = out.get("content", "")
+    if isinstance(content, str):
+        out["content"] = _truncate_text_to_token_budget(content, token_budget)
+        return out
+
+    if isinstance(content, list):
+        remaining = token_budget
+        new_content = []
+        for item in content:
+            if not isinstance(item, dict) or item.get("type") != "text":
+                new_content.append(item)
+                continue
+            text = item.get("text", "")
+            truncated = _truncate_text_to_token_budget(text, remaining)
+            cloned = dict(item)
+            cloned["text"] = truncated
+            new_content.append(cloned)
+            remaining -= _message_text_token_estimate(truncated)
+        out["content"] = new_content
+    return out
+
+
 def trim_for_context(messages: List[Dict], context_length: int, reserve_tokens: int = 512) -> List[Dict]:
     """Trim system messages to fit within context_length.
 
@@ -153,19 +202,31 @@ def trim_for_context(messages: List[Dict], context_length: int, reserve_tokens: 
             if estimate_tokens(trimmed) <= budget:
                 return _sanitize_tool_messages(essential_system + protected_msgs + convo_msgs)
 
-    # Still too big — drop older conversation turns BUT protect the last 10.
+    # Still too big — drop older conversation turns BUT always keep the current
+    # user turn. If a pasted message alone exceeds the model context, truncate
+    # that message with a visible notice instead of dropping it; otherwise the
+    # model appears to "ignore" large pastes because it never receives them.
     # Hermes-style: recent context matters more than old context.
     PROTECT_RECENT = 10
-    if len(convo_msgs) > PROTECT_RECENT:
-        old_msgs = convo_msgs[:-PROTECT_RECENT]
-        recent_msgs = convo_msgs[-PROTECT_RECENT:]
+    current_msg = convo_msgs[-1:] if convo_msgs else []
+    prior_convo = convo_msgs[:-1] if convo_msgs else []
+    if len(prior_convo) >= PROTECT_RECENT:
+        old_msgs = prior_convo[:-(PROTECT_RECENT - 1)]
+        recent_msgs = prior_convo[-(PROTECT_RECENT - 1):] + current_msg
         while old_msgs and estimate_tokens(essential_system + old_msgs + recent_msgs) > budget:
             old_msgs.pop(0)
         convo_msgs = old_msgs + recent_msgs
     else:
-        # Not enough messages to split — just trim from front
-        while convo_msgs and estimate_tokens(essential_system + convo_msgs) > budget:
-            convo_msgs.pop(0)
+        convo_msgs = prior_convo + current_msg
+        while prior_convo and estimate_tokens(essential_system + prior_convo + current_msg) > budget:
+            prior_convo.pop(0)
+        convo_msgs = prior_convo + current_msg
+
+    # If the current message itself is too large, shrink only that message.
+    if current_msg and estimate_tokens(essential_system + protected_msgs + convo_msgs) > budget:
+        prefix = essential_system + protected_msgs + convo_msgs[:-1]
+        available_for_current = max(64, budget - estimate_tokens(prefix))
+        convo_msgs[-1] = _truncate_message_to_token_budget(convo_msgs[-1], available_for_current)
 
     result = _sanitize_tool_messages(essential_system + protected_msgs + convo_msgs)
     logger.info(f"Trimmed to {estimate_tokens(result)} tokens ({len(result)} messages)")

--- a/src/document_processor.py
+++ b/src/document_processor.py
@@ -230,7 +230,7 @@ def analyze_image_with_vl_result(image_path: str) -> dict:
         last_err = None
         for i, (_url, _model, _headers) in enumerate([c for c in _vl_candidates if c and c[0] and c[1]]):
             try:
-                description = llm_call(_url, _model, vl_messages, headers=_headers, timeout=30)
+                description = llm_call(_url, _model, vl_messages, headers=_headers, timeout=120)
                 logger.info("VL analysis complete with model %s", _model)
                 return {"text": description, "model": _model}
             except Exception as e:

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -843,6 +843,10 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
     # can detect thinking-in-progress (some models output </think> but no <think>)
     _thinking_model = _supports_thinking(model)
     _first_content_sent = False
+    # Tracks whether the upstream produced any real output. If a 200 stream
+    # closes without an upstream [DONE] and nothing was emitted, that's almost
+    # always an upstream-side failure — surface it rather than ending silently.
+    _saw_content = False
 
     def _emit_tool_calls():
         """Build the tool_calls event string if any were accumulated."""
@@ -878,6 +882,19 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
                         if data.strip():
                             if data.startswith("{"):
                                 j = json.loads(data)
+                                # Some OpenAI-compatible servers (e.g. LM Studio)
+                                # return 200, open the stream, then emit an
+                                # {"error": ...} chunk when the request fails
+                                # mid-flight (a chat-template render error, OOM,
+                                # etc.). Surface it as an error event instead of
+                                # silently ignoring it — otherwise the UI spins
+                                # until the read timeout.
+                                if isinstance(j, dict) and j.get("error") and not j.get("choices"):
+                                    _e = j["error"]
+                                    _emsg = _e.get("message") if isinstance(_e, dict) else str(_e)
+                                    logger.warning(f"Upstream {_host_key(target_url)} streamed an error: {_emsg}")
+                                    yield f'event: error\ndata: {json.dumps({"error": _emsg or "Upstream error", "status": 502})}\n\n'
+                                    return
                                 # Usage chunk (from stream_options)
                                 _choices = j.get("choices") or []
                                 _delta0 = _choices[0].get("delta") if _choices else None
@@ -891,6 +908,7 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
                                         # Reasoning tokens (VLLM --reasoning-parser, e.g. Qwen3/DeepSeek-R1)
                                         reasoning = delta.get("reasoning_content", "")
                                         if reasoning:
+                                            _saw_content = True
                                             yield f'data: {json.dumps({"delta": reasoning, "thinking": True})}\n\n'
                                         content = delta.get("content", "")
                                         if content:
@@ -901,6 +919,7 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
                                             if _thinking_model and not _first_content_sent and content.lstrip().lower().startswith("</think"):
                                                 content = "<think>" + content
                                             _first_content_sent = True
+                                            _saw_content = True
                                             yield f'data: {json.dumps({"delta": content})}\n\n'
                                         # Native tool calls — accumulate across chunks
                                         for tc in delta.get("tool_calls", []):
@@ -919,9 +938,11 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
                                                     yield f'data: {json.dumps({"type": "tool_call_delta", "index": idx, "name": _tc_acc[idx]["name"], "arg_delta": func["arguments"]})}\n\n'
                                 elif "text" in j:
                                     if j["text"]:
+                                        _saw_content = True
                                         yield f'data: {json.dumps({"delta": j["text"]})}\n\n'
                             else:
                                 if data.strip():
+                                    _saw_content = True
                                     yield f'data: {json.dumps({"delta": data})}\n\n'
                     except Exception as e:
                         logger.error(f"Error parsing stream data: {e}")
@@ -931,6 +952,15 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
             tc_event = _emit_tool_calls()
             if tc_event:
                 yield tc_event
+            elif not _saw_content:
+                # The upstream returned 200, opened the stream, then closed it
+                # without emitting any content, tool calls, or a [DONE] of its
+                # own — almost always an upstream-side failure (e.g. a chat
+                # template that errored during render). Report it so the UI
+                # shows an error instead of an empty bubble / a hung spinner.
+                logger.warning(f"Upstream {_host_key(target_url)} closed the stream with no output")
+                yield f'event: error\ndata: {json.dumps({"error": f"{_host_key(target_url)} returned no output — the model or its prompt template likely errored (check the server log).", "status": 502})}\n\n'
+                return
             yield "data: [DONE]\n\n"
 
     except (httpx.ConnectError, httpx.ConnectTimeout) as e:

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -385,6 +385,47 @@ def _sanitize_llm_messages(messages: List[Dict]) -> List[Dict]:
             cleaned.append(item)
     return cleaned
 
+
+def _normalize_conversation(messages: List[Dict]) -> List[Dict]:
+    """Coerce a message list into the user-first, alternating shape that strict
+    chat templates (e.g. Qwen's jinja, which raises "No user query found in
+    messages") require — without changing meaning.
+
+    The chat UI seeds a greeting as an ``assistant`` message and, when a turn
+    fails, can leave two ``user`` turns back-to-back. Both produce a sequence
+    these templates reject. This:
+      - keeps a single leading ``system`` message untouched,
+      - drops any assistant/tool turns that precede the first ``user`` turn,
+      - merges consecutive same-role text turns into one (joined by a blank
+        line), leaving tool-call/non-string turns alone.
+    """
+    if not messages:
+        return messages
+    out: List[Dict] = []
+    body = messages
+    if body[0].get("role") == "system":
+        out.append(body[0])
+        body = body[1:]
+    # Drop leading non-user turns (the seeded assistant greeting, stray tools).
+    start = 0
+    while start < len(body) and body[start].get("role") != "user":
+        start += 1
+    for msg in body[start:]:
+        prev = out[-1] if out else None
+        mergeable = (
+            prev is not None
+            and prev.get("role") == msg.get("role")
+            and isinstance(prev.get("content"), str)
+            and isinstance(msg.get("content"), str)
+            and "tool_calls" not in prev and "tool_calls" not in msg
+            and "tool_call_id" not in prev and "tool_call_id" not in msg
+        )
+        if mergeable:
+            out[-1] = {**prev, "content": f"{prev['content']}\n\n{msg['content']}".strip()}
+        else:
+            out.append(msg)
+    return out
+
 def _normalize_anthropic_url(url: str) -> str:
     """Ensure Anthropic URL points to /v1/messages."""
     url = url.rstrip("/")
@@ -464,6 +505,7 @@ def llm_call(url: str, model: str, messages: List[Dict], temperature: float = LL
         messages_copy = [{"role": "system", "content": "\n\n".join(sys_parts)}] + non_sys
     else:
         messages_copy = non_sys
+    messages_copy = _normalize_conversation(messages_copy)
 
     provider = _detect_provider(url)
     cache_key = _get_cache_key(url, model, messages_copy, temperature, max_tokens)
@@ -572,6 +614,7 @@ async def llm_call_async(
         messages_copy = [{"role": "system", "content": "\n\n".join(sys_parts)}] + non_sys
     else:
         messages_copy = non_sys
+    messages_copy = _normalize_conversation(messages_copy)
 
     cache_key = _get_cache_key(url, model, messages_copy, temperature, max_tokens)
     cached_response = _get_cached_response(cache_key)
@@ -668,6 +711,7 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
         messages_copy = [{"role": "system", "content": "\n\n".join(sys_parts)}] + non_sys
     else:
         messages_copy = non_sys
+    messages_copy = _normalize_conversation(messages_copy)
 
     if provider == "anthropic":
         target_url = _normalize_anthropic_url(url)

--- a/static/app.js
+++ b/static/app.js
@@ -1025,16 +1025,10 @@ function initializeEventListeners() {
     });
   }
 
-  // "Chats" sidebar section header:
-  //   • Click the auto-injected chevron (section-management.js adds it)
-  //     or the empty area of the title → toggle collapse of the list.
-  //   • Click the "Chats" text label → open the Chats tab of the library.
-  // We stop propagation on the label so section-management.js's
-  // section-title click handler (which toggles collapse) doesn't also
-  // fire when the user is trying to open the library.
-  const chatsSectionLabel = el('chats-section-label');
-  if (chatsSectionLabel) {
-    chatsSectionLabel.addEventListener('click', (e) => {
+  // Manage Chats — opens Full Library modal (decoupled from Chats accordion toggle)
+  const chatsLibraryBtn = el('chats-library-btn');
+  if (chatsLibraryBtn) {
+    chatsLibraryBtn.addEventListener('click', (e) => {
       e.stopPropagation();
       if (sessionModule) sessionModule.openLibrary('chats');
     });

--- a/static/index.html
+++ b/static/index.html
@@ -1864,13 +1864,10 @@
         <div data-settings-panel="email" class="hidden">
           <div class="admin-card">
             <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg>Email Accounts</h2>
-            <div class="admin-toggle-sub" style="margin-bottom:8px">Configure one or more IMAP/SMTP accounts. The default account is used when nothing else is selected.</div>
-            <div id="set-email-accounts-list" style="display:flex;flex-direction:column;gap:6px;margin-bottom:8px"></div>
-            <div class="settings-row">
-              <span id="set-email-accounts-msg" style="font-size:11px;"></span>
-              <button class="admin-btn-add" id="set-email-accounts-add-btn" style="margin-left:auto;">+ Add Account</button>
+            <div class="settings-row" style="align-items:center;">
+              <div class="admin-toggle-sub" style="margin:0;flex:1;">Add, edit, delete, and test accounts in Integrations.</div>
+              <button class="admin-btn-add" id="set-email-open-integrations">Manage in Integrations</button>
             </div>
-            <div id="set-email-accounts-form" style="display:none;margin-top:8px;padding:10px;border:1px solid var(--border);border-radius:6px"></div>
           </div>
 
           <div class="admin-card">

--- a/static/index.html
+++ b/static/index.html
@@ -693,8 +693,16 @@
 
       <div class="section" id="sessions-section">
         <div class="section-header-flex">
-          <span class="section-title" id="chats-section-title"><svg class="section-icon" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg><span id="chats-section-label" class="section-title-label" style="cursor:pointer;" title="Open Library">Chats</span><span id="chats-notif-dot" class="sidebar-notif-dot" style="display:none"></span></span>
-          <div style="position:relative; display:inline-block;">
+          <span class="section-title" id="chats-section-title"><svg class="section-icon" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg><span id="chats-section-label" class="section-title-label">Chats</span><span id="chats-notif-dot" class="sidebar-notif-dot" style="display:none"></span></span>
+          <div style="position:relative; display:inline-block; display:flex; gap:4px; align-items:center;">
+            <button type="button" class="section-header-btn chats-manage-btn" id="chats-library-btn" title="Manage Chats (Library)">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="3" y="3" width="7" height="7"></rect>
+                <rect x="14" y="3" width="7" height="7"></rect>
+                <rect x="14" y="14" width="7" height="7"></rect>
+                <rect x="3" y="14" width="7" height="7"></rect>
+              </svg>
+            </button>
             <button type="button" class="section-header-btn" id="session-sort-btn" title="Sort sessions">
               <svg class="sort-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <line x1="4" y1="6" x2="20" y2="6"/>

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -53,6 +53,7 @@ async function loadUsers() {
           </div>
         </div>
         <div style="display:flex;gap:8px;align-items:center;">
+          <button class="admin-btn-sm" data-adm-rename-user="${esc(u.username)}" style="font-size:11px;">Rename</button>
           ${u.is_admin ? '' : `<button class="admin-btn-delete" data-adm-del-user="${esc(u.username)}" style="font-size:11px;">Remove</button>`}
           ${u.is_admin ? '' : '<svg class="admin-user-chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="opacity:0.3;transition:transform 0.2s,opacity 0.2s;"><polyline points="6 9 12 15 18 9"/></svg>'}
         </div>
@@ -106,7 +107,7 @@ async function loadUsers() {
         // Toggle panel visibility + rotate chevron + load models
         let _modelsLoaded = false;
         header.addEventListener('click', (e) => {
-          if (e.target.closest('.admin-btn-delete')) return;
+          if (e.target.closest('.admin-btn-delete, [data-adm-rename-user]')) return;
           privPanel.classList.toggle('hidden');
           const chevron = header.querySelector('.admin-user-chevron');
           if (chevron) {
@@ -140,6 +141,42 @@ async function loadUsers() {
           };
           if (input.type === 'checkbox') input.addEventListener('change', handler);
           else input.addEventListener('change', handler);
+        });
+      }
+
+      // Rename button
+      const renameBtn = row.querySelector('[data-adm-rename-user]');
+      if (renameBtn) {
+        renameBtn.addEventListener('click', async (e) => {
+          e.stopPropagation();
+          const oldUsername = renameBtn.dataset.admRenameUser;
+          const next = await uiModule.styledPrompt(`Rename "${oldUsername}"`, {
+            defaultValue: oldUsername,
+            placeholder: 'New username',
+            confirmText: 'Rename',
+          });
+          const username = (next || '').trim();
+          if (!username || username === oldUsername) return;
+          try {
+            const res = await fetch(`/api/auth/users/${encodeURIComponent(oldUsername)}/rename`, {
+              method: 'PUT',
+              credentials: 'same-origin',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ username }),
+            });
+            const data = await res.json().catch(() => ({}));
+            if (!res.ok) {
+              uiModule.showError(data.detail || 'Failed to rename user');
+              return;
+            }
+            if (data.renamed_self) {
+              window.location.reload();
+              return;
+            }
+            loadUsers();
+          } catch (err) {
+            uiModule.showError('Failed to rename user');
+          }
         });
       }
 

--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -3082,8 +3082,16 @@ function _nowClock() {
   return new Date().toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
 }
 function _fmtTime(s) {
-  // Show the time as written in the ICS file (ignore UTC offset).
   if (!s || s.length < 16) return '';
+  // Tz-aware timestamps from CalDAV/import are stored as UTC instants and
+  // serialized with Z/offset. Display them in the browser's local timezone;
+  // legacy naive timestamps keep their written wall-clock time.
+  if (/[Zz]$|[+\-]\d{2}:?\d{2}$/.test(s)) {
+    const d = new Date(s);
+    if (!isNaN(d)) {
+      return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+    }
+  }
   return s.slice(11, 16);
 }
 function _e(s) { return uiModule.esc ? uiModule.esc(s || '') : (s || '').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;'); }

--- a/static/js/cookbook-diagnosis.js
+++ b/static/js/cookbook-diagnosis.js
@@ -323,10 +323,10 @@ export const ERROR_PATTERNS = [
     ],
   },
   {
-    pattern: /diffusers.*No module named|diffusers.*command not found/i,
-    message: 'Diffusers is not installed. Run: pip install diffusers transformers accelerate',
+    pattern: /No module named ['"]?torch|No module named ['"]?diffusers|diffusers.*command not found/i,
+    message: 'Diffusion serving needs PyTorch and diffusers. Install diffusers from Cookbook → Dependencies.',
     fixes: [
-      { label: 'Copy install command', action: () => _copyText('pip install diffusers transformers accelerate') },
+      { label: 'Copy install command', action: () => _copyText('python3 -m pip install "diffusers[torch]"') },
     ],
   },
   {

--- a/static/js/cookbook-diagnosis.js
+++ b/static/js/cookbook-diagnosis.js
@@ -294,6 +294,21 @@ export const ERROR_PATTERNS = [
     ],
   },
   {
+    pattern: /Either a revision or a version must be specified|transformers\.integrations\.hub_kernels|kernels\/layer/i,
+    message: 'vLLM/Transformers kernel package mismatch.',
+    fixes: [
+      { label: 'Update vLLM/Transformers/kernels', action: (panel) => {
+        const taskEl = panel.closest('.cookbook-task');
+        const task = taskEl ? _loadTasks().find(t => t.sessionId === taskEl.dataset.taskId) : null;
+        const host = task?.remoteHost || '';
+        const prefix = _buildEnvPrefix();
+        const pipCmd = prefix ? prefix + ' python3 -m pip install -U vllm transformers kernels' : 'python3 -m pip install -U vllm transformers kernels';
+        const cmd = host ? _sshCmd(host, pipCmd) : pipCmd;
+        _launchServeTask('update-vllm-stack', 'pip-update', cmd);
+      }},
+    ],
+  },
+  {
     pattern: /ollama.*command not found/i,
     message: 'Ollama is not installed on this server. Run: curl -fsSL https://ollama.com/install.sh | sh',
     fixes: [

--- a/static/js/cookbook-hwfit.js
+++ b/static/js/cookbook-hwfit.js
@@ -1094,12 +1094,13 @@ export function _hwfitInit() {
     for (const sel of selectors) {
       if (!sel) continue;
       const currentVal = sel.value;
-      sel.innerHTML = `<option value="local">Local</option>`;
+      let html = `<option value="local">Local</option>`;
       _envState.servers.forEach((s, i) => {
         if (!s.host) return;
         const label = s.name || s.host || `Server ${i + 1}`;
-        sel.innerHTML += `<option value="${i}">${uiModule.esc(label)}</option>`;
+        html += `<option value="${i}">${uiModule.esc(label)}</option>`;
       });
+      sel.innerHTML = html;
       sel.value = currentVal;
     }
   }

--- a/static/js/cookbook.js
+++ b/static/js/cookbook.js
@@ -523,39 +523,42 @@ async function _fetchDependencies() {
     const pkgs = data.packages || [];
     if (!pkgs.length) { list.innerHTML = '<div class="hwfit-loading">No packages found</div>'; return; }
     const _winUnsupported = new Set(['diffusers', 'hf_transfer', 'vllm', 'rembg', 'gfpgan']);
-    // When a non-local server is selected, the Local-only packages aren't
-    // relevant to it — hide them so the list shows just that server's packages.
-    const _viewingRemote = !!(_dsel && _dsel.value && _dsel.value !== 'local');
-    let html = '';
-    for (const pkg of pkgs) {
+
+    const _statusTag = (pkg, isLocal, isSystemDep, winBlocked) => {
+      if (winBlocked) return `<span class="cookbook-dep-tag cookbook-dep-na">N/A</span>`;
+      if (pkg.installed && isSystemDep) return `<span class="cookbook-dep-tag cookbook-dep-installed" title="Found on selected server">Installed</span>`;
+      if (pkg.installed) return `<button class="cookbook-dep-tag cookbook-dep-installed cookbook-dep-installed-btn" title="Installed — click for actions"><span class="cookbook-dep-installed-label">Installed</span><span class="cookbook-dep-caret">&#9662;</span></button>`;
+      if (isSystemDep) return `<span class="cookbook-dep-tag cookbook-dep-na" title="${esc(pkg.install_hint || 'Install this OS package on the selected server.')}">Missing</span>`;
+      return `<button class="cookbook-dep-tag cookbook-dep-install" data-dep-pip="${esc(pkg.pip)}" data-dep-target="${isLocal ? 'local' : 'remote'}">Install</button>`;
+    };
+
+    const _depRow = (pkg) => {
       const isLocal = pkg.target === 'local';
-      if (_viewingRemote && isLocal) continue;
-      const winBlocked = !isLocal && _isWindows() && _winUnsupported.has(pkg.name);
-      const targetLabel = isLocal ? 'Local' : 'GPU server';
       const isSystemDep = pkg.kind === 'system';
-      html += `<div class="cookbook-dep-row${winBlocked ? ' cookbook-dep-blocked' : ''}" data-pkg-name="${esc(pkg.name)}" data-dep-pip="${esc(pkg.pip || '')}" data-dep-target="${isLocal ? 'local' : 'remote'}" data-dep-kind="${esc(pkg.kind || 'python')}">`;
-      html += `<div class="cookbook-dep-info">`;
-      html += `<div class="memory-item-title">${esc(pkg.name)}</div>`;
-      html += `<div class="memory-item-meta" style="font-size:10px;opacity:0.5;margin-top:2px;">${esc(pkg.desc)}</div>`;
-      html += `</div>`;
-      html += `<span class="cookbook-dep-tag cookbook-dep-target">${targetLabel}</span>`;
-      html += `<span class="cookbook-dep-tag cookbook-dep-cat">${esc(pkg.category)}</span>`;
-      if (winBlocked) {
-        html += `<span class="cookbook-dep-tag cookbook-dep-na">N/A</span>`;
-      } else if (pkg.installed) {
-        if (isSystemDep) {
-          html += `<span class="cookbook-dep-tag cookbook-dep-installed" title="Found on selected server">Installed</span>`;
-        } else {
-          html += `<button class="cookbook-dep-tag cookbook-dep-installed cookbook-dep-installed-btn" title="Installed — click for actions"><span class="cookbook-dep-installed-label">Installed</span><span class="cookbook-dep-caret">&#9662;</span></button>`;
-        }
-      } else if (isSystemDep) {
-        html += `<span class="cookbook-dep-tag cookbook-dep-na" title="${esc(pkg.install_hint || 'Install this OS package on the selected server.')}">Missing</span>`;
-      } else {
-        html += `<button class="cookbook-dep-tag cookbook-dep-install" data-dep-pip="${esc(pkg.pip)}" data-dep-target="${isLocal ? 'local' : 'remote'}">Install</button>`;
-      }
-      html += `</div>`;
-    }
-    list.innerHTML = html;
+      const winBlocked = !isLocal && _isWindows() && _winUnsupported.has(pkg.name);
+      return `<div class="cookbook-dep-row${winBlocked ? ' cookbook-dep-blocked' : ''}" data-pkg-name="${esc(pkg.name)}" data-dep-pip="${esc(pkg.pip || '')}" data-dep-target="${isLocal ? 'local' : 'remote'}" data-dep-kind="${esc(pkg.kind || 'python')}">`
+        + `<div class="cookbook-dep-info">`
+        + `<div class="memory-item-title">${esc(pkg.name)}</div>`
+        + `<div class="memory-item-meta" style="font-size:10px;opacity:0.5;margin-top:2px;">${esc(pkg.desc)}</div>`
+        + `</div>`
+        + `<span class="cookbook-dep-tag cookbook-dep-cat">${esc(pkg.category)}</span>`
+        + _statusTag(pkg, isLocal, isSystemDep, winBlocked)
+        + `</div>`;
+    };
+
+    const _section = (title, note, items) =>
+      items.length
+        ? `<div class="cookbook-dep-section"><span class="cookbook-dep-section-title">${title}</span><span class="cookbook-dep-section-note">${note}</span></div>` + items.map(_depRow).join('')
+        : '';
+
+    const _viewingRemote = !!(_dsel && _dsel.value && _dsel.value !== 'local');
+    const _appDeps = pkgs.filter(p => p.target === 'local');
+    const _serverDeps = pkgs.filter(p => p.target !== 'local');
+
+    list.innerHTML = [
+      _viewingRemote ? '' : _section('Odysseus app', 'Run inside the Odysseus app itself.', _appDeps),
+      _section('Server', 'Run on the server chosen above (Local, or a remote box over SSH).', _serverDeps),
+    ].join('');
 
     // Shared install/update routine — used by the Install button and the
     // "Update" item in an installed package's ⋮ menu. `upgrade` adds pip -U;
@@ -1475,7 +1478,7 @@ function _renderRecipes() {
   html += _buildServerOpts(false);
   html += '</select>';
   html += '</div>';
-  html += '<p class="memory-desc doclib-desc">Optional packages that extend Odysseus capabilities. Install on local or remote servers.</p>';
+  html += '<p class="memory-desc doclib-desc">Optional packages that extend Odysseus capabilities.</p>';
   html += '<div class="doclib-grid" id="cookbook-deps-list"></div>';
   html += '</div></div>';
 

--- a/static/js/cookbookRunning.js
+++ b/static/js/cookbookRunning.js
@@ -2158,10 +2158,6 @@ async function _reconnectTask(el, task) {
               task._serveReady = true;
               _updateTask(task.sessionId, { _serveReady: true });
             }
-            if (!task._serveReady && task.ts && (Date.now() - task.ts) > 300000) {
-              task._serveReady = true;
-              _updateTask(task.sessionId, { _serveReady: true });
-            }
             if (info.phase) {
               badge.textContent = info.phase;
               // Always the green "running" style — loading/warming is the same

--- a/static/js/emailLibrary.js
+++ b/static/js/emailLibrary.js
@@ -453,7 +453,7 @@ export function openEmailLibrary(opts = {}) {
   const existing = document.getElementById('email-lib-modal');
   if (existing) existing.remove();
   if (state._libEscHandler) {
-    document.removeEventListener('keydown', state._libEscHandler);
+    document.removeEventListener('keydown', state._libEscHandler, true);
     state._libEscHandler = null;
   }
   state._libOpen = true;
@@ -958,11 +958,13 @@ export function openEmailLibrary(opts = {}) {
 
   // ESC to close + Arrow nav + Delete on the selected / currently-expanded email.
   state._libEscHandler = (e) => {
+    const modal = document.getElementById('email-lib-modal');
+    if (!modal || modal.classList.contains('hidden')) return;
     if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      e.stopImmediatePropagation?.();
       if (state._selectMode) {
-        e.preventDefault();
-        e.stopPropagation();
-        e.stopImmediatePropagation?.();
         state._selectMode = false;
         state._selectedUids.clear();
         _updateBulkBar();
@@ -995,7 +997,7 @@ export function openEmailLibrary(opts = {}) {
       }
     }
   };
-  document.addEventListener('keydown', state._libEscHandler);
+  document.addEventListener('keydown', state._libEscHandler, true);
 
   _loadAccounts();
   _loadFolders();
@@ -1047,7 +1049,7 @@ export function closeEmailLibrary() {
   if (modal) modal.remove();
   _clearEmailDocumentSplit();
   if (state._libEscHandler) {
-    document.removeEventListener('keydown', state._libEscHandler);
+    document.removeEventListener('keydown', state._libEscHandler, true);
     state._libEscHandler = null;
   }
   state._libOpen = false;

--- a/static/js/emailLibrary.js
+++ b/static/js/emailLibrary.js
@@ -449,27 +449,12 @@ export function initEmailLibrary(config) {
 export function isOpen() { return state._libOpen; }
 
 export function openEmailLibrary(opts = {}) {
+  // Force-clean any stale state from previous attempts
   const existing = document.getElementById('email-lib-modal');
-  if (existing) {
-    existing.classList.remove('hidden');
-    existing.style.display = 'block';
-    state._libOpen = true;
-    if (window.innerWidth <= 768) {
-      document.getElementById('sidebar')?.classList.add('hidden');
-      document.getElementById('sidebar-backdrop')?.classList.remove('visible');
-    }
-    document.body.classList.add('email-front');
-    if (Object.prototype.hasOwnProperty.call(opts, 'account_id')) {
-      state._libAccountId = opts.account_id || null;
-      _publishActiveAccount();
-    }
-    if (opts.folder) state._libFolder = opts.folder;
-    state._libPendingExpandUid = opts.uid || null;
-    _loadAccounts();
-    _loadFolders();
-    _loadEmailReminderBellVisibility();
-    _loadEmails({ preserveCurrent: true });
-    return;
+  if (existing) existing.remove();
+  if (state._libEscHandler) {
+    document.removeEventListener('keydown', state._libEscHandler);
+    state._libEscHandler = null;
   }
   state._libOpen = true;
   // On mobile the sidebar overlays content — close it so the email view isn't
@@ -973,8 +958,6 @@ export function openEmailLibrary(opts = {}) {
 
   // ESC to close + Arrow nav + Delete on the selected / currently-expanded email.
   state._libEscHandler = (e) => {
-    const modal = document.getElementById('email-lib-modal');
-    if (!modal || modal.classList.contains('hidden')) return;
     if (e.key === 'Escape') {
       if (state._selectMode) {
         e.preventDefault();
@@ -1061,8 +1044,12 @@ function _renderAccountsStrip() {
 
 export function closeEmailLibrary() {
   const modal = document.getElementById('email-lib-modal');
-  if (modal) modal.classList.add('hidden');
+  if (modal) modal.remove();
   _clearEmailDocumentSplit();
+  if (state._libEscHandler) {
+    document.removeEventListener('keydown', state._libEscHandler);
+    state._libEscHandler = null;
+  }
   state._libOpen = false;
   // If the /email route collapsed the wide sidebar to make room for
   // the fullscreen modal, re-expand it now that the modal is gone.
@@ -1307,7 +1294,7 @@ async function _refreshUnreadBadge() {
   } catch (_) { _syncUnreadTabBadge(0); }
 }
 
-async function _loadEmails({ force = false, preserveCurrent = false } = {}) {
+async function _loadEmails({ force = false } = {}) {
   const seq = ++_libLoadSeq;
   state._libLoading = true;
   const accountAtStart = state._libAccountId || '';
@@ -1349,8 +1336,6 @@ async function _loadEmails({ force = false, preserveCurrent = false } = {}) {
     _renderGrid();
     const stats = document.getElementById('email-lib-stats');
     if (stats) stats.textContent = `${state._libTotal} emails`;
-  } else if (preserveCurrent && state._libEmails.length) {
-    sp = null;
   } else {
     grid.innerHTML = '';
     sp = spinnerModule.createWhirlpool(28);

--- a/static/js/emailLibrary.js
+++ b/static/js/emailLibrary.js
@@ -1788,6 +1788,34 @@ function _syncCardNavArrows(card) {
   if (next) next.disabled = !_findSiblingEmailCard(card, 1);
 }
 
+const _emailReadPrefetching = new Set();
+
+function _prefetchAdjacentEmails(card, count = 3) {
+  if (!card || state._libFolder === '__scheduled__') return;
+  const grid = card.closest('.doclib-grid');
+  if (!grid) return;
+  const cards = [...grid.querySelectorAll('.doclib-card[data-uid]')];
+  const idx = cards.indexOf(card);
+  if (idx === -1) return;
+  const targets = [];
+  for (let i = 1; i <= count; i++) {
+    if (cards[idx + i]) targets.push(cards[idx + i]);
+  }
+  if (targets.length < count) {
+    for (let i = 1; targets.length < count && cards[idx - i]; i++) targets.push(cards[idx - i]);
+  }
+  for (const target of targets) {
+    const uid = target.dataset.uid;
+    if (!uid) continue;
+    const key = `${state._libAccountId || ''}|${state._libFolder}|${uid}`;
+    if (_emailReadPrefetching.has(key)) continue;
+    _emailReadPrefetching.add(key);
+    fetch(`${API_BASE}/api/email/read/${encodeURIComponent(uid)}?folder=${encodeURIComponent(state._libFolder)}${_acct()}&mark_seen=false`)
+      .catch(() => {})
+      .finally(() => _emailReadPrefetching.delete(key));
+  }
+}
+
 async function _toggleCardPreview(card, em) {
   const grid = card.closest('.doclib-grid');
 
@@ -1843,6 +1871,7 @@ async function _toggleCardPreview(card, em) {
 
     // Mark as read locally
     _syncEmailReadState(em.uid, true);
+    _prefetchAdjacentEmails(card);
 
     // Build the attachments wrap using the shared helper so the signature-
     // image filter (small inline PNGs/JPGs, Outlook image001 placeholders,

--- a/static/js/emailLibrary.js
+++ b/static/js/emailLibrary.js
@@ -449,12 +449,27 @@ export function initEmailLibrary(config) {
 export function isOpen() { return state._libOpen; }
 
 export function openEmailLibrary(opts = {}) {
-  // Force-clean any stale state from previous attempts
   const existing = document.getElementById('email-lib-modal');
-  if (existing) existing.remove();
-  if (state._libEscHandler) {
-    document.removeEventListener('keydown', state._libEscHandler);
-    state._libEscHandler = null;
+  if (existing) {
+    existing.classList.remove('hidden');
+    existing.style.display = 'block';
+    state._libOpen = true;
+    if (window.innerWidth <= 768) {
+      document.getElementById('sidebar')?.classList.add('hidden');
+      document.getElementById('sidebar-backdrop')?.classList.remove('visible');
+    }
+    document.body.classList.add('email-front');
+    if (Object.prototype.hasOwnProperty.call(opts, 'account_id')) {
+      state._libAccountId = opts.account_id || null;
+      _publishActiveAccount();
+    }
+    if (opts.folder) state._libFolder = opts.folder;
+    state._libPendingExpandUid = opts.uid || null;
+    _loadAccounts();
+    _loadFolders();
+    _loadEmailReminderBellVisibility();
+    _loadEmails({ preserveCurrent: true });
+    return;
   }
   state._libOpen = true;
   // On mobile the sidebar overlays content — close it so the email view isn't
@@ -958,6 +973,8 @@ export function openEmailLibrary(opts = {}) {
 
   // ESC to close + Arrow nav + Delete on the selected / currently-expanded email.
   state._libEscHandler = (e) => {
+    const modal = document.getElementById('email-lib-modal');
+    if (!modal || modal.classList.contains('hidden')) return;
     if (e.key === 'Escape') {
       if (state._selectMode) {
         e.preventDefault();
@@ -1044,12 +1061,8 @@ function _renderAccountsStrip() {
 
 export function closeEmailLibrary() {
   const modal = document.getElementById('email-lib-modal');
-  if (modal) modal.remove();
+  if (modal) modal.classList.add('hidden');
   _clearEmailDocumentSplit();
-  if (state._libEscHandler) {
-    document.removeEventListener('keydown', state._libEscHandler);
-    state._libEscHandler = null;
-  }
   state._libOpen = false;
   // If the /email route collapsed the wide sidebar to make room for
   // the fullscreen modal, re-expand it now that the modal is gone.
@@ -1294,7 +1307,7 @@ async function _refreshUnreadBadge() {
   } catch (_) { _syncUnreadTabBadge(0); }
 }
 
-async function _loadEmails({ force = false } = {}) {
+async function _loadEmails({ force = false, preserveCurrent = false } = {}) {
   const seq = ++_libLoadSeq;
   state._libLoading = true;
   const accountAtStart = state._libAccountId || '';
@@ -1336,6 +1349,8 @@ async function _loadEmails({ force = false } = {}) {
     _renderGrid();
     const stats = document.getElementById('email-lib-stats');
     if (stats) stats.textContent = `${state._libTotal} emails`;
+  } else if (preserveCurrent && state._libEmails.length) {
+    sp = null;
   } else {
     grid.innerHTML = '';
     sp = spinnerModule.createWhirlpool(28);

--- a/static/js/group.js
+++ b/static/js/group.js
@@ -487,10 +487,11 @@ export async function showModelPicker() {
         `;
         const sel = document.createElement('select');
         sel.style.cssText = 'font-size:11px;padding:3px 6px;border-radius:4px;border:1px solid var(--border);background:var(--bg);color:var(--fg);max-width:140px;';
-        sel.innerHTML = '<option value="">No character</option>';
+        let optsHtml = '<option value="">No character</option>';
         characters.forEach(c => {
-          sel.innerHTML += `<option value="${c.id}">${uiModule.esc(c.name)}</option>`;
+          optsHtml += `<option value="${c.id}">${uiModule.esc(c.name)}</option>`;
         });
+        sel.innerHTML = optsHtml;
         sel.addEventListener('change', () => {
           if (sel.value) {
             const ch = characters.find(c => c.id === sel.value);

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -4106,17 +4106,26 @@ async function initUnifiedIntegrations() {
       el('uf-mcp-cancel').addEventListener('click', () => { formEl.style.display = 'none'; });
       el('uf-mcp-save').addEventListener('click', async () => {
         const transport = el('uf-mcp-transport').value;
-        const body = { name: el('uf-mcp-name').value, transport };
+        // routes/mcp_routes.py uses FastAPI Form(...) — send multipart, not JSON.
+        const fd = new FormData();
+        fd.append('name', el('uf-mcp-name').value);
+        fd.append('transport', transport);
         if (transport === 'stdio') {
-          body.command = el('uf-mcp-cmd').value;
-          try { body.args = JSON.parse(el('uf-mcp-args').value || '[]'); } catch (_) { body.args = []; }
-          try { body.env = JSON.parse(el('uf-mcp-env').value || '{}'); } catch (_) { body.env = {}; }
+          fd.append('command', el('uf-mcp-cmd').value);
+          let args = '[]'; try { args = JSON.stringify(JSON.parse(el('uf-mcp-args').value || '[]')); } catch (_) {}
+          let env  = '{}'; try { env  = JSON.stringify(JSON.parse(el('uf-mcp-env').value  || '{}')); } catch (_) {}
+          fd.append('args', args);
+          fd.append('env', env);
         } else {
-          body.url = el('uf-mcp-url').value;
+          fd.append('url', el('uf-mcp-url').value);
         }
         try {
-          await fetch('/api/mcp/servers', { method: 'POST', credentials: 'same-origin', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
-          el('uf-mcp-msg').textContent = 'Saved'; formEl.style.display = 'none'; await renderList();
+          const r = await fetch('/api/mcp/servers', { method: 'POST', credentials: 'same-origin', body: fd });
+          if (r.ok) {
+            el('uf-mcp-msg').textContent = 'Saved'; formEl.style.display = 'none'; await renderList();
+          } else {
+            el('uf-mcp-msg').textContent = `Failed (${r.status})`;
+          }
         } catch (_) { el('uf-mcp-msg').textContent = 'Failed'; }
       });
     }

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -2376,6 +2376,11 @@ async function initReminderSettings() {
 async function initEmailAccountsSettings() {
   const root = el('settings-modal');
   if (!root || !root.querySelector('[data-settings-panel="email"]')) return;
+  const manageBtn = el('set-email-open-integrations');
+  if (manageBtn && manageBtn.dataset.bound !== '1') {
+    manageBtn.dataset.bound = '1';
+    manageBtn.addEventListener('click', () => open('integrations'));
+  }
   const listEl = el('set-email-accounts-list');
   const msgEl = el('set-email-accounts-msg');
   const formEl = el('set-email-accounts-form');
@@ -3860,7 +3865,7 @@ async function initUnifiedIntegrations() {
         }
         el('uf-email-msg').textContent = 'Saved';
         el('uf-email-msg').style.color = 'var(--green,#50fa7b)';
-        integrationNotice = 'Email account saved. Go to Settings > Email for writing style, auto-tagging, spam triage, reminders, and reply settings.';
+        integrationNotice = 'Email account saved. For more settings, go to Settings > Email.';
         formEl.style.display = 'none';
         await renderList();
         notifyIntegrationsChanged();

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -516,14 +516,15 @@ export function styledPrompt(message, {
   });
 }
 
+// Lookup table for esc(); hoisted out of the replace callback so it is
+// allocated once rather than per matched character.
+const _ESC_MAP = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
 /**
  * HTML-escape a string to prevent XSS.
  * Canonical implementation — other modules should use uiModule.esc() instead of local copies.
  */
 export function esc(s) {
-  return (s || '').replace(/[&<>"']/g, function(m) {
-    return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m];
-  });
+  return (s || '').replace(/[&<>"']/g, (m) => _ESC_MAP[m]);
 }
 
 // ── Mobile: suppress synthetic click/mousedown on backdrop ──

--- a/static/style.css
+++ b/static/style.css
@@ -18007,6 +18007,21 @@ body.gallery-selecting .gallery-dl-btn,
 .cookbook-settings-stack.hidden { display: none; }
 .cookbook-dep-row.cookbook-dep-blocked { opacity: 0.4; }
 .cookbook-dep-info { flex: 1; min-width: 0; }
+.cookbook-dep-section {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin: 12px 2px 4px;
+}
+.cookbook-dep-section-title {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+.cookbook-dep-section-note {
+  font-size: 10px;
+  color: color-mix(in srgb, var(--fg) 50%, transparent);
+}
 .cookbook-dep-tag {
   font-size: 9px;
   padding: 0 8px;

--- a/static/style.css
+++ b/static/style.css
@@ -1208,6 +1208,25 @@ body.bg-pattern-sparkles {
     .section-header-btn.active { opacity: 0.9; color: var(--accent); }
     .section-header-btn svg { width: 12px; height: 12px; }
 
+    /* Chats library — grid icon, hover-reveal so the header only toggles collapse */
+    #sessions-section .chats-manage-btn {
+      opacity: 0;
+      transition: opacity 0.12s, background 0.08s;
+    }
+    #sessions-section .section-header-flex:hover .chats-manage-btn,
+    #sessions-section .chats-manage-btn:hover,
+    #sessions-section .chats-manage-btn:focus-visible {
+      opacity: 0.45;
+    }
+    #sessions-section .chats-manage-btn:hover,
+    #sessions-section .chats-manage-btn:focus-visible {
+      opacity: 1;
+    }
+    @media (hover: none) {
+      #sessions-section .chats-manage-btn { opacity: 0.35; }
+      #sessions-section .chats-manage-btn:active { opacity: 1; }
+    }
+
     /* Collapse chevron */
     .section-collapse-btn {
       all: unset;

--- a/static/style.css
+++ b/static/style.css
@@ -1690,6 +1690,10 @@ body.bg-pattern-sparkles {
       overflow: hidden;
       text-overflow: clip;
       white-space: nowrap;
+      /* .list-item sets line-height:1, which clips the tops of Fira Code's
+         tall ascenders under overflow:hidden. Give the label its own roomier
+         line box so glyph tops aren't sliced. */
+      line-height: 1.4;
     }
     input, textarea, button, select {
       background:var(--bg);

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 for mod in [
     'sqlalchemy', 'sqlalchemy.orm', 'sqlalchemy.ext', 'sqlalchemy.ext.declarative',
     'sqlalchemy.ext.hybrid', 'sqlalchemy.sql', 'sqlalchemy.sql.expression',
-    'src.database', 'src.endpoint_resolver',
+    'src.database',
     'src.agent_tools',
     'core.models', 'core.database',
 ]:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -32,10 +32,13 @@ class TestAppStructure:
         src_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "src")
         assert os.path.exists(src_path), "src directory should exist"
 
-    def test_env_file_exists(self):
-        """Test that .env file exists"""
-        env_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), ".env")
-        assert os.path.exists(env_path), ".env file should exist"
+    def test_env_file_is_optional_and_ignored(self):
+        """A fresh checkout should not require a private .env file."""
+        root = os.path.dirname(os.path.dirname(__file__))
+        gitignore_path = os.path.join(root, ".gitignore")
+        with open(gitignore_path, encoding="utf-8") as fh:
+            ignored = {line.strip() for line in fh}
+        assert ".env" in ignored, ".env should stay local and ignored"
 
     def test_env_example_exists(self):
         """Test that .env.example exists"""

--- a/tests/test_context_compactor.py
+++ b/tests/test_context_compactor.py
@@ -18,6 +18,7 @@ from src.context_compactor import (
     COMPACT_THRESHOLD,
     SELF_SUMMARY_SYSTEM_PROMPT,
     SUMMARY_MAX_TOKENS,
+    trim_for_context,
 )
 
 
@@ -53,3 +54,33 @@ class TestSelfSummaryPrompt:
 
     def test_mentions_compactions(self):
         assert "Compactions so far" in SELF_SUMMARY_SYSTEM_PROMPT
+
+
+class TestTrimForContext:
+    def test_keeps_current_large_user_message_by_truncating(self):
+        huge = "A" * 20000
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": huge},
+        ]
+
+        trimmed = trim_for_context(messages, context_length=2048, reserve_tokens=512)
+
+        user_msgs = [m for m in trimmed if m.get("role") == "user"]
+        assert len(user_msgs) == 1
+        content = user_msgs[0]["content"]
+        assert "pasted message was too large" in content
+        assert content.startswith("A")
+        assert len(content) < len(huge)
+
+    def test_drops_older_messages_before_latest_user_paste(self):
+        huge = "B" * 12000
+        messages = [{"role": "system", "content": "You are helpful."}]
+        messages.extend({"role": "user", "content": f"old-{i} " + ("x" * 1000)} for i in range(8))
+        messages.append({"role": "user", "content": huge})
+
+        trimmed = trim_for_context(messages, context_length=2048, reserve_tokens=512)
+
+        assert trimmed[-1]["role"] == "user"
+        assert "pasted message was too large" in trimmed[-1]["content"]
+        assert "old-0" not in "\n".join(str(m.get("content", "")) for m in trimmed)

--- a/tests/test_context_compactor.py
+++ b/tests/test_context_compactor.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 for mod in [
     'sqlalchemy', 'sqlalchemy.orm', 'sqlalchemy.ext', 'sqlalchemy.ext.declarative',
     'sqlalchemy.ext.hybrid', 'sqlalchemy.sql', 'sqlalchemy.sql.expression',
-    'src.database', 'src.endpoint_resolver',
+    'src.database',
     'core.models', 'core.database',
 ]:
     if mod not in sys.modules:

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -6,6 +6,13 @@ from unittest.mock import MagicMock
 import httpx
 import pytest
 
+_endpoint_resolver = sys.modules.get("src.endpoint_resolver")
+if _endpoint_resolver is not None and not getattr(_endpoint_resolver, "__file__", None):
+    # Other tests stub this module during collection. These helper tests need
+    # the real URL normalization helpers so Anthropic /v1 handling is covered.
+    sys.modules.pop("src.endpoint_resolver", None)
+    sys.modules.pop("routes.model_routes", None)
+
 if "core.database" not in sys.modules:
     _core_db = types.ModuleType("core.database")
     for _name in [

--- a/tests/test_shell_routes.py
+++ b/tests/test_shell_routes.py
@@ -1,7 +1,64 @@
-"""Tests for shell_routes.py — _find_line_break helper.
-Imports the function directly since it has no app dependencies."""
+"""Tests for shell_routes.py helpers."""
+
+import builtins
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
 
 from routes.shell_routes import _find_line_break
+
+
+def test_shell_routes_import_without_posix_pty_modules(monkeypatch):
+    """Native Windows has no fcntl/termios; importing routes must still work."""
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name in {"fcntl", "pty"}:
+            raise ImportError(f"No module named {name!r}")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    cached_modules = {name: sys.modules.pop(name, None) for name in ("fcntl", "pty")}
+
+    module_path = Path(__file__).resolve().parents[1] / "routes" / "shell_routes.py"
+    spec = importlib.util.spec_from_file_location("_shell_routes_without_pty", module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(spec.name, None)
+        for name, cached_module in cached_modules.items():
+            if cached_module is not None:
+                sys.modules[name] = cached_module
+
+    assert module.PTY_SUPPORTED is False
+    assert module._find_line_break(b"ok\n") == (2, 1)
+
+
+async def test_generate_pty_reports_explicit_unsupported_error(monkeypatch):
+    """Clients can distinguish unsupported PTY mode from process failures."""
+    import routes.shell_routes as shell_routes
+
+    monkeypatch.setattr(shell_routes, "PTY_SUPPORTED", False)
+    monkeypatch.setattr(shell_routes, "_PTY_IMPORT_ERROR", ImportError("No module named 'termios'"))
+
+    request = SimpleNamespace(is_disconnected=lambda: False)
+    events = [
+        json.loads(chunk.removeprefix("data: ").strip())
+        async for chunk in shell_routes._generate_pty("echo hi", 5, request)
+    ]
+
+    assert events == [
+        {
+            "stream": "stderr",
+            "data": "PTY streaming is not supported on this platform: No module named 'termios'",
+            "error": shell_routes.PTY_UNSUPPORTED_ERROR,
+        },
+        {"exit_code": -1, "error": shell_routes.PTY_UNSUPPORTED_ERROR},
+    ]
 
 
 class TestFindLineBreak:

--- a/tests/test_vision_model_detection.py
+++ b/tests/test_vision_model_detection.py
@@ -1,0 +1,30 @@
+"""Tests for is_vision_model (issue #124).
+
+Local vision models served through Ollama/llama.cpp show up under many
+names. If one isn't recognized as vision-capable, the image attachment is
+stripped from the request before it reaches the model, so it silently never
+sees the picture.
+"""
+from src.chat_helpers import is_vision_model
+
+
+def test_recognizes_local_and_hosted_vision_models():
+    for name in [
+        # the ones #124 missed
+        "moondream", "moondream:latest",
+        "llama3.2-vision:11b", "granite3.2-vision",
+        "qwen2.5-vl:7b", "qwen2.5vl", "internvl2.5", "cogvlm",
+        # already worked, keep them working
+        "llava", "llava:7b", "bakllava", "minicpm-v",
+        "gpt-4o", "claude-sonnet-4", "gemini-2.0-flash", "pixtral-12b",
+    ]:
+        assert is_vision_model(name), f"{name!r} should be detected as vision-capable"
+
+
+def test_text_only_models_not_flagged():
+    for name in ["qwen2.5:3b", "mistral", "llama3.1:8b", "deepseek-r1", "phi3", "vicuna", ""]:
+        assert not is_vision_model(name), f"{name!r} should not be flagged as vision"
+
+
+def test_none_is_safe():
+    assert is_vision_model(None) is False


### PR DESCRIPTION
## Problem

When an OpenAI-compatible upstream (e.g. **LM Studio**) returns `200`, opens the SSE stream, then fails mid-flight — a chat-template render error, OOM, etc. — the chat just **spins forever** (until the read timeout) or shows an empty bubble. No error is ever surfaced.

Concrete repro: LM Studio with a model whose jinja template rejects the payload logs `Streaming response...` then `Error rendering prompt with jinja template`, but the HTTP response was already `200`, so the error arrives *inside* the stream.

### Root cause

In the OpenAI branch of `stream_llm`:
- A mid-stream `{"error": ...}` chunk fell through the `usage`/`choices`/`text` checks and was **silently dropped**.
- An upstream that closed having emitted nothing fell through to a silent `data: [DONE]`.

Either way the client received no `event: error`, so the spinner never tore down.

## Fix

In `stream_llm` (OpenAI branch):
1. Detect an `{"error": ...}` chunk mid-stream → emit `event: error` and stop.
2. Track whether any real output (content / reasoning / tool calls) was produced. If the stream closes with **nothing** and no upstream `[DONE]`, emit `event: error` instead of a silent `[DONE]`.

The frontend already handles `event: error` (destroys the spinner, renders the message), so no client change is needed.

## Testing

Mock-stream unit tests covering:
- mid-stream `{"error":...}` chunk → `event: error`, no `[DONE]`
- 200 then empty close → `event: error` ("returned no output …")
- normal content + `[DONE]` → unchanged, no false error
- content without an upstream `[DONE]` → synthesized `[DONE]`, no false error

🤖 Generated with [Claude Code](https://claude.com/claude-code)