### PR TITLE
fix(security): encrypt CardDAV password at rest via secret_storage

### DIFF
--- a/routes/contacts_routes.py
+++ b/routes/contacts_routes.py
@@ -44,11 +44,12 @@ def _save_settings(settings):
 
 def _get_carddav_config():
     import os
+    from src.secret_storage import decrypt
     settings = _load_settings()
     return {
         "url": settings.get("carddav_url", os.environ.get("CARDDAV_URL", "")),
         "username": settings.get("carddav_username", os.environ.get("CARDDAV_USERNAME", "")),
-        "password": settings.get("carddav_password", os.environ.get("CARDDAV_PASSWORD", "")),
+        "password": decrypt(settings.get("carddav_password", "")) or os.environ.get("CARDDAV_PASSWORD", ""),
     }
 
 
@@ -774,6 +775,7 @@ def setup_contacts_routes():
     @router.put("/config")
     async def update_config(data: dict, _admin: str = Depends(require_admin)):
         settings = _load_settings()
+        from src.secret_storage import encrypt
         for key in ("carddav_url", "carddav_username", "carddav_password"):
             if key in data:
                 if key == "carddav_url" and str(data[key] or "").strip():
@@ -781,6 +783,8 @@ def setup_contacts_routes():
                         settings[key] = _validate_carddav_url(data[key])
                     except ValueError as e:
                         raise HTTPException(400, str(e))
+                elif key == "carddav_password" and data[key]:
+                    settings[key] = encrypt(data[key])
                 else:
                     settings[key] = data[key]
         _save_settings(settings)


### PR DESCRIPTION
## Summary

The CardDAV password was stored in **plaintext** in `data/settings.json` while every other credential (email IMAP/SMTP, CalDAV) is encrypted via `src.secret_storage` (Fernet). Any process with filesystem read access could obtain the CardDAV password.

- Encrypts the password on save via `encrypt()` in the `PUT /config` handler
- Decrypts on load via `decrypt()` in `_get_carddav_config()`
- Legacy plaintext passwords are transparently handled (`decrypt` passes through non-`enc:` values unchanged)

## Linked Issue

Fixes #2279

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets \`main\`
- [x] My changes are limited to the scope described above.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. \`python -m py_compile routes/contacts_routes.py\` — OK
2. \`python -m pytest tests/ -k contacts\` — 5 passed
3. Configure CardDAV in admin settings with a password
4. Check \`data/settings.json\` — \`carddav_password\` should have an \`enc:\` prefix
5. Verify CardDAV contacts still sync (password is decrypted on read)

🤖 Generated with [Claude Code](https://claude.com/claude-code)