### PR TITLE
feat: add PII sanitization layer for LLM calls (#538)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,27 @@ LLM_HOST=localhost
 # RESEARCH_LLM_ENDPOINT=http://localhost:8000/v1/chat/completions
 
 # ============================================================
+# PII Sanitization (Issue #538)
+# ============================================================
+
+# Enable PII sanitization layer before sending prompts to external LLMs.
+# Default: false. Requires a sanitizer service URL.
+# PII_SANITIZATION_ENABLED=false
+
+# URL of the PII sanitizer service (e.g. TrustBoost or local service).
+# The service should accept POST with {"text": "..."} and return JSON with
+# "sanitized_text" or "text" or "data.sanitized_content".
+# PII_SANITIZER_URL=https://api.trustboost.dev/sanitize
+
+# Policy on sanitization failure:
+# continue: (default) Log warning and send unsanitized messages to LLM.
+# block: Abort the request and return an error to the user.
+# PII_SANITIZATION_POLICY=continue
+
+# Timeout in seconds for the sanitization request.
+# PII_SANITIZER_TIMEOUT=5
+
+# ============================================================
 # Search & Web
 # ============================================================
 

--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ Odysseus is a self-hosted workspace with powerful local tools: shell access, fil
 - Keep `AUTH_ENABLED=true` for any network-accessible deployment.
 - Keep `LOCALHOST_BYPASS=false` outside local development.
 - Use `SECURE_COOKIES=true` when Odysseus is served through HTTPS by a trusted reverse proxy or private access gateway.
+- **PII Sanitization (Issue #538):** An optional sanitization layer can be enabled in `.env` (`PII_SANITIZATION_ENABLED=true`) to redact sensitive information (names, emails, tokens) before it leaves your machine for external LLM providers. See `.env.example` for configuration.
 - Do not expose it directly to the public internet without HTTPS and a trusted reverse proxy or private access layer.
 - Keep `.env`, `data/`, `logs/`, databases, uploads, generated media, backups, auth/session files, API keys, and model/provider tokens out of Git and private shares. They are ignored by default.
 - Review `data/auth.json` after first boot: disable open signup unless you intentionally want it, make only your own account admin, and keep demo/test accounts non-admin.

--- a/core/constants.py
+++ b/core/constants.py
@@ -38,3 +38,9 @@ CLEANUP_INTERVAL_HOURS = int(os.getenv("CLEANUP_INTERVAL_HOURS", "24"))
 # Default parameters
 DEFAULT_TEMPERATURE = 1.0
 DEFAULT_MAX_TOKENS = 0
+
+# PII Sanitization
+PII_SANITIZATION_ENABLED = os.getenv("PII_SANITIZATION_ENABLED", "False").lower() == "true"
+PII_SANITIZER_URL = os.getenv("PII_SANITIZER_URL", "")
+PII_SANITIZATION_POLICY = os.getenv("PII_SANITIZATION_POLICY", "warn").lower()  # "continue", "warn", "block"
+PII_SANITIZER_TIMEOUT = int(os.getenv("PII_SANITIZER_TIMEOUT", "5"))

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -9,6 +9,7 @@ import threading
 from fastapi import HTTPException
 from typing import Optional, Dict, List
 from src.model_context import get_context_length, DEFAULT_CONTEXT
+from src.sanitizer import sanitize_messages, sanitize_messages_sync
 from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
@@ -809,6 +810,7 @@ def llm_call(url: str, model: str, messages: List[Dict], temperature: float = LL
         h.update(headers)
 
     messages_copy = _sanitize_llm_messages(messages)
+    messages_copy = sanitize_messages_sync(messages_copy)
 
     # Consolidate multiple system messages into one at the start.
     sys_parts = []
@@ -953,6 +955,7 @@ async def llm_call_async(
     """Asynchronous LLM call using httpx with connection pooling, timeout, retry logic, and performance logging."""
     provider = _detect_provider(url)
     messages_copy = _sanitize_llm_messages(messages)
+    messages_copy = await sanitize_messages(messages_copy)
 
     # Consolidate multiple system messages into one at the start.
     sys_parts = []
@@ -1062,6 +1065,7 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
     """
     provider = _detect_provider(url)
     messages_copy = _sanitize_llm_messages(messages)
+    messages_copy = await sanitize_messages(messages_copy)
 
     # Consolidate multiple system messages into one at the start.
     # Some models (e.g. Qwen3.5) reject system messages that aren't first.

--- a/src/sanitizer.py
+++ b/src/sanitizer.py
@@ -1,0 +1,159 @@
+# src/sanitizer.py
+import os
+import httpx
+import logging
+import asyncio
+from typing import List, Dict, Any
+
+logger = logging.getLogger(__name__)
+
+# Load config from environment directly to avoid circular imports with core.constants
+def get_config():
+    return {
+        "enabled": os.getenv("PII_SANITIZATION_ENABLED", "False").lower() == "true",
+        "url": os.getenv("PII_SANITIZER_URL", ""),
+        "policy": os.getenv("PII_SANITIZATION_POLICY", "warn").lower(),
+        "timeout": float(os.getenv("PII_SANITIZER_TIMEOUT", "5"))
+    }
+
+async def sanitize_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    Sanitize PII from messages before sending to LLM.
+    Uses the configured sanitizer endpoint.
+    """
+    config = get_config()
+    if not config["enabled"] or not config["url"]:
+        return messages
+
+    try:
+        # Extract all text segments that need sanitization to batch them if possible,
+        # but for a generic architecture, we'll process them in parallel.
+        
+        tasks = []
+        indices = [] # Keep track of where each text came from
+        
+        for i, msg in enumerate(messages):
+            content = msg.get("content")
+            if isinstance(content, str) and content.strip():
+                tasks.append(_sanitize_text(content))
+                indices.append((i, None))
+            elif isinstance(content, list):
+                for j, block in enumerate(content):
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        text = block.get("text", "")
+                        if text.strip():
+                            tasks.append(_sanitize_text(text))
+                            indices.append((i, j))
+
+        if not tasks:
+            return messages
+
+        # Run all sanitization requests in parallel
+        results = await asyncio.gather(*tasks)
+        
+        # Reconstruct messages with sanitized content
+        sanitized_messages = [dict(m) for m in messages]
+        for (msg_idx, block_idx), sanitized_text in zip(indices, results):
+            if block_idx is None:
+                sanitized_messages[msg_idx]["content"] = sanitized_text
+            else:
+                # Deep copy the block to avoid mutating the original message list
+                new_block = dict(sanitized_messages[msg_idx]["content"][block_idx])
+                new_block["text"] = sanitized_text
+                
+                # Create a new list for content to ensure we don't mutate shared references
+                new_content = list(sanitized_messages[msg_idx]["content"])
+                new_content[block_idx] = new_block
+                sanitized_messages[msg_idx]["content"] = new_content
+                
+        return sanitized_messages
+
+    except Exception as e:
+        logger.error(f"PII sanitization failed: {e}")
+        policy = config["policy"]
+        if policy == "block":
+            raise RuntimeError(f"Request blocked: PII sanitization failed and policy is 'block'. Error: {e}")
+        elif policy == "warn":
+            logger.warning("PII sanitization failed; proceeding with unsanitized messages per policy.")
+        
+        return messages
+
+def sanitize_messages_sync(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Synchronous wrapper for sanitize_messages."""
+    config = get_config()
+    if not config["enabled"] or not config["url"]:
+        return messages
+    
+    try:
+        import asyncio
+        try:
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                # We are in a thread with a running loop (e.g. FastAPI worker thread)
+                # This is tricky in Python. For sync calls in FastAPI threads, 
+                # we can use a fresh loop or run_coroutine_threadsafe.
+                # However, llm_call is often called from FastAPI's threadpool.
+                return asyncio.run(_sanitize_messages_async_wrapper(messages))
+            else:
+                return loop.run_until_complete(sanitize_messages(messages))
+        except RuntimeError:
+            return asyncio.run(sanitize_messages(messages))
+    except Exception as e:
+        logger.error(f"PII sanitization (sync) failed: {e}")
+        if config["policy"] == "block":
+            raise RuntimeError(f"Request blocked: PII sanitization failed and policy is 'block'. Error: {e}")
+        return messages
+
+async def _sanitize_messages_async_wrapper(messages):
+    return await sanitize_messages(messages)
+
+async def _sanitize_text(text: str) -> str:
+    """Send text to sanitizer endpoint and return sanitized version."""
+    if not text or not text.strip():
+        return text
+
+    config = get_config()
+    try:
+        async with httpx.AsyncClient(timeout=config["timeout"]) as client:
+            # Generic provider architecture: POST JSON with a "text" field.
+            # This supports TrustBoost and other common PII scrubbing APIs.
+            payload = {"text": text}
+            response = await client.post(config["url"], json=payload)
+            response.raise_for_status()
+            
+            data = response.json()
+            
+            # Heuristic to find sanitized content in generic JSON response
+            # 1. TrustBoost: data["data"]["sanitized_content"]
+            # 2. Common: data["sanitized_text"] or data["text"]
+            # 3. Fallback: Check if response is just a string or has a clear result field
+            
+            if isinstance(data, str):
+                return data
+                
+            sanitized = None
+            if isinstance(data, dict):
+                # Try common keys
+                keys = ["sanitized_content", "sanitized_text", "text", "output", "result"]
+                for k in keys:
+                    if k in data:
+                        sanitized = data[k]
+                        break
+                
+                # Try nested data (TrustBoost style)
+                if sanitized is None and "data" in data and isinstance(data["data"], dict):
+                    inner = data["data"]
+                    for k in keys:
+                        if k in inner:
+                            sanitized = inner[k]
+                            break
+            
+            if sanitized is not None:
+                return str(sanitized)
+            
+            logger.warning(f"Sanitizer at {PII_SANITIZER_URL} returned unrecognized format: {data}")
+            return text
+
+    except Exception as e:
+        logger.debug(f"Error calling sanitizer at {PII_SANITIZER_URL}: {e}")
+        raise e

--- a/tests/test_sanitizer.py
+++ b/tests/test_sanitizer.py
@@ -1,0 +1,98 @@
+# tests/test_sanitizer.py
+import pytest
+import json
+import httpx
+import os
+from unittest.mock import patch, MagicMock
+from src.sanitizer import sanitize_messages, sanitize_messages_sync
+
+# Mock messages
+MESSAGES = [
+    {"role": "system", "content": "Keep my secrets."},
+    {"role": "user", "content": "My email is john.doe@example.com and my phone is 555-1234."},
+    {"role": "assistant", "content": [{"type": "text", "text": "I will redact John Doe's info."}]}
+]
+
+@pytest.mark.asyncio
+async def test_sanitizer_disabled():
+    """Test that messages are not changed when sanitizer is disabled."""
+    with patch.dict(os.environ, {"PII_SANITIZATION_ENABLED": "False", "PII_SANITIZER_URL": "http://mock-sanitizer/sanitize"}):
+        result = await sanitize_messages(MESSAGES)
+        assert result == MESSAGES
+
+@pytest.mark.asyncio
+async def test_sanitizer_no_url():
+    """Test that messages are not changed when URL is missing."""
+    with patch.dict(os.environ, {"PII_SANITIZATION_ENABLED": "True", "PII_SANITIZER_URL": ""}):
+        result = await sanitize_messages(MESSAGES)
+        assert result == MESSAGES
+
+@pytest.mark.asyncio
+async def test_sanitizer_success():
+    """Test successful sanitization."""
+    env = {
+        "PII_SANITIZATION_ENABLED": "True",
+        "PII_SANITIZER_URL": "http://mock-sanitizer/sanitize"
+    }
+    
+    # Mock responses for different segments
+    mock_responses = [
+        {"sanitized_text": "Keep my secrets."},
+        {"sanitized_text": "My email is [REDACTED] and my phone is [REDACTED]."},
+        {"sanitized_text": "I will redact [REDACTED]'s info."}
+    ]
+    
+    class MockClient:
+        def __init__(self, *args, **kwargs): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *args): pass
+        async def post(self, url, json=None, **kwargs):
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = mock_responses.pop(0) if mock_responses else {"text": "default"}
+            mock_resp.raise_for_status = MagicMock()
+            return mock_resp
+
+    with patch.dict(os.environ, env):
+        with patch("httpx.AsyncClient", side_effect=MockClient):
+            result = await sanitize_messages(MESSAGES)
+            
+            assert result[0]["content"] == "Keep my secrets."
+            assert "[REDACTED]" in result[1]["content"]
+            assert "john.doe@example.com" not in result[1]["content"]
+            assert "[REDACTED]" in result[2]["content"][0]["text"]
+
+@pytest.mark.asyncio
+async def test_sanitizer_timeout_continue():
+    """Test policy='continue' on timeout."""
+    env = {
+        "PII_SANITIZATION_ENABLED": "True",
+        "PII_SANITIZER_URL": "http://mock-sanitizer/sanitize",
+        "PII_SANITIZATION_POLICY": "continue"
+    }
+    
+    with patch.dict(os.environ, env):
+        with patch("httpx.AsyncClient.post", side_effect=httpx.TimeoutException("Timeout")):
+            result = await sanitize_messages(MESSAGES)
+            assert result == MESSAGES # Should return original messages
+
+@pytest.mark.asyncio
+async def test_sanitizer_failure_block():
+    """Test policy='block' on failure."""
+    env = {
+        "PII_SANITIZATION_ENABLED": "True",
+        "PII_SANITIZER_URL": "http://mock-sanitizer/sanitize",
+        "PII_SANITIZATION_POLICY": "block"
+    }
+    
+    with patch.dict(os.environ, env):
+        with patch("httpx.AsyncClient.post", side_effect=httpx.HTTPStatusError("Error", request=MagicMock(), response=MagicMock())):
+            with pytest.raises(RuntimeError) as excinfo:
+                await sanitize_messages(MESSAGES)
+            assert "Request blocked" in str(excinfo.value)
+
+def test_sanitizer_sync_disabled():
+    """Test sync wrapper when disabled."""
+    with patch.dict(os.environ, {"PII_SANITIZATION_ENABLED": "False"}):
+        result = sanitize_messages_sync(MESSAGES)
+        assert result == MESSAGES


### PR DESCRIPTION
## Summary

Adds an optional PII (Personally Identifiable Information) sanitization layer to protect sensitive data before it is sent to external LLM providers. Since Odysseus automatically gathers context from local sources like emails, calendar events, and shell outputs, this feature allows users to redact identifiers (names, emails, phone numbers, etc.) when using cloud-based models. 

The implementation is vendor-agnostic; it uses a generic hook in `src/llm_core.py` that sends message content to a configured POST endpoint (like TrustBoost or a local scrubber) before reaching the provider. It supports both async and sync paths, with parallel processing for multi-block messages to minimize latency.

## Linked Issue

Closes #538

## Type of Change

- [x] New feature (non-breaking — adds new behaviour)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Configure a sanitizer endpoint in your `.env` (e.g., using a local mock or `https://api.trustboost.dev/sanitize`):
   ```bash
   PII_SANITIZATION_ENABLED=true
   PII_SANITIZER_URL=http://your-sanitizer/sanitize
   PII_SANITIZATION_POLICY=warn
   ```
2. Start Odysseus and send a message containing an email address or a specific name to a cloud model (e.g., GPT-4 or Claude).
3. Verify via logs or a network proxy that the payload sent to the LLM provider has the sensitive info redacted.
4. Test failure behavior by setting `PII_SANITIZER_URL` to an invalid address and toggling `PII_SANITIZATION_POLICY` between `warn` and `block`.
5. Run the new tests: `pytest tests/test_sanitizer.py`.

## Visual / UI changes — REQUIRED if you touched anything that renders

**N/A** (Backend implementation only; configuration is currently handled via environment variables).
