### PR TITLE
fix(models): handle bare-list /v1/models response (Together AI "no models")

### DIFF
--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -493,10 +493,12 @@ def _probe_endpoint(base_url: str, api_key: str = None, timeout: int = 5) -> Lis
         r = httpx.get(url, headers=headers, timeout=timeout)
         r.raise_for_status()
         data = r.json()
-        # OpenAI format: {"data": [{"id": "model-name"}]}
-        models = [m.get("id") for m in (data.get("data") or []) if m.get("id")]
+        # OpenAI returns {"data": [{"id": ...}]}, but some compatible providers
+        # (e.g. Together) return a bare list [{"id": ...}] — accept both.
+        items = data if isinstance(data, list) else (data.get("data") or [])
+        models = [m.get("id") for m in items if isinstance(m, dict) and m.get("id")]
         # Ollama format: {"models": [{"name": "model-name"}]}
-        if not models:
+        if not models and isinstance(data, dict):
             models = [m.get("name") or m.get("model") for m in (data.get("models") or []) if m.get("name") or m.get("model")]
         if models:
             # Z.AI coding plan omits some working models from /models;

--- a/routes/webhook_routes.py
+++ b/routes/webhook_routes.py
@@ -332,8 +332,9 @@ def setup_webhook_routes(
                         resp = await client.get(models_url, headers=hdrs)
                         resp.raise_for_status()
                         data = resp.json()
-                        ids = [m.get("id") for m in (data.get("data") or []) if m.get("id")]
-                        if not ids:
+                        items = data if isinstance(data, list) else (data.get("data") or [])
+                        ids = [m.get("id") for m in items if isinstance(m, dict) and m.get("id")]
+                        if not ids and isinstance(data, dict):
                             ids = [
                                 m.get("name") or m.get("model")
                                 for m in (data.get("models") or [])

--- a/src/ai_interaction.py
+++ b/src/ai_interaction.py
@@ -112,7 +112,8 @@ def _resolve_model(spec: str) -> Tuple[str, str, Dict]:
                     r = httpx.get(build_models_url(base), headers=headers, timeout=5)
                     r.raise_for_status()
                     data = r.json()
-                    model_ids = [m.get("id") for m in (data.get("data") or []) if m.get("id")]
+                    items = data if isinstance(data, list) else (data.get("data") or [])
+                    model_ids = [m.get("id") for m in items if isinstance(m, dict) and m.get("id")]
                     if not model_ids:
                         model_ids = [
                             m.get("name") or m.get("model")
@@ -1124,7 +1125,8 @@ async def do_list_models(content: str, session_id: Optional[str] = None) -> Dict
                     r = httpx.get(build_models_url(base), headers=headers, timeout=5)
                     r.raise_for_status()
                     data = r.json()
-                    model_ids = [m.get("id") for m in (data.get("data") or []) if m.get("id")]
+                    items = data if isinstance(data, list) else (data.get("data") or [])
+                    model_ids = [m.get("id") for m in items if isinstance(m, dict) and m.get("id")]
                     if not model_ids:
                         model_ids = [
                             m.get("name") or m.get("model")
@@ -1603,7 +1605,9 @@ async def do_generate_image(content: str, session_id: Optional[str] = None, owne
                         try:
                             _r = _req.get(_ibase + "/models", timeout=3)
                             _r.raise_for_status()
-                            _mids = [m.get("id") for m in (_r.json().get("data") or []) if m.get("id")]
+                            _data = _r.json()
+                            _ditems = _data if isinstance(_data, list) else (_data.get("data") or [])
+                            _mids = [m.get("id") for m in _ditems if isinstance(m, dict) and m.get("id")]
                             if _mids:
                                 model_spec = _mids[0]
                                 break

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -759,8 +759,10 @@ def list_model_ids(base_chat_url: str, timeout: int = LLMConfig.DEFAULT_TIMEOUT,
         r = httpx.get(models_url, headers=h, timeout=timeout)
         r.raise_for_status()
         data = r.json()
-        model_ids = [m.get("id") for m in (data.get("data") or []) if m.get("id")]
-        if not model_ids:
+        # Some OpenAI-compatible APIs (e.g. Together) return a bare list here.
+        items = data if isinstance(data, list) else (data.get("data") or [])
+        model_ids = [m.get("id") for m in items if isinstance(m, dict) and m.get("id")]
+        if not model_ids and isinstance(data, dict):
             model_ids = [
                 m.get("name") or m.get("model")
                 for m in (data.get("models") or [])

--- a/src/model_discovery.py
+++ b/src/model_discovery.py
@@ -169,8 +169,10 @@ class ModelDiscovery:
             r = httpx.get(f"{base}/models", timeout=3)
             if not r.is_success:
                 return None
-            data = r.json() or {}
-            ids = [m.get("id") for m in (data.get("data") or []) if m.get("id")]
+            data = r.json()
+            # Some OpenAI-compatible servers return a bare list, not {"data": [...]}.
+            items = data if isinstance(data, list) else ((data or {}).get("data") or [])
+            ids = [m.get("id") for m in items if isinstance(m, dict) and m.get("id")]
             if ids:
                 return {
                     "host": host,


### PR DESCRIPTION
## Summary

Adding a Together AI endpoint with a valid key shows "no models", even though the `/v1/models` request returns `200`. Together (and some other OpenAI-compatible providers) return the model list as a bare JSON array `[{"id": ...}]` rather than the OpenAI `{"data": [...]}` envelope, so `data.get("data")` raises `'list' object has no attribute 'get'`. The probe catches that and — because an API key is set — returns an empty list instead of falling back, so the picker ends up empty.

This accepts both shapes (`[...]` and `{"data": [...]}`) everywhere we parse a `/models` response: the endpoint probe, `list_model_ids`, local discovery, the agent's model tools, and webhook model selection. OpenAI / Ollama / others are unchanged.

## Linked Issue

Fixes #2202

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Settings → Model Endpoints → add `https://api.together.xyz/v1` with a valid Together API key.
2. On `main` the picker shows "no models"; the log has `GET .../v1/models "200 OK"` immediately followed by `Failed to probe ... 'list' object has no attribute 'get'`.
3. With this change the endpoint loads its models (Llama-4 Scout/Maverick, DeepSeek-R1, Qwen2.5-72B-Turbo, …). An OpenAI endpoint still lists normally — no regression.

## Visual / UI changes — REQUIRED if you touched anything that renders

N/A — backend only (`/v1/models` response parsing). Nothing rendered changes.
