### PR TITLE
Don't leak model identities in blind compare sessions (#1285)

### DIFF
--- a/routes/compare_routes.py
+++ b/routes/compare_routes.py
@@ -47,12 +47,24 @@ def setup_compare_routes(session_manager: SessionManager):
         sid_a = str(uuid.uuid4())
         sid_b = str(uuid.uuid4())
 
-        # Create ephemeral sessions (prefixed [CMP])
-        for sid, model, endpoint in [(sid_a, model_a, endpoint_a), (sid_b, model_b, endpoint_b)]:
+        blind = str(is_blind).lower() == "true"
+
+        # Create ephemeral sessions (prefixed [CMP]). In blind mode the session
+        # name must NOT reveal the model: the sidebar and /api/sessions expose it,
+        # which let a user map "Model A" to the real model before voting and
+        # defeated blind compare (issue #1285). Use the same neutral slot labels
+        # the pane UI uses ("Model A"/"Model B").
+        for slot, (sid, model, endpoint) in enumerate(
+            [(sid_a, model_a, endpoint_a), (sid_b, model_b, endpoint_b)]
+        ):
             user = getattr(request.state, 'current_user', None)
+            sess_name = (
+                f"[CMP] Model {chr(ord('A') + slot)}"
+                if blind else f"[CMP] {model.split('/')[-1]}"
+            )
             session_manager.create_session(
                 session_id=sid,
-                name=f"[CMP] {model.split('/')[-1]}",
+                name=sess_name,
                 endpoint_url=endpoint,
                 model=model,
                 rag=False,
@@ -76,7 +88,6 @@ def setup_compare_routes(session_manager: SessionManager):
                 db.close()
 
         # Blind mapping: randomly assign left/right
-        blind = str(is_blind).lower() == "true"
         if blind:
             mapping = {"left": "a", "right": "b"}
             if random.random() > 0.5:
@@ -107,12 +118,14 @@ def setup_compare_routes(session_manager: SessionManager):
         session_left = sid_a if mapping["left"] == "a" else sid_b
         session_right = sid_a if mapping["right"] == "a" else sid_b
 
+        # In blind mode, do not echo which model is on which side — the reveal
+        # happens on vote (issue #1285).
         return {
             "id": comp_id,
             "session_left": session_left,
             "session_right": session_right,
-            "model_left": model_a if mapping["left"] == "a" else model_b,
-            "model_right": model_a if mapping["right"] == "a" else model_b,
+            "model_left": None if blind else (model_a if mapping["left"] == "a" else model_b),
+            "model_right": None if blind else (model_a if mapping["right"] == "a" else model_b),
             "is_blind": blind,
             "mapping": mapping,
         }

--- a/static/js/compare/index.js
+++ b/static/js/compare/index.js
@@ -210,7 +210,9 @@ async function _buildCompareUI() {
     for (let i = 0; i < n; i++) {
       const m = state._selectedModels[i];
       const fd = new FormData();
-      fd.append('name', '[CMP] ' + modelShorts[i]);
+      // Blind mode: keep the session name neutral so the sidebar / /api/sessions
+      // don't reveal the model behind "Model A/B" before voting (issue #1285).
+      fd.append('name', state._blindMode ? '[CMP] Model ' + _slotChar(i) : '[CMP] ' + modelShorts[i]);
       fd.append('endpoint_url', m.endpoint || '');
       fd.append('model', m.model || '');
       if (m.endpointId) {

--- a/static/js/compare/panes.js
+++ b/static/js/compare/panes.js
@@ -380,9 +380,11 @@ async function _addPane(anchorBtn) {
 async function _createAndAppendPane(m) {
   const i = state._selectedModels.length;  // New index
 
-  // Create session
+  // Create session. Blind mode: neutral name so the sidebar / /api/sessions
+  // don't reveal the model before voting (issue #1285).
   const fd = new FormData();
-  fd.append('name', '[CMP] ' + m.name);
+  const _slot = state._parallel ? String.fromCharCode(65 + i) : String(i + 1);
+  fd.append('name', state._blindMode ? '[CMP] Model ' + _slot : '[CMP] ' + m.name);
   fd.append('endpoint_url', m.url || '');
   fd.append('model', m.id || '');
   if (m.endpointId) {
@@ -584,7 +586,10 @@ function _showModelSwapDropdown(paneIdx, titleBtn) {
         fetch(`${state.API_BASE}/api/session/${oldSid}`, { method: 'DELETE' }).catch(() => {});
       }
       const fd = new FormData();
-      fd.append('name', '[CMP] ' + m.name);
+      // Blind mode: neutral name so the swapped-in model isn't revealed via the
+      // sidebar / /api/sessions before voting (issue #1285).
+      const _slot = state._parallel ? String.fromCharCode(65 + paneIdx) : String(paneIdx + 1);
+      fd.append('name', state._blindMode ? '[CMP] Model ' + _slot : '[CMP] ' + m.name);
       fd.append('endpoint_url', m.url || '');
       fd.append('model', m.id || '');
       if (m.endpointId) {

--- a/tests/test_compare_blind_no_leak.py
+++ b/tests/test_compare_blind_no_leak.py
@@ -1,0 +1,113 @@
+"""Regression tests for issue #1285 — blind compare leaked model identities.
+
+Compare's blind mode anonymizes the pane headers ("Model A"/"Model B"), but the
+backend `/api/compare/start` path still named the helper sessions after the real
+models (`[CMP] gpt-4o`) and echoed `model_left`/`model_right` in the response —
+so the sidebar, `/api/sessions`, and the start response all revealed which model
+was which before the user voted, defeating blind compare.
+
+These tests drive the real `/api/compare/start` handler directly (no TestClient,
+which hangs in this env) and pin that blind mode neither names sessions after the
+model nor returns the model sides, while non-blind mode is unchanged.
+"""
+import types
+import tempfile
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+from fastapi import APIRouter
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import NullPool
+
+import core.database as cdb
+import routes.compare_routes as cr
+
+
+@pytest.fixture
+def temp_db(monkeypatch):
+    tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    tmp.close()
+    engine = create_engine(
+        f"sqlite:///{tmp.name}",
+        connect_args={"check_same_thread": False},
+        poolclass=NullPool,
+    )
+    cdb.Base.metadata.create_all(engine)
+    TS = sessionmaker(bind=engine)
+    monkeypatch.setattr(cr, "SessionLocal", TS)
+    return TS
+
+
+class _FakeManager:
+    def __init__(self):
+        self.created = {}      # sid -> name
+        self.sessions = {}
+
+    def create_session(self, session_id, name, endpoint_url, model, rag=False, owner=None):
+        self.created[session_id] = name
+        self.sessions[session_id] = types.SimpleNamespace(headers={})
+        return self.sessions[session_id]
+
+
+def _start_endpoint(manager):
+    # Module-level router accumulates routes across setup calls — reset it.
+    cr.router = APIRouter(prefix="/api/compare", tags=["compare"])
+    cr.setup_compare_routes(manager)
+    for r in cr.router.routes:
+        if getattr(r, "path", None) == "/api/compare/start" and "POST" in getattr(r, "methods", set()):
+            return r.endpoint
+    raise AssertionError("start endpoint not found")
+
+
+def _request():
+    return types.SimpleNamespace(state=types.SimpleNamespace(current_user="tester"))
+
+
+def test_blind_start_does_not_leak_model(temp_db):
+    mgr = _FakeManager()
+    endpoint = _start_endpoint(mgr)
+    resp = endpoint(
+        _request(), prompt="hi", model_a="gpt-4o", model_b="llama-3.1-70b",
+        endpoint_a="http://a", endpoint_b="http://b", is_blind="true",
+    )
+    # Session names must NOT contain the real model ids.
+    names = list(mgr.created.values())
+    assert names and all("gpt-4o" not in n and "llama" not in n for n in names), names
+    assert sorted(names) == ["[CMP] Model A", "[CMP] Model B"]
+    # The response must not reveal which model is on which side before voting.
+    assert resp["model_left"] is None and resp["model_right"] is None
+    assert resp["is_blind"] is True
+
+
+def test_non_blind_start_keeps_real_names(temp_db):
+    mgr = _FakeManager()
+    endpoint = _start_endpoint(mgr)
+    resp = endpoint(
+        _request(), prompt="hi", model_a="gpt-4o", model_b="llama-3.1-70b",
+        endpoint_a="http://a", endpoint_b="http://b", is_blind="false",
+    )
+    names = list(mgr.created.values())
+    assert any("gpt-4o" in n for n in names)
+    # Non-blind mapping is fixed left=a, right=b.
+    assert resp["model_left"] == "gpt-4o" and resp["model_right"] == "llama-3.1-70b"
+    assert resp["is_blind"] is False
+
+
+# The frontend session-creation path is the one the live UI uses; it pulls in
+# browser globals so it can't be imported under node. Guard the masking at the
+# source level so a future edit can't silently drop it (issue #1285).
+@pytest.mark.parametrize("relpath", [
+    "static/js/compare/index.js",
+    "static/js/compare/panes.js",
+])
+def test_frontend_masks_session_name_in_blind_mode(relpath):
+    src = (_REPO / relpath).read_text(encoding="utf-8")
+    # Every place that names a [CMP] session must be gated on blind mode and
+    # fall back to a neutral "Model X" label.
+    assert "state._blindMode ? '[CMP] Model '" in src, relpath
+    # The old unconditional real-name append must be gone.
+    assert "fd.append('name', '[CMP] ' + modelShorts[i])" not in src
+    assert "fd.append('name', '[CMP] ' + m.name)" not in src


### PR DESCRIPTION
## Problem

Compare's **blind** mode anonymizes the pane headers ("Model A"/"Model B"), but each pane still creates a backend chat session named after the **real model**, and `/api/compare/start` echoes the models — so the sidebar, `GET /api/sessions`, and the start response all reveal which model is which **before the user votes**, defeating blind compare (#1285).

## Fix

Two paths create these sessions; both are handled:

**Frontend (the path the live UI uses)** — `static/js/compare/index.js` and `static/js/compare/panes.js` create sessions via `/api/session` with `name = '[CMP] ' + realModel`. Now, when `state._blindMode` is on, they use the neutral slot label the pane UI already shows: `'[CMP] Model ' + slot`. Mirrors the existing `state._blindMode ? 'Model ' + _slotChar(i) : ...` idiom at `index.js`.

**Backend (the `/api/compare/start` API path)** — `routes/compare_routes.py` now names the helper sessions `[CMP] Model A/B` in blind mode and returns `model_left`/`model_right` as `null` (the reveal already happens on vote). Non-blind behaviour is unchanged.

## Tests — `tests/test_compare_blind_no_leak.py`

- **Backend, red→green** (direct handler, no TestClient): blind `/api/compare/start` names no session after the model and returns no model sides — verified failing on the old code, passing on the fix; non-blind still keeps real names + model sides.
- Frontend masking is guarded at the source level (those modules pull in browser globals, so they can't run under node) so the blind gate can't be silently dropped.

```
./venv/bin/python -m pytest -q tests/test_compare_blind_no_leak.py   # 4 passed
node --check static/js/compare/index.js static/js/compare/panes.js   # ok
```

Note: the saved-compare-results path (when the user explicitly saves to a folder) still keeps real model names, as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)