### PR TITLE
fix: _parse_msg_content corrupting JSON-array-like text messages on reload

### DIFF
--- a/core/session_manager.py
+++ b/core/session_manager.py
@@ -37,7 +37,18 @@ def _parse_msg_content(raw):
     if isinstance(raw, str) and raw.startswith('[{') and '"type"' in raw:
         try:
             parsed = json.loads(raw)
-            if isinstance(parsed, list) and all(isinstance(p, dict) for p in parsed):
+            # Only treat as serialized multimodal content when EVERY element is
+            # a dict whose "type" is a recognized content-block kind. Otherwise a
+            # plain text message that merely *looks* like a JSON array of objects
+            # (e.g. a user pasting an API schema/sample with a "type" field) was
+            # silently parsed back into a list, destroying the original string.
+            _BLOCK_TYPES = {
+                "text", "image", "image_url", "audio", "input_audio",
+                "input_image", "document", "file",
+            }
+            if (isinstance(parsed, list) and parsed
+                    and all(isinstance(p, dict) and p.get("type") in _BLOCK_TYPES
+                            for p in parsed)):
                 return parsed
         except (json.JSONDecodeError, ValueError):
             pass

--- a/tests/test_parse_msg_content_jsonlike_string.py
+++ b/tests/test_parse_msg_content_jsonlike_string.py
@@ -1,0 +1,80 @@
+"""A plain text message that merely *looks* like a JSON array of objects must
+NOT be silently re-parsed into a list on reload.
+
+_parse_msg_content de-serializes multimodal (image/audio) content back into a
+list of content blocks. The old heuristic accepted ANY string that started
+with "[{" and contained the substring '"type"'. A user who pasted an API
+schema / sample such as `[{"type": "object", "name": "foo"}]` therefore had
+their text message permanently corrupted into a Python list on the next
+session hydration. The fix restricts the round-trip to lists whose elements
+are all recognized content-block types (text/image_url/audio/...).
+"""
+import tempfile
+import uuid
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import NullPool
+
+import core.database as cdb
+from core.database import Session as DbSession
+from core.models import ChatMessage
+
+_TMPDB = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+_ENGINE = create_engine(
+    f"sqlite:///{_TMPDB.name}",
+    connect_args={"check_same_thread": False},
+    poolclass=NullPool,
+)
+cdb.Base.metadata.create_all(_ENGINE)
+_TS = sessionmaker(bind=_ENGINE, autoflush=False, autocommit=False)
+
+
+@pytest.fixture
+def manager(monkeypatch):
+    import core.session_manager as sm
+    monkeypatch.setattr(sm, "SessionLocal", _TS)
+    mgr = sm.SessionManager.__new__(sm.SessionManager)
+    mgr.sessions = {}
+    return mgr
+
+
+def _make_session(sid, owner="alice"):
+    db = _TS()
+    try:
+        db.add(DbSession(id=sid, owner=owner, name="chat",
+                         endpoint_url="http://x", model="gpt-4o",
+                         archived=False, message_count=1))
+        db.commit()
+    finally:
+        db.close()
+
+
+def test_jsonlike_user_string_not_corrupted(manager):
+    sid = "sess-" + uuid.uuid4().hex[:8]
+    _make_session(sid)
+    text = '[{"type": "object", "name": "foo"}]'
+    msgs = [ChatMessage(role="user", content=text)]
+    assert manager.replace_messages(sid, msgs) is True
+
+    manager.sessions.clear()
+    reloaded = manager.get_session(sid)
+    # Must come back as the ORIGINAL STRING, not silently parsed into a list.
+    assert isinstance(reloaded.history[0].content, str)
+    assert reloaded.history[0].content == text
+
+
+def test_real_multimodal_content_still_round_trips(manager):
+    sid = "sess-" + uuid.uuid4().hex[:8]
+    _make_session(sid)
+    multimodal = [
+        {"type": "text", "text": "what is this?"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+    ]
+    msgs = [ChatMessage(role="user", content=multimodal)]
+    assert manager.replace_messages(sid, msgs) is True
+
+    manager.sessions.clear()
+    reloaded = manager.get_session(sid)
+    assert reloaded.history[0].content == multimodal


### PR DESCRIPTION
## Summary

`_parse_msg_content` (`core/session_manager.py`) deserializes stored message content back into a list when it's multimodal (image/audio blocks). It treated **any** string that starts with `[{` and contains the substring `"type"` as serialized content, requiring only that each element be a `dict` — it never checked that `"type"` is a real content-block kind:

```python
if isinstance(raw, str) and raw.startswith('[{') and '"type"' in raw:
    parsed = json.loads(raw)
    if isinstance(parsed, list) and all(isinstance(p, dict) for p in parsed):
        return parsed
```

So a **plain text message** whose content happens to be a JSON array of typed objects — e.g. a user pasting an API schema/sample like `[{"type": "object", "name": "foo"}]`, a JSON Schema, or a tool-definition snippet — is silently parsed from a `str` into a `list` on the next hydration, **destroying the original string** (round-trip data loss).

This runs on **every session load from the DB**: `_parse_msg_content` is called by `_db_to_session` → `_load_session_from_db` → `get_session` (loading a chat, history endpoint, fork, compaction reload, etc.).

**Fix:** only treat the string as serialized content when it parses to a non-empty list whose every element is a dict whose `"type"` is a recognized content-block kind (`text`, `image`, `image_url`, `audio`, `input_audio`, `input_image`, `document`, `file`). Real multimodal content still round-trips — verified that `src/document_processor.py` emits exactly these block types — while JSON-looking text strings are left untouched.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

<!-- Drag and drop images or a screen recording here. Required for any UI/visual change. -->

## Linked Issue

Part of #2121

## How to Test

1. Run the regression test added in this PR: `pytest tests/test_parse_msg_content_jsonlike_string.py`. It fails on the pre-fix code and passes after the fix.
2. See the Summary above for the exact before/after behaviour the test exercises.

