### PR TITLE
fix: skip tool-index warmup when remote embeddings are down (M22)

### DIFF
--- a/app.py
+++ b/app.py
@@ -730,11 +730,22 @@ async def startup_event():
     # (showing up as a big `tool_selection` time). Doing it here makes the
     # first turn as fast as subsequent ones (warm embed ≈ a few ms).
     async def _warmup_tool_index():
+        # FAST-FAIL if remote embeddings are down. Local FastEmbed is known to
+        # hang/spin on Python 3.14 during bulk indexing at startup (M22).
+        try:
+            from src.embeddings import _http_embed_down as _hed
+            if _hed:
+                logger.info("[startup] Skipping tool-index warmup (remote embeddings unavailable)")
+                return
+        except Exception:
+            pass
+
         try:
             from src.tool_index import get_tool_index
             idx = await asyncio.to_thread(get_tool_index)
             if idx:
-                await asyncio.to_thread(idx.index_builtin_tools)
+                # get_tool_index already calls index_builtin_tools during init;
+                # don't double-call it here to save startup time / CPU.
                 await asyncio.to_thread(idx.get_tools_for_query, "warmup", 8)
                 logger.info("[startup] Tool index pre-warmed")
         except Exception as e:

--- a/src/tool_index.py
+++ b/src/tool_index.py
@@ -466,7 +466,15 @@ def get_tool_index() -> Optional[ToolIndex]:
 
     try:
         _tool_index = ToolIndex()
-        _tool_index.index_builtin_tools()
+        # Skip re-indexing on warm starts if the built-in tool registry
+        # hasn't changed. Saves a costly embed batch on every restart.
+        new_fp = hashlib.sha256(
+            ",".join(sorted(BUILTIN_TOOL_DESCRIPTIONS.keys())).encode()
+        ).hexdigest()
+        if getattr(_tool_index, "_fingerprint", "") != new_fp:
+            _tool_index.index_builtin_tools()
+        else:
+            logger.debug("ToolIndex registry unchanged; skipping re-index")
         return _tool_index
     except Exception as e:
         logger.warning(f"ToolIndex init failed (will retry in {_RETRY_INTERVAL}s): {e}")


### PR DESCRIPTION
## Summary

Fix a startup hang where the uvicorn process pegs 98% CPU indefinitely when the remote embedding server (Ollama/vLLM/llama.cpp) is unreachable. The fallback to local FastEmbed/ONNX can spin on Python 3.14 during the tool-index warmup. This PR makes the warmup fast-fail when the remote endpoint is latched as down, removes a redundant re-index call, and skips re-embedding when the built-in tool registry fingerprint is unchanged on warm starts.

Observed before fix: uvicorn consumed 100% CPU for 3+ hours after a fresh boot with no Ollama running; core temps hit 95°C. After fix: warmup short-circuits, CPU stays idle.

Fixes #M22 (internal — see `odysseus` repo issue tracker).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have searched for existing issues and PRs to avoid duplicates.

## How to Test

1. Stop the local embedding server (e.g. `systemctl --user stop ollama` or simply don't run one) and ensure `EMBEDDING_URL` points at a port nothing is listening on.
2. Start the service: `systemctl --user start odysseus.service`.
3. Watch CPU usage: `top -p $(pgrep -f 'uvicorn app:app')`.
   - **Before fix:** `uvicorn` settles at ~98% CPU and stays there; logs stop after `Application starting up...`.
   - **After fix:** `uvicorn` returns to idle within ~1s; logs include `[startup] Skipping tool-index warmup (remote embeddings unavailable)`.
4. Bring the embedding server back up and restart the service to confirm the warmup still runs normally (look for `[startup] Tool index pre-warmed` and `ToolIndex registry unchanged; skipping re-index` on subsequent restarts).

## Diff

```
 app.py            | 13 ++++++++++++-
 src/tool_index.py | 10 +++++++++-
 2 files changed, 21 insertions(+), 2 deletions(-)
```
