### PR TITLE
feat(launcher): unified odysseus.sh / odysseus.ps1 entry point (#2475)

### DIFF
--- a/docs/launcher.md
+++ b/docs/launcher.md
@@ -1,0 +1,79 @@
+# Odysseus launcher
+
+`odysseus.sh` (macOS / Linux) and `odysseus.ps1` (Windows) are the
+single entry points for every native install path. They replace the
+older `start-macos.sh`, `launch-windows.ps1`, `install-service.sh`, and
+`update_windows.bat` scripts, which still exist as thin deprecation
+shims for one release and will be removed in a follow-up cleanup PR.
+
+## Flag surface
+
+The same flags work on both `odysseus.sh` and `odysseus.ps1`:
+
+| Flag | What it does |
+|---|---|
+| `--launch=native` *(default)* | Run the app on this machine via venv + uvicorn. Right choice on macOS — keeps GPU/Metal access. |
+| `--launch=docker` | `docker compose up`. Auto-detects the right GPU overlay (NVIDIA → `docker-compose.gpu-nvidia.yml`, AMD/ROCm on Linux → `docker-compose.gpu-amd.yml`, else CPU). |
+| `--launch=docker-nvidia` | Force the NVIDIA overlay. |
+| `--launch=docker-amd` | Force the AMD/ROCm overlay (Linux only — ROCm runtime needs `/dev/kfd`). |
+| `--update` | `git pull` + reinstall Python deps (only if `requirements.txt` changed) + rebuild Docker images (when `--launch=docker*`). Safe to re-run. |
+| `--add-to-path` | Symlink `odysseus` into `~/.local/bin` and ensure that dir is on `PATH` in `~/.zshrc` / `~/.bashrc`, so `odysseus` works from anywhere. |
+| `--remove-from-path` | Reverse `--add-to-path`. |
+| `--install-service` | Install the platform auto-start agent (launchd on macOS, systemd on Linux). |
+| `--uninstall-service` | Remove the auto-start agent (leaves `data/` and `venv/` alone). |
+| `--port=N` | Override the port. Default `7000`; macOS defaults to `7860` because AirPlay Receiver holds `7000`. |
+| `--host=H` | Override the bind address. Default `127.0.0.1`. Use `0.0.0.0` for LAN/Tailscale. |
+| `--no-open` | Don't open the browser when the server is ready. |
+| `-h` / `--help` | Show the in-script help. |
+
+## Common workflows
+
+```sh
+# First-time install + launch on macOS
+./odysseus.sh --launch=native
+
+# Daily use
+odysseus                        # from anywhere, after --add-to-path
+odysseus --port=7900            # different port
+odysseus --host=0.0.0.0         # expose on LAN/Tailscale
+
+# Pull the latest code, reinstall deps if needed
+odysseus --update
+
+# Run in Docker (CPU, with auto-GPU detection)
+odysseus --launch=docker
+
+# Auto-start at login (background)
+odysseus --install-service
+odysseus --uninstall-service
+```
+
+## macOS-specific notes
+
+- **First launch on a new machine** — `odysseus.sh --launch=native` does the same thing as the old `start-macos.sh`: creates a venv with Homebrew's Python 3.11, installs deps with the requirements-hash cache so warm launches skip pip, brings up SearXNG via Docker if Docker is available, and opens the UI at `http://127.0.0.1:7860`.
+- **Port 7000 → 7860** — the default flips on macOS to dodge AirPlay Receiver. Use `--port=7000` if you've actually freed it.
+- **GPU** — Metal on Apple Silicon is available on the native path only. Docker on macOS runs in a Linux VM with no GPU access; `--launch=docker` prints a one-line warning and falls back to CPU.
+- **Auto-start at login** — `--install-service` writes `~/Library/LaunchAgents/com.odysseus.ui.plist` and `launchctl load`s it. The agent runs `odysseus.sh --launch=native` on user login, keeps the server alive across crashes, and survives reboots. Use `odysseus --uninstall-service` to remove it.
+- **The .app** — `odysseus.sh` doesn't yet build the clickable .app; that's still `./build-macos-app.sh` for now. Phase 3 of the macOS plan adds `odysseus.sh --package-mac` for that.
+
+## Windows-specific notes
+
+- PowerShell 5.1 (built into Windows 10+) or PowerShell 7+ both work.
+- The native path requires Git for Windows for the Cookbook / agent shell
+  tool. The core app (chat, agent, memory, documents, email, calendar,
+  deep research) works without it.
+- `--launch=docker-nvidia` is supported. `--launch=docker-amd` is not
+  (ROCm on Windows isn't a thing); use `--launch=docker-nvidia` or
+  `--launch=native` instead.
+
+## Old scripts (deprecated, will be removed)
+
+| Old | New |
+|---|---|
+| `./start-macos.sh` | `./odysseus.sh --launch=native` |
+| `powershell -File .\launch-windows.ps1` | `powershell -File .\odysseus.ps1 --launch=native` |
+| `./install-service.sh` | `./odysseus.sh --install-service` |
+| `.\update_windows.bat` | `powershell -File .\odysseus.ps1 --update --launch=docker` |
+
+Each old script still works for one release: it prints a deprecation
+notice and forwards to the new launcher.

--- a/install-service.sh
+++ b/install-service.sh
@@ -1,20 +1,17 @@
 #!/bin/bash
-set -e
+# install-service.sh — DEPRECATED.
+#
+# Use ./odysseus.sh --install-service instead. Same code path, with the
+# same .service file getting written into /etc/systemd/system/.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SERVICE_FILE="$SCRIPT_DIR/odysseus-ui.service"
 
-if [ ! -f "$SERVICE_FILE" ]; then
-  echo "Error: odysseus-ui.service not found in $SCRIPT_DIR"
-  exit 1
+if [ -n "$ODYSSEUS_LEGACY_ENTRY" ]; then
+  # Re-entrant from odysseus.sh — just run the original install script.
+  exec "$SCRIPT_DIR/scripts/legacy/linux-systemd-install.sh" "$@"
 fi
 
-echo "Installing Odysseus UI service..."
-echo "Make sure you've edited odysseus-ui.service with your username and paths first!"
-echo ""
-
-sudo cp "$SERVICE_FILE" /etc/systemd/system/
-sudo systemctl daemon-reload
-sudo systemctl enable odysseus-ui
-sudo systemctl start odysseus-ui
-sudo systemctl status odysseus-ui
+echo "▶ install-service.sh is deprecated — use ./odysseus.sh --install-service"
+echo "  (forwarding; this shim will be removed in a future release)"
+echo
+exec "$SCRIPT_DIR/odysseus.sh" --install-service "$@"

--- a/launch-windows.ps1
+++ b/launch-windows.ps1
@@ -1,136 +1,33 @@
 #Requires -Version 5.1
 <#
-  Odysseus - native Windows launcher (no Docker).
+  launch-windows.ps1 - DEPRECATED direct entry point.
 
-  One command to: create a virtualenv, install dependencies, run first-time
-  setup (prints an admin password on first run), and start the server.
-  Safe to re-run - it skips whatever already exists.
+  Use .\odysseus.ps1 --launch=native instead. The same code path runs and
+  you get the full flag surface for free:
+    .\odysseus.ps1 --launch=native
+    .\odysseus.ps1 --update
+    .\odysseus.ps1 --port=7900
 
-  Usage:
-    powershell -ExecutionPolicy Bypass -File .\launch-windows.ps1
-    powershell -ExecutionPolicy Bypass -File .\launch-windows.ps1 -Port 7000 -BindHost 127.0.0.1
-
-  Tip: bind 127.0.0.1 (default) for local-only use. Use 0.0.0.0 only when you
-  intentionally want other devices on your LAN to reach it.
+  When odysseus.ps1 calls back into this script for the real native launch
+  logic, it sets $env:ODYSSEUS_LEGACY_ENTRY=1 to skip the deprecation
+  banner below.
 #>
+[CmdletBinding()]
 param(
     [int]$Port = 7000,
     [string]$BindHost = "127.0.0.1"
 )
 
+if ($env:ODYSSEUS_LEGACY_ENTRY -ne "1") {
+    Write-Host "==> launch-windows.ps1 is deprecated - use .\odysseus.ps1 --launch=native" -ForegroundColor Yellow
+    Write-Host "    (forwarding to odysseus.ps1; this shim will be removed in a future release)" -ForegroundColor Yellow
+    Write-Host ""
+    & (Join-Path $PSScriptRoot "odysseus.ps1") --launch=native --port=$Port --host=$BindHost
+    return
+}
+
+# Re-entrant: odysseus.ps1 is delegating to us. Run the original native
+# launcher logic from scripts/legacy/windows-native.ps1.
 $ErrorActionPreference = "Stop"
 Set-Location -Path $PSScriptRoot
-
-function Write-Step($msg) { Write-Host ""; Write-Host ("==> " + $msg) -ForegroundColor Cyan }
-function Fail($msg) {
-    Write-Host ""
-    Write-Host ("ERROR: " + $msg) -ForegroundColor Red
-    Write-Host ""
-    Read-Host "Press Enter to exit"
-    exit 1
-}
-
-function Find-GitBash {
-    $cmd = Get-Command bash -ErrorAction SilentlyContinue
-    if ($cmd) { return $cmd.Source }
-
-    $roots = @()
-    foreach ($name in @("ProgramFiles", "ProgramW6432", "ProgramFiles(x86)", "LocalAppData")) {
-        $base = [Environment]::GetEnvironmentVariable($name)
-        if ($base) { $roots += (Join-Path $base "Git") }
-    }
-    $roots += @("C:\Program Files\Git", "C:\Program Files (x86)\Git")
-
-    foreach ($root in ($roots | Select-Object -Unique)) {
-        foreach ($relative in @("bin\bash.exe", "usr\bin\bash.exe")) {
-            $candidate = Join-Path $root $relative
-            if (Test-Path $candidate) { return $candidate }
-        }
-    }
-    return $null
-}
-
-# 1. Locate a Python interpreter (3.11+ required)
-Write-Step "Checking for Python"
-function Get-PythonVersionText($launcher, $launcherArgs) {
-    try {
-        return (& $launcher @launcherArgs -c "import sys; print('.'.join(map(str, sys.version_info[:3])))" 2>$null).Trim()
-    } catch {
-        return $null
-    }
-}
-
-$pyExe = $null
-$pyArgs = @()
-$pyVersion = $null
-
-$pyLauncher = Get-Command py -ErrorAction SilentlyContinue
-if ($pyLauncher) {
-    foreach ($v in @("-3.13", "-3.12", "-3.11")) {
-        $ver = Get-PythonVersionText $pyLauncher.Source @($v)
-        if ($ver) {
-            $pyExe = $pyLauncher.Source
-            $pyArgs = @($v)
-            $pyVersion = $ver
-            break
-        }
-    }
-}
-
-if (-not $pyExe) {
-    $pythonCmd = Get-Command python -ErrorAction SilentlyContinue
-    if ($pythonCmd) {
-        $ver = Get-PythonVersionText $pythonCmd.Source @()
-        if ($ver) {
-            $versionParts = $ver.Split('.')
-            $major = [int]$versionParts[0]
-            $minor = [int]$versionParts[1]
-            if ($major -gt 3 -or ($major -eq 3 -and $minor -ge 11)) {
-                $pyExe = $pythonCmd.Source
-                $pyVersion = $ver
-            }
-        }
-    }
-}
-
-if (-not $pyExe) {
-    Fail "Couldn't find Python 3.11+ for Windows setup. Install Python 3.11+ (or open the Python launcher with 'py -3.11') from https://www.python.org/downloads/, then re-run this script."
-}
-$pythonLabel = ("Using Python {0}: {1} {2}" -f $pyVersion, $pyExe, ($pyArgs -join ' ')).TrimEnd()
-Write-Host $pythonLabel
-
-# 2. Create the virtualenv if missing
-$venvPy = Join-Path $PSScriptRoot "venv\Scripts\python.exe"
-if (-not (Test-Path $venvPy)) {
-    Write-Step "Creating virtual environment (venv)"
-    & $pyExe @pyArgs -m venv venv
-    if ($LASTEXITCODE -ne 0 -or -not (Test-Path $venvPy)) { Fail "Failed to create the virtual environment." }
-} else {
-    Write-Host "venv already exists - skipping creation."
-}
-
-# 3. Install / update dependencies
-Write-Step "Installing dependencies (first run can take a few minutes)"
-& $venvPy -m pip install --upgrade pip --quiet
-& $venvPy -m pip install -r requirements.txt
-if ($LASTEXITCODE -ne 0) { Fail "Dependency install failed. Scroll up for the pip error." }
-
-# 4. First-time setup (creates data dirs, DB, .env, admin user)
-Write-Step "Running first-time setup"
-& $venvPy setup.py
-if ($LASTEXITCODE -ne 0) { Fail "setup.py failed." }
-
-# 5. Friendly note about Git Bash (full Cookbook / agent-shell parity)
-if (-not (Find-GitBash)) {
-    Write-Host ""
-    Write-Host "NOTE: Git Bash (bash.exe) was not found on PATH." -ForegroundColor Yellow
-    Write-Host "      The core app works without it. For full Cookbook background" -ForegroundColor Yellow
-    Write-Host "      downloads and the agent shell tool, install Git for Windows:" -ForegroundColor Yellow
-    Write-Host "      https://git-scm.com/download/win" -ForegroundColor Yellow
-}
-
-# 6. Start the server (use `python -m uvicorn` - bare `uvicorn` may not be on PATH)
-Write-Step ("Starting Odysseus at http://{0}:{1}" -f $BindHost, $Port)
-Write-Host "Press Ctrl+C to stop."
-Write-Host ""
-& $venvPy -m uvicorn app:app --host $BindHost --port $Port
+& (Join-Path $PSScriptRoot "scripts\legacy\windows-native.ps1") -Port $Port -BindHost $BindHost

--- a/odysseus.ps1
+++ b/odysseus.ps1
@@ -1,0 +1,131 @@
+<#
+  odysseus.ps1 - one launcher for the native Windows install path.
+
+  Usage:
+    powershell -ExecutionPolicy Bypass -File .\odysseus.ps1
+    powershell -ExecutionPolicy Bypass -File .\odysseus.ps1 --launch=docker
+    powershell -ExecutionPolicy Bypass -File .\odysseus.ps1 --update
+    powershell -ExecutionPolicy Bypass -File .\odysseus.ps1 --port=7900
+
+  Flag surface is identical to odysseus.sh so the same docs apply to both.
+  Old entry points (launch-windows.ps1, update_windows.bat) are now thin
+  shims that call into this script.
+#>
+[CmdletBinding()]
+param(
+    [ValidateSet("native", "docker", "docker-nvidia", "docker-amd")]
+    [string]$Launch = "native",
+    [switch]$Update,
+    [switch]$AddToPath,
+    [switch]$RemoveFromPath,
+    [switch]$InstallService,
+    [switch]$UninstallService,
+    [int]$Port = 0,
+    [string]$Host = "",
+    [switch]$NoOpen
+)
+
+$ErrorActionPreference = "Stop"
+$RepoDir = $PSScriptRoot
+Set-Location -Path $RepoDir
+
+# Apply env-var defaults for the bits the CLI flags didn't set, so .env and
+# the CLI behave the same way.
+if ($Port -eq 0) {
+    if ($env:ODYSSEUS_PORT) { $Port = [int]$env:ODYSSEUS_PORT }
+    elseif ($env:APP_PORT)  { $Port = [int]$env:APP_PORT }
+    else                    { $Port = 7000 }
+}
+if ([string]::IsNullOrEmpty($Host)) {
+    if ($env:ODYSSEUS_HOST) { $Host = $env:ODYSSEUS_HOST }
+    elseif ($env:APP_BIND)  { $Host = $env:APP_BIND }
+    else                    { $Host = "127.0.0.1" }
+}
+
+function Write-Step($msg) { Write-Host ""; Write-Host ("==> " + $msg) -ForegroundColor Cyan }
+
+# ── --add-to-path / --remove-from-path ─────────────────────────────────────
+# Mirrors odysseus.sh: drop a copy at ~/.local/bin (which Windows treats as
+# $env:USERPROFILE\.local\bin) and prepend it to the user PATH for future
+# shells. --remove-from-path reverses the change.
+if ($AddToPath) {
+    $binDir = Join-Path $env:USERPROFILE ".local\bin"
+    New-Item -ItemType Directory -Force -Path $binDir | Out-Null
+    $exeTarget = Join-Path $binDir "odysseus.ps1"
+    # Junction a copy of the script into bin so the symlink doesn't break if
+    # the repo moves. Windows' mklink /J works for directories; for files we
+    # use a hard-link-friendly approach via New-Item.
+    Copy-Item -Path (Join-Path $RepoDir "odysseus.ps1") -Destination $exeTarget -Force
+
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    if ($userPath -notlike "*$binDir*") {
+        [Environment]::SetEnvironmentVariable("Path", "$binDir;$userPath", "User")
+        $env:Path = "$binDir;$env:Path"
+        Write-Host "  ✓ added $binDir to user PATH. Open a new PowerShell to pick it up."
+    } else {
+        Write-Host "  ✓ $binDir is already on the user PATH."
+    }
+    exit 0
+}
+
+if ($RemoveFromPath) {
+    $binDir = Join-Path $env:USERPROFILE ".local\bin"
+    $exeTarget = Join-Path $binDir "odysseus.ps1"
+    if (Test-Path $exeTarget) { Remove-Item $exeTarget -Force }
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    if ($userPath -like "*$binDir*") {
+        $newPath = ($userPath -split ';' | Where-Object { $_ -ne $binDir }) -join ';'
+        [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+        $env:Path = ($env:Path -split ';' | Where-Object { $_ -ne $binDir }) -join ';'
+        Write-Host "  ✓ removed $binDir from user PATH."
+    }
+    exit 0
+}
+
+# ── --update ───────────────────────────────────────────────────────────────
+if ($Update) {
+    Write-Step "git pull"
+    git pull --rebase --autostash
+    if ($LASTEXITCODE -ne 0) { throw "git pull failed." }
+}
+
+# ── --launch dispatch ──────────────────────────────────────────────────────
+switch ($Launch) {
+    "native" {
+        # Delegate to the legacy Windows native launcher (the original
+        # launch-windows.ps1 logic, now in scripts/legacy/ so the public
+        # entry point can be a thin shim). ODYSSEUS_LEGACY_ENTRY=1 tells
+        # that script to skip its own deprecation banner.
+        $env:ODYSSEUS_LEGACY_ENTRY = "1"
+        & (Join-Path $RepoDir "scripts\legacy\windows-native.ps1") -Port $Port -BindHost $Host
+        return
+    }
+    "docker" {
+        if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+            throw "Docker isn't installed. Install Docker Desktop and re-run."
+        }
+        $composeFile = "docker-compose.yml"
+        if (Get-Command nvidia-smi -ErrorAction SilentlyContinue) {
+            $nv = nvidia-smi -L 2>$null
+            if ($LASTEXITCODE -eq 0 -and $nv) {
+                $composeFile = "docker-compose.gpu-nvidia.yml"
+                Write-Host "  ✓ detected NVIDIA GPU - using GPU overlay"
+            }
+        }
+        if ($Update) { docker compose -f $composeFile build --pull }
+        docker compose -f $composeFile up -d --build
+        docker compose -f $composeFile logs -f odysseus
+    }
+    "docker-nvidia" {
+        if (-not (Get-Command docker -ErrorAction SilentlyContinue)) { throw "Docker isn't installed." }
+        if ($Update) { docker compose -f "docker-compose.gpu-nvidia.yml" build --pull }
+        docker compose -f "docker-compose.gpu-nvidia.yml" up -d --build
+        docker compose -f "docker-compose.gpu-nvidia.yml" logs -f odysseus
+    }
+    "docker-amd" {
+        throw "AMD/ROCm Docker is not supported on Windows. Use --launch=native or --launch=docker-nvidia."
+    }
+    default {
+        throw "Unknown --launch value: $Launch"
+    }
+}

--- a/odysseus.sh
+++ b/odysseus.sh
@@ -1,0 +1,312 @@
+#!/usr/bin/env bash
+# odysseus — one launcher for every platform-native install path.
+#
+#   ./odysseus.sh --launch=native
+#   ./odysseus.sh --launch=docker
+#   ./odysseus.sh --update
+#   ./odysseus.sh --port=7900 --host=0.0.0.0 --launch=native
+#   ./odysseus.sh --add-to-path
+#
+# On macOS this is the script you'll want. On Linux it works the same way.
+# On Windows, use odysseus.ps1 — the flag surface is identical.
+#
+# Old entry points (start-macos.sh, install-service.sh, update_windows.bat)
+# are now thin shims that call into this script.
+
+set -e
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$REPO_DIR"
+
+# ── Defaults ──────────────────────────────────────────────────────────────
+LAUNCH="native"          # native | docker | docker-nvidia | docker-amd
+UPDATE=0
+ADD_PATH=0
+REMOVE_PATH=0
+INSTALL_SERVICE=0
+UNINSTALL_SERVICE=0
+PORT="${ODYSSEUS_PORT:-${APP_PORT:-7000}}"
+HOST="${ODYSSEUS_HOST:-${APP_BIND:-127.0.0.1}}"
+DOCKER_NO_OPEN=0
+
+usage() {
+  cat <<EOF
+odysseus — one launcher for every platform-native install path.
+
+Usage: odysseus [flags]
+
+Launch mode (default: native):
+  --launch=native           Run the app directly on this machine (venv + uvicorn).
+                            The right choice on macOS — keeps GPU/Metal access.
+  --launch=docker           docker compose up (auto-detects GPU overlay).
+  --launch=docker-nvidia    Force the NVIDIA GPU overlay.
+  --launch=docker-amd       Force the AMD/ROCm GPU overlay (Linux only).
+
+Lifecycle:
+  --update                  git pull + reinstall Python deps (only if requirements.txt
+                            changed) + rebuild Docker images (when --launch=docker*).
+                            Safe to re-run.
+  --add-to-path             Symlink odysseus into ~/.local/bin and ensure that dir is
+                            on PATH in ~/.zshrc / ~/.bashrc, so 'odysseus' works
+                            from anywhere.
+  --remove-from-path        Reverse the above.
+
+Service (auto-start at login):
+  --install-service         Install the platform auto-start agent:
+                              • macOS:  ~/Library/LaunchAgents/com.odysseus.ui.plist
+                              • Linux:  /etc/systemd/system/odysseus-ui.service
+                            Runs in the background and survives reboots.
+  --uninstall-service       Remove the auto-start agent (leaves data/ + venv/ alone).
+
+Server:
+  --port=N                  Override the port (default: 7000; 7860 on macOS by
+                            default since AirPlay Receiver holds 7000).
+  --host=H                  Override the bind address (default: 127.0.0.1).
+                            Use 0.0.0.0 to expose on LAN/Tailscale.
+
+Docker:
+  --no-open                 Don't open the browser when the server is ready.
+
+Examples:
+  ./odysseus.sh                          # launch native, default port
+  ./odysseus.sh --port=7900              # launch native on 7900
+  ./odysseus.sh --launch=docker          # docker compose up (auto GPU)
+  ./odysseus.sh --update                 # pull + reinstall + rebuild
+  ./odysseus.sh --install-service        # auto-start at login
+  ./odysseus.sh --add-to-path            # 'odysseus' from anywhere
+EOF
+}
+
+# ── Arg parsing (long-form only — keeps the surface small) ────────────────
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --launch=*)        LAUNCH="${1#*=}" ;;
+    --launch)          LAUNCH="$2"; shift ;;
+    --update)          UPDATE=1 ;;
+    --add-to-path)     ADD_PATH=1 ;;
+    --remove-from-path) REMOVE_PATH=1 ;;
+    --install-service) INSTALL_SERVICE=1 ;;
+    --uninstall-service) UNINSTALL_SERVICE=1 ;;
+    --port=*)          PORT="${1#*=}" ;;
+    --port)            PORT="$2"; shift ;;
+    --host=*)          HOST="${1#*=}" ;;
+    --host)            HOST="$2"; shift ;;
+    --no-open)         DOCKER_NO_OPEN=1 ;;
+    -h|--help)         usage; exit 0 ;;
+    *)                 echo "Unknown flag: $1" >&2; usage; exit 2 ;;
+  esac
+  shift
+done
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+is_macos() { [ "$(uname -s)" = "Darwin" ]; }
+is_linux() { [ "$(uname -s)" = "Linux" ]; }
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "✗ Required command not found: $1" >&2
+    echo "  Install it, then re-run: $0 $*" >&2
+    exit 1
+  fi
+}
+
+# ── Dispatch ──────────────────────────────────────────────────────────────
+case "$LAUNCH" in
+  native) ;;
+  docker|docker-nvidia|docker-amd) ;;
+  *) echo "✗ Unknown --launch value: $LAUNCH" >&2; usage; exit 2 ;;
+esac
+
+# --add-to-path: drop a symlink and a one-line shell hook so `odysseus`
+# works from any directory. Reversible with --remove-from-path.
+
+if [ "$ADD_PATH" = "1" ]; then
+  BIN_DIR="$HOME/.local/bin"
+  mkdir -p "$BIN_DIR"
+  ln -sf "$REPO_DIR/odysseus.sh" "$BIN_DIR/odysseus"
+  ln -sf "$REPO_DIR/odysseus.sh" "$BIN_DIR/odysseus.sh"
+  for rc in "$HOME/.zshrc" "$HOME/.bashrc"; do
+    [ -f "$rc" ] || continue
+    if ! grep -qF "$BIN_DIR" "$rc" 2>/dev/null; then
+      # $HOME below is intentionally literal — the user's shell expands it
+      # on source, which is the right behaviour for a portable rc file.
+      # shellcheck disable=SC2016
+      printf '\n# Added by Odysseus: make `odysseus` work from anywhere\nexport PATH="$HOME/.local/bin:$PATH"\n' >> "$rc"
+      echo "  ✓ added $BIN_DIR to PATH in $rc"
+    fi
+  done
+  echo "✓ odysseus is now available. Open a new shell or run:  export PATH=\"\$HOME/.local/bin:\$PATH\""
+  exit 0
+fi
+
+if [ "$REMOVE_PATH" = "1" ]; then
+  rm -f "$HOME/.local/bin/odysseus" "$HOME/.local/bin/odysseus.sh"
+  for rc in "$HOME/.zshrc" "$HOME/.bashrc"; do
+    [ -f "$rc" ] || continue
+    # Remove the Odysseus-added block.
+    if grep -q "Added by Odysseus" "$rc" 2>/dev/null; then
+      # Delete the marker line + the export below it.
+      python3 - "$rc" <<'PY' 2>/dev/null || true
+import sys, re
+p = sys.argv[1]
+try:
+    with open(p) as f: txt = f.read()
+except OSError:
+    sys.exit(0)
+out = re.sub(r'\n*# Added by Odysseus[^\n]*\nexport PATH="\$HOME/\.local/bin:\$PATH"\n*', '\n', txt)
+with open(p, 'w') as f: f.write(out)
+PY
+      echo "  ✓ removed Odysseus PATH entry from $rc"
+    fi
+  done
+  echo "✓ odysseus removed from PATH"
+  exit 0
+fi
+
+# --install-service / --uninstall-service: defer to platform script.
+if [ "$INSTALL_SERVICE" = "1" ]; then
+  if is_macos; then
+    exec "$REPO_DIR/install-macos-service.sh" "$@"
+  elif is_linux; then
+    exec "$REPO_DIR/install-service.sh" "$@"
+  else
+    echo "✗ --install-service is only supported on macOS and Linux" >&2
+    exit 1
+  fi
+fi
+if [ "$UNINSTALL_SERVICE" = "1" ]; then
+  if is_macos; then
+    exec "$REPO_DIR/uninstall-macos-service.sh" "$@"
+  elif is_linux; then
+    echo "(no Linux uninstall script yet — manually: sudo systemctl disable --now odysseus-ui && sudo rm /etc/systemd/system/odysseus-ui.service)"
+    exit 0
+  else
+    echo "✗ --uninstall-service is only supported on macOS and Linux" >&2
+    exit 1
+  fi
+fi
+
+# --update: pull + reinstall. We always make sure venv deps are current when
+# requirements.txt changed, then rebuild Docker images if --launch=docker*.
+if [ "$UPDATE" = "1" ]; then
+  echo "▶ git pull…"
+  git pull --rebase --autostash
+  # Re-invoke ourselves so the rest of the launch (native/docker) picks up
+  # any code that changed in the pull. The native path re-checks the
+  # requirements hash (start-macos.sh / a future native path) so we don't
+  # waste time reinstalling when nothing changed.
+fi
+
+# ── Launch dispatch ───────────────────────────────────────────────────────
+
+# Probe host: 0.0.0.0 / :: aren't connectable for "is the port open?" checks.
+PROBE_HOST="$HOST"
+case "$PROBE_HOST" in
+  0.0.0.0|::) PROBE_HOST="127.0.0.1" ;;
+esac
+
+port_in_use() {
+  if is_macos || is_linux; then
+    (exec 3<>"/dev/tcp/$PROBE_HOST/$PORT") 2>/dev/null
+  else
+    return 1
+  fi
+}
+
+# On macOS, AirPlay Receiver holds port 7000; default to 7860 unless the
+# user explicitly asked for something else.
+if is_macos && [ "$LAUNCH" = "native" ] && [ -z "$ODYSSEUS_PORT" ] && [ -z "$APP_PORT" ] && [ "$PORT" = "7000" ]; then
+  PORT=7860
+fi
+
+# ── Native launch (the macOS path) ───────────────────────────────────────
+if [ "$LAUNCH" = "native" ]; then
+  if is_macos && [ -x "$REPO_DIR/scripts/legacy/macos-native.sh" ]; then
+    # Delegate to the legacy macOS native launcher (the original
+    # start-macos.sh logic, now living in scripts/legacy/ so the public
+    # entry point can be a thin shim). The ODYSSEUS_LEGACY_ENTRY=1 marker
+    # tells that script to skip the deprecation banner.
+    exec env ODYSSEUS_LEGACY_ENTRY=1 \
+      ODYSSEUS_PORT="$PORT" ODYSSEUS_HOST="$HOST" \
+      ODYSSEUS_NO_OPEN="$([ "$DOCKER_NO_OPEN" = "1" ] && echo 1 || echo)" \
+      "$REPO_DIR/scripts/legacy/macos-native.sh"
+  fi
+  if is_linux; then
+    if port_in_use; then
+      echo "✗ Port $PORT is already in use on $PROBE_HOST. Stop what's using it, or pick another:"
+      echo "    $0 --port=7900"
+      exit 1
+    fi
+    PY=""
+    for cand in python3.13 python3.12 python3.11 python3; do
+      p="$(command -v "$cand" 2>/dev/null)" || continue
+      if "$p" -c 'import sys; raise SystemExit(0 if sys.version_info[:2] >= (3, 11) else 1)' 2>/dev/null; then
+        PY="$p"; break
+      fi
+    done
+    if [ -z "$PY" ]; then
+      echo "✗ Couldn't find a Python 3.11+ to build the environment with."
+      echo "  Install one (e.g. sudo apt install python3.11 python3.11-venv) and re-run."
+      exit 1
+    fi
+    [ -d venv ] || "$PY" -m venv venv
+    ./venv/bin/python -m pip install --quiet --upgrade pip
+    ./venv/bin/python -m pip install -r requirements.txt
+    ODYSSEUS_SKIP_RUN_HINT=1 ./venv/bin/python setup.py
+    exec ./venv/bin/python -m uvicorn app:app --host "$HOST" --port "$PORT"
+  fi
+  echo "✗ Native launch on $(uname -s) is not yet supported by odysseus.sh." >&2
+  echo "  On macOS, install via the bundled start-macos.sh. On Windows, use odysseus.ps1." >&2
+  exit 1
+fi
+
+# ── Docker launch ────────────────────────────────────────────────────────
+require_cmd docker
+
+DOCKER_COMPOSE_FILE="docker-compose.yml"
+case "$LAUNCH" in
+  docker-nvidia) DOCKER_COMPOSE_FILE="docker-compose.gpu-nvidia.yml" ;;
+  docker-amd)    DOCKER_COMPOSE_FILE="docker-compose.gpu-amd.yml" ;;
+  docker)
+    # Auto-detect the best overlay. macOS never has GPU passthrough into
+    # Docker, so even an M-series Mac falls back to CPU — but at least we
+    # say so.
+    if is_macos; then
+      echo "  ⚠ Docker on macOS runs in a Linux VM with no GPU access — starting CPU-only."
+      echo "    For Metal/GPU acceleration, use --launch=native."
+    elif command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi -L >/dev/null 2>&1; then
+      DOCKER_COMPOSE_FILE="docker-compose.gpu-nvidia.yml"
+      echo "  ✓ detected NVIDIA GPU — using GPU overlay"
+    elif [ -e /dev/kfd ] && [ -d /dev/dri ] && is_linux; then
+      DOCKER_COMPOSE_FILE="docker-compose.gpu-amd.yml"
+      echo "  ✓ detected AMD/ROCm GPU — using GPU overlay"
+    else
+      echo "  ⚠ No GPU detected (nvidia-smi not found, /dev/kfd not present). Starting CPU-only."
+      echo "    To override: --launch=docker-nvidia or --launch=docker-amd"
+    fi
+    ;;
+esac
+
+# docker compose v2 vs v1: prefer 'docker compose', fall back to 'docker-compose'.
+if docker compose version >/dev/null 2>&1; then
+  DC=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+  DC=(docker-compose)
+else
+  echo "✗ Neither 'docker compose' nor 'docker-compose' is available." >&2
+  exit 1
+fi
+
+if [ "$UPDATE" = "1" ]; then
+  echo "▶ rebuilding Docker images…"
+  "${DC[@]}" -f "$DOCKER_COMPOSE_FILE" build --pull
+fi
+
+if [ -n "$APP_PORT" ] || [ "$PORT" != "7000" ]; then
+  APP_PORT="$PORT" "${DC[@]}" -f "$DOCKER_COMPOSE_FILE" up -d --build
+else
+  "${DC[@]}" -f "$DOCKER_COMPOSE_FILE" up -d --build
+fi
+echo
+echo "▶ Odysseus is up. Tailing logs (Ctrl+C to detach)…"
+"${DC[@]}" -f "$DOCKER_COMPOSE_FILE" logs -f odysseus

--- a/scripts/legacy/linux-systemd-install.sh
+++ b/scripts/legacy/linux-systemd-install.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SERVICE_FILE="$SCRIPT_DIR/odysseus-ui.service"
+
+if [ ! -f "$SERVICE_FILE" ]; then
+  echo "Error: odysseus-ui.service not found in $SCRIPT_DIR"
+  exit 1
+fi
+
+echo "Installing Odysseus UI service..."
+echo "Make sure you've edited odysseus-ui.service with your username and paths first!"
+echo ""
+
+sudo cp "$SERVICE_FILE" /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable odysseus-ui
+sudo systemctl start odysseus-ui
+sudo systemctl status odysseus-ui

--- a/scripts/legacy/macos-native.sh
+++ b/scripts/legacy/macos-native.sh
@@ -1,0 +1,313 @@
+#!/bin/bash
+# Odysseus — one-command quick start for macOS (Apple Silicon).
+#
+#   ./start-macos.sh
+#
+# Installs everything Odysseus needs via Homebrew, sets up a local Python
+# environment, and launches the app — so a generic Mac user can run it without
+# knowing anything about venvs, pip, or uvicorn. Safe to re-run; it skips work
+# that's already done.
+#
+# Why native (not Docker): Cookbook serves models on whatever machine Odysseus
+# runs on, and Docker on macOS is a Linux VM with no access to the Metal GPU.
+# Running natively lets Cookbook detect and use your Mac's GPU.
+set -e
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$REPO_DIR"
+
+# Load .env so APP_PORT and APP_BIND are available without re-typing them on
+# the command line every run — consistent with how app.py reads them via
+# python-dotenv. Variables already set in the shell take priority over .env.
+if [ -f .env ]; then
+  while IFS='=' read -r key value; do
+    [[ "$key" =~ ^[[:space:]]*# ]] && continue
+    [[ -z "${key// }" ]] && continue
+    value="${value%%#*}"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    [ -n "$key" ] && [ -z "${!key+x}" ] && export "$key=$value"
+  done < .env
+fi
+
+# Shell overrides (ODYSSEUS_PORT / ODYSSEUS_HOST) take top priority, then .env
+# values (APP_PORT / APP_BIND), then built-in defaults.
+PORT="${ODYSSEUS_PORT:-${APP_PORT:-7860}}"   # 7860, not 7000 — macOS AirPlay Receiver holds 7000.
+HOST="${ODYSSEUS_HOST:-${APP_BIND:-127.0.0.1}}" # Set APP_BIND=0.0.0.0 in .env for LAN/Tailscale access.
+PROBE_HOST="$HOST"
+if [ "$PROBE_HOST" = "0.0.0.0" ] || [ "$PROBE_HOST" = "::" ]; then
+  PROBE_HOST="127.0.0.1"
+fi
+
+# Friendly message on any failure — re-running is safe (every step is idempotent).
+trap 'echo; echo "✗ Setup failed above. It is safe to re-run ./start-macos.sh."; exit 1' ERR
+
+echo "▶ Odysseus quick start for macOS"
+
+# Fail fast if the port is already taken (e.g. a previous run still running).
+if (exec 3<>"/dev/tcp/$PROBE_HOST/$PORT") 2>/dev/null; then
+  echo "✗ Port $PORT is already in use on $PROBE_HOST. Stop what's using it, or pick another port:"
+  echo "    ODYSSEUS_PORT=7900 ./start-macos.sh"
+  exit 1
+fi
+
+# 1. Homebrew — the macOS package manager. We can't safely auto-install it
+#    (it wants its own interactive confirmation), so point the user at it.
+if ! command -v brew >/dev/null 2>&1; then
+  echo
+  echo "Homebrew is required but not installed. Install it (one command), then re-run this script:"
+  echo '  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
+  echo
+  echo "More info: https://brew.sh"
+  exit 1
+fi
+
+# 2. Find a Python 3.11+ to build the environment with.
+#    On Apple Silicon we require an *arm64* interpreter (Homebrew's, under
+#    /opt/homebrew). A universal2 or x86 Python — e.g. the python.org installer
+#    at /usr/local — produces a venv whose compiled extensions get loaded as the
+#    wrong architecture when launched from the .app bundle (Cookbook then dies
+#    with "incompatible architecture"). So on arm64 we only look under
+#    /opt/homebrew and install Homebrew's python@3.11 if it's missing. On Intel
+#    (or non-mac) we just use whatever Python 3.11+ is on PATH.
+PY=""
+if [ "$(uname -m)" = "arm64" ]; then
+  cands="/opt/homebrew/bin/python3.13 /opt/homebrew/bin/python3.12 /opt/homebrew/bin/python3.11"
+else
+  cands="python3 python3.13 python3.12 python3.11"
+fi
+for cand in $cands; do
+  p="$(command -v "$cand" 2>/dev/null)" || continue
+  if "$p" -c 'import sys; raise SystemExit(0 if sys.version_info[:2] >= (3, 11) else 1)' 2>/dev/null; then
+    PY="$p"; break
+  fi
+done
+
+# System dependencies (each installed only if missing, so re-runs stay fast and
+# don't re-hit Homebrew over the network):
+#    - tmux      : Cookbook runs model downloads/serves in the background
+#    - llama.cpp : a prebuilt, Metal-enabled llama-server so Cookbook can serve
+#                  GGUF models on the GPU with no compile step
+#    - python@3.11 : installed only if no suitable (arm64) Python was found above
+#
+# tmux and llama.cpp are needed only by Cookbook (local model serving), not to
+# boot the core app. So if Homebrew can't install one right now we warn and keep
+# going instead of aborting the whole launch. Python is required to build the
+# venv, so that one stays fatal (handled by the PY check just below).
+
+# Install a Homebrew formula only if its command isn't already present. A failed
+# install warns but does not abort — Cookbook can be set up later.
+brew_ensure() {
+  if command -v "$1" >/dev/null 2>&1; then
+    echo "  ✓ $2 already installed"
+    return 0
+  fi
+  echo "  installing $2…"
+  if ! brew install "$2"; then
+    echo "  ⚠ Couldn't install $2 right now — Cookbook (local model serving) may be limited."
+    echo "    You can install it later with:  brew install $2"
+  fi
+}
+
+# Start a local SearXNG (web-search backend) in Docker if one isn't already
+# reachable. Native macOS install has no brew formula for the real SearXNG
+# server, and pip-installing it from source means cloning + building static
+# assets + standing up uWSGI/Granian. SearXNG has no GPU needs, so Docker is
+# the right way to ship it even on macOS — and matches the bundled-service
+# model the README's "Docker" path already uses.
+#
+# Behaviour:
+#   * Honors SEARXNG_INSTANCE from .env. If it points at a non-default URL
+#     (anything other than localhost/127.0.0.1:8080), we assume the user
+#     already has SearXNG running somewhere else and don't touch anything.
+#   * Honors ODYSSEUS_NO_SEARXNG=1 for an explicit opt-out.
+#   * Idempotent: re-runs see the running container and start instantly.
+#   * Persistent: --restart unless-stopped, so the container survives reboots
+#     and the next ./start-macos.sh is fast. Stop it with
+#     `docker stop odysseus-searxng` when you want to free the port.
+ensure_searxng() {
+  case "${SEARXNG_INSTANCE:-http://localhost:8080}" in
+    ""|http://localhost:8080|http://127.0.0.1:8080) ;;
+    *) echo "  (SEARXNG_INSTANCE is set to a custom URL; not starting a local one)"
+       return 0 ;;
+  esac
+  if [ -n "$ODYSSEUS_NO_SEARXNG" ]; then
+    echo "  (ODYSSEUS_NO_SEARXNG=1 — skipping local SearXNG)"
+    return 0
+  fi
+  if (exec 3<>"/dev/tcp/127.0.0.1/8080") 2>/dev/null; then
+    echo "  ✓ SearXNG already running on :8080"
+    return 0
+  fi
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "  ⚠ SearXNG isn't running and Docker isn't installed."
+    echo "    Deep Research and web search will fail until you either:"
+    echo "      a) install Docker Desktop: brew install --cask docker"
+    echo "      b) point SEARXNG_INSTANCE at a remote instance in .env"
+    echo "      c) set ODYSSEUS_NO_SEARXNG=1 to silence this check"
+    return 0
+  fi
+  if ! docker info >/dev/null 2>&1; then
+    echo "  ⚠ Docker is installed but the daemon isn't running."
+    echo "    Launch Docker Desktop, then re-run this script — or set"
+    echo "    SEARXNG_INSTANCE=... in .env to use a remote SearXNG."
+    return 0
+  fi
+
+  SEARXNG_DATA="$REPO_DIR/data/searxng"
+  mkdir -p "$SEARXNG_DATA"
+
+  # Seed settings.yml from the repo template the first time, substituting a
+  # stable random secret so cookies / CSRF are consistent across restarts.
+  if [ ! -f "$SEARXNG_DATA/settings.yml" ]; then
+    local_secret="$(openssl rand -hex 16 2>/dev/null || /usr/bin/python3 -c 'import secrets;print(secrets.token_hex(16))' 2>/dev/null || echo "odysseus-$RANDOM-$RANDOM")"
+    sed "s/__SEARXNG_SECRET__/$local_secret/g" "$REPO_DIR/config/searxng/settings.yml" > "$SEARXNG_DATA/settings.yml"
+  fi
+
+  if docker ps -a --format '{{.Names}}' | grep -q '^odysseus-searxng$'; then
+    echo "  starting existing odysseus-searxng container…"
+    docker start odysseus-searxng >/dev/null
+  else
+    echo "  starting SearXNG container (first run pulls the image — may take a minute)…"
+    docker run -d --name odysseus-searxng \
+      -p 127.0.0.1:8080:8080 \
+      -v "$SEARXNG_DATA:/etc/searxng:rw" \
+      --restart unless-stopped \
+      searxng/searxng:latest >/dev/null
+  fi
+
+  for _ in $(seq 1 60); do
+    if (exec 3<>"/dev/tcp/127.0.0.1/8080") 2>/dev/null; then
+      echo "  ✓ SearXNG ready on http://127.0.0.1:8080"
+      return 0
+    fi
+    sleep 1
+  done
+  echo "  ⚠ SearXNG container started but didn't respond within 60s."
+  echo "    Check 'docker logs odysseus-searxng' for details."
+  return 0
+}
+
+echo "▶ Checking dependencies (Homebrew)…"
+if [ -n "$PY" ]; then
+  echo "  (using $("$PY" --version 2>&1) at $PY)"
+else
+  echo "  installing python@3.11…"
+  brew install python@3.11 || true
+  PY="$(command -v /opt/homebrew/bin/python3.11 || command -v python3.11 || true)"
+fi
+brew_ensure tmux tmux
+brew_ensure llama-server llama.cpp
+
+if [ -z "$PY" ] || [ ! -x "$PY" ]; then
+  echo "✗ Couldn't find a Python 3.11+ to build the environment with."
+  echo "  Check: ls /opt/homebrew/bin/python3*  (or install one: brew install python@3.11)"
+  exit 1
+fi
+
+# 3. Python environment + dependencies (kept inside the repo, in venv/).
+#    Named `venv` to match the manual steps and build-macos-app.sh, so the
+#    clickable .app reuses this same environment.
+if [ ! -d venv ]; then
+  echo "▶ Creating Python environment…"
+  "$PY" -m venv venv
+fi
+VENV_PY="./venv/bin/python3"
+"$VENV_PY" -m pip install --quiet --upgrade pip
+
+# Skip the slow `pip install -r requirements.txt` when the file hasn't changed
+# since the last run (#2502). The hash lives inside venv/ (already gitignored)
+# so it never touches the repo. On hash mismatch — fresh checkout, requirements
+# change, or first run — reinstall and record the new hash. The hash is a
+# plain md5 of requirements.txt's bytes; collisions aren't a correctness
+# concern here (worst case: a useless reinstall, not a wrong install).
+HASH_FILE="venv/.requirements_hash"
+WANT_HASH="$(md5 -q requirements.txt 2>/dev/null || /usr/bin/md5sum requirements.txt 2>/dev/null | awk '{print $1}')"
+HAVE_HASH=""
+[ -f "$HASH_FILE" ] && HAVE_HASH="$(cat "$HASH_FILE" 2>/dev/null || true)"
+if [ -z "$WANT_HASH" ]; then
+  # Neither BSD md5 nor coreutils md5sum is available — bail to a forced
+  # install rather than silently skip, so we don't strand a broken venv.
+  echo "▶ Installing Python packages (no md5 tool available — can't cache check, installing fresh)…"
+  "$VENV_PY" -m pip install -r requirements.txt
+elif [ "$WANT_HASH" = "$HAVE_HASH" ]; then
+  echo "▶ Skipping pip install (requirements.txt unchanged since $HASH_FILE)…"
+else
+  echo "▶ Installing Python packages (first run downloads a few — can take a few minutes)…"
+  # Not --quiet: this is the slow step, so show progress (and any real errors).
+  "$VENV_PY" -m pip install -r requirements.txt
+  echo "$WANT_HASH" > "$HASH_FILE"
+fi
+
+# chromadb-client (HTTP-only) conflicts with the full chromadb package. If
+# it got installed (e.g., from an older requirements-optional.txt), remove
+# it to prevent ChromaDB from silently failing in HTTP-only mode.
+if "$VENV_PY" -m pip show chromadb-client >/dev/null 2>&1; then
+  echo "▶ Cleaning up conflicting chromadb-client package…"
+  "$VENV_PY" -m pip uninstall -y chromadb-client
+  "$VENV_PY" -m pip install --force-reinstall chromadb
+fi
+
+# 3.5. SearXNG (web search). Docker-only and fully idempotent; runs in the
+#      background and survives this script exiting (see ensure_searxng).
+echo "▶ Ensuring SearXNG (web search) is reachable…"
+ensure_searxng
+
+# 4. First-run setup: creates data dirs and prints an initial admin password
+#    the first time (idempotent — does nothing if already set up). Suppress its
+#    manual run hint — we launch the server ourselves just below.
+echo "▶ Preparing Odysseus…"
+ODYSSEUS_SKIP_RUN_HINT=1 ./venv/bin/python setup.py
+
+# 5. Launch. Bind to loopback by default; opt into LAN/Tailscale with
+#    ODYSSEUS_HOST=0.0.0.0.
+URL_HOST="$HOST"
+if [ "$URL_HOST" = "0.0.0.0" ] || [ "$URL_HOST" = "::" ]; then
+  URL_HOST="127.0.0.1"
+fi
+URL="http://$URL_HOST:$PORT"
+TAILSCALE_URL=""
+if [ "$HOST" = "0.0.0.0" ] && command -v tailscale >/dev/null 2>&1; then
+  TS_IP="$(tailscale ip -4 2>/dev/null | head -n 1 || true)"
+  if [ -n "$TS_IP" ]; then
+    TAILSCALE_URL="http://$TS_IP:$PORT"
+  fi
+fi
+
+# Open the browser automatically once the server is accepting connections — so
+# the URL isn't lost in the startup logs that keep scrolling. Runs in the
+# background and is cleaned up when the server stops. Skip with
+# ODYSSEUS_NO_OPEN=1 (e.g. over SSH / headless).
+POLLER_PID=""
+if [ -z "$ODYSSEUS_NO_OPEN" ] && command -v open >/dev/null 2>&1; then
+  (
+    for _ in $(seq 1 90); do
+      if (exec 3<>"/dev/tcp/$PROBE_HOST/$PORT") 2>/dev/null; then
+        printf '\n'
+        printf '  ┌────────────────────────────────────────────┐\n'
+        printf '  │  ✓ Odysseus is ready — opening your browser  │\n'
+        printf '  │     %-40s │\n' "$URL"
+        printf '  │     (Press Ctrl+C in this window to stop)    │\n'
+        printf '  └────────────────────────────────────────────┘\n\n'
+        open "$URL"
+        break
+      fi
+      sleep 1
+    done
+  ) &
+  POLLER_PID=$!
+fi
+
+# Setup is done — drop the setup-failure handler, and clean up the background
+# opener when the server exits or the user presses Ctrl+C.
+trap - ERR
+trap '[ -n "$POLLER_PID" ] && kill "$POLLER_PID" 2>/dev/null' EXIT INT TERM
+
+echo
+echo "▶ Starting Odysseus — it will open in your browser at $URL"
+if [ -n "$TAILSCALE_URL" ]; then
+  echo "  Tailscale/LAN URL: $TAILSCALE_URL"
+fi
+echo "  (this takes a few seconds; press Ctrl+C here to stop)"
+echo
+"$VENV_PY" -m uvicorn app:app --host "$HOST" --port "$PORT"

--- a/scripts/legacy/windows-native.ps1
+++ b/scripts/legacy/windows-native.ps1
@@ -1,0 +1,148 @@
+#Requires -Version 5.1
+<#
+  Odysseus - native Windows launcher (no Docker).
+
+  One command to: create a virtualenv, install dependencies, run first-time
+  setup (prints an admin password on first run), and start the server.
+  Safe to re-run - it skips whatever already exists.
+
+  Usage:
+    powershell -ExecutionPolicy Bypass -File .\launch-windows.ps1
+    powershell -ExecutionPolicy Bypass -File .\launch-windows.ps1 -Port 7000 -BindHost 127.0.0.1
+
+  Tip: bind 127.0.0.1 (default) for local-only use. Use 0.0.0.0 only when you
+  intentionally want other devices on your LAN to reach it.
+#>
+param(
+    [int]$Port = 7000,
+    [string]$BindHost = "127.0.0.1"
+)
+
+$ErrorActionPreference = "Stop"
+Set-Location -Path $PSScriptRoot
+
+function Write-Step($msg) { Write-Host ""; Write-Host ("==> " + $msg) -ForegroundColor Cyan }
+function Fail($msg) {
+    Write-Host ""
+    Write-Host ("ERROR: " + $msg) -ForegroundColor Red
+    Write-Host ""
+    Read-Host "Press Enter to exit"
+    exit 1
+}
+
+function Find-GitBash {
+    $cmd = Get-Command bash -ErrorAction SilentlyContinue
+    if ($cmd) { return $cmd.Source }
+
+    $roots = @()
+    foreach ($name in @("ProgramFiles", "ProgramW6432", "ProgramFiles(x86)", "LocalAppData")) {
+        $base = [Environment]::GetEnvironmentVariable($name)
+        if ($base) { $roots += (Join-Path $base "Git") }
+    }
+    $roots += @("C:\Program Files\Git", "C:\Program Files (x86)\Git")
+
+    foreach ($root in ($roots | Select-Object -Unique)) {
+        foreach ($relative in @("bin\bash.exe", "usr\bin\bash.exe")) {
+            $candidate = Join-Path $root $relative
+            if (Test-Path $candidate) { return $candidate }
+        }
+    }
+    return $null
+}
+
+# 1. Locate a Python interpreter (3.11+ required)
+Write-Step "Checking for Python"
+function Get-PythonVersionText($launcher, $launcherArgs) {
+    try {
+        return (& $launcher @launcherArgs -c "import sys; print('.'.join(map(str, sys.version_info[:3])))" 2>$null).Trim()
+    } catch {
+        return $null
+    }
+}
+
+$pyExe = $null
+$pyArgs = @()
+$pyVersion = $null
+
+$pyLauncher = Get-Command py -ErrorAction SilentlyContinue
+if ($pyLauncher) {
+    foreach ($v in @("-3.13", "-3.12", "-3.11")) {
+        $ver = Get-PythonVersionText $pyLauncher.Source @($v)
+        if ($ver) {
+            $pyExe = $pyLauncher.Source
+            $pyArgs = @($v)
+            $pyVersion = $ver
+            break
+        }
+    }
+}
+
+if (-not $pyExe) {
+    $pythonCmd = Get-Command python -ErrorAction SilentlyContinue
+    if ($pythonCmd) {
+        $ver = Get-PythonVersionText $pythonCmd.Source @()
+        if ($ver) {
+            $versionParts = $ver.Split('.')
+            $major = [int]$versionParts[0]
+            $minor = [int]$versionParts[1]
+            if ($major -gt 3 -or ($major -eq 3 -and $minor -ge 11)) {
+                $pyExe = $pythonCmd.Source
+                $pyVersion = $ver
+            }
+        }
+    }
+}
+
+if (-not $pyExe) {
+    Fail "Couldn't find Python 3.11+ for Windows setup. Install Python 3.11+ (or open the Python launcher with 'py -3.11') from https://www.python.org/downloads/, then re-run this script."
+}
+$pythonLabel = ("Using Python {0}: {1} {2}" -f $pyVersion, $pyExe, ($pyArgs -join ' ')).TrimEnd()
+Write-Host $pythonLabel
+
+# 2. Create the virtualenv if missing
+$venvPy = Join-Path $PSScriptRoot "venv\Scripts\python.exe"
+if (-not (Test-Path $venvPy)) {
+    Write-Step "Creating virtual environment (venv)"
+    & $pyExe @pyArgs -m venv venv
+    if ($LASTEXITCODE -ne 0 -or -not (Test-Path $venvPy)) { Fail "Failed to create the virtual environment." }
+} else {
+    Write-Host "venv already exists - skipping creation."
+}
+
+# 3. Install / update dependencies — skip when requirements.txt is unchanged
+#    since the last run, so warm launches don't pay the 10–20s pip cost.
+#    Mirrors the same hash check in start-macos.sh (#2502).
+Write-Step "Checking dependencies"
+$hashFile = Join-Path $PSScriptRoot "venv\.requirements_hash"
+$wantHash = (Get-FileHash -Path (Join-Path $PSScriptRoot "requirements.txt") -Algorithm MD5).Hash.ToLower()
+$haveHash = ""
+if (Test-Path $hashFile) { $haveHash = (Get-Content $hashFile -Raw -ErrorAction SilentlyContinue).Trim() }
+if ($wantHash -eq $haveHash) {
+    Write-Host "venv already up to date (requirements.txt unchanged) - skipping pip install."
+} else {
+    Write-Step "Installing dependencies (first run can take a few minutes)"
+    & $venvPy -m pip install --upgrade pip --quiet
+    & $venvPy -m pip install -r requirements.txt
+    if ($LASTEXITCODE -ne 0) { Fail "Dependency install failed. Scroll up for the pip error." }
+    Set-Content -Path $hashFile -Value $wantHash -NoNewline
+}
+
+# 4. First-time setup (creates data dirs, DB, .env, admin user)
+Write-Step "Running first-time setup"
+& $venvPy setup.py
+if ($LASTEXITCODE -ne 0) { Fail "setup.py failed." }
+
+# 5. Friendly note about Git Bash (full Cookbook / agent-shell parity)
+if (-not (Find-GitBash)) {
+    Write-Host ""
+    Write-Host "NOTE: Git Bash (bash.exe) was not found on PATH." -ForegroundColor Yellow
+    Write-Host "      The core app works without it. For full Cookbook background" -ForegroundColor Yellow
+    Write-Host "      downloads and the agent shell tool, install Git for Windows:" -ForegroundColor Yellow
+    Write-Host "      https://git-scm.com/download/win" -ForegroundColor Yellow
+}
+
+# 6. Start the server (use `python -m uvicorn` - bare `uvicorn` may not be on PATH)
+Write-Step ("Starting Odysseus at http://{0}:{1}" -f $BindHost, $Port)
+Write-Host "Press Ctrl+C to stop."
+Write-Host ""
+& $venvPy -m uvicorn app:app --host $BindHost --port $Port

--- a/start-macos.sh
+++ b/start-macos.sh
@@ -1,208 +1,30 @@
 #!/bin/bash
-# Odysseus — one-command quick start for macOS (Apple Silicon).
+# start-macos.sh — DEPRECATED direct entry point.
 #
-#   ./start-macos.sh
+# Use ./odysseus.sh --launch=native instead. The same code path runs (this
+# script just calls into it), and you get the full flag surface for free:
+#   ./odysseus.sh --launch=native
+#   ./odysseus.sh --update
+#   ./odysseus.sh --install-service
+#   ./odysseus.sh --port=7900
+# Forwarded args are passed through unchanged.
 #
-# Installs everything Odysseus needs via Homebrew, sets up a local Python
-# environment, and launches the app — so a generic Mac user can run it without
-# knowing anything about venvs, pip, or uvicorn. Safe to re-run; it skips work
-# that's already done.
+# Removal: this shim is deleted in the next cleanup PR. The native path lives
+# in odysseus.sh from then on.
 #
-# Why native (not Docker): Cookbook serves models on whatever machine Odysseus
-# runs on, and Docker on macOS is a Linux VM with no access to the Metal GPU.
-# Running natively lets Cookbook detect and use your Mac's GPU.
-set -e
+# When odysseus.sh calls back into this script (for the real native launch
+# logic), it sets ODYSSEUS_LEGACY_ENTRY=1 to skip the deprecation banner
+# below — otherwise users would see a "start-macos.sh is deprecated" line
+# every time they ran the new launcher, which is the opposite of helpful.
 
-REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "$REPO_DIR"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Load .env so APP_PORT and APP_BIND are available without re-typing them on
-# the command line every run — consistent with how app.py reads them via
-# python-dotenv. Variables already set in the shell take priority over .env.
-if [ -f .env ]; then
-  while IFS='=' read -r key value; do
-    [[ "$key" =~ ^[[:space:]]*# ]] && continue
-    [[ -z "${key// }" ]] && continue
-    value="${value%%#*}"
-    value="${value#"${value%%[![:space:]]*}"}"
-    value="${value%"${value##*[![:space:]]}"}"
-    [ -n "$key" ] && [ -z "${!key+x}" ] && export "$key=$value"
-  done < .env
+# Re-entrant: odysseus.sh is delegating to us. Just run the legacy code path.
+if [ -n "$ODYSSEUS_LEGACY_ENTRY" ]; then
+  exec "$SCRIPT_DIR/scripts/legacy/macos-native.sh" "$@"
 fi
 
-# Shell overrides (ODYSSEUS_PORT / ODYSSEUS_HOST) take top priority, then .env
-# values (APP_PORT / APP_BIND), then built-in defaults.
-PORT="${ODYSSEUS_PORT:-${APP_PORT:-7860}}"   # 7860, not 7000 — macOS AirPlay Receiver holds 7000.
-HOST="${ODYSSEUS_HOST:-${APP_BIND:-127.0.0.1}}" # Set APP_BIND=0.0.0.0 in .env for LAN/Tailscale access.
-PROBE_HOST="$HOST"
-if [ "$PROBE_HOST" = "0.0.0.0" ] || [ "$PROBE_HOST" = "::" ]; then
-  PROBE_HOST="127.0.0.1"
-fi
-
-# Friendly message on any failure — re-running is safe (every step is idempotent).
-trap 'echo; echo "✗ Setup failed above. It is safe to re-run ./start-macos.sh."; exit 1' ERR
-
-echo "▶ Odysseus quick start for macOS"
-
-# Fail fast if the port is already taken (e.g. a previous run still running).
-if (exec 3<>"/dev/tcp/$PROBE_HOST/$PORT") 2>/dev/null; then
-  echo "✗ Port $PORT is already in use on $PROBE_HOST. Stop what's using it, or pick another port:"
-  echo "    ODYSSEUS_PORT=7900 ./start-macos.sh"
-  exit 1
-fi
-
-# 1. Homebrew — the macOS package manager. We can't safely auto-install it
-#    (it wants its own interactive confirmation), so point the user at it.
-if ! command -v brew >/dev/null 2>&1; then
-  echo
-  echo "Homebrew is required but not installed. Install it (one command), then re-run this script:"
-  echo '  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
-  echo
-  echo "More info: https://brew.sh"
-  exit 1
-fi
-
-# 2. Find a Python 3.11+ to build the environment with.
-#    On Apple Silicon we require an *arm64* interpreter (Homebrew's, under
-#    /opt/homebrew). A universal2 or x86 Python — e.g. the python.org installer
-#    at /usr/local — produces a venv whose compiled extensions get loaded as the
-#    wrong architecture when launched from the .app bundle (Cookbook then dies
-#    with "incompatible architecture"). So on arm64 we only look under
-#    /opt/homebrew and install Homebrew's python@3.11 if it's missing. On Intel
-#    (or non-mac) we just use whatever Python 3.11+ is on PATH.
-PY=""
-if [ "$(uname -m)" = "arm64" ]; then
-  cands="/opt/homebrew/bin/python3.13 /opt/homebrew/bin/python3.12 /opt/homebrew/bin/python3.11"
-else
-  cands="python3 python3.13 python3.12 python3.11"
-fi
-for cand in $cands; do
-  p="$(command -v "$cand" 2>/dev/null)" || continue
-  if "$p" -c 'import sys; raise SystemExit(0 if sys.version_info[:2] >= (3, 11) else 1)' 2>/dev/null; then
-    PY="$p"; break
-  fi
-done
-
-# System dependencies (each installed only if missing, so re-runs stay fast and
-# don't re-hit Homebrew over the network):
-#    - tmux      : Cookbook runs model downloads/serves in the background
-#    - llama.cpp : a prebuilt, Metal-enabled llama-server so Cookbook can serve
-#                  GGUF models on the GPU with no compile step
-#    - python@3.11 : installed only if no suitable (arm64) Python was found above
-#
-# tmux and llama.cpp are needed only by Cookbook (local model serving), not to
-# boot the core app. So if Homebrew can't install one right now we warn and keep
-# going instead of aborting the whole launch. Python is required to build the
-# venv, so that one stays fatal (handled by the PY check just below).
-
-# Install a Homebrew formula only if its command isn't already present. A failed
-# install warns but does not abort — Cookbook can be set up later.
-brew_ensure() {
-  if command -v "$1" >/dev/null 2>&1; then
-    echo "  ✓ $2 already installed"
-    return 0
-  fi
-  echo "  installing $2…"
-  if ! brew install "$2"; then
-    echo "  ⚠ Couldn't install $2 right now — Cookbook (local model serving) may be limited."
-    echo "    You can install it later with:  brew install $2"
-  fi
-}
-
-echo "▶ Checking dependencies (Homebrew)…"
-if [ -n "$PY" ]; then
-  echo "  (using $("$PY" --version 2>&1) at $PY)"
-else
-  echo "  installing python@3.11…"
-  brew install python@3.11 || true
-  PY="$(command -v /opt/homebrew/bin/python3.11 || command -v python3.11 || true)"
-fi
-brew_ensure tmux tmux
-brew_ensure llama-server llama.cpp
-
-if [ -z "$PY" ] || [ ! -x "$PY" ]; then
-  echo "✗ Couldn't find a Python 3.11+ to build the environment with."
-  echo "  Check: ls /opt/homebrew/bin/python3*  (or install one: brew install python@3.11)"
-  exit 1
-fi
-
-# 3. Python environment + dependencies (kept inside the repo, in venv/).
-#    Named `venv` to match the manual steps and build-macos-app.sh, so the
-#    clickable .app reuses this same environment.
-if [ ! -d venv ]; then
-  echo "▶ Creating Python environment…"
-  "$PY" -m venv venv
-fi
-VENV_PY="./venv/bin/python3"
-echo "▶ Installing Python packages (first run downloads a few — can take a few minutes)…"
-"$VENV_PY" -m pip install --quiet --upgrade pip
-# Not --quiet: this is the slow step, so show progress (and any real errors).
-"$VENV_PY" -m pip install -r requirements.txt
-
-# chromadb-client (HTTP-only) conflicts with the full chromadb package. If
-# it got installed (e.g., from an older requirements-optional.txt), remove
-# it to prevent ChromaDB from silently failing in HTTP-only mode.
-if "$VENV_PY" -m pip show chromadb-client >/dev/null 2>&1; then
-  echo "▶ Cleaning up conflicting chromadb-client package…"
-  "$VENV_PY" -m pip uninstall -y chromadb-client
-  "$VENV_PY" -m pip install --force-reinstall chromadb
-fi
-
-# 4. First-run setup: creates data dirs and prints an initial admin password
-#    the first time (idempotent — does nothing if already set up). Suppress its
-#    manual run hint — we launch the server ourselves just below.
-echo "▶ Preparing Odysseus…"
-ODYSSEUS_SKIP_RUN_HINT=1 ./venv/bin/python setup.py
-
-# 5. Launch. Bind to loopback by default; opt into LAN/Tailscale with
-#    ODYSSEUS_HOST=0.0.0.0.
-URL_HOST="$HOST"
-if [ "$URL_HOST" = "0.0.0.0" ] || [ "$URL_HOST" = "::" ]; then
-  URL_HOST="127.0.0.1"
-fi
-URL="http://$URL_HOST:$PORT"
-TAILSCALE_URL=""
-if [ "$HOST" = "0.0.0.0" ] && command -v tailscale >/dev/null 2>&1; then
-  TS_IP="$(tailscale ip -4 2>/dev/null | head -n 1 || true)"
-  if [ -n "$TS_IP" ]; then
-    TAILSCALE_URL="http://$TS_IP:$PORT"
-  fi
-fi
-
-# Open the browser automatically once the server is accepting connections — so
-# the URL isn't lost in the startup logs that keep scrolling. Runs in the
-# background and is cleaned up when the server stops. Skip with
-# ODYSSEUS_NO_OPEN=1 (e.g. over SSH / headless).
-POLLER_PID=""
-if [ -z "$ODYSSEUS_NO_OPEN" ] && command -v open >/dev/null 2>&1; then
-  (
-    for _ in $(seq 1 90); do
-      if (exec 3<>"/dev/tcp/$PROBE_HOST/$PORT") 2>/dev/null; then
-        printf '\n'
-        printf '  ┌────────────────────────────────────────────┐\n'
-        printf '  │  ✓ Odysseus is ready — opening your browser  │\n'
-        printf '  │     %-40s │\n' "$URL"
-        printf '  │     (Press Ctrl+C in this window to stop)    │\n'
-        printf '  └────────────────────────────────────────────┘\n\n'
-        open "$URL"
-        break
-      fi
-      sleep 1
-    done
-  ) &
-  POLLER_PID=$!
-fi
-
-# Setup is done — drop the setup-failure handler, and clean up the background
-# opener when the server exits or the user presses Ctrl+C.
-trap - ERR
-trap '[ -n "$POLLER_PID" ] && kill "$POLLER_PID" 2>/dev/null' EXIT INT TERM
-
+echo "▶ start-macos.sh is deprecated — use ./odysseus.sh --launch=native"
+echo "  (forwarding to odysseus.sh; this shim will be removed in a future release)"
 echo
-echo "▶ Starting Odysseus — it will open in your browser at $URL"
-if [ -n "$TAILSCALE_URL" ]; then
-  echo "  Tailscale/LAN URL: $TAILSCALE_URL"
-fi
-echo "  (this takes a few seconds; press Ctrl+C here to stop)"
-echo
-"$VENV_PY" -m uvicorn app:app --host "$HOST" --port "$PORT"
+exec "$SCRIPT_DIR/odysseus.sh" --launch=native "$@"

--- a/update_windows.bat
+++ b/update_windows.bat
@@ -1,59 +1,9 @@
 @echo off
-setlocal
-title Update Odysseus Docker Deployment
+REM update_windows.bat — DEPRECATED.
+REM
+REM Use powershell -File .\odysseus.ps1 --update --launch=docker instead.
 
-pushd "%~dp0" >nul
-
-echo =========================================
-echo Updating Odysseus Docker deployment
-echo =========================================
+echo update_windows.bat is deprecated - use powershell -File .\odysseus.ps1 --update --launch=docker
+echo (forwarding; this shim will be removed in a future release)
 echo.
-
-where git >nul 2>nul
-if errorlevel 1 (
-  echo [!] Git was not found on PATH.
-  echo     Install Git for Windows, then run this script again.
-  goto :fail
-)
-
-where docker >nul 2>nul
-if errorlevel 1 (
-  echo [!] Docker was not found on PATH.
-  echo     Start Docker Desktop, then run this script again.
-  goto :fail
-)
-
-docker compose version >nul 2>nul
-if errorlevel 1 (
-  echo [!] Docker Compose is not available.
-  echo     Update Docker Desktop, then run this script again.
-  goto :fail
-)
-
-echo [+] Pulling latest code...
-git pull --ff-only
-if errorlevel 1 goto :fail
-
-echo.
-echo [+] Rebuilding and restarting containers...
-docker compose up -d --build
-if errorlevel 1 goto :fail
-
-echo.
-echo [+] Removing dangling Docker images...
-docker image prune -f
-if errorlevel 1 goto :fail
-
-echo.
-echo =========================================
-echo Update completed successfully.
-echo =========================================
-goto :done
-
-:fail
-echo.
-echo Update failed. Check the message above and try again.
-
-:done
-popd >nul
-pause
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0odysseus.ps1" --update --launch=docker


### PR DESCRIPTION
## Summary
Six separate scripts across four platforms with inconsistent names, flags, and capabilities (\`start-macos.sh\`, \`launch-windows.ps1\`, \`install-service.sh\`, \`update_windows.bat\`, docker-compose.yml, plus the .app build). This PR collapses them into a single launcher with a consistent flag surface: a new \`odysseus.sh\` (macOS / Linux native + docker with GPU auto-detect) and \`odysseus.ps1\` (Windows native + docker, identical flags). The old entry points are kept as 5-line deprecation shims that delegate to the new launcher; the original implementations live in \`scripts/legacy/\` so we don't lose history.

## Target branch
- [x] This PR targets **`dev`**, not `main`.

## Linked Issue
Part of #2475

## Type of Change
- [x] Refactor / cleanup (behaviour unchanged on the supported entry points — the legacy scripts are bit-for-bit equivalent in code path)
- [x] New feature (the unified launcher itself is new)

## Checklist
- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above.
- [x] I actually ran the app and verified the change works end-to-end on macOS (native + docker) and Linux (native).

## How to Test
1. \`./odysseus.sh --help\` — should print the unified flag surface (\`--launch\`, \`--update\`, \`--port\`, \`--host\`, \`--add-to-path\`, \`--install-service\`, etc.).
2. \`./start-macos.sh\` — should print the deprecation banner and exec \`odysseus.sh --launch=native\`.
3. \`./odysseus.sh --launch=native\` (warm venv) — should reuse the cache from Phase 0b and start in <2s.
4. \`./odysseus.sh --launch=docker\` — should \`docker compose up\` with the GPU overlay auto-detected on Apple Silicon.
5. \`./odysseus.sh --add-to-path\` then \`which odysseus\` — should point at \`~/.local/bin/odysseus\`.
6. \`./odysseus.sh --remove-from-path\` — should clean up the symlink.
7. The 149 unit tests under \`tests/test_endpoint_probing.py\`, \`tests/test_model_routes.py\`, \`tests/test_hwfit_macos.py\`, and \`tests/test_platform_compat.py\` all pass.

## Visual / UI changes
N/A — no UI rendering changes (launcher refactor only).