### PR TITLE
Fix: email search crash on null spinner + ReferenceError in summarize catch

### DIFF
--- a/static/js/emailLibrary.js
+++ b/static/js/emailLibrary.js
@@ -1550,7 +1550,7 @@ async function _doSearch() {
     const accountQS = accountAtStart ? `&account_id=${encodeURIComponent(accountAtStart)}` : '';
     const res = await fetch(`${API_BASE}/api/email/search?folder=${encodeURIComponent(folderAtStart)}${accountQS}&q=${encodeURIComponent(q)}&limit=100`);
     const data = await res.json();
-    sp.destroy();
+    if (sp) sp.destroy();
     if (
       seq !== _libSearchSeq ||
       q !== state._libSearch.trim() ||
@@ -1569,7 +1569,7 @@ async function _doSearch() {
     const stats = document.getElementById('email-lib-stats');
     if (stats) stats.textContent = `${data.total || results.length} match${(data.total || results.length) === 1 ? '' : 'es'}`;
   } catch (e) {
-    sp.destroy();
+    if (sp) sp.destroy();
     grid.innerHTML = '<div class="email-loading">Search failed</div>';
   }
 }
@@ -4387,7 +4387,7 @@ async function _generateSummary(reader, data, btn) {
   } catch (e) {
     sp.destroy();
     panel.remove();
-    if (uiModule) uiModule.showError?.('Failed to summarize');
+    import('./ui.js').then(m => m.showError && m.showError('Failed to summarize')).catch(() => {});
   } finally {
     if (btn) btn.disabled = false;
   }


### PR DESCRIPTION
## Summary

Two independent crashes in `static/js/emailLibrary.js`:

**Crash 1 — search:** `_renderEmailLoading()` can return `null` (e.g. when the spinner is skipped on a folder cache hit), so the bare `sp.destroy()` in `_doSearch()` throws `TypeError: Cannot read properties of null (reading 'destroy')`.

**Crash 2 — summarize:** the catch block references an undeclared `uiModule`, raising `ReferenceError: uiModule is not defined` *inside* the error handler — which swallows the original fetch error and shows nothing to the user.

## Changes

- `static/js/emailLibrary.js:1553, 1572` — guard with `if (sp) sp.destroy();`, matching the existing null-guarded `sp.destroy()` calls already used elsewhere in this file (e.g. lines 1699/1708/1724).
- `static/js/emailLibrary.js:4390` — replace the undefined `uiModule` reference with the `import('./ui.js').then(m => m.showError && m.showError(...))` idiom the rest of the file uses, so a summarize failure shows an error toast instead of crashing the handler.

No visual/style changes — this only fixes error-path logic.

## Testing

- `node --check static/js/emailLibrary.js` passes.

Fixes #1916