### PR TITLE
fix(context-budget): ignore invalid context budget numbers

### DIFF
--- a/src/context_budget.py
+++ b/src/context_budget.py
@@ -18,6 +18,13 @@ DEFAULT_BUDGET = 6000
 DEFAULT_HEADROOM = 0.85
 
 
+def _int_or_zero(value) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
 def compute_input_token_budget(
     configured: int,
     context_length: int,
@@ -42,8 +49,8 @@ def compute_input_token_budget(
         - When the window is unknown, fall back to the configured/default value
           (preserving the previous behaviour).
     """
-    configured = int(configured or 0)
-    context_length = int(context_length or 0)
+    configured = _int_or_zero(configured)
+    context_length = _int_or_zero(context_length)
 
     if explicit and configured > 0:
         return min(configured, context_length) if context_length > 0 else configured

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -33,6 +33,11 @@ def test_unknown_window_falls_back_to_configured():
     assert compute_input_token_budget(0, 0, explicit=False) == 6000  # default
 
 
+def test_invalid_numeric_inputs_fall_back_cleanly():
+    assert compute_input_token_budget("bad", "also bad", explicit=False) == 6000
+    assert compute_input_token_budget("bad", 128000, explicit=True) == int(128000 * 0.85)
+
+
 def test_is_setting_overridden_reads_raw_saved_file(tmp_path, monkeypatch):
     import src.settings as settings
 


### PR DESCRIPTION
## Summary

Small guard for the agent input budget helper.

If a saved setting or model context value is not numeric, `compute_input_token_budget` now falls back through the existing default/auto branches instead of throwing on `int(...)`.

## Linked Issue

Part of #1883.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`, the current default branch.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I ran the app or included the existing app/visual smoke check recorded for this branch.

## How to Test

1. `./venv/bin/python -m pytest -q tests/test_context_budget.py`
2. `./venv/bin/python -m py_compile src/context_budget.py tests/test_context_budget.py`
3. `git diff --check origin/main...HEAD`

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI/render path touched.

### Screenshots / clips

N/A
