### PR TITLE
fix(mail): ignore non-string CLI recipient chunks

### DIFF
--- a/scripts/odysseus-mail
+++ b/scripts/odysseus-mail
@@ -108,6 +108,8 @@ def _q(name: str) -> str:
 
 
 def _split_recipients(value: str) -> list[str]:
+    if not isinstance(value, str):
+        return []
     return [r.strip() for r in (value or "").split(",") if r.strip()]
 
 

--- a/tests/cli/test_mail_cli_recipients.py
+++ b/tests/cli/test_mail_cli_recipients.py
@@ -48,3 +48,10 @@ def test_recipient_list_rejects_empty_envelope(monkeypatch):
         assert exc.code == 1
     else:
         raise AssertionError("expected empty recipient list to exit")
+
+
+def test_split_recipients_ignores_non_string_values(monkeypatch):
+    cli = _load_mail_cli(monkeypatch)
+
+    assert cli._split_recipients(None) == []
+    assert cli._split_recipients(["a@example.test"]) == []

--- a/tests/test_mail_cli_recipients.py
+++ b/tests/test_mail_cli_recipients.py
@@ -55,3 +55,10 @@ def test_recipient_list_rejects_empty_envelope(monkeypatch):
         assert exc.code == 1
     else:
         raise AssertionError("expected empty recipient list to exit")
+
+
+def test_split_recipients_ignores_non_string_values(monkeypatch):
+    cli = _load_mail_cli(monkeypatch)
+
+    assert cli._split_recipients(None) == []
+    assert cli._split_recipients(["a@example.test"]) == []


### PR DESCRIPTION
## Summary

Small guard for the mail CLI recipient parser.

Non-string recipient chunks now behave like an empty recipient field instead of throwing inside `.split()`. Normal comma-separated strings are unchanged.

## Linked Issue

Part of #1883.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`, the current default branch.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I ran the app or included the existing app/visual smoke check recorded for this branch.

## How to Test

1. `./venv/bin/python -m pytest -q tests/cli/test_mail_cli_recipients.py`
2. `./venv/bin/python -m py_compile scripts/odysseus-mail tests/cli/test_mail_cli_recipients.py`
3. `git diff --check origin/main...HEAD`

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI/render path touched.

### Screenshots / clips

N/A

