### PR TITLE
fix: hwfit params_b/is_prequantized crash on non-string catalog fields

### DIFF
--- a/services/hwfit/models.py
+++ b/services/hwfit/models.py
@@ -130,7 +130,7 @@ def is_prequantized(model):
         or re.search(r"(^|[-_/])fp8($|[-_/\s])", text) is not None
         or (not (model.get("is_gguf") or model.get("gguf_sources")) and re.search(r"(^|[-_/])(?:int)?8bit($|[-_/\s])", text) is not None)
         or any(x in text for x in ("awq", "gptq", "mlx"))
-        or any(q.startswith(p) for p in PREQUANTIZED_PREFIXES)
+        or any(isinstance(q, str) and q.startswith(p) for p in PREQUANTIZED_PREFIXES)
     )
 
 
@@ -140,7 +140,7 @@ def params_b(model):
         return raw / 1_000_000_000.0
 
     pc = model.get("parameter_count", "")
-    if pc:
+    if isinstance(pc, str) and pc:
         pc = pc.strip().upper()
         m = re.match(r"^([\d.]+)\s*([BKMGT]?)$", pc)
         if m:

--- a/tests/test_hwfit_models_nonstring_fields.py
+++ b/tests/test_hwfit_models_nonstring_fields.py
@@ -1,0 +1,31 @@
+"""Harden hwfit model-catalog parsing against non-string field values.
+
+`params_b` and `is_prequantized` read free-form fields straight off the HF
+catalog JSON. `parameter_count` is normally a string like "7B" and
+`quantization` a string like "FP8", but a catalog row can carry a non-string
+(e.g. an integer parameter_count, or a null/number quantization). The code
+called `pc.strip()` / `q.startswith(...)` directly, so one such row raised
+AttributeError and aborted the whole ranking pass (params_b/is_prequantized
+run for every model). Non-strings are now treated as unknown.
+"""
+from services.hwfit.models import params_b, is_prequantized
+
+
+def test_params_b_nonstring_count_does_not_raise():
+    assert params_b({"parameter_count": 7}) == 0.0
+    assert params_b({"parameter_count": ["7B"]}) == 0.0
+
+
+def test_params_b_valid_count_still_parses():
+    assert params_b({"parameter_count": "7B"}) == 7.0
+    assert params_b({"parameters_raw": 7_000_000_000}) == 7.0
+
+
+def test_is_prequantized_nonstring_quantization_does_not_raise():
+    assert is_prequantized({"quantization": 8}) is False
+    assert is_prequantized({"name": "plain-model", "quantization": 123}) is False
+
+
+def test_is_prequantized_still_detects_real_markers():
+    assert is_prequantized({"name": "some-model-awq"}) is True
+    assert is_prequantized({"quantization": "FP8-Mixed"}) is True


### PR DESCRIPTION
## Summary

`params_b` and `is_prequantized` (services/hwfit/models.py) read free-form fields straight off the HuggingFace model-catalog JSON and run for EVERY model during the ranking pass. `parameter_count` is normally a string like "7B" and `quantization` a string like "FP8", but a catalog row can legitimately carry a non-string (an integer `parameter_count`, or a null/number `quantization`). The code called `pc.strip().upper()` and `q.startswith(prefix)` directly, so one such row raised `AttributeError` and aborted the entire hardware-fit ranking request (mirroring the existing multi-dot guard in `params_b`, which already treats a malformed count as unknown). This adds `isinstance(..., str)` checks so a non-string field is treated as unknown size / not-prequantized instead of crashing.

## Linked Issue

Part of #2112

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run the regression test added in this PR: `pytest tests/test_hwfit_models_nonstring_fields.py`. It fails on the pre-fix code and passes after the fix.
2. See the Summary above for the exact before/after behaviour the test exercises.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

<!-- Drag and drop images or a screen recording here. Required for any UI/visual change. -->


