### PR TITLE
[codex] Fix Cookbook Docker cache and GPU serving

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
+ENV HOME=/app \
+    HF_HOME=/app/.cache/huggingface \
+    HUGGINGFACE_HUB_CACHE=/app/.cache/huggingface/hub \
+    XDG_CACHE_HOME=/app/.cache \
+    XDG_DATA_HOME=/app/.local/share \
+    PYTHONUSERBASE=/app/.local \
+    PATH=/app/.local/bin:$PATH
+
 # Install Python deps first (layer cache)
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
@@ -29,8 +37,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy app code
 COPY . .
 
-# Create data directory (mount a volume here for persistence)
-RUN mkdir -p data logs services/cache/search
+# Create data/cache directories (mount volumes here for persistence)
+RUN mkdir -p data logs services/cache/search .cache/huggingface .local
 
 # Entrypoint that drops to PUID/PGID (default 1000:1000) and repairs
 # ownership on the bind-mounted /app/data and /app/logs. Without this,

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -1,0 +1,74 @@
+FROM nvidia/cuda:12.8.1-devel-ubuntu24.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG LLAMA_CPP_REF=master
+ARG CUDA_ARCHITECTURES=120
+
+# System deps. This image is intentionally heavier than Dockerfile: it is the
+# llama.cpp CUDA image and includes a full CUDA toolchain for a GPU llama-server.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    cmake \
+    curl \
+    git \
+    gosu \
+    libgomp1 \
+    nodejs \
+    npm \
+    openssh-client \
+    python-is-python3 \
+    python3 \
+    python3-dev \
+    python3-pip \
+    tmux \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt
+
+# Build native llama-server once into /usr/local/bin. Cookbook will prefer this
+# binary and skip the fragile first-serve source build/fallback path.
+RUN git clone --depth 1 --branch "$LLAMA_CPP_REF" https://github.com/ggml-org/llama.cpp.git \
+    && ln -sf libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 \
+    && export LIBRARY_PATH="/usr/local/cuda/lib64/stubs:${LIBRARY_PATH:-}" \
+    && cmake -S llama.cpp -B llama.cpp/build \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DGGML_CUDA=ON \
+        -DCMAKE_CUDA_ARCHITECTURES="$CUDA_ARCHITECTURES" \
+        -DCMAKE_EXE_LINKER_FLAGS="-L/usr/local/cuda/lib64/stubs -Wl,-rpath-link,/usr/local/cuda/lib64/stubs" \
+        -DCMAKE_SHARED_LINKER_FLAGS="-L/usr/local/cuda/lib64/stubs -Wl,-rpath-link,/usr/local/cuda/lib64/stubs" \
+    && cmake --build llama.cpp/build -j"$(nproc)" --target llama-server \
+    && install -m 0755 llama.cpp/build/bin/llama-server /usr/local/bin/llama-server \
+    && find llama.cpp/build/bin -maxdepth 1 -type f \( -name 'lib*.so' -o -name 'lib*.so.*' \) \
+        -exec install -m 0644 {} /usr/local/lib/ \; \
+    && ldconfig \
+    && rm -rf llama.cpp
+
+WORKDIR /app
+
+ENV HOME=/app \
+    HF_HOME=/app/.cache/huggingface \
+    HUGGINGFACE_HUB_CACHE=/app/.cache/huggingface/hub \
+    XDG_CACHE_HOME=/app/.cache \
+    XDG_DATA_HOME=/app/.local/share \
+    PYTHONUSERBASE=/app/.local \
+    PATH=/app/.local/bin:$PATH
+
+# Install Python deps first (layer cache). Ubuntu 24.04 marks system Python as
+# externally managed, so explicit --break-system-packages is required here.
+COPY requirements.txt .
+RUN python -m pip install --break-system-packages --no-cache-dir -r requirements.txt
+
+# Copy app code
+COPY . .
+
+# Create data/cache directories (mount volumes here for persistence)
+RUN mkdir -p data logs services/cache/search .cache/huggingface .local
+
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+EXPOSE 7000
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "7000"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,65 @@
+SHELL := /usr/bin/env bash
+
+.PHONY: help start stop restart build rebuild cuda-build cuda-rebuild cuda-start cuda-enable logs ps config gpu-check gpu-enable
+
+help:
+	@printf 'Odysseus Docker targets:\n'
+	@printf '  make start       Start services, building changed images if needed\n'
+	@printf '  make stop        Stop services and remove orphan containers\n'
+	@printf '  make restart     Stop, then start\n'
+	@printf '  make build       Build the Odysseus image using Docker cache\n'
+	@printf '  make rebuild     Stop, rebuild Odysseus with no cache, then start\n'
+	@printf '  make cuda-build  Build the CUDA llama.cpp Odysseus image\n'
+	@printf '  make cuda-rebuild Enable CUDA llama.cpp overlay, no-cache rebuild, then start\n'
+	@printf '  make cuda-start  Enable CUDA llama.cpp overlay, then start\n'
+	@printf '  make logs        Follow Odysseus app logs\n'
+	@printf '  make ps          Show Compose service status\n'
+	@printf '  make config      Render merged Compose config\n'
+	@printf '  make gpu-check   Verify host Docker GPU passthrough\n'
+	@printf '  make gpu-enable  Enable the NVIDIA Compose overlay in .env\n'
+
+start:
+	docker compose up -d --build
+
+stop:
+	docker compose down --remove-orphans
+
+restart: stop start
+
+build:
+	docker compose build odysseus
+
+rebuild:
+	docker compose down --remove-orphans
+	docker compose build --no-cache --pull odysseus
+	docker compose up -d
+
+cuda-build:
+	COMPOSE_FILE=docker-compose.yml:docker/gpu.nvidia.llamacpp.yml docker compose build odysseus
+
+cuda-rebuild:
+	scripts/check-docker-gpu.sh --enable-nvidia-overlay --yes
+	sed -i 's#^COMPOSE_FILE=.*#COMPOSE_FILE=docker-compose.yml:docker/gpu.nvidia.llamacpp.yml#' .env
+	docker compose down --remove-orphans
+	docker compose build --no-cache --pull odysseus
+	docker compose up -d
+
+cuda-start:
+	scripts/check-docker-gpu.sh --enable-nvidia-overlay --yes
+	sed -i 's#^COMPOSE_FILE=.*#COMPOSE_FILE=docker-compose.yml:docker/gpu.nvidia.llamacpp.yml#' .env
+	docker compose up -d --build
+
+logs:
+	docker compose logs -f odysseus
+
+ps:
+	docker compose ps
+
+config:
+	docker compose config
+
+gpu-check:
+	scripts/check-docker-gpu.sh
+
+gpu-enable:
+	scripts/check-docker-gpu.sh --enable-nvidia-overlay

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,12 @@ services:
       - RESEARCH_LLM_ENDPOINT=${RESEARCH_LLM_ENDPOINT:-}
       - HF_TOKEN=${HF_TOKEN:-}
       - HUGGING_FACE_HUB_TOKEN=${HUGGING_FACE_HUB_TOKEN:-}
+      - HOME=/app
+      - HF_HOME=/app/.cache/huggingface
+      - HUGGINGFACE_HUB_CACHE=/app/.cache/huggingface/hub
+      - XDG_CACHE_HOME=/app/.cache
+      - XDG_DATA_HOME=/app/.local/share
+      - PYTHONUSERBASE=/app/.local
       - SEARXNG_INSTANCE=http://searxng:8080
       - CHROMADB_HOST=chromadb
       - CHROMADB_PORT=8000

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -14,6 +14,16 @@ set -e
 PUID="${PUID:-1000}"
 PGID="${PGID:-1000}"
 
+# Docker persistence contract: user installs and model caches must live under
+# bind-mounted /app paths, not /root. Export before setup.py and uvicorn so every
+# subprocess inherits the same cache/home roots.
+export HOME="${ODYSSEUS_HOME:-/app}"
+export HF_HOME="${HF_HOME:-/app/.cache/huggingface}"
+export HUGGINGFACE_HUB_CACHE="${HUGGINGFACE_HUB_CACHE:-$HF_HOME/hub}"
+export XDG_CACHE_HOME="${XDG_CACHE_HOME:-/app/.cache}"
+export XDG_DATA_HOME="${XDG_DATA_HOME:-/app/.local/share}"
+export PYTHONUSERBASE="${PYTHONUSERBASE:-/app/.local}"
+
 # Reuse an existing matching group/user if the host's UID/GID already
 # corresponds to one in /etc/passwd (e.g. when the image is rebuilt
 # and "odysseus" already exists at the same id). Otherwise create.

--- a/docker/gpu.nvidia.llamacpp.yml
+++ b/docker/gpu.nvidia.llamacpp.yml
@@ -1,0 +1,40 @@
+# NVIDIA llama.cpp CUDA overlay. Enable by setting COMPOSE_FILE in .env:
+#   COMPOSE_FILE=docker-compose.yml:docker/gpu.nvidia.llamacpp.yml
+#
+# This overlay is stronger than docker/gpu.nvidia.yml:
+# - requests NVIDIA GPUs at runtime
+# - builds Odysseus from Dockerfile.cuda
+# - preinstalls a CUDA-enabled native llama-server in the image
+#
+# Optional build overrides:
+#   LLAMA_CPP_REF=<branch-or-tag-or-commit>
+#   CUDA_ARCHITECTURES=120
+#
+# RTX 5090 uses compute capability 12.0, represented as 120.
+services:
+  odysseus:
+    build:
+      context: .
+      dockerfile: Dockerfile.cuda
+      args:
+        LLAMA_CPP_REF: ${LLAMA_CPP_REF:-master}
+        CUDA_ARCHITECTURES: ${CUDA_ARCHITECTURES:-120}
+    image: odysseus-odysseus:cuda-llamacpp
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=compute,utility
+      - CUDA_HOME=/usr/local/cuda
+      - LD_LIBRARY_PATH=/usr/local/lib:/usr/local/cuda/lib64:${LD_LIBRARY_PATH:-}
+      - HOME=/app
+      - HF_HOME=/app/.cache/huggingface
+      - HUGGINGFACE_HUB_CACHE=/app/.cache/huggingface/hub
+      - XDG_CACHE_HOME=/app/.cache
+      - XDG_DATA_HOME=/app/.local/share
+      - PYTHONUSERBASE=/app/.local
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/routes/cookbook_helpers.py
+++ b/routes/cookbook_helpers.py
@@ -148,6 +148,25 @@ def _local_tooling_path_export(executable: str) -> str:
     return f'export PATH="{esc}:$PATH"'
 
 
+def _local_persistent_home_exports() -> list[str]:
+    """Environment lines for local Cookbook runners.
+
+    Docker persists Cookbook downloads and user installs at /app/.cache and
+    /app/.local. Native/remote hosts should keep their normal HOME semantics,
+    so this only activates when the app is running from the Docker /app tree.
+    """
+    return [
+        'if [ -d /app ] && [ -d /app/data ]; then',
+        '  export HOME="${ODYSSEUS_HOME:-/app}"',
+        '  export HF_HOME="${HF_HOME:-/app/.cache/huggingface}"',
+        '  export HUGGINGFACE_HUB_CACHE="${HUGGINGFACE_HUB_CACHE:-$HF_HOME/hub}"',
+        '  export XDG_CACHE_HOME="${XDG_CACHE_HOME:-/app/.cache}"',
+        '  export XDG_DATA_HOME="${XDG_DATA_HOME:-/app/.local/share}"',
+        '  export PYTHONUSERBASE="${PYTHONUSERBASE:-/app/.local}"',
+        'fi',
+    ]
+
+
 def _pip_install_no_cache(cmd: str) -> str:
     """Add ``--no-cache-dir`` to a pip install command.
 
@@ -385,7 +404,20 @@ def _cached_model_scan_script(model_dirs: list[str] | None = None) -> str:
         "            seen.add(name)",
         "            models.append({'repo_id':name,'size_bytes':size_bytes,'nb_files':1,'has_incomplete':False,'path':'ollama','backend':'ollama','is_ollama':True})",
         "        return",
-        "scan_hf(os.path.expanduser('~/.cache/huggingface/hub'))",
+        "def hf_cache_roots():",
+        "    roots = []",
+        "    def add(p):",
+        "        if not p: return",
+        "        p = os.path.expanduser(p)",
+        "        if p not in roots: roots.append(p)",
+        "    add(os.environ.get('HUGGINGFACE_HUB_CACHE'))",
+        "    hf_home = os.environ.get('HF_HOME')",
+        "    if hf_home: add(os.path.join(hf_home, 'hub'))",
+        "    xdg = os.environ.get('XDG_CACHE_HOME')",
+        "    if xdg: add(os.path.join(xdg, 'huggingface', 'hub'))",
+        "    add('~/.cache/huggingface/hub')",
+        "    return roots",
+        "for _hf_root in hf_cache_roots(): scan_hf(_hf_root)",
         "scan_ollama()",
         "scan_ollama_api()",
     ]
@@ -550,7 +582,18 @@ def _append_llama_cpp_linux_accel_build_lines(runner_lines: list[str]) -> None:
     # check — a machine with both stacks should honor the native HIP toolchain on
     # AMD hosts instead of accidentally preferring a stray nvcc wheel.
     runner_lines.append('    for _cudir in ~/.local/lib/python*/site-packages/nvidia/cu13 ~/.local/lib/python*/site-packages/nvidia/cu12 ~/.local/lib/python*/site-packages/nvidia/cuda_nvcc; do')
-    runner_lines.append('      [ -x "$_cudir/bin/nvcc" ] && export CUDA_HOME="$_cudir" && export PATH="$_cudir/bin:$PATH" && break')
+    runner_lines.append('      if [ -x "$_cudir/bin/nvcc" ]; then')
+    runner_lines.append('        export CUDA_HOME="$_cudir"')
+    runner_lines.append('        export CUDAToolkit_ROOT="$_cudir"')
+    runner_lines.append('        export PATH="$_cudir/bin:$PATH"')
+    runner_lines.append('        export LD_LIBRARY_PATH="$_cudir/lib:$_cudir/lib64:${LD_LIBRARY_PATH:-}"')
+    runner_lines.append('        export CMAKE_LIBRARY_PATH="$_cudir/lib:$_cudir/lib64:${CMAKE_LIBRARY_PATH:-}"')
+    runner_lines.append('        for _lib in cudart cublas cublasLt; do')
+    runner_lines.append('          _match=$(ls "$_cudir/lib/lib${_lib}.so"* "$_cudir/lib64/lib${_lib}.so"* 2>/dev/null | head -1 || true)')
+    runner_lines.append('          [ -n "$_match" ] && [ ! -e "$(dirname "$_match")/lib${_lib}.so" ] && ln -sf "$(basename "$_match")" "$(dirname "$_match")/lib${_lib}.so" 2>/dev/null || true')
+    runner_lines.append('        done')
+    runner_lines.append('        break')
+    runner_lines.append('      fi')
     runner_lines.append('    done')
     # rm -rf build so a prior poisoned CMakeCache.txt (e.g. from a failed CUDA
     # or HIP attempt) doesn't cause the next configure to reuse stale settings.
@@ -623,7 +666,7 @@ class ModelDownloadRequest(BaseModel):
     ssh_port: str | None = None    # e.g. "8022" for Termux
     platform: str | None = None    # "linux", "termux", or "windows"
     local_dir: str | None = None   # base dir to download into (a per-model subfolder is created under it); None = default HF cache
-    disable_hf_transfer: bool = False  # skip the Rust hf_transfer downloader — slower but far more reliable on large files (used by retries)
+    disable_hf_transfer: bool = False  # legacy field name; use conservative HF transfer settings on retries
 
 
 class ServeRequest(BaseModel):
@@ -652,7 +695,7 @@ def _parse_serve_phase(snapshot: str, task_type: str = "serve") -> dict:
 
     load_matches = re.findall(r'Loading safetensors.*?(\d+)%', flat)
     # Prefer "Downloading (incomplete total...)" (real aggregate bytes) over
-    # "Fetching N files" (whole-file count, lags with hf_transfer's chunked pulls).
+    # "Fetching N files" (whole-file count, can lag behind chunked pulls).
     downloading_matches = re.findall(r'Downloading.*?(\d+)%', flat)
     fetching_matches = re.findall(r'Fetching.*?(\d+)%', flat)
     dl_matches = downloading_matches if downloading_matches else fetching_matches

--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -36,7 +36,8 @@ from routes.cookbook_helpers import (
     _validate_repo_id, _validate_serve_model_id, _validate_include, _validate_remote_host, _validate_token,
     _validate_local_dir, _validate_ssh_port, _validate_gpus, _shell_path,
     _ps_squote, _bash_squote, _validate_serve_cmd, _parse_serve_phase,
-    _safe_env_prefix, _local_tooling_path_export, _append_serve_preflight_exit_lines,
+    _safe_env_prefix, _local_tooling_path_export, _local_persistent_home_exports,
+    _append_serve_preflight_exit_lines,
     _append_serve_exit_code_lines, _append_llama_cpp_linux_accel_build_lines, _cached_model_scan_script,
     _ollama_bind_from_cmd, _pip_install_fallback_chain, _pip_install_no_cache, _venv_safe_local_pip_install_cmd,
     ModelDownloadRequest, ServeRequest,
@@ -50,6 +51,71 @@ _HF_TOKEN_STATUS_SNIPPET = (
     'Add one in Odysseus Settings -> Cookbook -> HuggingFace Token."; '
     'fi'
 )
+
+_HF_MODEL_PAYLOAD_EXTENSIONS = (
+    ".gguf",
+    ".safetensors",
+    ".bin",
+    ".pt",
+    ".pth",
+    ".onnx",
+    ".mlpackage",
+)
+
+
+def _hf_download_verify_py(repo_id: str, include: str | None, local_dir: str | None) -> str:
+    """Python verifier embedded in cookbook download runners.
+
+    `hf download` can exit successfully after creating/reusing a snapshot while
+    no serveable model payload was fetched, especially when an include glob
+    matches metadata only or nothing useful. Treat that as a failed download so
+    the UI does not offer a broken "Serve" action.
+    """
+    return (
+        "import fnmatch, os, sys\n"
+        f"repo_id = {repo_id!r}\n"
+        f"include = {include!r}\n"
+        f"local_dir = {local_dir!r}\n"
+        f"payload_exts = {list(_HF_MODEL_PAYLOAD_EXTENSIONS)!r}\n"
+        "if local_dir:\n"
+        "    roots = [os.path.expanduser(local_dir)]\n"
+        "else:\n"
+        "    cache = os.environ.get('HF_HOME') or os.path.expanduser('~/.cache/huggingface')\n"
+        "    roots = [os.path.join(cache, 'hub', 'models--' + repo_id.replace('/', '--'), 'snapshots')]\n"
+        "matches = []\n"
+        "for root in roots:\n"
+        "    if not os.path.isdir(root):\n"
+        "        continue\n"
+        "    for base, _, files in os.walk(root):\n"
+        "        for name in files:\n"
+        "            path = os.path.join(base, name)\n"
+        "            rel = os.path.relpath(path, root).replace(os.sep, '/')\n"
+        "            if include and not (fnmatch.fnmatch(name, include) or fnmatch.fnmatch(rel, include)):\n"
+        "                continue\n"
+        "            if not name.lower().endswith(tuple(payload_exts)):\n"
+        "                continue\n"
+        "            try:\n"
+        "                size = os.path.getsize(path)\n"
+        "            except OSError:\n"
+        "                size = 0\n"
+        "            if size > 0:\n"
+        "                matches.append((path, size))\n"
+        "if not matches:\n"
+        "    target = include or 'model payload'\n"
+        "    print(f'DOWNLOAD_FAILED no non-empty model payload found for {repo_id} ({target})')\n"
+        "    sys.exit(42)\n"
+        "total = sum(size for _, size in matches)\n"
+        "print(f'[odysseus] verified {len(matches)} model payload file(s), {total} bytes')\n"
+    )
+
+
+def _hf_download_verify_bash(repo_id: str, include: str | None, local_dir: str | None) -> str:
+    return "python3 - <<'PY'\n" + _hf_download_verify_py(repo_id, include, local_dir) + "PY"
+
+
+def _hf_download_verify_powershell(repo_id: str, include: str | None, local_dir: str | None) -> list[str]:
+    return ["$verifyPy = @'", _hf_download_verify_py(repo_id, include, local_dir).rstrip(), "'@", "python -c $verifyPy"]
+
 
 def setup_cookbook_routes() -> APIRouter:
     router = APIRouter(tags=["cookbook"])
@@ -437,6 +503,8 @@ def setup_cookbook_routes() -> APIRouter:
         # No script/tee needed — we'll use tmux capture-pane to read output
         lines = ["#!/bin/bash"]
         lines.extend(_user_shell_path_bootstrap())
+        if not req.remote_host and req.platform != "windows":
+            lines.extend(_local_persistent_home_exports())
         if req.hf_token:
             lines.append(f"export HF_TOKEN='{_bash_squote(req.hf_token)}'")
         # Ensure pip-user scripts (e.g. hf CLI installed via --user) are on PATH
@@ -446,18 +514,17 @@ def setup_cookbook_routes() -> APIRouter:
         # activated venv. Local bash runs only — meaningless over SSH/Windows.
         if not req.remote_host and req.platform != "windows":
             lines.append(_local_tooling_path_export(sys.executable))
-        # Best-effort install hf CLI (always). hf_transfer (Rust parallel downloader)
-        # is fast but flaky on large files — it tends to crash near the end at high
-        # throughput. Retries set disable_hf_transfer to fall back to the plain,
-        # slower-but-reliable downloader (resumes cleanly from the .incomplete files).
+        # Best-effort install hf CLI (always). Modern huggingface_hub uses Xet
+        # for high-performance transfers; the old HF_HUB_ENABLE_HF_TRANSFER flag
+        # now only emits a deprecation warning and no longer enables the fast path.
         # Use `python3 -m pip` not `pip` — macOS has no bare `pip` command.
         lines.append(f"command -v hf >/dev/null 2>&1 || {_pip_install_fallback_chain('huggingface_hub', upgrade=True)}")
         if req.disable_hf_transfer:
-            lines.append("export HF_HUB_ENABLE_HF_TRANSFER=0")
+            lines.append("export HF_XET_HIGH_PERFORMANCE=0")
             lines.append("export HF_HUB_DOWNLOAD_MAX_WORKERS=4")
         else:
-            lines.append(f"python3 -c 'import hf_transfer' 2>/dev/null || {_pip_install_fallback_chain('hf_transfer')}")
-            lines.append("python3 -c 'import hf_transfer' 2>/dev/null && export HF_HUB_ENABLE_HF_TRANSFER=1")
+            lines.append(f"python3 -c 'import hf_xet' 2>/dev/null || {_pip_install_fallback_chain('hf_xet')}")
+            lines.append("python3 -c 'import hf_xet' 2>/dev/null && export HF_XET_HIGH_PERFORMANCE=1")
             lines.append("export HF_HUB_DOWNLOAD_MAX_WORKERS=8")
 
         remote = req.remote_host  # None for local
@@ -494,18 +561,23 @@ def setup_cookbook_routes() -> APIRouter:
             ps_lines.append('    python -c "import huggingface_hub" 2>$null')
             ps_lines.append('    if ($LASTEXITCODE -eq 0) {{')
             ps_lines.append('      Write-Host "hf CLI not found, using Python huggingface_hub..."')
-            ps_lines.append('      python -m pip install -q hf_transfer 2>$null')
-            ps_lines.append('      $env:HF_HUB_ENABLE_HF_TRANSFER = "1"')
+            ps_lines.append('      python -m pip install -q hf_xet 2>$null')
+            ps_lines.append('      $env:HF_XET_HIGH_PERFORMANCE = "1"')
             ps_lines.append(f"      python -c \"import os; from huggingface_hub import snapshot_download; snapshot_download('{req.repo_id}'{_dl_pyarg}, max_workers=8)\"")
             ps_lines.append('    }} else {{')
             ps_lines.append('      Write-Host "Installing huggingface-hub..."')
-            ps_lines.append('      python -m pip install -q huggingface-hub hf_transfer')
-            ps_lines.append('      $env:HF_HUB_ENABLE_HF_TRANSFER = "1"')
+            ps_lines.append('      python -m pip install -q huggingface-hub hf_xet')
+            ps_lines.append('      $env:HF_XET_HIGH_PERFORMANCE = "1"')
             ps_lines.append(f"      python -c \"import os; from huggingface_hub import snapshot_download; snapshot_download('{req.repo_id}'{_dl_pyarg}, max_workers=8)\"")
             ps_lines.append('    }}')
             ps_lines.append('  }}')
-            ps_lines.append('  if ($LASTEXITCODE -eq 0) {{ Write-Host ""; Write-Host "DOWNLOAD_OK" }}')
-            ps_lines.append('  else {{ Write-Host ""; Write-Host "DOWNLOAD_FAILED (exit $LASTEXITCODE)" }}')
+            ps_lines.append('  $downloadExit = $LASTEXITCODE')
+            ps_lines.append('  if ($downloadExit -eq 0) {{')
+            ps_lines.extend("    " + line if line else line for line in _hf_download_verify_powershell(req.repo_id, req.include, _dl_base))
+            ps_lines.append('    $downloadExit = $LASTEXITCODE')
+            ps_lines.append('  }}')
+            ps_lines.append('  if ($downloadExit -eq 0) {{ Write-Host ""; Write-Host "DOWNLOAD_OK" }}')
+            ps_lines.append('  else {{ Write-Host ""; Write-Host "DOWNLOAD_FAILED (exit $downloadExit)" }}')
             ps_lines.append('}} catch {{')
             ps_lines.append('  Write-Host ""; Write-Host "DOWNLOAD_FAILED ($_)"')
             ps_lines.append('}}')
@@ -550,17 +622,15 @@ def setup_cookbook_routes() -> APIRouter:
                 )
             # Ensure pip-user scripts (e.g. hf CLI installed via --user) are on PATH
             runner_lines.append('export PATH="$HOME/.local/bin:$PATH"')
-            # Install hf CLI + optional hf_transfer best-effort. Retries disable
-            # hf_transfer because the Rust parallel path is fast but has been
-            # flaky near the end of very large multi-file downloads.
+            # Install hf CLI + hf_xet best-effort so future runs get the fast path.
             # Use --break-system-packages on PEP-668 systems (Arch, newer Debian) so it doesn't bail.
             runner_lines.append(f"command -v hf >/dev/null 2>&1 || {_pip_install_fallback_chain('huggingface_hub', python_cmd='pip', upgrade=True)}")
             if req.disable_hf_transfer:
-                runner_lines.append("export HF_HUB_ENABLE_HF_TRANSFER=0")
+                runner_lines.append("export HF_XET_HIGH_PERFORMANCE=0")
                 runner_lines.append("export HF_HUB_DOWNLOAD_MAX_WORKERS=4")
             else:
-                runner_lines.append(f"python3 -c 'import hf_transfer' 2>/dev/null || {_pip_install_fallback_chain('hf_transfer', python_cmd='pip')}")
-                runner_lines.append("python3 -c 'import hf_transfer' 2>/dev/null && export HF_HUB_ENABLE_HF_TRANSFER=1")
+                runner_lines.append(f"python3 -c 'import hf_xet' 2>/dev/null || {_pip_install_fallback_chain('hf_xet', python_cmd='pip')}")
+                runner_lines.append("python3 -c 'import hf_xet' 2>/dev/null && export HF_XET_HIGH_PERFORMANCE=1")
                 runner_lines.append("export HF_HUB_DOWNLOAD_MAX_WORKERS=8")
             # Surface whether the HF token actually reached THIS server, so a gated
             # download's "not authorized" failure can be told apart from a missing
@@ -578,13 +648,18 @@ def setup_cookbook_routes() -> APIRouter:
             runner_lines.append('  pip install --no-deps -q huggingface-hub 2>/dev/null')
             if req.disable_hf_transfer:
                 runner_lines.append('  pip install -q filelock fsspec packaging pyyaml tqdm typer httpx requests 2>/dev/null')
-                runner_lines.append('  export HF_HUB_ENABLE_HF_TRANSFER=0')
+                runner_lines.append('  export HF_XET_HIGH_PERFORMANCE=0')
             else:
-                runner_lines.append('  pip install -q filelock fsspec packaging pyyaml tqdm typer httpx requests hf_transfer 2>/dev/null')
-                runner_lines.append("  python3 -c 'import hf_transfer' 2>/dev/null && export HF_HUB_ENABLE_HF_TRANSFER=1")
+                runner_lines.append('  pip install -q filelock fsspec packaging pyyaml tqdm typer httpx requests hf_xet 2>/dev/null')
+                runner_lines.append("  python3 -c 'import hf_xet' 2>/dev/null && export HF_XET_HIGH_PERFORMANCE=1")
             runner_lines.append(f'  python3 -c "import os; from huggingface_hub import snapshot_download; snapshot_download(\'{req.repo_id}\'{_dl_pyarg}, max_workers={4 if req.disable_hf_transfer else 8})"')
             runner_lines.append('fi')
-            runner_lines.append('_ec=$?; if [ $_ec -eq 0 ]; then echo ""; echo "DOWNLOAD_OK"; else echo ""; echo "DOWNLOAD_FAILED (exit $_ec)"; fi')
+            runner_lines.append('ODYSSEUS_DL_EXIT=$?')
+            runner_lines.append('if [ "$ODYSSEUS_DL_EXIT" -eq 0 ]; then')
+            runner_lines.append(_hf_download_verify_bash(req.repo_id, req.include, _dl_base))
+            runner_lines.append('ODYSSEUS_DL_EXIT=$?')
+            runner_lines.append('fi')
+            runner_lines.append('if [ "$ODYSSEUS_DL_EXIT" -eq 0 ]; then echo ""; echo "DOWNLOAD_OK"; else echo ""; echo "DOWNLOAD_FAILED (exit $ODYSSEUS_DL_EXIT)"; fi')
             runner_lines.append(f"rm -f {remote_runner}")
             runner_lines.append('exec "${SHELL:-/bin/bash}"')
             runner_path = TMUX_LOG_DIR / f"{session_id}_run.sh"
@@ -615,11 +690,21 @@ def setup_cookbook_routes() -> APIRouter:
                 # Detached path: no controlling TTY, so skip `< /dev/null`
                 # (handled by Popen stdin=DEVNULL) and don't keep a shell open.
                 lines.append(hf_cmd)
-                lines.append('_ec=$?; if [ $_ec -eq 0 ]; then echo ""; echo "DOWNLOAD_OK"; else echo ""; echo "DOWNLOAD_FAILED (exit $_ec)"; fi')
+                lines.append('ODYSSEUS_DL_EXIT=$?')
+                lines.append('if [ "$ODYSSEUS_DL_EXIT" -eq 0 ]; then')
+                lines.append(_hf_download_verify_bash(req.repo_id, req.include, _dl_base))
+                lines.append('ODYSSEUS_DL_EXIT=$?')
+                lines.append('fi')
+                lines.append('if [ "$ODYSSEUS_DL_EXIT" -eq 0 ]; then echo ""; echo "DOWNLOAD_OK"; else echo ""; echo "DOWNLOAD_FAILED (exit $ODYSSEUS_DL_EXIT)"; fi')
             else:
                 # < /dev/null suppresses interactive "update available? [Y/n]" prompt
                 lines.append(f"{hf_cmd} < /dev/null")
-                lines.append('_ec=$?; if [ $_ec -eq 0 ]; then echo ""; echo "DOWNLOAD_OK"; else echo ""; echo "DOWNLOAD_FAILED (exit $_ec)"; fi')
+                lines.append('ODYSSEUS_DL_EXIT=$?')
+                lines.append('if [ "$ODYSSEUS_DL_EXIT" -eq 0 ]; then')
+                lines.append(_hf_download_verify_bash(req.repo_id, req.include, _dl_base))
+                lines.append('ODYSSEUS_DL_EXIT=$?')
+                lines.append('fi')
+                lines.append('if [ "$ODYSSEUS_DL_EXIT" -eq 0 ]; then echo ""; echo "DOWNLOAD_OK"; else echo ""; echo "DOWNLOAD_FAILED (exit $ODYSSEUS_DL_EXIT)"; fi')
                 lines.append(f"rm -f '{wrapper_script}'")
                 lines.append('exec "${SHELL:-/bin/bash}"')
                 wrapper_script.write_text("\n".join(lines) + "\n", encoding="utf-8")
@@ -1005,6 +1090,8 @@ def setup_cookbook_routes() -> APIRouter:
             # ── Linux/Termux: bash + tmux (existing flow) ──
             runner_lines = ["#!/bin/bash"]
             runner_lines.extend(_user_shell_path_bootstrap())
+            if not remote:
+                runner_lines.extend(_local_persistent_home_exports())
             runner_lines.append('ODYSSEUS_PREFLIGHT_EXIT=""')
             # Put Odysseus's own venv bin on PATH (local runs only) so the serve
             # shell resolves the bundled python3/hf, mirroring the download flow.
@@ -1073,6 +1160,29 @@ def setup_cookbook_routes() -> APIRouter:
                 runner_lines.append('    ODYSSEUS_PREFLIGHT_EXIT=127')
                 runner_lines.append('  fi')
                 runner_lines.append('fi')
+                if req.gpus:
+                    runner_lines.append('# Refuse a silent CPU fallback when the user requested GPU llama.cpp serving.')
+                    runner_lines.append('if [ -z "$ODYSSEUS_PREFLIGHT_EXIT" ] && [ -n "${CUDA_VISIBLE_DEVICES:-}" ]; then')
+                    runner_lines.append('  ODYSSEUS_LLAMA_GPU_BACKEND=""')
+                    runner_lines.append('  if command -v llama-server &>/dev/null; then')
+                    runner_lines.append('    _llama_info="$(llama-server --list-devices 2>&1 || llama-server --version 2>&1 || true)"')
+                    runner_lines.append('    echo "$_llama_info" | grep -Eiq "cuda|cublas|ggml-cuda|hip|rocm" && ODYSSEUS_LLAMA_GPU_BACKEND=1')
+                    runner_lines.append('  fi')
+                    runner_lines.append('  if [ -z "$ODYSSEUS_LLAMA_GPU_BACKEND" ] && python3 -c "import llama_cpp" 2>/dev/null; then')
+                    runner_lines.append('    _llama_py_info="$(python3 - <<\'PY\' 2>/dev/null || true')
+                    runner_lines.append('import llama_cpp')
+                    runner_lines.append('print(llama_cpp.llama_print_system_info().decode("utf-8", "replace"))')
+                    runner_lines.append('PY')
+                    runner_lines.append(')"')
+                    runner_lines.append('    echo "$_llama_py_info" | grep -Eiq "cuda|cublas|ggml-cuda|hip|rocm" && ODYSSEUS_LLAMA_GPU_BACKEND=1')
+                    runner_lines.append('  fi')
+                    runner_lines.append('  if [ -z "$ODYSSEUS_LLAMA_GPU_BACKEND" ]; then')
+                    runner_lines.append('    echo "ERROR: GPU was selected, but the available llama.cpp runtime is CPU-only."')
+                    runner_lines.append('    echo "Docker can see the GPU, but llama-server/llama-cpp-python was not built with CUDA/HIP support."')
+                    runner_lines.append('    echo "Use Ollama for this GGUF now, or install a CUDA/HIP-enabled llama.cpp runtime before launching llama.cpp with GPUs."')
+                    runner_lines.append('    ODYSSEUS_PREFLIGHT_EXIT=70')
+                    runner_lines.append('  fi')
+                    runner_lines.append('fi')
             elif "ollama" in req.cmd:
                 handled_ollama_serve = True
                 _ollama_default_host = "0.0.0.0" if remote else "127.0.0.1"
@@ -1316,7 +1426,7 @@ def setup_cookbook_routes() -> APIRouter:
             cmd = f"ssh {pf}{host} '{setup_script}'"
         else:
             # Linux: auto-install tmux (via whichever package manager is available)
-            # and huggingface_hub + hf_transfer (falling back to --user/--break-system-packages
+            # and huggingface_hub + hf_xet (falling back to --user/--break-system-packages
             # on PEP-668 locked distros like Arch / newer Debian).
             setup_script = (
                 # Install tmux if missing — try common package managers; skip if no sudo
@@ -1330,9 +1440,9 @@ def setup_cookbook_routes() -> APIRouter:
                 "fi; "
                 "command -v tmux >/dev/null 2>&1 || echo 'WARNING: tmux missing and auto-install failed (need passwordless sudo). Install manually.'; "
                 # Install Python bits. Try system install first; fall back to --user --break-system-packages on PEP 668 systems.
-                "pip install -q huggingface_hub hf_transfer 2>/dev/null || "
-                "pip install --user --break-system-packages -q huggingface_hub hf_transfer 2>/dev/null || "
-                "pip3 install --user --break-system-packages -q huggingface_hub hf_transfer 2>/dev/null; "
+                "pip install -q huggingface_hub hf_xet 2>/dev/null || "
+                "pip install --user --break-system-packages -q huggingface_hub hf_xet 2>/dev/null || "
+                "pip3 install --user --break-system-packages -q huggingface_hub hf_xet 2>/dev/null; "
                 "python3 -c 'from huggingface_hub import snapshot_download; print(\"OK\")'"
             )
             cmd = f"ssh {pf}{host} '{setup_script}'"
@@ -2078,7 +2188,7 @@ def setup_cookbook_routes() -> APIRouter:
 
                 # Capture last lines for progress. Prefer the "Downloading" line
                 # (real aggregate bytes) over "Fetching N files" (whole-file count that
-                # lags with hf_transfer). Falls back to the true last line otherwise.
+                # lags behind chunked transfers). Falls back to the true last line otherwise.
                 if is_alive:
                     try:
                         cap = subprocess.run(capture_cmd, timeout=10, capture_output=True, text=True)

--- a/scripts/hf_download.py
+++ b/scripts/hf_download.py
@@ -150,13 +150,13 @@ def main():
     # Disable HF progress bars (we provide our own)
     os.environ["HF_HUB_DISABLE_PROGRESS_BARS"] = "0"
 
-    # Enable Rust-backed parallel downloader if available — big throughput win.
+    # Enable Xet-backed high-performance transfers if available.
     # Must be set before importing huggingface_hub.
     try:
-        import hf_transfer  # noqa: F401
-        os.environ.setdefault("HF_HUB_ENABLE_HF_TRANSFER", "1")
+        import hf_xet  # noqa: F401
+        os.environ.setdefault("HF_XET_HIGH_PERFORMANCE", "1")
     except ImportError:
-        print("HINT pip install hf_transfer for faster downloads", flush=True)
+        print("HINT pip install hf_xet for faster downloads", flush=True)
 
     _patch_tqdm()
 

--- a/static/js/cookbook.js
+++ b/static/js/cookbook.js
@@ -437,6 +437,13 @@ export function _buildServeCmd(f, modelName, backend) {
       const s = String(v || '').replace(/\s+/g, '');
       return /^\d+(?:\.\d+)?(?:,\d+(?:\.\d+)?)*$/.test(s) ? s : '';
     };
+    const _lcpKvType = (v) => {
+      const s = String(v || '').trim().toLowerCase();
+      // llama-cpp-python expects raw GGML enum integers here, while native
+      // llama-server accepts names like q8_0. Keep native flags readable and
+      // translate only for the Python fallback.
+      return ({ f16: '1', q4_0: '2', q8_0: '8' })[s] || '';
+    };
     let _lcExtra = '';
     let _lcpExtra = '';
     if (_ncm !== '' && Number(_ncm) > 0) {
@@ -449,8 +456,8 @@ export function _buildServeCmd(f, modelName, backend) {
     }
     if (_kv) {
       _lcExtra += ` --cache-type-k ${_kv} --cache-type-v ${_kv}`;
-      // llama-cpp-python exposes these as type_k/type_v; pass through best-effort.
-      _lcpExtra += ` --type_k ${_kv} --type_v ${_kv}`;
+      const _pyKv = _lcpKvType(_kv);
+      if (_pyKv) _lcpExtra += ` --type_k ${_pyKv} --type_v ${_pyKv}`;
     }
     const _llamaFit = String(f.llama_fit || '').trim();
     if (['on', 'off'].includes(_llamaFit)) _lcExtra += ` --fit ${_llamaFit}`;
@@ -1633,7 +1640,7 @@ function _renderRecipes() {
   html += '<span class="cookbook-serve-dir-edit" title="Edit in Settings">edit</span>';
   html += '</div>';
   html += '<div style="display:flex;gap:4px;align-items:center;margin-top:4px;">';
-  html += '<select class="memory-sort-select" id="hwfit-cache-server" style="height:24px;">' + _buildServerOpts(true) + '</select>';
+  html += '<select class="memory-sort-select" id="hwfit-cache-server" style="height:24px;">' + _buildServerOpts(false) + '</select>';
   html += '<select class="memory-sort-select" id="serve-sort" style="height:24px;">';
   html += '<option value="name">Name</option><option value="size-desc">Size \u2193</option><option value="size-asc">Size \u2191</option><option value="recent">Recent</option>';
   html += '</select>';

--- a/static/js/cookbookRunning.js
+++ b/static/js/cookbookRunning.js
@@ -241,7 +241,7 @@ export function _parseServePhase(snapshot) {
   const loadMatches = [...flat.matchAll(/Loading safetensors.*?(\d+)%/g)];
   // "Downloading (incomplete total...)" tracks real aggregate bytes; prefer it
   // over "Fetching N files" which only counts fully-closed files and lags badly
-  // with hf_transfer's parallel-chunk strategy (often sits at 0/N for most of the run).
+  // with chunked transfer strategies (often sits at 0/N for most of the run).
   const downloadingMatches = [...flat.matchAll(/Downloading.*?(\d+)%/g)];
   const fetchingMatches = [...flat.matchAll(/Fetching.*?(\d+)%/g)];
   const dlMatches = downloadingMatches.length ? downloadingMatches : fetchingMatches;
@@ -1067,7 +1067,7 @@ async function _retryTask(el, task) {
 
 async function _retryDownload(name, payload, replaceSessionId = '') {
   try {
-    // A retry means the fast hf_transfer path already failed once — fall back to
+    // A retry means the fast transfer path already failed once — fall back to
     // the plain, reliable downloader for this and any further attempt (it resumes
     // from the cached .incomplete files, so no progress is lost).
     const _payload = { ...(payload || {}), disable_hf_transfer: true };
@@ -2427,7 +2427,7 @@ async function _reconnectTask(el, task) {
             const lastPct = pctMatches.length ? pctMatches[pctMatches.length - 1][1] : null;
             const speedMatch = [...snapshot.matchAll(/([\d.]+)(?:MB|GB)\/s/g)];
             const lastSpeed = speedMatch.length ? speedMatch[speedMatch.length - 1][0] : null;
-            // hf_transfer prints "Downloading (incomplete total...): 73% | 1.81G/2.49G"
+            // High-performance HF transfers can print "Downloading (incomplete total...): 73% | 1.81G/2.49G"
             // — the real aggregate byte progress. The "Fetching N files" line (often
             // last in the output) sits at 0%, so lastPct/_fetchPct can read 0 even at
             // 73% done. Prefer this aggregate when present.
@@ -2437,7 +2437,7 @@ async function _reconnectTask(el, task) {
             // Stale download detection.
             // Use the DOWNLOADED-BYTE count ("1.81G" from "1.81G/2.49G") as the
             // progress signal: it climbs continuously while transferring (even when
-            // the % plateaus during a big hf_transfer chunk) and FREEZES when stuck.
+            // the % plateaus during a big transfer chunk) and FREEZES when stuck.
             // The % alone plateaus (false stall), and a frozen frame still shows a
             // stale speed/ETA — so keying off speed masked real stalls (that's why a
             // 97%-stuck download went undetected). Bytes are the honest signal; fall
@@ -2490,7 +2490,7 @@ async function _reconnectTask(el, task) {
                   ? { ...task.payload }
                   : { repo_id: task.repo || task.name, remote_host: task.remoteHost || '' };
                 if (_envState.hfToken) dlPayload.hf_token = _envState.hfToken;
-                // Stalled with hf_transfer — restart on the reliable downloader.
+                // Stalled on the fast transfer path — restart with conservative settings.
                 dlPayload.disable_hf_transfer = true;
                 // Don't overwrite env_prefix — task.payload already has the correct
                 // "source <path>" form. The bare envPath would miss the `source` and

--- a/tests/test_cookbook_helpers.py
+++ b/tests/test_cookbook_helpers.py
@@ -12,6 +12,7 @@ from routes.cookbook_helpers import (
     _append_serve_preflight_exit_lines,
     _llama_cpp_rebuild_cmd,
     _local_tooling_path_export,
+    _local_persistent_home_exports,
     _pip_install_attempt,
     _pip_install_fallback_chain,
     _ollama_bind_from_cmd,
@@ -81,6 +82,15 @@ def test_local_tooling_path_export_prepends_interpreter_bin():
         _local_tooling_path_export("/opt/venv/bin/python")
         == 'export PATH="/opt/venv/bin:$PATH"'
     )
+
+
+def test_local_persistent_home_exports_pin_docker_cache_paths():
+    script = "\n".join(_local_persistent_home_exports())
+
+    assert 'export HOME="${ODYSSEUS_HOME:-/app}"' in script
+    assert 'export HF_HOME="${HF_HOME:-/app/.cache/huggingface}"' in script
+    assert 'export HUGGINGFACE_HUB_CACHE="${HUGGINGFACE_HUB_CACHE:-$HF_HOME/hub}"' in script
+    assert 'export PYTHONUSERBASE="${PYTHONUSERBASE:-/app/.local}"' in script
 
 
 def test_local_tooling_path_export_preserves_spaces_and_expands_path():
@@ -189,6 +199,20 @@ def test_serve_runner_installs_llama_cpp_server_extra():
     # The [server] extra is requested in the build/fallback paths.
     assert "'llama-cpp-python[server]'" in src
     assert "_pip_install_fallback_chain('llama-cpp-python[server]'" in src
+
+
+def test_serve_runner_refuses_cpu_only_llama_cpp_when_gpu_selected():
+    """GPU-selected llama.cpp serving must not silently fall back to CPU-only
+    llama-cpp-python when CUDA/HIP build detection fails."""
+    import pathlib
+    src = (pathlib.Path(__file__).resolve().parent.parent
+           / "routes" / "cookbook_routes.py").read_text(encoding="utf-8")
+
+    assert "Refuse a silent CPU fallback when the user requested GPU llama.cpp serving." in src
+    assert "llama-server --list-devices" in src
+    assert "ERROR: GPU was selected, but the available llama.cpp runtime is CPU-only." in src
+    assert "llama_print_system_info" in src
+    assert "ODYSSEUS_PREFLIGHT_EXIT=70" in src
 
 
 def test_venv_safe_local_pip_install_strips_user_flags_only_for_local_venv():

--- a/tests/test_cookbook_hf_download.py
+++ b/tests/test_cookbook_hf_download.py
@@ -1,0 +1,23 @@
+import subprocess
+
+from routes.cookbook_routes import _hf_download_verify_bash
+
+
+def test_hf_download_verifier_rejects_empty_snapshot(tmp_path):
+    script = _hf_download_verify_bash("org/model", None, str(tmp_path))
+
+    result = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+
+    assert result.returncode == 42
+    assert "no non-empty model payload found" in result.stdout
+
+
+def test_hf_download_verifier_accepts_matching_payload(tmp_path):
+    model_file = tmp_path / "model.Q4_K_M.gguf"
+    model_file.write_bytes(b"payload")
+    script = _hf_download_verify_bash("org/model", "*Q4_K_M*.gguf", str(tmp_path))
+
+    result = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+
+    assert result.returncode == 0
+    assert "verified 1 model payload file" in result.stdout

--- a/tests/test_cookbook_serve_local_cache.py
+++ b/tests/test_cookbook_serve_local_cache.py
@@ -1,0 +1,25 @@
+"""Regression guard: Serve must be able to list Docker-local HF cache models.
+
+Downloads done from Docker land in the Local container cache. If the Serve cache
+server selector excludes Local, freshly downloaded models can be complete on disk
+but invisible in the Serve tab.
+"""
+from pathlib import Path
+
+
+SRC = Path(__file__).resolve().parent.parent / "static/js/cookbook.js"
+
+
+def test_serve_cache_selector_includes_local_server():
+    text = SRC.read_text(encoding="utf-8")
+    assert (
+        'id="hwfit-cache-server" style="height:24px;">\' + _buildServerOpts(false)'
+        in text
+    )
+
+
+def test_download_selector_still_excludes_local_server():
+    text = SRC.read_text(encoding="utf-8")
+    marker = 'id="hwfit-dl-server"'
+    idx = text.index(marker)
+    assert "_buildServerOpts(true)" in text[idx : idx + 260]

--- a/tests/test_docker_persistence_config.py
+++ b/tests/test_docker_persistence_config.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_docker_compose_persists_cookbook_cache_and_user_installs():
+    compose = (ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+
+    assert "./data/huggingface:/app/.cache/huggingface" in compose
+    assert "./data/local:/app/.local" in compose
+    assert "HOME=/app" in compose
+    assert "HF_HOME=/app/.cache/huggingface" in compose
+    assert "HUGGINGFACE_HUB_CACHE=/app/.cache/huggingface/hub" in compose
+    assert "PYTHONUSERBASE=/app/.local" in compose
+
+
+def test_docker_entrypoint_exports_persistent_home_before_setup():
+    entrypoint = (ROOT / "docker" / "entrypoint.sh").read_text(encoding="utf-8")
+
+    home_idx = entrypoint.index('export HOME="${ODYSSEUS_HOME:-/app}"')
+    setup_idx = entrypoint.index("python /app/setup.py")
+    assert home_idx < setup_idx
+    assert 'export HF_HOME="${HF_HOME:-/app/.cache/huggingface}"' in entrypoint
+    assert 'export PYTHONUSERBASE="${PYTHONUSERBASE:-/app/.local}"' in entrypoint
+
+
+def test_cuda_overlay_keeps_persistent_home_env():
+    overlay = (ROOT / "docker" / "gpu.nvidia.llamacpp.yml").read_text(encoding="utf-8")
+
+    assert "HOME=/app" in overlay
+    assert "HF_HOME=/app/.cache/huggingface" in overlay
+    assert "PYTHONUSERBASE=/app/.local" in overlay
+
+
+def test_cached_model_scanner_uses_explicit_hf_cache_envs():
+    source = (ROOT / "routes" / "cookbook_helpers.py").read_text(encoding="utf-8")
+
+    assert "os.environ.get('HUGGINGFACE_HUB_CACHE')" in source
+    assert "os.environ.get('HF_HOME')" in source
+    assert "for _hf_root in hf_cache_roots(): scan_hf(_hf_root)" in source


### PR DESCRIPTION
## Summary

Fixes Cookbook Docker installs where downloaded Hugging Face models and user-installed serve dependencies could disappear after container rebuilds or remain invisible in the Serve tab. This also adds a focused NVIDIA CUDA llama.cpp Docker overlay so Docker users with NVIDIA GPUs can run a prebuilt CUDA `llama-server` instead of hitting fragile first-serve source builds.

## Linked Issue

Fixes #191

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Start Odysseus with Docker and the NVIDIA llama.cpp overlay: `COMPOSE_FILE=docker-compose.yml:docker/gpu.nvidia.llamacpp.yml docker compose up -d --build`.
2. In the container, confirm the CUDA llama server sees the GPU: `docker compose exec odysseus llama-server --list-devices`.
3. In Cookbook, download a GGUF model from Hugging Face and confirm the download prints `DOWNLOAD_OK` only after verifying a non-empty model payload.
4. Rebuild/recreate the Odysseus container and confirm the downloaded model remains under `data/huggingface` and user-installed CLIs remain under `data/local`.
5. Open Cookbook -> Serve -> Local and confirm Docker-local Hugging Face GGUFs appear alongside Ollama models.

## Validation

- `PYTEST_ADDOPTS='' python -m pytest -o addopts='' tests/test_cookbook_helpers.py tests/test_cookbook_hf_download.py tests/test_cookbook_serve_local_cache.py tests/test_docker_persistence_config.py tests/test_cookbook_dependency_completion_regression.py`
- `node --check static/js/cookbook.js && node --check static/js/cookbookRunning.js`
- Rebuilt/recreated the CUDA Docker image and verified `llama-server --list-devices` sees `CUDA0: NVIDIA GeForce RTX 5090`.
- Verified the live cache scanner returns Docker-local Hugging Face GGUFs plus Ollama models.

## Visual / UI changes — REQUIRED if you touched anything that renders

This changes Cookbook Serve behavior so the Local cache source is available for Docker-local Hugging Face models. It does not introduce new styling, colors, spacing, icons, or component patterns.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: the change uses Odysseus's existing visual language.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

Not attached. This PR does not alter visual styling; it changes which existing Serve cache options and cached models are shown.
