### PR TITLE
fix(gallery): normalize CLI text fields

### DIFF
--- a/scripts/odysseus-gallery
+++ b/scripts/odysseus-gallery
@@ -38,23 +38,27 @@ def _preview_text(value, limit: int = 200) -> str:
     return text[:limit]
 
 
+def _text_field(value) -> str:
+    return value if isinstance(value, str) else ""
+
+
 def _serialize_image(i: "GalleryImage") -> dict:
     return {
         "id": i.id,
-        "filename": i.filename,
+        "filename": _text_field(i.filename),
         "prompt": _preview_text(i.prompt),
-        "model": i.model or "",
-        "size": i.size or "",
-        "tags": i.tags or "",
+        "model": _text_field(i.model),
+        "size": _text_field(i.size),
+        "tags": _text_field(i.tags),
         "favorite": bool(i.favorite),
-        "album_id": i.album_id or "",
-        "session_id": i.session_id or "",
+        "album_id": _text_field(i.album_id),
+        "session_id": _text_field(i.session_id),
         "width": i.width,
         "height": i.height,
         "file_size": i.file_size,
         "taken_at": i.taken_at.isoformat() if i.taken_at else "",
-        "camera_make": i.camera_make or "",
-        "camera_model": i.camera_model or "",
+        "camera_make": _text_field(i.camera_make),
+        "camera_model": _text_field(i.camera_model),
         "created_at": i.created_at.isoformat() if i.created_at else "",
     }
 
@@ -93,11 +97,11 @@ def cmd_show(args):
         if not i:
             fail(f"no image with id {args.id!r}")
         out = _serialize_image(i)
-        out["prompt_full"] = i.prompt or ""
-        out["ai_tags"] = i.ai_tags or ""
+        out["prompt_full"] = _text_field(i.prompt)
+        out["ai_tags"] = _text_field(i.ai_tags)
         out["gps_lat"] = i.gps_lat or ""
         out["gps_lng"] = i.gps_lng or ""
-        out["file_hash"] = i.file_hash or ""
+        out["file_hash"] = _text_field(i.file_hash)
         emit(out, args)
     finally:
         db.close()

--- a/tests/cli/test_gallery_cli_preview.py
+++ b/tests/cli/test_gallery_cli_preview.py
@@ -15,16 +15,21 @@ def test_preview_text_ignores_non_string(monkeypatch):
     assert cli._preview_text(None) == ""
     assert cli._preview_text(123) == ""
     assert cli._preview_text("p" * 250) == "p" * 200
+    assert cli._text_field("ok") == "ok"
+    assert cli._text_field(123) == ""
 
 
 def test_serialize_image_does_not_crash_on_non_string_prompt(monkeypatch):
     make_core_db_stub(monkeypatch, models=["GalleryImage", "GalleryAlbum"])
     cli = load_script("odysseus-gallery")
     img = SimpleNamespace(
-        id="i1", filename="a.png", prompt=123, model=None, size=None, tags=None,
+        id="i1", filename=123, prompt=123, model=123, size=None, tags=["bad"],
         favorite=0, album_id=None, session_id=None, width=1, height=1, file_size=1,
-        taken_at=None, camera_make=None, camera_model=None, created_at=None,
+        taken_at=None, camera_make=123, camera_model=None, created_at=None,
     )
     out = cli._serialize_image(img)
     assert out["prompt"] == ""
+    assert out["filename"] == ""
+    assert out["model"] == ""
+    assert out["tags"] == ""
     assert out["id"] == "i1"

--- a/tests/test_gallery_cli_preview.py
+++ b/tests/test_gallery_cli_preview.py
@@ -33,15 +33,20 @@ def test_preview_text_ignores_non_string(monkeypatch):
     assert cli._preview_text(None) == ""
     assert cli._preview_text(123) == ""
     assert cli._preview_text("p" * 250) == "p" * 200
+    assert cli._text_field("ok") == "ok"
+    assert cli._text_field(123) == ""
 
 
 def test_serialize_image_does_not_crash_on_non_string_prompt(monkeypatch):
     cli = _load_cli(monkeypatch)
     img = SimpleNamespace(
-        id="i1", filename="a.png", prompt=123, model=None, size=None, tags=None,
+        id="i1", filename=123, prompt=123, model=123, size=None, tags=["bad"],
         favorite=0, album_id=None, session_id=None, width=1, height=1, file_size=1,
-        taken_at=None, camera_make=None, camera_model=None, created_at=None,
+        taken_at=None, camera_make=123, camera_model=None, created_at=None,
     )
     out = cli._serialize_image(img)
     assert out["prompt"] == ""
+    assert out["filename"] == ""
+    assert out["model"] == ""
+    assert out["tags"] == ""
     assert out["id"] == "i1"


### PR DESCRIPTION
## Summary

The gallery CLI already guards prompt previews against non-string values. A few other text fields still pass malformed values through unchanged during serialization.

What changed:
- added `_text_field` for gallery CLI text fields
- summary fields like filename/model/tags/camera now fall back to empty string on bad shapes
- valid strings keep the same output

## Linked Issue

Part of #1883.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`, the current default branch.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I ran the app or included the existing app/visual smoke check recorded for this branch.

## How to Test

1. `./venv/bin/python -m pytest -q tests/cli/test_gallery_cli_preview.py tests/cli/test_gallery_cli_album_count.py`
2. `./venv/bin/python -m py_compile scripts/odysseus-gallery tests/cli/test_gallery_cli_preview.py tests/cli/test_gallery_cli_album_count.py`
3. `git diff --check origin/main...HEAD`
4. `app smoke: `uvicorn app:app` on `127.0.0.1:7027`, then `GET /api/version``

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI/render path touched.

### Screenshots / clips

N/A

