### PR TITLE
fix(backup): skip vanished backup list entries

### DIFF
--- a/scripts/odysseus-backup
+++ b/scripts/odysseus-backup
@@ -133,16 +133,30 @@ def cmd_list(args):
         emit([], args)
         return
     entries = []
-    for p in sorted(_BACKUP_DIR.iterdir(), key=lambda x: x.stat().st_mtime, reverse=True):
-        if not p.is_file():
-            continue
-        entries.append({
-            "path": str(p),
-            "name": p.name,
-            "bytes": p.stat().st_size,
-            "modified": datetime.fromtimestamp(p.stat().st_mtime).isoformat(),
-        })
+    for p in _BACKUP_DIR.iterdir():
+        entry = _backup_entry(p)
+        if entry is not None:
+            entries.append(entry)
+    entries.sort(key=lambda entry: entry["_mtime"], reverse=True)
+    for entry in entries:
+        entry.pop("_mtime", None)
     emit(entries, args)
+
+
+def _backup_entry(p):
+    try:
+        if not p.is_file():
+            return None
+        st = p.stat()
+    except OSError:
+        return None
+    return {
+        "path": str(p),
+        "name": p.name,
+        "bytes": st.st_size,
+        "modified": datetime.fromtimestamp(st.st_mtime).isoformat(),
+        "_mtime": st.st_mtime,
+    }
 
 
 def cmd_verify(args):

--- a/scripts/odysseus-backup
+++ b/scripts/odysseus-backup
@@ -133,16 +133,27 @@ def cmd_list(args):
         emit([], args)
         return
     entries = []
-    for p in sorted(_BACKUP_DIR.iterdir(), key=lambda x: x.stat().st_mtime, reverse=True):
-        if not p.is_file():
-            continue
-        entries.append({
-            "path": str(p),
-            "name": p.name,
-            "bytes": p.stat().st_size,
-            "modified": datetime.fromtimestamp(p.stat().st_mtime).isoformat(),
-        })
+    for p in _BACKUP_DIR.iterdir():
+        entry = _backup_entry(p)
+        if entry is not None:
+            entries.append(entry)
+    entries.sort(key=lambda entry: entry["modified"], reverse=True)
     emit(entries, args)
+
+
+def _backup_entry(p):
+    try:
+        if not p.is_file():
+            return None
+        st = p.stat()
+    except OSError:
+        return None
+    return {
+        "path": str(p),
+        "name": p.name,
+        "bytes": st.st_size,
+        "modified": datetime.fromtimestamp(st.st_mtime).isoformat(),
+    }
 
 
 def cmd_verify(args):

--- a/tests/test_backup_cli_security.py
+++ b/tests/test_backup_cli_security.py
@@ -30,6 +30,24 @@ def _verify_args(path: Path):
     return SimpleNamespace(path=str(path), pretty=False)
 
 
+def test_backup_entry_skips_files_that_disappear():
+    backup = _load_backup_cli()
+
+    class Vanished:
+        name = "gone.tar.gz"
+
+        def is_file(self):
+            return True
+
+        def stat(self):
+            raise FileNotFoundError("gone")
+
+        def __str__(self):
+            return "backups/gone.tar.gz"
+
+    assert backup._backup_entry(Vanished()) is None
+
+
 def test_snapshot_rejects_output_inside_data_dir(tmp_path, monkeypatch):
     backup = _load_backup_cli()
     repo = tmp_path / "repo"

--- a/tests/test_backup_cli_security.py
+++ b/tests/test_backup_cli_security.py
@@ -30,6 +30,46 @@ def _verify_args(path: Path):
     return SimpleNamespace(path=str(path), pretty=False)
 
 
+def test_backup_entry_skips_files_that_disappear():
+    backup = _load_backup_cli()
+
+    class Vanished:
+        name = "gone.tar.gz"
+
+        def is_file(self):
+            return True
+
+        def stat(self):
+            raise FileNotFoundError("gone")
+
+        def __str__(self):
+            return "backups/gone.tar.gz"
+
+    assert backup._backup_entry(Vanished()) is None
+
+
+def test_backup_list_sorts_by_captured_mtime(monkeypatch):
+    backup = _load_backup_cli()
+    first = SimpleNamespace(name="older.tar.gz")
+    second = SimpleNamespace(name="newer.tar.gz")
+    monkeypatch.setattr(backup, "_BACKUP_DIR", SimpleNamespace(
+        is_dir=lambda: True,
+        iterdir=lambda: [first, second],
+    ))
+    monkeypatch.setattr(backup, "_backup_entry", lambda p: {
+        "name": p.name,
+        "modified": "2026-10-25T01:45:00" if p is first else "2026-10-25T01:15:00",
+        "_mtime": 100 if p is first else 200,
+    })
+    seen = []
+    monkeypatch.setattr(backup, "emit", lambda payload, args: seen.append(payload))
+
+    backup.cmd_list(SimpleNamespace(pretty=False))
+
+    assert [entry["name"] for entry in seen[0]] == ["newer.tar.gz", "older.tar.gz"]
+    assert all("_mtime" not in entry for entry in seen[0])
+
+
 def test_snapshot_rejects_output_inside_data_dir(tmp_path, monkeypatch):
     backup = _load_backup_cli()
     repo = tmp_path / "repo"


### PR DESCRIPTION
## Summary

`odysseus-backup list` statted files while sorting and then statted them again while serializing. If a backup file disappears between those steps, the CLI can fail instead of just omitting the vanished entry.

What changed:
- added `_backup_entry` with OSError handling
- backup entries are collected first, then sorted by their captured timestamp
- valid backup files keep the same output fields

## Linked Issue

Part of #1883.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`, the current default branch.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I ran the app or included the existing app/visual smoke check recorded for this branch.

## How to Test

1. `./venv/bin/python -m pytest -q tests/test_backup_cli_security.py`
2. `./venv/bin/python -m py_compile scripts/odysseus-backup tests/test_backup_cli_security.py`
3. `git diff --check origin/main...HEAD`
4. `app smoke: `uvicorn app:app` on `127.0.0.1:7024`, then `GET /api/version``

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI/render path touched.

### Screenshots / clips

N/A
