### PR TITLE
fix: _matchesCombo crashes on non-string keybind from server

### DIFF
--- a/static/js/keyboard-shortcuts.js
+++ b/static/js/keyboard-shortcuts.js
@@ -16,7 +16,7 @@ const _defaultKeybinds = {
 };
 
 export function _matchesCombo(e, combo, isMac = IS_MAC) {
-  if (!combo) return false;
+  if (typeof combo !== 'string' || !combo) return false;
   // Drop AltGr keystrokes so typing characters on non-US layouts can't fire a
   // Ctrl+Alt shortcut — e.g. the destructive delete_session. See platform.js.
   if (isAltGrEvent(e, isMac)) return false;

--- a/tests/test_matchescombo_nonstring_js.py
+++ b/tests/test_matchescombo_nonstring_js.py
@@ -1,0 +1,47 @@
+"""Pin _matchesCombo (static/js/keyboard-shortcuts.js) against a non-string
+keybind. Driven through `node --input-type=module` (same approach as
+tests/test_markdown_table_row_js.py); skips when `node` is missing.
+
+Regression: keybinds are merged from the server response of
+`/api/auth/settings` (`{ ..._defaultKeybinds, ...s.keybinds }`). A corrupt
+or malformed `keybinds` value (e.g. a number instead of "ctrl+k") reached
+`combo.split('+')` and threw "combo.split is not a function", breaking the
+whole keydown handler. The guard treats any non-string combo as "no match".
+"""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_MOD = _REPO / "static" / "js" / "keyboard-shortcuts.js"
+_HAS_NODE = shutil.which("node") is not None
+
+_EVENT = "{key:'k',ctrlKey:false,altKey:false,shiftKey:false,metaKey:false}"
+
+
+def _match(combo_js):
+    js = f"""
+    import {{ _matchesCombo }} from '{_MOD.as_posix()}';
+    console.log(JSON.stringify(_matchesCombo({_EVENT}, {combo_js})));
+    """
+    proc = subprocess.run(
+        ["node", "--input-type=module"],
+        input=js, capture_output=True, text=True, cwd=str(_REPO), timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout.strip())
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_non_string_combo_is_no_match():
+    assert _match("123") is False
+    assert _match("{}") is False
+    assert _match("null") is False
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_matching_combo_still_fires():
+    assert _match("'k'") is True


### PR DESCRIPTION
## Summary

`_matchesCombo` powers every keyboard shortcut. Keybinds are taken from the server: `initKeyboardShortcuts` does `window._odysseusKeybinds = { ..._defaultKeybinds, ...s.keybinds }` with `s` parsed from `/api/auth/settings`. The function guards `if (!combo) return false` but then calls `combo.split('+')`, so a malformed/corrupt keybind value that is a non-string (e.g. a number or object instead of "ctrl+k") is truthy, slips past the `!combo` check and throws `combo.split is not a function` inside the global keydown handler — which then stops processing all shortcuts for that keypress. This tightens the guard to treat any non-string combo as 'no match'.

## Linked Issue

Part of #2112

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run the regression test added in this PR: `pytest tests/test_matchescombo_nonstring_js.py`. It fails on the pre-fix code and passes after the fix.
2. See the Summary above for the exact before/after behaviour the test exercises.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

<!-- Drag and drop images or a screen recording here. Required for any UI/visual change. -->


