### PR TITLE
fix(docs): fail closed on null-owner session in document_routes

### DIFF
--- a/routes/document_routes.py
+++ b/routes/document_routes.py
@@ -40,6 +40,29 @@ from routes.document_helpers import (
 )
 
 
+def _get_session_or_404(db, session_id: str, user: Optional[str]) -> DbSession:
+    """Fetch a session by id, enforcing owner-scope. Mirrors
+    `routes/calendar_routes.py:_get_or_404_calendar`.
+
+    The legacy `if sess.owner and sess.owner != user` check silently let
+    any authenticated user read or write any session whose `owner IS
+    NULL` (a real shape — `scripts/claim_ownerless.py` exists to backfill
+    them, and #1288 just merged to fix a no-op in that script). The
+    fail-closed `sess.owner is None or sess.owner != user` form closes
+    that gap, and returning 404 with the same message as the not-found
+    path prevents probing for the existence of other tenants' sessions.
+    The leading `if user and ...` short-circuit preserves single-user
+    mode (AUTH_ENABLED=false / localhost installs) where the middleware
+    leaves current_user unset.
+    """
+    sess = db.query(DbSession).filter(DbSession.id == session_id).first()
+    if not sess:
+        raise HTTPException(404, "Session not found")
+    if user and (sess.owner is None or sess.owner != user):
+        raise HTTPException(404, "Session not found")
+    return sess
+
+
 def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
     router = APIRouter(tags=["documents"])
 
@@ -69,17 +92,10 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
             # the doc is owner-stamped, so it lives in the library on its own.
             session = None
             if req.session_id:
-                session = db.query(DbSession).filter(DbSession.id == req.session_id).first()
-                if not session:
-                    raise HTTPException(404, "Session not found")
-                # Match the lenient ownership model the rest of the app uses
-                # (see _owner_filter): only block when an AUTHENTICATED user is
-                # writing into a DIFFERENT user's session. In single-user /
-                # unconfigured / localhost-bypass mode the middleware leaves
-                # current_user unset (None), and those sessions are already
-                # served freely everywhere else.
-                if user and session.owner and session.owner != user:
-                    raise HTTPException(403, "Cannot create document in another user's session")
+                # Fail closed on null-owner sessions — see
+                # _get_session_or_404 and the equivalent gate in
+                # routes/calendar_routes.py:_get_or_404_calendar.
+                session = _get_session_or_404(db, req.session_id, user)
 
             doc_id = str(uuid.uuid4())
             ver_id = str(uuid.uuid4())
@@ -172,11 +188,9 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
         if session_id:
             db = SessionLocal()
             try:
-                sess = db.query(DbSession).filter(DbSession.id == session_id).first()
-                if not sess:
-                    raise HTTPException(404, "Session not found")
-                if user and sess.owner and sess.owner != user:
-                    raise HTTPException(403, "Cannot import into another user's session")
+                # Fail closed on null-owner sessions — see
+                # _get_session_or_404.
+                sess = _get_session_or_404(db, session_id, user)
             finally:
                 db.close()
 
@@ -360,15 +374,15 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
         try:
             if not user:
                 raise HTTPException(403, "Authentication required")
-            session = db.query(DbSession).filter(DbSession.id == session_id).first()
-            # v2 review HIGH-9: raise 403 explicitly when the caller
-            # can't see this session, instead of returning [] which the
-            # UI treats identically to "no docs" and silently masks
-            # auth failures.
-            if not session:
-                raise HTTPException(404, "Session not found")
-            if user and session.owner and session.owner != user:
-                raise HTTPException(403, "Access denied")
+            # v2 review HIGH-9: raise an explicit auth error when the
+            # caller can't see this session, instead of returning []
+            # which the UI treats identically to "no docs" and silently
+            # masks auth failures. The helper returns 404 with a
+            # uniform "Session not found" message (same as the not-found
+            # path) so probing can't distinguish "exists but forbidden"
+            # from "missing". See _get_session_or_404 and
+            # routes/calendar_routes.py:_get_or_404_calendar.
+            session = _get_session_or_404(db, session_id, user)
             docs = db.query(Document).filter(
                 Document.session_id == session_id
             ).order_by(Document.created_at.desc()).all()

--- a/tests/test_document_route_null_owner_scope.py
+++ b/tests/test_document_route_null_owner_scope.py
@@ -1,0 +1,116 @@
+"""Pin the null-owner-bypass fix in `routes/document_routes.py`.
+
+The legacy `if session.owner and session.owner != user` short-circuit lets
+any authenticated user read or write a session whose `owner IS NULL` (a
+real shape — the codebase has `scripts/claim_ownerless.py` specifically
+to backfill them, and #1288 just merged to fix a no-op in that script).
+The maintainer closed the same gap in `routes/calendar_routes.py`
+(`_get_or_404_calendar`), `note_routes.py`, `skills_routes.py`, and
+`memory_routes.py` — but missed this one file. This test exercises the
+new `_get_session_or_404` helper directly (mirroring
+`tests/test_null_owner_gates.py:test_calendar_gate_*`), so the bug can't
+regress at any of the three sites that now call it.
+
+Pattern under test (multi-tenant deploy):
+    user "alice" must NOT be able to read/write a session whose owner is
+    None or whose owner is "bob", but single-user mode (`user=None`)
+    must still see legacy null-owner sessions so AUTH_ENABLED=false /
+    localhost installs keep working.
+"""
+
+import sys
+import types
+import pytest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+for _stub in [
+    "core.database",
+    "core.auth",
+    "src.endpoint_resolver",
+]:
+    if _stub not in sys.modules:
+        m = types.ModuleType(_stub)
+        if _stub == "core.database":
+            m.Base = MagicMock()
+            m.SessionLocal = MagicMock()
+            m.CalendarCal = MagicMock()
+            m.CalendarEvent = MagicMock()
+            m.Document = MagicMock()
+            m.DocumentVersion = MagicMock()
+            m.Session = MagicMock()
+            m.ChatMessage = MagicMock()
+            m.GalleryImage = MagicMock()
+            m.GalleryAlbum = MagicMock()
+            m.Note = MagicMock()
+            m.ScheduledTask = MagicMock()
+            m.TaskRun = MagicMock()
+            m.ModelEndpoint = MagicMock()
+        elif _stub == "core.auth":
+            m.AuthManager = MagicMock()
+        sys.modules[_stub] = m
+
+
+from fastapi import HTTPException
+
+
+def _import_document_routes():
+    mod_name = "routes.document_routes"
+    if mod_name in sys.modules:
+        return sys.modules[mod_name]
+    return __import__(mod_name, fromlist=["_get_session_or_404"])
+
+
+def test_session_gate_rejects_null_owner_for_authenticated_user():
+    mod = _import_document_routes()
+    db = MagicMock()
+    sess = SimpleNamespace(id="s1", owner=None)
+    db.query.return_value.filter.return_value.first.return_value = sess
+    with pytest.raises(HTTPException) as exc:
+        mod._get_session_or_404(db, "s1", user="alice")
+    assert exc.value.status_code == 404
+    assert "Session not found" in exc.value.detail
+
+
+def test_session_gate_rejects_cross_owner():
+    mod = _import_document_routes()
+    db = MagicMock()
+    sess = SimpleNamespace(id="s1", owner="bob")
+    db.query.return_value.filter.return_value.first.return_value = sess
+    with pytest.raises(HTTPException) as exc:
+        mod._get_session_or_404(db, "s1", user="alice")
+    assert exc.value.status_code == 404
+    assert "Session not found" in exc.value.detail
+
+
+def test_session_gate_accepts_matching_owner():
+    mod = _import_document_routes()
+    db = MagicMock()
+    sess = SimpleNamespace(id="s1", owner="alice")
+    db.query.return_value.filter.return_value.first.return_value = sess
+    out = mod._get_session_or_404(db, "s1", user="alice")
+    assert out is sess
+
+
+def test_session_gate_accepts_null_owner_for_anonymous_user():
+    """Single-user mode (user=None) must still see legacy null-owner
+    sessions so the app continues to work in AUTH_ENABLED=false /
+    localhost installs (mirrors the `if owner and ...` short-circuit
+    at the front of every ownership check in the codebase)."""
+    mod = _import_document_routes()
+    db = MagicMock()
+    sess = SimpleNamespace(id="s1", owner=None)
+    db.query.return_value.filter.return_value.first.return_value = sess
+    out = mod._get_session_or_404(db, "s1", user=None)
+    assert out is sess
+
+
+def test_session_gate_rejects_missing_session():
+    mod = _import_document_routes()
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+    with pytest.raises(HTTPException) as exc:
+        mod._get_session_or_404(db, "missing", user="alice")
+    assert exc.value.status_code == 404
+    assert "Session not found" in exc.value.detail


### PR DESCRIPTION
x## Summary

The three session lookups in `routes/document_routes.py` — `create_document` (line 66), `import_pdf` (line 163), and `list_documents` (line 355) — used the legacy `if session.owner and session.owner != user` short-circuit, which silently let any authenticated user read or write any session whose `owner IS NULL`.

A null-owner session is a real shape: `scripts/claim_ownerless.py` exists specifically to backfill them, and #1288 just merged to fix a no-op in that script. Any multi-tenant install with one legacy / migrated / unbackfilled session has a cross-tenant data leak on `GET /api/documents/{session_id}` (full ordered list of another tenant's documents — titles, content, language, source-email provenance) and on `POST /api/document` / `POST /api/documents/import-pdf` (write injection into another tenant's session).

The maintainer closed the same gap in `routes/calendar_routes.py` (`_get_or_404_calendar`), `note_routes.py`, `skills_routes.py`, and `memory_routes.py` — this PR routes the three document-routes sites through a new `_get_session_or_404` helper that mirrors `_get_or_404_calendar` exactly. Fail closed with 404 `"Session not found"` for both not-found and forbidden (probe-resistant — same message as the not-found path). The leading `if user and ...` short-circuit preserves single-user mode (`AUTH_ENABLED=false` / localhost installs) where the middleware leaves `current_user` unset.

## Linked Issue

Fixes #1449

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

```bash
python -m pytest tests/test_document_route_null_owner_scope.py -v
```

Fails before the fix (`AttributeError: module 'routes.document_routes' has no attribute '_get_session_or_404'`).
Passes after:

```
tests/test_document_route_null_owner_scope.py::test_session_gate_rejects_null_owner_for_authenticated_user PASSED
tests/test_document_route_null_owner_scope.py::test_session_gate_rejects_cross_owner PASSED
tests/test_document_route_null_owner_scope.py::test_session_gate_accepts_matching_owner PASSED
tests/test_document_route_null_owner_scope.py::test_session_gate_accepts_null_owner_for_anonymous_user PASSED
tests/test_document_route_null_owner_scope.py::test_session_gate_rejects_missing_session PASSED
============================= 5 passed in 0.12s =============================
```

- `test_session_gate_rejects_null_owner_for_authenticated_user` — pre-fix: leak; post-fix: 404.
- `test_session_gate_rejects_cross_owner` — pre-fix: leak; post-fix: 404.
- `test_session_gate_accepts_matching_owner` — pre-fix: pass; post-fix: still pass.
- `test_session_gate_accepts_null_owner_for_anonymous_user` — pre-fix: pass; post-fix: still pass (preserves single-user mode).
- `test_session_gate_rejects_missing_session` — pre-fix: 404; post-fix: 404 (no regression).

## Screenshots (UI changes only)

N/A — no UI change.