### PR TITLE
fix(history): scope compaction utility endpoint to session owner

### DIFF
--- a/routes/history_routes.py
+++ b/routes/history_routes.py
@@ -526,8 +526,10 @@ def setup_history_routes(session_manager) -> APIRouter:
                 for m in older
             )
 
-            # Use utility model if available
-            util_url, util_model, util_headers = resolve_endpoint("utility")
+            # Use the session owner's utility model if available; ownerless
+            # sessions keep the legacy/global lookup.
+            owner = getattr(session, "owner", None)
+            util_url, util_model, util_headers = resolve_endpoint("utility", owner=owner or None)
             compact_url = util_url or session.endpoint_url
             compact_model = util_model or session.model
             compact_headers = util_headers if util_url else session.headers

--- a/src/context_compactor.py
+++ b/src/context_compactor.py
@@ -311,8 +311,10 @@ async def maybe_compact(
         if "[Conversation summary" in m.get("content", "")
     )
 
-    # Use utility model if configured, otherwise fall back to session model
-    util_url, util_model, util_headers = resolve_endpoint("utility")
+    # Use the owner's utility model if configured, otherwise fall back to the
+    # session model. A missing owner preserves single-user / legacy behavior.
+    owner = getattr(session, "owner", None)
+    util_url, util_model, util_headers = resolve_endpoint("utility", owner=owner or None)
     compact_url = util_url or endpoint_url
     compact_model = util_model or model
     compact_headers = util_headers if util_url else headers

--- a/tests/test_context_compactor.py
+++ b/tests/test_context_compactor.py
@@ -133,7 +133,7 @@ class TestMaybeCompactFourthMessage:
 
         cc.get_context_length = lambda url, model: context_length
         cc.llm_call_async = _fake_summary
-        cc.resolve_endpoint = lambda which: (None, None, None)
+        cc.resolve_endpoint = lambda which, **kwargs: (None, None, None)
         cc._update_session_history = lambda *a, **k: None
         try:
             return asyncio.run(
@@ -192,3 +192,42 @@ class TestMaybeCompactFourthMessage:
         ]}
         result = self._run(messages)
         assert len(result) == 3 and result[2] is True
+
+    def test_resolves_utility_endpoint_for_session_owner(self):
+        calls = []
+        messages = self._four_turn_history_with_tool_call()
+        session = type("Session", (), {"owner": "alice"})()
+
+        orig_ctx = cc.get_context_length
+        orig_call = cc.llm_call_async
+        orig_resolve = cc.resolve_endpoint
+        orig_update = cc._update_session_history
+
+        async def _fake_summary(*a, **k):
+            return "compact summary text"
+
+        def _fake_resolve(which, **kwargs):
+            calls.append((which, kwargs.get("owner")))
+            return (None, None, None)
+
+        cc.get_context_length = lambda url, model: 500
+        cc.llm_call_async = _fake_summary
+        cc.resolve_endpoint = _fake_resolve
+        cc._update_session_history = lambda *a, **k: None
+        try:
+            asyncio.run(
+                maybe_compact(
+                    session=session,
+                    endpoint_url="http://local/v1/chat/completions",
+                    model="local-model",
+                    messages=list(messages),
+                    headers={},
+                )
+            )
+        finally:
+            cc.get_context_length = orig_ctx
+            cc.llm_call_async = orig_call
+            cc.resolve_endpoint = orig_resolve
+            cc._update_session_history = orig_update
+
+        assert calls == [("utility", "alice")]

--- a/tests/test_history_compact_owner_scope.py
+++ b/tests/test_history_compact_owner_scope.py
@@ -1,0 +1,101 @@
+"""Regression: manual chat compaction must resolve utility endpoints per owner."""
+
+from types import SimpleNamespace
+
+import pytest
+
+import routes.history_routes as history_routes
+import src.endpoint_resolver as endpoint_resolver
+import src.llm_core as llm_core
+import src.model_context as model_context
+from core.models import ChatMessage
+
+
+class _FakeQuery:
+    def filter(self, *args, **kwargs):
+        return self
+
+    def order_by(self, *args, **kwargs):
+        return self
+
+    def all(self):
+        return []
+
+    def first(self):
+        return None
+
+
+class _FakeDb:
+    def query(self, *args, **kwargs):
+        return _FakeQuery()
+
+    def add(self, *args, **kwargs):
+        pass
+
+    def commit(self):
+        pass
+
+    def close(self):
+        pass
+
+
+class _FakeSessionManager:
+    def __init__(self, session):
+        self._session = session
+        self.saved = False
+
+    def get_session(self, session_id):
+        return self._session
+
+    def save_sessions(self):
+        self.saved = True
+
+
+@pytest.mark.asyncio
+async def test_manual_compact_resolves_utility_endpoint_for_session_owner(monkeypatch):
+    calls = []
+    session = SimpleNamespace(
+        owner="alice",
+        endpoint_url="http://session/v1/chat/completions",
+        model="session-model",
+        headers={"Authorization": "Bearer session"},
+        history=[
+            ChatMessage(role="user", content=f"message {i}")
+            for i in range(8)
+        ],
+    )
+    session.get_context_messages = lambda: [
+        msg.to_dict() for msg in session.history
+    ]
+    manager = _FakeSessionManager(session)
+
+    def fake_resolve_endpoint(setting_prefix, *args, **kwargs):
+        calls.append((setting_prefix, kwargs.get("owner")))
+        return (
+            "http://utility/v1/chat/completions",
+            "utility-model",
+            {"Authorization": "Bearer utility"},
+        )
+
+    async def fake_llm_call_async(*args, **kwargs):
+        return "manual compact summary"
+
+    monkeypatch.setattr(history_routes, "_verify_session_owner", lambda *a, **k: None)
+    monkeypatch.setattr(history_routes, "SessionLocal", lambda: _FakeDb())
+    monkeypatch.setattr(model_context, "get_context_length", lambda *a, **k: 4096)
+    monkeypatch.setattr(model_context, "estimate_tokens", lambda messages: len(messages) * 10)
+    monkeypatch.setattr(endpoint_resolver, "resolve_endpoint", fake_resolve_endpoint)
+    monkeypatch.setattr(llm_core, "llm_call_async", fake_llm_call_async)
+
+    router = history_routes.setup_history_routes(manager)
+    endpoint = next(
+        route.endpoint
+        for route in router.routes
+        if route.path == "/api/session/{session_id}/compact"
+    )
+
+    result = await endpoint(SimpleNamespace(), "session-1")
+
+    assert calls == [("utility", "alice")]
+    assert result["status"] == "ok"
+    assert manager.saved is True


### PR DESCRIPTION
## Summary

Scoped chat compaction utility endpoint resolution to the session owner so automatic and manual compaction use the correct per-user utility endpoint configuration instead of falling back to a global lookup.

## Linked Issue

Fixes #2408

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run `python -m pytest -q tests/test_context_compactor.py tests/test_history_compact_owner_scope.py`.
2. Run `python -m py_compile src/context_compactor.py routes/history_routes.py tests/test_context_compactor.py tests/test_history_compact_owner_scope.py`.
3. Configure a user-owned utility endpoint, trigger chat compaction for that user's session, and verify the utility endpoint lookup receives the session owner.

## Visual / UI changes

No UI or visual changes. This PR only touches backend compaction endpoint resolution and regression tests.

### Screenshots / clips

Not applicable.