### PR TITLE
fix: TTS available crashes on non-string tts_provider

### DIFF
--- a/services/tts/tts_service.py
+++ b/services/tts/tts_service.py
@@ -66,7 +66,7 @@ class TTSService:
         if provider == "local":
             kokoro = self._get_kokoro()
             return kokoro is not None and kokoro.available
-        if provider.startswith("endpoint:"):
+        if isinstance(provider, str) and provider.startswith("endpoint:"):
             return True  # assume reachable; errors surface at synthesis time
         return False
 

--- a/tests/test_tts_available_nonstring_provider.py
+++ b/tests/test_tts_available_nonstring_provider.py
@@ -1,0 +1,17 @@
+from services.tts.tts_service import TTSService
+
+
+def test_available_tolerates_non_string_provider(tmp_path):
+    """A hand-edited/corrupt data/settings.json can store a non-string
+    tts_provider (e.g. null or a number). available reads it and calls
+    provider.startswith("endpoint:"), which raised AttributeError on a
+    non-str. It must instead fall through and report unavailable."""
+    service = TTSService(cache_dir=str(tmp_path))
+    service._load_settings = lambda: {
+        "tts_enabled": True,
+        "tts_provider": 123,
+        "tts_model": "tts-1",
+        "tts_voice": "alloy",
+        "tts_speed": "1",
+    }
+    assert service.available is False


### PR DESCRIPTION
## Summary

`TTSService.available` reads `tts_provider` from `data/settings.json` and calls `provider.startswith("endpoint:")` on it. The settings layer deliberately tolerates hand-edited / agent-written config — the adjacent `_safe_speed` helper already guards a corrupt `tts_speed` for exactly this reason — so a non-string `tts_provider` (e.g. `null` or a number) reaches this line and raises `AttributeError: 'int' object has no attribute 'startswith'`, breaking the property and any caller that probes TTS availability. This adds an `isinstance(provider, str)` check before the `.startswith` call so a non-string provider simply falls through to `return False`.

## Linked Issue

Part of #2112

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run the regression test added in this PR: `pytest tests/test_tts_available_nonstring_provider.py`. It fails on the pre-fix code and passes after the fix.
2. See the Summary above for the exact before/after behaviour the test exercises.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

<!-- Drag and drop images or a screen recording here. Required for any UI/visual change. -->


