### PR TITLE
fix: odysseus-memory cmd_add crashes on non-dict existing memory row

### DIFF
--- a/scripts/odysseus-memory
+++ b/scripts/odysseus-memory
@@ -90,7 +90,7 @@ def cmd_add(args):
     # add_entry doesn't save by default — the call in chat does it
     # after dedup checks. Persist here so a one-shot CLI add sticks.
     all_entries = _manager().load_all()
-    if not any(e.get("id") == entry.get("id") for e in all_entries):
+    if not any(isinstance(e, dict) and e.get("id") == entry.get("id") for e in all_entries):
         all_entries.append(entry)
         _manager().save(all_entries)
     emit(entry, args)

--- a/tests/test_memory_cli_add_nondict.py
+++ b/tests/test_memory_cli_add_nondict.py
@@ -1,0 +1,46 @@
+"""cmd_add (scripts/odysseus-memory) must tolerate a non-dict row in the
+existing store. Every other command funnels load_all() through
+`_memory_entries()` (which drops non-dicts), but cmd_add iterated the raw
+list in its dedup check: `any(e.get("id") == ... for e in all_entries)`
+crashed with AttributeError on a corrupt/hand-edited memory.json row that
+is not a dict. The isinstance check short-circuits before `.get`.
+"""
+import importlib.machinery
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_cli(monkeypatch):
+    svc = types.ModuleType("services.memory.memory")
+    svc.MemoryManager = MagicMock()
+    monkeypatch.setitem(sys.modules, "services.memory.memory", svc)
+    path = ROOT / "scripts" / "odysseus-memory"
+    loader = importlib.machinery.SourceFileLoader("odysseus_memory_cli_add", str(path))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+def test_cmd_add_tolerates_non_dict_existing_row(monkeypatch):
+    cli = _load_cli(monkeypatch)
+    cli._mgr = MagicMock()
+    cli._mgr.add_entry.return_value = {"id": "m2", "text": "new"}
+    cli._mgr.load_all.return_value = [
+        {"id": "m1", "text": "existing"},
+        "corrupt-row",
+        None,
+    ]
+    emitted = []
+    monkeypatch.setattr(cli, "emit", lambda value, args: emitted.append(value))
+
+    cli.cmd_add(SimpleNamespace(text="new", category="fact", owner=None))
+
+    assert emitted == [{"id": "m2", "text": "new"}]
+    cli._mgr.save.assert_called_once()


### PR DESCRIPTION
## Summary

The `odysseus-memory` CLI funnels `MemoryManager.load_all()` through the `_memory_entries()` helper (which drops non-dict rows) in every command except `cmd_add`. `cmd_add`'s dedup check iterated the raw list — `any(e.get("id") == entry.get("id") for e in all_entries)` — so a corrupt or hand-edited `memory.json` containing a non-dict row (a bare string or null) crashed the add with `AttributeError: 'str' object has no attribute 'get'`. This adds an `isinstance(e, dict)` check that short-circuits before `.get`, matching how the rest of the CLI already treats the store. The saved content is unchanged.

## Linked Issue

Part of #2112

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run the regression test added in this PR: `pytest tests/test_memory_cli_add_nondict.py`. It fails on the pre-fix code and passes after the fix.
2. See the Summary above for the exact before/after behaviour the test exercises.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

<!-- Drag and drop images or a screen recording here. Required for any UI/visual change. -->


