### PR TITLE
feat(macos): per-user LaunchAgent for auto-start at login (#2475)

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,10 +252,28 @@ docker compose logs --tail=120 odysseus
 docker compose logs odysseus | grep -E 'ChromaDB|MemoryVectorStore|DEGRADED'
 ```
 
-**macOS details.** `start-macos.sh` installs Homebrew deps, creates the venv,
-runs setup, and starts uvicorn on port `7860` because AirPlay often holds
-`7000`. It uses llama.cpp/Ollama for Metal. vLLM/SGLang are CUDA/ROCm-only and
-do not run on macOS. MLX-only models are not served by Odysseus.
+**macOS details.** `odysseus.sh --launch=native` (or the legacy
+`start-macos.sh` shim) installs Homebrew deps, creates the venv, runs
+setup, and starts uvicorn on port `7860` because AirPlay often holds
+`7000`. It uses llama.cpp/Ollama for Metal. vLLM/SGLang are CUDA/ROCm-only
+and do not run on macOS. MLX-only models are not served by Odysseus.
+
+> **Repo location matters.** `launchd` cannot execute scripts under
+> `~/Desktop`, `~/Documents`, or `~/Downloads` (macOS TCC). Keep the
+> repo at `~/odysseus` (or anywhere outside those folders) and the
+> `--install-service` check will pass. The script fails fast with a
+> one-liner fix if you forget.
+
+To run Odysseus in the background and have it auto-start at login:
+
+```sh
+./odysseus.sh --install-service   # installs ~/Library/LaunchAgents/com.odysseus.ui.plist
+./odysseus.sh --uninstall-service # tears it down
+./odysseus.sh --update            # pulls + restarts the agent cleanly
+```
+
+See `docs/launcher.md` for the full flag reference, and `docs/macos.md`
+for the full macOS story (TCC, port 7860, Apple Silicon, GPU, file layout).
 
 </details>
 

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -1,0 +1,150 @@
+# Odysseus on macOS
+
+This doc covers everything macOS-specific. For the launcher flags
+themselves, see [`docs/launcher.md`](launcher.md).
+
+## One-shot install
+
+```sh
+git clone https://github.com/pewdiepie-archdaemon/odysseus.git
+cd odysseus
+./odysseus.sh --launch=native
+```
+
+That command:
+
+1. Installs Homebrew if it's missing.
+2. Installs Python 3.11, Docker Desktop, and git via Homebrew if any of
+   them are missing.
+3. Creates `venv/` with `python3.11` and installs the pinned deps.
+4. If Docker is available, starts a persistent `searxng/searxng` container
+   on `127.0.0.1:8080` (honors `SEARXNG_INSTANCE` and `ODYSSEUS_NO_SEARXNG=1`).
+5. Runs `python setup.py` to provision the local data directory.
+6. Starts uvicorn on `127.0.0.1:7860` and opens the browser.
+
+Re-running is fast: the requirements-hash cache skips `pip install` when
+`requirements.txt` is unchanged.
+
+## Auto-start at login
+
+```sh
+./odysseus.sh --install-service
+```
+
+> **The repo must NOT be under `~/Desktop`, `~/Documents`, or
+> `~/Downloads`.** macOS's TCC framework blocks launchd from
+> executing scripts that live in those folders. The install script
+> detects this and prints a one-liner fix. The convention is
+> `~/odysseus`.
+
+This drops a per-user LaunchAgent at:
+
+```
+~/Library/LaunchAgents/com.odysseus.ui.plist
+```
+
+and bootstraps it into the `gui/$(id -u)` launchd domain. The agent:
+
+- starts on login (`RunAtLoad = true`)
+- respawns on crash (`KeepAlive.Crashed = true`, `SuccessfulExit = false`)
+- throttles to one restart per 10 s so a crash loop doesn't hammer the box
+- logs to `~/Library/Logs/Odysseus/{stdout,stderr}.log`
+- runs `odysseus.sh --launch=native --no-open` (so the server starts but
+  the browser doesn't pop every time you log in)
+- inherits an explicit `PATH` (`/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin`)
+  because launchd's default `PATH` doesn't include Homebrew
+- runs in the user's GUI session (`ProcessType = Interactive`) so any
+  Keychain access works the same as a Terminal launch
+
+### Update flow
+
+```sh
+./odysseus.sh --update
+```
+
+On macOS, the launcher:
+
+1. Detects whether the agent is loaded.
+2. If so, `launchctl bootout`s it (cleanly stops the uvicorn child).
+3. `git pull --rebase --autostash`.
+4. Re-bootstraps the agent and `kickstart -k`s it to start fresh.
+
+The native launcher (running inside the agent) also re-checks the
+requirements-hash on every launch, so a no-op update doesn't trigger
+a reinstall.
+
+### Inspection
+
+```sh
+launchctl print gui/$(id -u)/com.odysseus.ui
+tail -f ~/Library/Logs/Odysseus/stdout.log
+launchctl list | grep odysseus
+```
+
+### Removal
+
+```sh
+./odysseus.sh --uninstall-service
+```
+
+Bootouts the agent, removes the plist, and leaves `~/Library/Logs/Odysseus/`
+in place for grepping. Reinstall is one command away.
+
+## Port 7000 vs 7860
+
+macOS Monterey+ runs AirPlay Receiver on port 7000. Odysseus detects
+this and flips the default to 7860. To force a different port:
+
+```sh
+./odysseus.sh --port=7900
+# or persistently in .env:
+echo "APP_PORT=7900" >> .env
+```
+
+## Apple Silicon vs Intel
+
+The launcher auto-detects Apple Silicon via `uname -m` and points
+to `/opt/homebrew` (Apple Silicon's Homebrew prefix) rather than
+`/usr/local` (Intel's). It also enables Metal in llama.cpp/Ollama
+where the relevant env var exists.
+
+## GPU acceleration
+
+The native path uses llama.cpp or Ollama with Metal on Apple Silicon.
+The Docker path does not — Docker on macOS runs in a Linux VM with no
+GPU passthrough. If you see a "CPU only" warning from
+`odysseus --launch=docker`, that's expected; use `--launch=native` for
+GPU.
+
+## File layout when run as a service
+
+| File | Purpose |
+|---|---|
+| `~/Library/LaunchAgents/com.odysseus.ui.plist` | LaunchAgent definition |
+| `~/Library/Logs/Odysseus/stdout.log` | stdout of the launcher |
+| `~/Library/Logs/Odysseus/stderr.log` | stderr of the launcher (uvicorn logs go here) |
+
+Nothing under the repo is moved by the service install — `data/`,
+`venv/`, and the SearXNG settings live in their original locations so
+the CLI and service paths share state. (The `.app` distribution in
+Phase 3 will move `data/` to `~/Library/Application Support/Odysseus/`
+only when launched from the .app bundle, not from the CLI.)
+
+## Why the repo must live outside `~/Desktop`
+
+macOS's Transparency, Consent, and Control (TCC) framework restricts
+what `launchd` can access when it runs a LaunchAgent. A Terminal
+session inherits your user's TCC consents (Desktop, Documents,
+Downloads); `launchd` does not. So a repo cloned into `~/Desktop/`
+will install the plist fine, but every time the agent tries to spawn
+it will fail with:
+
+```
+bash: /Users/you/Desktop/odysseus/odysseus.sh: Operation not permitted
+shell-init: error retrieving current directory: getcwd: cannot access
+parent directories: Operation not permitted
+```
+
+The fix is to keep the repo outside TCC scope. `~/odysseus` is the
+convention. The install script detects this and refuses to install
+with a one-liner fix; you don't have to remember.

--- a/install-macos-service.sh
+++ b/install-macos-service.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# install-macos-service.sh — install Odysseus as a per-user LaunchAgent
+# so it auto-starts at login and survives crashes.
+#
+#   ~/Library/LaunchAgents/com.odysseus.ui.plist
+#   /Users/USER/Library/Logs/Odysseus/{stdout,stderr}.log
+#
+# Run via:
+#   ./odysseus.sh --install-service
+# or directly:
+#   ./install-macos-service.sh
+#
+# Idempotent: re-running with the same path updates the plist in place
+# and reloads the agent.
+
+set -e
+
+# ── Resolve paths ──────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Honor ODYSSEUS_REPO_DIR if set — useful when the user has symlinked
+# install-macos-service.sh into a different location (e.g. a non-TCC
+# wrapper script).
+REPO_DIR="${ODYSSEUS_REPO_DIR:-$SCRIPT_DIR}"
+
+LABEL="com.odysseus.ui"
+PLIST_PATH="$HOME/Library/LaunchAgents/${LABEL}.plist"
+LOG_DIR="$HOME/Library/Logs/Odysseus"
+STDOUT_LOG="$LOG_DIR/stdout.log"
+STDERR_LOG="$LOG_DIR/stderr.log"
+
+# Make sure we never trash an existing plist from a different repo path.
+EXISTING_PROG=""
+EXISTING_CWD=""
+if [ -f "$PLIST_PATH" ]; then
+  EXISTING_PROG=$(/usr/libexec/PlistBuddy -c "Print :ProgramArguments:0" "$PLIST_PATH" 2>/dev/null || true)
+  EXISTING_CWD=$(/usr/libexec/PlistBuddy -c "Print :WorkingDirectory" "$PLIST_PATH" 2>/dev/null || true)
+fi
+
+# Sanity: the path the launcher is going to call must exist, and Python 3.11+
+# must be reachable inside that environment. We don't try to *create* the
+# venv here — that's the launcher's job. We just fail loud if the venv is
+# missing so the user knows to run `odysseus --launch=native` first.
+if [ ! -x "$REPO_DIR/odysseus.sh" ]; then
+  echo "✗ odysseus.sh not found at $REPO_DIR/odysseus.sh" >&2
+  exit 1
+fi
+
+# ── TCC path check ────────────────────────────────────────────────────────
+# macOS's Transparency, Consent, and Control (TCC) framework restricts
+# what launchd can access when it runs a LaunchAgent. Files under
+# ~/Desktop/, ~/Documents/, and ~/Downloads/ are in TCC's "user data"
+# set, and launchd will get "Operation not permitted" when it tries to
+# exec a shell script living there. (A Terminal session has TCC consent
+# for these folders; the launchd process does not.) This means a repo
+# cloned into Desktop/ or Documents/ will install the plist fine but
+# the agent will refuse to spawn.
+#
+# The right answer is to keep the repo outside those folders — `~/odysseus`
+# is the convention. Detect and fail with a one-liner fix.
+case "$REPO_DIR" in
+  "$HOME"/Desktop/*|"$HOME"/Documents/*|"$HOME"/Downloads/*)
+    echo "✗ Repo path is under a TCC-protected folder: $REPO_DIR" >&2
+    echo "" >&2
+    echo "  launchd cannot execute scripts under ~/Desktop, ~/Documents," >&2
+    echo "  or ~/Downloads (macOS file-vault consent). The agent will" >&2
+    echo "  install but refuse to start." >&2
+    echo "" >&2
+    echo "  Move the repo out of the protected folder and re-run:" >&2
+    echo "" >&2
+    echo "    mv \"$REPO_DIR\" \"$HOME/odysseus\"" >&2
+    echo "    cd ~/odysseus" >&2
+    echo "    ./odysseus.sh --install-service" >&2
+    echo "" >&2
+    echo "  Or set ODYSSEUS_REPO_DIR= to a non-protected path." >&2
+    exit 1
+    ;;
+esac
+
+# ── Detect brew prefix for the embedded PATH ──────────────────────────────
+# launchd's default PATH is /usr/bin:/bin — no /opt/homebrew/bin, no
+# /usr/local/bin. The native launcher needs brew's python3.11 and the
+# `open` command lives in /usr/bin so that's fine, but `git` (used by
+# --update) and a few other tools need to be on PATH inside the agent.
+BREW_PREFIX=""
+if [ -x /opt/homebrew/bin/brew ]; then
+  BREW_PREFIX="/opt/homebrew"
+elif [ -x /usr/local/bin/brew ]; then
+  BREW_PREFIX="/usr/local"
+fi
+LAUNCHD_PATH="$BREW_PREFIX/bin:/usr/local/bin:/usr/bin:/bin"
+
+# ── Generate the plist ────────────────────────────────────────────────────
+mkdir -p "$(dirname "$PLIST_PATH")"
+mkdir -p "$LOG_DIR"
+
+cat > "$PLIST_PATH" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${LABEL}</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>${REPO_DIR}/odysseus.sh</string>
+        <string>--launch=native</string>
+        <string>--no-open</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>${REPO_DIR}</string>
+
+    <!-- Run at user login (and on demand via launchctl start). -->
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- Respawn on crash, but not on a clean exit. SuccessfulExit=false
+         means: relaunch on anything other than exit code 0. Crashed=true
+         is a synonym for "exit code != 0" but we keep both for clarity. -->
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+        <key>Crashed</key>
+        <true/>
+    </dict>
+
+    <!-- Don't spin in a tight crash loop. -->
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <!-- Logs. We append rather than truncate so the user can post-mortem. -->
+    <key>StandardOutPath</key>
+    <string>${STDOUT_LOG}</string>
+    <key>StandardErrorPath</key>
+    <string>${STDERR_LOG}</string>
+
+    <!-- Interactive = share the user's GUI session, so anything that needs
+         the keychain (e.g. secrets fetched from Keychain) works. -->
+    <key>ProcessType</key>
+    <string>Interactive</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>${LAUNCHD_PATH}</string>
+        <key>ODYSSEUS_SERVICE_MODE</key>
+        <string>launchd</string>
+    </dict>
+</dict>
+</plist>
+PLIST
+
+# ── Validate the plist is well-formed ─────────────────────────────────────
+if ! plutil -lint "$PLIST_PATH" >/dev/null 2>&1; then
+  echo "✗ plist failed plutil -lint; not loading." >&2
+  plutil -lint "$PLIST_PATH" >&2 || true
+  exit 1
+fi
+
+# ── Load (or reload) the agent ────────────────────────────────────────────
+# launchctl bootstrap is the modern API (macOS 10.11+); it cleanly handles
+# "already loaded" by unloading first.
+DOMAIN="gui/$(id -u)"
+
+# Clear any "disabled" override from a previous install. The per-user
+# launchd override db (~/Library/Preferences/com.apple.launchd.<UID>.plist
+# — or the in-memory version of it) can hold a `Disabled = true` entry
+# left behind by a prior --uninstall-service, a `launchctl disable` call,
+# or a botched install. If that entry is set, bootstrap will succeed
+# but the agent will refuse to spawn, surfacing as a silent
+# "Bootstrap failed: 5: Input/output error" on the *next* install attempt.
+# Always clear it before bootstrapping.
+launchctl enable "$DOMAIN/$LABEL" 2>/dev/null || true
+launchctl enable "system/$LABEL" 2>/dev/null || true
+
+if launchctl print "$DOMAIN/$LABEL" >/dev/null 2>&1; then
+  echo "▶ unloading existing agent (different path or update)…"
+  launchctl bootout "$DOMAIN/$LABEL" 2>/dev/null || true
+fi
+
+# Also nuke any old-style "loaded into the system domain" copy of the
+# same label — defensive, in case someone installed it manually with
+# `launchctl load -w` before this script existed.
+launchctl bootout "system/$LABEL" 2>/dev/null || true
+
+echo "▶ loading $LABEL into $DOMAIN…"
+if ! launchctl bootstrap "$DOMAIN" "$PLIST_PATH" 2>&1; then
+  echo "✗ launchctl bootstrap failed." >&2
+  exit 1
+fi
+
+# Re-enable in case the bootstrap above flipped the bit (it shouldn't,
+# but be defensive). enable is idempotent.
+launchctl enable "$DOMAIN/$LABEL" 2>/dev/null || true
+
+# Kick it once now so the user can see it's working without re-logging in.
+launchctl kickstart -k "$DOMAIN/$LABEL" 2>/dev/null || true
+
+echo
+echo "✓ Odysseus auto-start installed."
+echo "  plist:  $PLIST_PATH"
+echo "  logs:   $LOG_DIR/"
+echo "  status: launchctl print $DOMAIN/$LABEL"
+echo
+if [ -n "$EXISTING_PROG" ] && [ "$EXISTING_PROG" != "${REPO_DIR}/odysseus.sh" ]; then
+  echo "  ⚠ replaced previous install at: $EXISTING_PROG"
+fi
+if [ -n "$EXISTING_CWD" ] && [ "$EXISTING_CWD" != "$REPO_DIR" ]; then
+  echo "  ⚠ replaced previous WorkingDirectory: $EXISTING_CWD"
+fi
+echo
+echo "  Stop:   launchctl bootout $DOMAIN/$LABEL"
+echo "  Start:  launchctl bootstrap $DOMAIN $PLIST_PATH"
+echo "  Logs:   tail -f $STDOUT_LOG $STDERR_LOG"
+echo "  Remove: ./odysseus.sh --uninstall-service"

--- a/odysseus.sh
+++ b/odysseus.sh
@@ -1,0 +1,336 @@
+#!/usr/bin/env bash
+# odysseus — one launcher for every platform-native install path.
+#
+#   ./odysseus.sh --launch=native
+#   ./odysseus.sh --launch=docker
+#   ./odysseus.sh --update
+#   ./odysseus.sh --port=7900 --host=0.0.0.0 --launch=native
+#   ./odysseus.sh --add-to-path
+#
+# On macOS this is the script you'll want. On Linux it works the same way.
+# On Windows, use odysseus.ps1 — the flag surface is identical.
+#
+# Old entry points (start-macos.sh, install-service.sh, update_windows.bat)
+# are now thin shims that call into this script.
+
+set -e
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$REPO_DIR"
+
+# ── Defaults ──────────────────────────────────────────────────────────────
+LAUNCH="native"          # native | docker | docker-nvidia | docker-amd
+UPDATE=0
+ADD_PATH=0
+REMOVE_PATH=0
+INSTALL_SERVICE=0
+UNINSTALL_SERVICE=0
+PORT="${ODYSSEUS_PORT:-${APP_PORT:-7000}}"
+HOST="${ODYSSEUS_HOST:-${APP_BIND:-127.0.0.1}}"
+DOCKER_NO_OPEN=0
+
+usage() {
+  cat <<EOF
+odysseus — one launcher for every platform-native install path.
+
+Usage: odysseus [flags]
+
+Launch mode (default: native):
+  --launch=native           Run the app directly on this machine (venv + uvicorn).
+                            The right choice on macOS — keeps GPU/Metal access.
+  --launch=docker           docker compose up (auto-detects GPU overlay).
+  --launch=docker-nvidia    Force the NVIDIA GPU overlay.
+  --launch=docker-amd       Force the AMD/ROCm GPU overlay (Linux only).
+
+Lifecycle:
+  --update                  git pull + reinstall Python deps (only if requirements.txt
+                            changed) + rebuild Docker images (when --launch=docker*).
+                            Safe to re-run.
+  --add-to-path             Symlink odysseus into ~/.local/bin and ensure that dir is
+                            on PATH in ~/.zshrc / ~/.bashrc, so 'odysseus' works
+                            from anywhere.
+  --remove-from-path        Reverse the above.
+
+Service (auto-start at login):
+  --install-service         Install the platform auto-start agent:
+                              • macOS:  ~/Library/LaunchAgents/com.odysseus.ui.plist
+                              • Linux:  /etc/systemd/system/odysseus-ui.service
+                            Runs in the background and survives reboots.
+  --uninstall-service       Remove the auto-start agent (leaves data/ + venv/ alone).
+
+Server:
+  --port=N                  Override the port (default: 7000; 7860 on macOS by
+                            default since AirPlay Receiver holds 7000).
+  --host=H                  Override the bind address (default: 127.0.0.1).
+                            Use 0.0.0.0 to expose on LAN/Tailscale.
+
+Docker:
+  --no-open                 Don't open the browser when the server is ready.
+
+Examples:
+  ./odysseus.sh                          # launch native, default port
+  ./odysseus.sh --port=7900              # launch native on 7900
+  ./odysseus.sh --launch=docker          # docker compose up (auto GPU)
+  ./odysseus.sh --update                 # pull + reinstall + rebuild
+  ./odysseus.sh --install-service        # auto-start at login
+  ./odysseus.sh --add-to-path            # 'odysseus' from anywhere
+EOF
+}
+
+# ── Arg parsing (long-form only — keeps the surface small) ────────────────
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --launch=*)        LAUNCH="${1#*=}" ;;
+    --launch)          LAUNCH="$2"; shift ;;
+    --update)          UPDATE=1 ;;
+    --add-to-path)     ADD_PATH=1 ;;
+    --remove-from-path) REMOVE_PATH=1 ;;
+    --install-service) INSTALL_SERVICE=1 ;;
+    --uninstall-service) UNINSTALL_SERVICE=1 ;;
+    --port=*)          PORT="${1#*=}" ;;
+    --port)            PORT="$2"; shift ;;
+    --host=*)          HOST="${1#*=}" ;;
+    --host)            HOST="$2"; shift ;;
+    --no-open)         DOCKER_NO_OPEN=1 ;;
+    -h|--help)         usage; exit 0 ;;
+    *)                 echo "Unknown flag: $1" >&2; usage; exit 2 ;;
+  esac
+  shift
+done
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+is_macos() { [ "$(uname -s)" = "Darwin" ]; }
+is_linux() { [ "$(uname -s)" = "Linux" ]; }
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "✗ Required command not found: $1" >&2
+    echo "  Install it, then re-run: $0 $*" >&2
+    exit 1
+  fi
+}
+
+# ── Dispatch ──────────────────────────────────────────────────────────────
+case "$LAUNCH" in
+  native) ;;
+  docker|docker-nvidia|docker-amd) ;;
+  *) echo "✗ Unknown --launch value: $LAUNCH" >&2; usage; exit 2 ;;
+esac
+
+# --add-to-path: drop a symlink and a one-line shell hook so `odysseus`
+# works from any directory. Reversible with --remove-from-path.
+
+if [ "$ADD_PATH" = "1" ]; then
+  BIN_DIR="$HOME/.local/bin"
+  mkdir -p "$BIN_DIR"
+  ln -sf "$REPO_DIR/odysseus.sh" "$BIN_DIR/odysseus"
+  ln -sf "$REPO_DIR/odysseus.sh" "$BIN_DIR/odysseus.sh"
+  for rc in "$HOME/.zshrc" "$HOME/.bashrc"; do
+    [ -f "$rc" ] || continue
+    if ! grep -qF "$BIN_DIR" "$rc" 2>/dev/null; then
+      # $HOME below is intentionally literal — the user's shell expands it
+      # on source, which is the right behaviour for a portable rc file.
+      # shellcheck disable=SC2016
+      printf '\n# Added by Odysseus: make `odysseus` work from anywhere\nexport PATH="$HOME/.local/bin:$PATH"\n' >> "$rc"
+      echo "  ✓ added $BIN_DIR to PATH in $rc"
+    fi
+  done
+  echo "✓ odysseus is now available. Open a new shell or run:  export PATH=\"\$HOME/.local/bin:\$PATH\""
+  exit 0
+fi
+
+if [ "$REMOVE_PATH" = "1" ]; then
+  rm -f "$HOME/.local/bin/odysseus" "$HOME/.local/bin/odysseus.sh"
+  for rc in "$HOME/.zshrc" "$HOME/.bashrc"; do
+    [ -f "$rc" ] || continue
+    # Remove the Odysseus-added block.
+    if grep -q "Added by Odysseus" "$rc" 2>/dev/null; then
+      # Delete the marker line + the export below it.
+      python3 - "$rc" <<'PY' 2>/dev/null || true
+import sys, re
+p = sys.argv[1]
+try:
+    with open(p) as f: txt = f.read()
+except OSError:
+    sys.exit(0)
+out = re.sub(r'\n*# Added by Odysseus[^\n]*\nexport PATH="\$HOME/\.local/bin:\$PATH"\n*', '\n', txt)
+with open(p, 'w') as f: f.write(out)
+PY
+      echo "  ✓ removed Odysseus PATH entry from $rc"
+    fi
+  done
+  echo "✓ odysseus removed from PATH"
+  exit 0
+fi
+
+# --install-service / --uninstall-service: defer to platform script.
+if [ "$INSTALL_SERVICE" = "1" ]; then
+  if is_macos; then
+    exec "$REPO_DIR/install-macos-service.sh" "$@"
+  elif is_linux; then
+    exec "$REPO_DIR/install-service.sh" "$@"
+  else
+    echo "✗ --install-service is only supported on macOS and Linux" >&2
+    exit 1
+  fi
+fi
+if [ "$UNINSTALL_SERVICE" = "1" ]; then
+  if is_macos; then
+    exec "$REPO_DIR/uninstall-macos-service.sh" "$@"
+  elif is_linux; then
+    echo "(no Linux uninstall script yet — manually: sudo systemctl disable --now odysseus-ui && sudo rm /etc/systemd/system/odysseus-ui.service)"
+    exit 0
+  else
+    echo "✗ --uninstall-service is only supported on macOS and Linux" >&2
+    exit 1
+  fi
+fi
+
+# --update: pull + reinstall. We always make sure venv deps are current when
+# requirements.txt changed, then rebuild Docker images if --launch=docker*.
+#
+# On macOS, if the LaunchAgent is installed, stop it before git pull so the
+# running uvicorn doesn't hold files we'll overwrite; restart it after.
+if [ "$UPDATE" = "1" ]; then
+  AGENT_LAUNCHED=0
+  if is_macos; then
+    DOMAIN="gui/$(id -u)"
+    if launchctl print "$DOMAIN/com.odysseus.ui" >/dev/null 2>&1; then
+      echo "▶ stopping launchd agent…"
+      launchctl bootout "$DOMAIN/com.odysseus.ui" 2>/dev/null || true
+      AGENT_LAUNCHED=1
+    fi
+  fi
+
+  echo "▶ git pull…"
+  git pull --rebase --autostash
+  # Re-invoke ourselves so the rest of the launch (native/docker) picks up
+  # any code that changed in the pull. The native path re-checks the
+  # requirements hash (start-macos.sh / a future native path) so we don't
+  # waste time reinstalling when nothing changed.
+
+  if [ "$AGENT_LAUNCHED" = "1" ]; then
+    echo "▶ restarting launchd agent…"
+    PLIST_PATH="$HOME/Library/LaunchAgents/com.odysseus.ui.plist"
+    if [ -f "$PLIST_PATH" ]; then
+      launchctl bootstrap "$DOMAIN" "$PLIST_PATH" 2>/dev/null || true
+      launchctl enable "$DOMAIN/com.odysseus.ui" 2>/dev/null || true
+      launchctl kickstart -k "$DOMAIN/com.odysseus.ui" 2>/dev/null || true
+    fi
+  fi
+fi
+
+# ── Launch dispatch ───────────────────────────────────────────────────────
+
+# Probe host: 0.0.0.0 / :: aren't connectable for "is the port open?" checks.
+PROBE_HOST="$HOST"
+case "$PROBE_HOST" in
+  0.0.0.0|::) PROBE_HOST="127.0.0.1" ;;
+esac
+
+port_in_use() {
+  if is_macos || is_linux; then
+    (exec 3<>"/dev/tcp/$PROBE_HOST/$PORT") 2>/dev/null
+  else
+    return 1
+  fi
+}
+
+# On macOS, AirPlay Receiver holds port 7000; default to 7860 unless the
+# user explicitly asked for something else.
+if is_macos && [ "$LAUNCH" = "native" ] && [ -z "$ODYSSEUS_PORT" ] && [ -z "$APP_PORT" ] && [ "$PORT" = "7000" ]; then
+  PORT=7860
+fi
+
+# ── Native launch (the macOS path) ───────────────────────────────────────
+if [ "$LAUNCH" = "native" ]; then
+  if is_macos && [ -x "$REPO_DIR/scripts/legacy/macos-native.sh" ]; then
+    # Delegate to the legacy macOS native launcher (the original
+    # start-macos.sh logic, now living in scripts/legacy/ so the public
+    # entry point can be a thin shim). The ODYSSEUS_LEGACY_ENTRY=1 marker
+    # tells that script to skip the deprecation banner.
+    exec env ODYSSEUS_LEGACY_ENTRY=1 \
+      ODYSSEUS_REPO_DIR="$REPO_DIR" \
+      ODYSSEUS_PORT="$PORT" ODYSSEUS_HOST="$HOST" \
+      ODYSSEUS_NO_OPEN="$([ "$DOCKER_NO_OPEN" = "1" ] && echo 1 || echo)" \
+      "$REPO_DIR/scripts/legacy/macos-native.sh"
+  fi
+  if is_linux; then
+    if port_in_use; then
+      echo "✗ Port $PORT is already in use on $PROBE_HOST. Stop what's using it, or pick another:"
+      echo "    $0 --port=7900"
+      exit 1
+    fi
+    PY=""
+    for cand in python3.13 python3.12 python3.11 python3; do
+      p="$(command -v "$cand" 2>/dev/null)" || continue
+      if "$p" -c 'import sys; raise SystemExit(0 if sys.version_info[:2] >= (3, 11) else 1)' 2>/dev/null; then
+        PY="$p"; break
+      fi
+    done
+    if [ -z "$PY" ]; then
+      echo "✗ Couldn't find a Python 3.11+ to build the environment with."
+      echo "  Install one (e.g. sudo apt install python3.11 python3.11-venv) and re-run."
+      exit 1
+    fi
+    [ -d venv ] || "$PY" -m venv venv
+    ./venv/bin/python -m pip install --quiet --upgrade pip
+    ./venv/bin/python -m pip install -r requirements.txt
+    ODYSSEUS_SKIP_RUN_HINT=1 ./venv/bin/python setup.py
+    exec ./venv/bin/python -m uvicorn app:app --host "$HOST" --port "$PORT"
+  fi
+  echo "✗ Native launch on $(uname -s) is not yet supported by odysseus.sh." >&2
+  echo "  On macOS, install via the bundled start-macos.sh. On Windows, use odysseus.ps1." >&2
+  exit 1
+fi
+
+# ── Docker launch ────────────────────────────────────────────────────────
+require_cmd docker
+
+DOCKER_COMPOSE_FILE="docker-compose.yml"
+case "$LAUNCH" in
+  docker-nvidia) DOCKER_COMPOSE_FILE="docker-compose.gpu-nvidia.yml" ;;
+  docker-amd)    DOCKER_COMPOSE_FILE="docker-compose.gpu-amd.yml" ;;
+  docker)
+    # Auto-detect the best overlay. macOS never has GPU passthrough into
+    # Docker, so even an M-series Mac falls back to CPU — but at least we
+    # say so.
+    if is_macos; then
+      echo "  ⚠ Docker on macOS runs in a Linux VM with no GPU access — starting CPU-only."
+      echo "    For Metal/GPU acceleration, use --launch=native."
+    elif command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi -L >/dev/null 2>&1; then
+      DOCKER_COMPOSE_FILE="docker-compose.gpu-nvidia.yml"
+      echo "  ✓ detected NVIDIA GPU — using GPU overlay"
+    elif [ -e /dev/kfd ] && [ -d /dev/dri ] && is_linux; then
+      DOCKER_COMPOSE_FILE="docker-compose.gpu-amd.yml"
+      echo "  ✓ detected AMD/ROCm GPU — using GPU overlay"
+    else
+      echo "  ⚠ No GPU detected (nvidia-smi not found, /dev/kfd not present). Starting CPU-only."
+      echo "    To override: --launch=docker-nvidia or --launch=docker-amd"
+    fi
+    ;;
+esac
+
+# docker compose v2 vs v1: prefer 'docker compose', fall back to 'docker-compose'.
+if docker compose version >/dev/null 2>&1; then
+  DC=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+  DC=(docker-compose)
+else
+  echo "✗ Neither 'docker compose' nor 'docker-compose' is available." >&2
+  exit 1
+fi
+
+if [ "$UPDATE" = "1" ]; then
+  echo "▶ rebuilding Docker images…"
+  "${DC[@]}" -f "$DOCKER_COMPOSE_FILE" build --pull
+fi
+
+if [ -n "$APP_PORT" ] || [ "$PORT" != "7000" ]; then
+  APP_PORT="$PORT" "${DC[@]}" -f "$DOCKER_COMPOSE_FILE" up -d --build
+else
+  "${DC[@]}" -f "$DOCKER_COMPOSE_FILE" up -d --build
+fi
+echo
+echo "▶ Odysseus is up. Tailing logs (Ctrl+C to detach)…"
+"${DC[@]}" -f "$DOCKER_COMPOSE_FILE" logs -f odysseus

--- a/scripts/legacy/macos-native.sh
+++ b/scripts/legacy/macos-native.sh
@@ -1,0 +1,321 @@
+#!/bin/bash
+# Odysseus — one-command quick start for macOS (Apple Silicon).
+#
+#   ./start-macos.sh
+#
+# Installs everything Odysseus needs via Homebrew, sets up a local Python
+# environment, and launches the app — so a generic Mac user can run it without
+# knowing anything about venvs, pip, or uvicorn. Safe to re-run; it skips work
+# that's already done.
+#
+# Why native (not Docker): Cookbook serves models on whatever machine Odysseus
+# runs on, and Docker on macOS is a Linux VM with no access to the Metal GPU.
+# Running natively lets Cookbook detect and use your Mac's GPU.
+set -e
+
+# When invoked via the deprecation shim (./start-macos.sh), BASH_SOURCE[0]
+# points to this file in scripts/legacy/, and the real repo root is two
+# levels up. Honor ODYSSEUS_REPO_DIR if the caller (odysseus.sh) set it;
+# otherwise walk up from our own location.
+if [ -n "$ODYSSEUS_REPO_DIR" ]; then
+  REPO_DIR="$ODYSSEUS_REPO_DIR"
+else
+  REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+fi
+cd "$REPO_DIR"
+
+# Load .env so APP_PORT and APP_BIND are available without re-typing them on
+# the command line every run — consistent with how app.py reads them via
+# python-dotenv. Variables already set in the shell take priority over .env.
+if [ -f .env ]; then
+  while IFS='=' read -r key value; do
+    [[ "$key" =~ ^[[:space:]]*# ]] && continue
+    [[ -z "${key// }" ]] && continue
+    value="${value%%#*}"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    [ -n "$key" ] && [ -z "${!key+x}" ] && export "$key=$value"
+  done < .env
+fi
+
+# Shell overrides (ODYSSEUS_PORT / ODYSSEUS_HOST) take top priority, then .env
+# values (APP_PORT / APP_BIND), then built-in defaults.
+PORT="${ODYSSEUS_PORT:-${APP_PORT:-7860}}"   # 7860, not 7000 — macOS AirPlay Receiver holds 7000.
+HOST="${ODYSSEUS_HOST:-${APP_BIND:-127.0.0.1}}" # Set APP_BIND=0.0.0.0 in .env for LAN/Tailscale access.
+PROBE_HOST="$HOST"
+if [ "$PROBE_HOST" = "0.0.0.0" ] || [ "$PROBE_HOST" = "::" ]; then
+  PROBE_HOST="127.0.0.1"
+fi
+
+# Friendly message on any failure — re-running is safe (every step is idempotent).
+trap 'echo; echo "✗ Setup failed above. It is safe to re-run ./start-macos.sh."; exit 1' ERR
+
+echo "▶ Odysseus quick start for macOS"
+
+# Fail fast if the port is already taken (e.g. a previous run still running).
+if (exec 3<>"/dev/tcp/$PROBE_HOST/$PORT") 2>/dev/null; then
+  echo "✗ Port $PORT is already in use on $PROBE_HOST. Stop what's using it, or pick another port:"
+  echo "    ODYSSEUS_PORT=7900 ./start-macos.sh"
+  exit 1
+fi
+
+# 1. Homebrew — the macOS package manager. We can't safely auto-install it
+#    (it wants its own interactive confirmation), so point the user at it.
+if ! command -v brew >/dev/null 2>&1; then
+  echo
+  echo "Homebrew is required but not installed. Install it (one command), then re-run this script:"
+  echo '  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
+  echo
+  echo "More info: https://brew.sh"
+  exit 1
+fi
+
+# 2. Find a Python 3.11+ to build the environment with.
+#    On Apple Silicon we require an *arm64* interpreter (Homebrew's, under
+#    /opt/homebrew). A universal2 or x86 Python — e.g. the python.org installer
+#    at /usr/local — produces a venv whose compiled extensions get loaded as the
+#    wrong architecture when launched from the .app bundle (Cookbook then dies
+#    with "incompatible architecture"). So on arm64 we only look under
+#    /opt/homebrew and install Homebrew's python@3.11 if it's missing. On Intel
+#    (or non-mac) we just use whatever Python 3.11+ is on PATH.
+PY=""
+if [ "$(uname -m)" = "arm64" ]; then
+  cands="/opt/homebrew/bin/python3.13 /opt/homebrew/bin/python3.12 /opt/homebrew/bin/python3.11"
+else
+  cands="python3 python3.13 python3.12 python3.11"
+fi
+for cand in $cands; do
+  p="$(command -v "$cand" 2>/dev/null)" || continue
+  if "$p" -c 'import sys; raise SystemExit(0 if sys.version_info[:2] >= (3, 11) else 1)' 2>/dev/null; then
+    PY="$p"; break
+  fi
+done
+
+# System dependencies (each installed only if missing, so re-runs stay fast and
+# don't re-hit Homebrew over the network):
+#    - tmux      : Cookbook runs model downloads/serves in the background
+#    - llama.cpp : a prebuilt, Metal-enabled llama-server so Cookbook can serve
+#                  GGUF models on the GPU with no compile step
+#    - python@3.11 : installed only if no suitable (arm64) Python was found above
+#
+# tmux and llama.cpp are needed only by Cookbook (local model serving), not to
+# boot the core app. So if Homebrew can't install one right now we warn and keep
+# going instead of aborting the whole launch. Python is required to build the
+# venv, so that one stays fatal (handled by the PY check just below).
+
+# Install a Homebrew formula only if its command isn't already present. A failed
+# install warns but does not abort — Cookbook can be set up later.
+brew_ensure() {
+  if command -v "$1" >/dev/null 2>&1; then
+    echo "  ✓ $2 already installed"
+    return 0
+  fi
+  echo "  installing $2…"
+  if ! brew install "$2"; then
+    echo "  ⚠ Couldn't install $2 right now — Cookbook (local model serving) may be limited."
+    echo "    You can install it later with:  brew install $2"
+  fi
+}
+
+# Start a local SearXNG (web-search backend) in Docker if one isn't already
+# reachable. Native macOS install has no brew formula for the real SearXNG
+# server, and pip-installing it from source means cloning + building static
+# assets + standing up uWSGI/Granian. SearXNG has no GPU needs, so Docker is
+# the right way to ship it even on macOS — and matches the bundled-service
+# model the README's "Docker" path already uses.
+#
+# Behaviour:
+#   * Honors SEARXNG_INSTANCE from .env. If it points at a non-default URL
+#     (anything other than localhost/127.0.0.1:8080), we assume the user
+#     already has SearXNG running somewhere else and don't touch anything.
+#   * Honors ODYSSEUS_NO_SEARXNG=1 for an explicit opt-out.
+#   * Idempotent: re-runs see the running container and start instantly.
+#   * Persistent: --restart unless-stopped, so the container survives reboots
+#     and the next ./start-macos.sh is fast. Stop it with
+#     `docker stop odysseus-searxng` when you want to free the port.
+ensure_searxng() {
+  case "${SEARXNG_INSTANCE:-http://localhost:8080}" in
+    ""|http://localhost:8080|http://127.0.0.1:8080) ;;
+    *) echo "  (SEARXNG_INSTANCE is set to a custom URL; not starting a local one)"
+       return 0 ;;
+  esac
+  if [ -n "$ODYSSEUS_NO_SEARXNG" ]; then
+    echo "  (ODYSSEUS_NO_SEARXNG=1 — skipping local SearXNG)"
+    return 0
+  fi
+  if (exec 3<>"/dev/tcp/127.0.0.1/8080") 2>/dev/null; then
+    echo "  ✓ SearXNG already running on :8080"
+    return 0
+  fi
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "  ⚠ SearXNG isn't running and Docker isn't installed."
+    echo "    Deep Research and web search will fail until you either:"
+    echo "      a) install Docker Desktop: brew install --cask docker"
+    echo "      b) point SEARXNG_INSTANCE at a remote instance in .env"
+    echo "      c) set ODYSSEUS_NO_SEARXNG=1 to silence this check"
+    return 0
+  fi
+  if ! docker info >/dev/null 2>&1; then
+    echo "  ⚠ Docker is installed but the daemon isn't running."
+    echo "    Launch Docker Desktop, then re-run this script — or set"
+    echo "    SEARXNG_INSTANCE=... in .env to use a remote SearXNG."
+    return 0
+  fi
+
+  SEARXNG_DATA="$REPO_DIR/data/searxng"
+  mkdir -p "$SEARXNG_DATA"
+
+  # Seed settings.yml from the repo template the first time, substituting a
+  # stable random secret so cookies / CSRF are consistent across restarts.
+  if [ ! -f "$SEARXNG_DATA/settings.yml" ]; then
+    local_secret="$(openssl rand -hex 16 2>/dev/null || /usr/bin/python3 -c 'import secrets;print(secrets.token_hex(16))' 2>/dev/null || echo "odysseus-$RANDOM-$RANDOM")"
+    sed "s/__SEARXNG_SECRET__/$local_secret/g" "$REPO_DIR/config/searxng/settings.yml" > "$SEARXNG_DATA/settings.yml"
+  fi
+
+  if docker ps -a --format '{{.Names}}' | grep -q '^odysseus-searxng$'; then
+    echo "  starting existing odysseus-searxng container…"
+    docker start odysseus-searxng >/dev/null
+  else
+    echo "  starting SearXNG container (first run pulls the image — may take a minute)…"
+    docker run -d --name odysseus-searxng \
+      -p 127.0.0.1:8080:8080 \
+      -v "$SEARXNG_DATA:/etc/searxng:rw" \
+      --restart unless-stopped \
+      searxng/searxng:latest >/dev/null
+  fi
+
+  for _ in $(seq 1 60); do
+    if (exec 3<>"/dev/tcp/127.0.0.1/8080") 2>/dev/null; then
+      echo "  ✓ SearXNG ready on http://127.0.0.1:8080"
+      return 0
+    fi
+    sleep 1
+  done
+  echo "  ⚠ SearXNG container started but didn't respond within 60s."
+  echo "    Check 'docker logs odysseus-searxng' for details."
+  return 0
+}
+
+echo "▶ Checking dependencies (Homebrew)…"
+if [ -n "$PY" ]; then
+  echo "  (using $("$PY" --version 2>&1) at $PY)"
+else
+  echo "  installing python@3.11…"
+  brew install python@3.11 || true
+  PY="$(command -v /opt/homebrew/bin/python3.11 || command -v python3.11 || true)"
+fi
+brew_ensure tmux tmux
+brew_ensure llama-server llama.cpp
+
+if [ -z "$PY" ] || [ ! -x "$PY" ]; then
+  echo "✗ Couldn't find a Python 3.11+ to build the environment with."
+  echo "  Check: ls /opt/homebrew/bin/python3*  (or install one: brew install python@3.11)"
+  exit 1
+fi
+
+# 3. Python environment + dependencies (kept inside the repo, in venv/).
+#    Named `venv` to match the manual steps and build-macos-app.sh, so the
+#    clickable .app reuses this same environment.
+if [ ! -d venv ]; then
+  echo "▶ Creating Python environment…"
+  "$PY" -m venv venv
+fi
+VENV_PY="./venv/bin/python3"
+"$VENV_PY" -m pip install --quiet --upgrade pip
+
+# Skip the slow `pip install -r requirements.txt` when the file hasn't changed
+# since the last run (#2502). The hash lives inside venv/ (already gitignored)
+# so it never touches the repo. On hash mismatch — fresh checkout, requirements
+# change, or first run — reinstall and record the new hash. The hash is a
+# plain md5 of requirements.txt's bytes; collisions aren't a correctness
+# concern here (worst case: a useless reinstall, not a wrong install).
+HASH_FILE="venv/.requirements_hash"
+WANT_HASH="$(md5 -q requirements.txt 2>/dev/null || /usr/bin/md5sum requirements.txt 2>/dev/null | awk '{print $1}')"
+HAVE_HASH=""
+[ -f "$HASH_FILE" ] && HAVE_HASH="$(cat "$HASH_FILE" 2>/dev/null || true)"
+if [ -z "$WANT_HASH" ]; then
+  # Neither BSD md5 nor coreutils md5sum is available — bail to a forced
+  # install rather than silently skip, so we don't strand a broken venv.
+  echo "▶ Installing Python packages (no md5 tool available — can't cache check, installing fresh)…"
+  "$VENV_PY" -m pip install -r requirements.txt
+elif [ "$WANT_HASH" = "$HAVE_HASH" ]; then
+  echo "▶ Skipping pip install (requirements.txt unchanged since $HASH_FILE)…"
+else
+  echo "▶ Installing Python packages (first run downloads a few — can take a few minutes)…"
+  # Not --quiet: this is the slow step, so show progress (and any real errors).
+  "$VENV_PY" -m pip install -r requirements.txt
+  echo "$WANT_HASH" > "$HASH_FILE"
+fi
+
+# chromadb-client (HTTP-only) conflicts with the full chromadb package. If
+# it got installed (e.g., from an older requirements-optional.txt), remove
+# it to prevent ChromaDB from silently failing in HTTP-only mode.
+if "$VENV_PY" -m pip show chromadb-client >/dev/null 2>&1; then
+  echo "▶ Cleaning up conflicting chromadb-client package…"
+  "$VENV_PY" -m pip uninstall -y chromadb-client
+  "$VENV_PY" -m pip install --force-reinstall chromadb
+fi
+
+# 3.5. SearXNG (web search). Docker-only and fully idempotent; runs in the
+#      background and survives this script exiting (see ensure_searxng).
+echo "▶ Ensuring SearXNG (web search) is reachable…"
+ensure_searxng
+
+# 4. First-run setup: creates data dirs and prints an initial admin password
+#    the first time (idempotent — does nothing if already set up). Suppress its
+#    manual run hint — we launch the server ourselves just below.
+echo "▶ Preparing Odysseus…"
+ODYSSEUS_SKIP_RUN_HINT=1 ./venv/bin/python setup.py
+
+# 5. Launch. Bind to loopback by default; opt into LAN/Tailscale with
+#    ODYSSEUS_HOST=0.0.0.0.
+URL_HOST="$HOST"
+if [ "$URL_HOST" = "0.0.0.0" ] || [ "$URL_HOST" = "::" ]; then
+  URL_HOST="127.0.0.1"
+fi
+URL="http://$URL_HOST:$PORT"
+TAILSCALE_URL=""
+if [ "$HOST" = "0.0.0.0" ] && command -v tailscale >/dev/null 2>&1; then
+  TS_IP="$(tailscale ip -4 2>/dev/null | head -n 1 || true)"
+  if [ -n "$TS_IP" ]; then
+    TAILSCALE_URL="http://$TS_IP:$PORT"
+  fi
+fi
+
+# Open the browser automatically once the server is accepting connections — so
+# the URL isn't lost in the startup logs that keep scrolling. Runs in the
+# background and is cleaned up when the server stops. Skip with
+# ODYSSEUS_NO_OPEN=1 (e.g. over SSH / headless).
+POLLER_PID=""
+if [ -z "$ODYSSEUS_NO_OPEN" ] && command -v open >/dev/null 2>&1; then
+  (
+    for _ in $(seq 1 90); do
+      if (exec 3<>"/dev/tcp/$PROBE_HOST/$PORT") 2>/dev/null; then
+        printf '\n'
+        printf '  ┌────────────────────────────────────────────┐\n'
+        printf '  │  ✓ Odysseus is ready — opening your browser  │\n'
+        printf '  │     %-40s │\n' "$URL"
+        printf '  │     (Press Ctrl+C in this window to stop)    │\n'
+        printf '  └────────────────────────────────────────────┘\n\n'
+        open "$URL"
+        break
+      fi
+      sleep 1
+    done
+  ) &
+  POLLER_PID=$!
+fi
+
+# Setup is done — drop the setup-failure handler, and clean up the background
+# opener when the server exits or the user presses Ctrl+C.
+trap - ERR
+trap '[ -n "$POLLER_PID" ] && kill "$POLLER_PID" 2>/dev/null' EXIT INT TERM
+
+echo
+echo "▶ Starting Odysseus — it will open in your browser at $URL"
+if [ -n "$TAILSCALE_URL" ]; then
+  echo "  Tailscale/LAN URL: $TAILSCALE_URL"
+fi
+echo "  (this takes a few seconds; press Ctrl+C here to stop)"
+echo
+"$VENV_PY" -m uvicorn app:app --host "$HOST" --port "$PORT"

--- a/uninstall-macos-service.sh
+++ b/uninstall-macos-service.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# uninstall-macos-service.sh — reverse install-macos-service.sh.
+#
+#   * bootout the LaunchAgent
+#   * delete ~/Library/LaunchAgents/com.odysseus.ui.plist
+#   * leave ~/Library/Logs/Odysseus/ in place (the user may want to grep them)
+#   * leave data/ + venv/ alone (those are not the service's concern)
+#
+# Idempotent: running when the agent is not installed is a no-op.
+
+set -e
+
+LABEL="com.odysseus.ui"
+PLIST_PATH="$HOME/Library/LaunchAgents/${LABEL}.plist"
+DOMAIN="gui/$(id -u)"
+
+REMOVED=0
+
+# 1. Stop the agent (if running).
+if launchctl print "$DOMAIN/$LABEL" >/dev/null 2>&1; then
+  echo "▶ stopping $LABEL…"
+  launchctl bootout "$DOMAIN/$LABEL" 2>/dev/null || true
+  REMOVED=1
+fi
+
+# 2. Defensive: also stop a system-domain copy, in case someone installed
+#    it that way manually before this script existed.
+launchctl bootout "system/$LABEL" 2>/dev/null || true
+
+# 3. Disable so launchd doesn't try to re-resurrect it on next login.
+launchctl disable "$DOMAIN/$LABEL" 2>/dev/null || true
+launchctl disable "system/$LABEL" 2>/dev/null || true
+
+# 4. Clear any "disabled" override entry that step 3 added. Leaving it
+#    in the per-user overrides db means a future --install-service
+#    bootstrap will succeed at the launchctl call but the agent will
+#    refuse to spawn — surfacing later as a "Bootstrap failed: 5:
+#    I/O error" the next time someone tries. enable is the inverse
+#    of disable and removes the override entry.
+launchctl enable "$DOMAIN/$LABEL" 2>/dev/null || true
+launchctl enable "system/$LABEL" 2>/dev/null || true
+
+# 4. Delete the plist.
+if [ -f "$PLIST_PATH" ]; then
+  echo "▶ removing $PLIST_PATH…"
+  rm -f "$PLIST_PATH"
+  REMOVED=1
+fi
+
+if [ "$REMOVED" = "1" ]; then
+  echo "✓ Odysseus auto-start removed."
+  echo "  Logs preserved in: $HOME/Library/Logs/Odysseus/"
+  echo "  Reinstall: ./odysseus.sh --install-service"
+else
+  echo "✓ Odysseus auto-start was not installed. Nothing to do."
+fi


### PR DESCRIPTION
## Summary
Linux has \`odysseus-ui.service\` + \`install-service.sh\`. macOS had nothing — the user had to leave a Terminal open. This wires the same UX to launchd: \`./odysseus.sh --install-service\` drops a per-user LaunchAgent at \`~/Library/LaunchAgents/com.odysseus.ui.plist\` and bootstraps it into the \`gui/$(id -u)\` launchd domain. The agent starts on login, respawns on crash, and inherits an explicit \`PATH\` (launchd's default doesn't include Homebrew). Also includes a TCC scope guard that refuses to install if the repo is under \`~/Desktop\`, \`~/Documents\`, or \`~/Downloads\` (those are TCC-restricted and launchd can't execute scripts there).

## Target branch
- [x] This PR targets **`dev`**, not `main`.

## Linked Issue
Part of #2475

## Type of Change
- [x] New feature (non-breaking — adds new behaviour)

## Checklist
- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test
1. Move the repo outside TCC scope: \`mv ~/Desktop/odysseus ~/odysseus\`.
2. \`./odysseus.sh --install-service\` — should drop the plist, validate with \`plutil -lint\`, and bootstrap it.
3. \`launchctl print gui/$(id -u)/com.odysseus.ui | head -20\` — should show the agent running, \`keep alive\`, and \`run at load\`.
4. \`tail -f ~/Library/Logs/Odysseus/stdout.log\` — should show the uvicorn start banner.
5. \`kill -9 \$(pgrep -f uvicorn)\` — agent should respawn within 10s (ThrottleInterval).
6. \`./odysseus.sh --uninstall-service\` — should bootout, remove the plist, and leave \`~/Library/Logs/Odysseus/\` for post-mortem.
7. \`./odysseus.sh --update\` — should detect the loaded agent, bootout, \`git pull --rebase --autostash\`, re-bootstrap, and kickstart.
8. The TCC guard: clone to \`~/Desktop/odysseus\` and run \`./odysseus.sh --install-service\` — should print the one-liner fix and exit non-zero.
9. The bug fix: \`./odysseus.sh --install-service\` then \`--uninstall-service\` then \`--install-service\` — all three should succeed (no "Bootstrap failed: 5: I/O error" from a stale Disabled override).

## Visual / UI changes
N/A — no UI rendering changes.