### PR TITLE
fix(url-safety): reject resolver results without IPs

### DIFF
--- a/src/url_safety.py
+++ b/src/url_safety.py
@@ -79,12 +79,18 @@ def check_outbound_url(
     if not raw_ips:
         return False, "host does not resolve"
 
+    saw_ip = False
     for raw in raw_ips:
+        if not isinstance(raw, str):
+            continue
         try:
             ip = ipaddress.ip_address(raw.split("%")[0])  # strip IPv6 zone id
         except ValueError:
             continue
+        saw_ip = True
         reason = _classify(ip, block_private=block_private)
         if reason:
             return False, reason
+    if not saw_ip:
+        return False, "host does not resolve to an IP"
     return True, "ok"

--- a/tests/test_url_safety.py
+++ b/tests/test_url_safety.py
@@ -68,3 +68,23 @@ def test_unresolvable_host_blocked():
     ok, reason = check_outbound_url("http://does-not-resolve.invalid", resolver=PUBLIC)
     assert ok is False
     assert "resolve" in reason
+
+
+def test_resolver_values_must_include_a_parseable_ip():
+    ok, reason = check_outbound_url(
+        "https://example.test",
+        resolver=lambda _host: [None, 123, "not-an-ip"],
+    )
+
+    assert ok is False
+    assert "does not resolve to an IP" in reason
+
+
+def test_resolver_skips_invalid_values_but_accepts_public_ip():
+    ok, reason = check_outbound_url(
+        "https://example.test",
+        resolver=lambda _host: [None, "not-an-ip", "93.184.216.34"],
+    )
+
+    assert ok is True
+    assert reason == "ok"


### PR DESCRIPTION
## Summary

Small guard for outbound URL safety checks.

If a resolver returns only non-string or unparsable values, the URL is now rejected instead of passing as `ok`. Mixed results still work when there is a real public IP in the list.

## Linked Issue

Part of #1883.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`, the current default branch.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I ran the app or included the existing app/visual smoke check recorded for this branch.

## How to Test

1. `./venv/bin/python -m pytest -q tests/test_url_safety.py`
2. `./venv/bin/python -m py_compile src/url_safety.py tests/test_url_safety.py`
3. `git diff --check origin/main...HEAD`

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI/render path touched.

### Screenshots / clips

N/A
