### PR TITLE
fix(sessions): entity-link anchors must not trigger session navigation

### DIFF
--- a/static/js/sessions.js
+++ b/static/js/sessions.js
@@ -1489,6 +1489,8 @@ export async function loadSessions() {
 }
 
 export async function selectSession(id, { keepSidebar = false } = {}) {
+  // Guard: entity-link anchors (#document-x, #note-x, etc.) are not session IDs
+  if (/^(document|note|image|email|event|task|skill|research)-/.test(id)) return;
   // Exit compare mode cleanly if active
   if (window.compareModule && window.compareModule.isActive()) {
     window.compareModule.deactivate(true);


### PR DESCRIPTION
## Summary

Clicking an entity-link anchor (`#document-<id>`, `#note-<id>`, etc.) emitted by the agent caused `selectSession()` to be called with the entity ID, clearing the current chat and navigating to a blank session.

This PR adds a two-line guard at the top of `selectSession()` in `sessions.js` that returns early when the id matches the entity-link pattern — preventing entity anchors from being treated as session lookups.

Note: the `hashchange` guard for the same pattern was added by PR #2055. The `openNote()` export for note links is now present in upstream. This PR's contribution is the `selectSession()` path guard only.

## Linked Issue

Fixes #2464

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [[open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues)](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [[open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls)](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

1. Start an agent session and ask it to create a document and a note, then provide links to both.
2. Click the `#document-<id>` link — confirm the document panel opens and the current chat session is unchanged.
3. Click the `#note-<id>` link — confirm the notes panel opens and scrolls to the correct note.
4. Confirm no errors in the browser console.