### PR TITLE
fix(personal-docs): ignore non-string personal doc text

### DIFF
--- a/src/personal_docs.py
+++ b/src/personal_docs.py
@@ -68,6 +68,8 @@ def read_text_file(path: str) -> str:
 
 def split_chunks(text: str, size: int = config.CHUNK_SIZE, overlap: int = config.CHUNK_OVERLAP) -> List[str]:
     """Split text into overlapping chunks."""
+    if not isinstance(text, str):
+        return []
     text = text.strip()
     if not text:
         return []
@@ -87,7 +89,8 @@ def split_chunks(text: str, size: int = config.CHUNK_SIZE, overlap: int = config
 
 def tokenize(s: str) -> Set[str]:
     """Tokenize string into words, excluding stop words."""
-    tokens = re.findall(r"[A-Za-z0-9_\-]+", (s or "").lower())
+    text = s if isinstance(s, str) else ""
+    tokens = re.findall(r"[A-Za-z0-9_\-]+", text.lower())
     return set(t for t in tokens if t not in config.STOP_WORDS and len(t) > 1)
 
 def load_personal_index(

--- a/tests/test_personal_docs_keyword_nondict.py
+++ b/tests/test_personal_docs_keyword_nondict.py
@@ -1,4 +1,4 @@
-from src.personal_docs import retrieve_personal_keyword
+from src.personal_docs import retrieve_personal_keyword, split_chunks
 
 
 def test_retrieve_personal_keyword_skips_non_dict_rows():
@@ -19,3 +19,17 @@ def test_retrieve_personal_keyword_tolerates_missing_chunks_key():
     index = [{"name": "empty.txt"}, {"name": "doc.txt", "chunks": ["alpha beta gamma"]}]
     out = retrieve_personal_keyword(index, "beta", k=5)
     assert out == ["[doc.txt :: chunk 1]\nalpha beta gamma"]
+
+
+def test_retrieve_personal_keyword_ignores_non_string_text():
+    index = [{"name": "doc.txt", "chunks": [None, ["beta"], "alpha beta gamma"]}]
+
+    assert retrieve_personal_keyword(index, ["beta"], k=5) == []
+    assert retrieve_personal_keyword(index, "beta", k=5) == [
+        "[doc.txt :: chunk 3]\nalpha beta gamma"
+    ]
+
+
+def test_split_chunks_ignores_non_string_text():
+    assert split_chunks(None, size=1000, overlap=200) == []
+    assert split_chunks(["hello"], size=1000, overlap=200) == []


### PR DESCRIPTION
## Summary

Small guard for personal-doc keyword search.

Non-string query/chunk text now behaves like empty text instead of crashing tokenization. Valid indexed strings are unchanged.

## Linked Issue

Part of #1883.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`, the current default branch.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I ran the app or included the existing app/visual smoke check recorded for this branch.

## How to Test

1. `./venv/bin/python -m pytest -q tests/test_personal_docs_keyword_nondict.py`
2. `./venv/bin/python -m py_compile src/personal_docs.py tests/test_personal_docs_keyword_nondict.py`
3. `git diff --check origin/main...HEAD`

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI/render path touched.

### Screenshots / clips

N/A
