### PR TITLE
fix(hwfit): ignore invalid serve profile inputs

### DIFF
--- a/services/hwfit/profiles.py
+++ b/services/hwfit/profiles.py
@@ -103,6 +103,9 @@ def compute_serve_profiles(system, model, serve_weights_gb=None, serve_quant=Non
     in the actual serving knobs (n_cpu_moe, KV-cache type, context). serve_quant
     is the file's quant label (e.g. "Q4_K_M") just for display.
     """
+    if not isinstance(system, dict) or not isinstance(model, dict):
+        return []
+
     vram = float(system.get("gpu_vram_gb") or 0)
     if vram <= 0:
         return []

--- a/tests/test_serve_profiles.py
+++ b/tests/test_serve_profiles.py
@@ -28,6 +28,12 @@ def _sys(vram, family="rdna"):
     return {"backend": "rocm", "gpu_vram_gb": vram, "gpu_family": family}
 
 
+def test_compute_serve_profiles_ignores_invalid_inputs():
+    assert compute_serve_profiles(None, _DENSE_8B) == []
+    assert compute_serve_profiles(_sys(8), None) == []
+    assert compute_serve_profiles(["bad"], _DENSE_8B) == []
+
+
 def test_big_moe_on_small_card_offloads_not_fails():
     """A 35B MoE can't hold its weights on 16 GB, so the Quality profile must
     offload experts to CPU (n_cpu_moe > 0) rather than be dropped."""


### PR DESCRIPTION
## Summary

Small guard for serve profile computation.

If the caller passes a malformed `system` or `model` payload, `compute_serve_profiles` now returns no profiles instead of crashing on `.get()`. Valid profile generation is unchanged.

## Linked Issue

Part of #1883.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`, the current default branch.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I ran the app or included the existing app/visual smoke check recorded for this branch.

## How to Test

1. `./venv/bin/python -m pytest -q tests/test_serve_profiles.py`
2. `./venv/bin/python -m py_compile services/hwfit/profiles.py tests/test_serve_profiles.py`
3. `git diff --check origin/main...HEAD`

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI/render path touched.

### Screenshots / clips

N/A
