### PR TITLE
fix(atomic-io): reject non-string text writes

### DIFF
--- a/core/atomic_io.py
+++ b/core/atomic_io.py
@@ -34,6 +34,8 @@ def atomic_write_json(path: str, data: Any, *, indent: Optional[int] = None) -> 
 
 
 def atomic_write_text(path: str, text: str) -> None:
+    if not isinstance(text, str):
+        raise TypeError("atomic_write_text expects a string")
     os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
     tmp = f"{path}.tmp.{os.getpid()}"
     with open(tmp, "w", encoding="utf-8") as f:

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -138,6 +138,16 @@ def test_atomic_write_text_leaves_no_tmp_file(tmp_path):
     assert _tmp_siblings(tmp_path, "note.txt") == []
 
 
+def test_atomic_write_text_rejects_non_string_before_tmp_file(tmp_path):
+    target = tmp_path / "note.txt"
+
+    with pytest.raises(TypeError):
+        atomic_write_text(str(target), 123)
+
+    assert not target.exists()
+    assert _tmp_siblings(tmp_path, "note.txt") == []
+
+
 # ---------------------------------------------------------------------------
 # atomic_write_text — failure path: target preserved when replace fails.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Small guard for `atomic_write_text`.

If a caller passes a non-string value, it now fails before opening the temp file. That keeps the atomic write path from leaving a stray temp sibling behind on a bad call.

## Linked Issue

Part of #1883.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`, the current default branch.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I ran the app or included the existing app/visual smoke check recorded for this branch.

## How to Test

1. `./venv/bin/python -m pytest -q tests/test_atomic_io.py`
2. `./venv/bin/python -m py_compile core/atomic_io.py tests/test_atomic_io.py`
3. `git diff --check origin/main...HEAD`

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI/render path touched.

### Screenshots / clips

N/A
