### PR TITLE
fix(notes): skip non-dict checklist item rows

### DIFF
--- a/scripts/odysseus-notes
+++ b/scripts/odysseus-notes
@@ -36,7 +36,9 @@ def _load_items(raw) -> list:
         items = json.loads(raw)
     except (TypeError, json.JSONDecodeError):
         return []
-    return items if isinstance(items, list) else []
+    if not isinstance(items, list):
+        return []
+    return [item for item in items if isinstance(item, dict)]
 
 
 def _serialize(n: "Note") -> dict:

--- a/tests/cli/test_notes_cli_items.py
+++ b/tests/cli/test_notes_cli_items.py
@@ -46,3 +46,25 @@ def test_serialize_keeps_list_note_items(monkeypatch):
     )
 
     assert cli._serialize(note)["items"] == [{"text": "done"}]
+
+
+def test_serialize_skips_invalid_note_item_rows(monkeypatch):
+    make_core_db_stub(monkeypatch, models=["Note"])
+    cli = load_script("odysseus-notes")
+    note = SimpleNamespace(
+        id="n1",
+        title="Checklist",
+        content="",
+        items='[{"text": "done"}, "bad", null, 3]',
+        note_type="checklist",
+        color=None,
+        label=None,
+        pinned=False,
+        archived=False,
+        due_date=None,
+        source=None,
+        created_at=None,
+        updated_at=None,
+    )
+
+    assert cli._serialize(note)["items"] == [{"text": "done"}]

--- a/tests/test_notes_cli_items.py
+++ b/tests/test_notes_cli_items.py
@@ -64,3 +64,24 @@ def test_serialize_keeps_list_note_items(monkeypatch):
     )
 
     assert cli._serialize(note)["items"] == [{"text": "done"}]
+
+
+def test_serialize_skips_invalid_note_item_rows(monkeypatch):
+    cli = _load_cli(monkeypatch)
+    note = SimpleNamespace(
+        id="n1",
+        title="Checklist",
+        content="",
+        items='[{"text": "done"}, "bad", null, 3]',
+        note_type="checklist",
+        color=None,
+        label=None,
+        pinned=False,
+        archived=False,
+        due_date=None,
+        source=None,
+        created_at=None,
+        updated_at=None,
+    )
+
+    assert cli._serialize(note)["items"] == [{"text": "done"}]


### PR DESCRIPTION
## Summary

`odysseus-notes` already falls back when the stored checklist JSON is malformed. This also handles the next bad shape: a JSON list that contains non-object rows.

What changed:
- `_load_items` still accepts stored JSON lists
- non-dict checklist rows are skipped
- valid item objects keep the same serialized output

## Linked Issue

Part of #1883.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`, the current default branch.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I ran the app or included the existing app/visual smoke check recorded for this branch.

## How to Test

1. `./venv/bin/python -m pytest -q tests/cli/test_notes_cli_items.py`
2. `./venv/bin/python -m py_compile scripts/odysseus-notes tests/cli/test_notes_cli_items.py`
3. `git diff --check origin/main...HEAD`
4. `app smoke: `uvicorn app:app` on `127.0.0.1:7023`, then `GET /api/version``

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI/render path touched.

### Screenshots / clips

N/A

