### PR TITLE
feat(macos): hardened Odysseus.app with menu bar + clean shutdown

### DIFF
--- a/app/macos/OdysseusLauncher.swift
+++ b/app/macos/OdysseusLauncher.swift
@@ -1,0 +1,449 @@
+// OdysseusLauncher.swift — minimal Cocoa host for the Odysseus .app bundle.
+//
+// What this file does:
+//   * Lives in the .app as Contents/MacOS/Odysseus (built by build-macos-app.sh).
+//   * Spawns the bash worker (`odysseus-app.sh` in Contents/Resources) and
+//     supervises it.
+//   * Shows a menu bar item (NSStatusItem) with the current server state.
+//   * Forwards Cmd-Q into a SIGTERM to the worker and waits for clean exit.
+//   * Reads ~/Library/Application Support/Odysseus/state.json — written
+//     by the worker — to drive the menu bar UI.
+//
+// What this file intentionally does NOT do:
+//   * It does not bundle Python, the venv, or the source code. The .app
+//     is a launcher that drives a separate repo install (~/odysseus or
+//     whatever INSTALL_DIR was baked in at build time).
+//   * It does not request code signing. The .app is ad-hoc signed at
+//     build time, which is enough to launch locally and to be moved
+//     around the user's machine. Distribution to other people needs
+//     a Developer ID, which is out of scope.
+//
+// Build:
+//   swiftc -O -target arm64-apple-macosx11.0 \
+//          -framework Cocoa -framework Foundation \
+//          -o Odysseus OdysseusLauncher.swift
+// (build-macos-app.sh handles the invocation.)
+
+import Cocoa
+
+// MARK: - State model
+
+struct AppState: Decodable {
+    enum State: String, Decodable { case starting, running, stopped, error }
+    let state: State
+    let port: Int
+    let pid: Int
+    let url: String
+    let message: String
+}
+
+extension AppState.State {
+    var menuBarTitle: String {
+        switch self {
+        case .starting: return "⚙︎ Odysseus"
+        case .running:  return "● Odysseus"
+        case .stopped:  return "○ Odysseus"
+        case .error:    return "✕ Odysseus"
+        }
+    }
+    var isError: Bool { self == .error }
+}
+
+// MARK: - Worker process
+
+final class Worker {
+    let path: String
+    let installDir: String
+    let port: Int
+    private(set) var process: Process?
+    private(set) var stdoutPipe: Pipe?
+    private(set) var stderrPipe: Pipe?
+
+    init(path: String, installDir: String, port: Int) {
+        self.path = path
+        self.installDir = installDir
+        self.port = port
+    }
+
+    func start() throws {
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: "/bin/bash")
+        p.arguments = [path]
+        // Forward ODYSSEUS_FROM_APP=1 so the bash worker knows to
+        // relocate data/ to ~/Library/Application Support/Odysseus.
+        var env = ProcessInfo.processInfo.environment
+        env["ODYSSEUS_FROM_APP"] = "1"
+        env["ODYSSEUS_PORT"] = String(port)
+        p.environment = env
+        p.currentDirectoryURL = URL(fileURLWithPath: installDir)
+
+        let out = Pipe()
+        let err = Pipe()
+        p.standardOutput = out
+        p.standardError = err
+        stdoutPipe = out
+        stderrPipe = err
+
+        // Don't crash the host if the worker dies — we want the menu
+        // bar UI to keep working so the user can read the error and
+        // pick "Open in Terminal" / "Reveal Log".
+        p.terminationHandler = { _ in
+            DispatchQueue.main.async {
+                NotificationCenter.default.post(name: .workerDidExit, object: nil)
+            }
+        }
+        try p.run()
+        process = p
+    }
+
+    func terminate(gracefulSeconds: Double = 5.0, completion: (() -> Void)? = nil) {
+        guard let p = process, p.isRunning else {
+            completion?()
+            return
+        }
+        p.terminate()
+        // Wait for the worker to exit cleanly. We poll rather than
+        // block on waitUntilExit() because the Cocoa run loop still
+        // needs to spin for applicationShouldTerminate's
+        // .terminateLater reply to land.
+        DispatchQueue.global(qos: .userInitiated).async {
+            let deadline = Date().addingTimeInterval(gracefulSeconds)
+            while p.isRunning && Date() < deadline {
+                Thread.sleep(forTimeInterval: 0.1)
+            }
+            if p.isRunning {
+                // Worker ignored SIGTERM. Send SIGINT (Process.interrupt)
+                // before SIGKILL as a last-ditch attempt at clean exit.
+                p.interrupt()
+                Thread.sleep(forTimeInterval: 0.5)
+                if p.isRunning { kill(p.processIdentifier, SIGKILL) }
+            }
+            DispatchQueue.main.async { completion?() }
+        }
+    }
+}
+
+extension Notification.Name {
+    static let workerDidExit = Notification.Name("com.odysseus.workerDidExit")
+}
+
+// MARK: - State file watcher
+
+final class StateWatcher {
+    private var source: DispatchSourceFileSystemObject?
+    private let url: URL
+    private let queue = DispatchQueue(label: "com.odysseus.statewatcher")
+    private(set) var last: AppState?
+
+    init(url: URL) {
+        self.url = url
+    }
+
+    func start(_ onChange: @escaping (AppState) -> Void) {
+        // Make sure the file exists so DispatchSource has something to watch.
+        let fm = FileManager.default
+        if !fm.fileExists(atPath: url.path) {
+            try? Data().write(to: url)
+        }
+        // Read once synchronously so the menu bar has a value on first paint.
+        if let initial = read() {
+            last = initial
+            onChange(initial)
+        }
+        let fd = open(url.path, O_EVTONLY)
+        guard fd >= 0 else { return }
+        let src = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd, eventMask: [.write, .extend, .rename], queue: queue
+        )
+        src.setEventHandler { [weak self] in
+            DispatchQueue.main.async {
+                guard let self = self, let s = self.read() else { return }
+                self.last = s
+                onChange(s)
+            }
+        }
+        src.setCancelHandler { close(fd) }
+        src.resume()
+        source = src
+    }
+
+    private func read() -> AppState? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? JSONDecoder().decode(AppState.self, from: data)
+    }
+}
+
+// MARK: - AppDelegate
+
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    private var statusItem: NSStatusItem!
+    private var menu: NSMenu!
+    private var statusMenuItem: NSMenuItem!
+    private var portMenuItem: NSMenuItem!
+    private var openMenuItem: NSMenuItem!
+    private var openInTerminalItem: NSMenuItem!
+    private var revealLogItem: NSMenuItem!
+    private var quitItem: NSMenuItem!
+
+    private var worker: Worker!
+    private var watcher: StateWatcher!
+    private var currentState: AppState?
+    private let workerInstallDir: String
+    private let workerPort: Int
+
+    // Both values are baked in at build time as command-line args to the
+    // Swift binary: --install-dir <path> --port <N>. Reading them in
+    // main() makes the build script's job easy.
+    init(installDir: String, port: Int) {
+        self.workerInstallDir = installDir
+        self.workerPort = port
+        super.init()
+    }
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        // Catch SIGTERM/SIGINT before Cocoa does, so we can forward
+        // them to the worker as a clean shutdown.
+        installSignalHandlers()
+
+        // ── Menu bar ───────────────────────────────────────────────────
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        statusItem.button?.title = "○ Odysseus"
+        statusItem.button?.toolTip = "Odysseus — starting…"
+
+        menu = NSMenu()
+        statusMenuItem = NSMenuItem(title: "Starting…", action: nil, keyEquivalent: "")
+        statusMenuItem.isEnabled = false
+        menu.addItem(statusMenuItem)
+
+        portMenuItem = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+        portMenuItem.isEnabled = false
+        menu.addItem(portMenuItem)
+
+        menu.addItem(NSMenuItem.separator())
+
+        openMenuItem = NSMenuItem(title: "Open in Browser", action: #selector(openInBrowser), keyEquivalent: "o")
+        openMenuItem.target = self
+        menu.addItem(openMenuItem)
+
+        openInTerminalItem = NSMenuItem(title: "Open in Terminal", action: #selector(openInTerminal), keyEquivalent: "t")
+        openInTerminalItem.target = self
+        menu.addItem(openInTerminalItem)
+
+        revealLogItem = NSMenuItem(title: "Reveal Log in Finder", action: #selector(revealLog), keyEquivalent: "l")
+        revealLogItem.target = self
+        menu.addItem(revealLogItem)
+
+        menu.addItem(NSMenuItem.separator())
+        quitItem = NSMenuItem(title: "Quit Odysseus", action: #selector(quit), keyEquivalent: "q")
+        quitItem.target = self
+        menu.addItem(quitItem)
+        statusItem.menu = menu
+
+        // ── Worker ────────────────────────────────────────────────────
+        let appSupport = (NSHomeDirectory() as NSString)
+            .appendingPathComponent("Library/Application Support/Odysseus")
+        let stateFile = URL(fileURLWithPath: appSupport).appendingPathComponent("state.json")
+
+        watcher = StateWatcher(url: stateFile)
+        watcher.start { [weak self] state in
+            self?.applyState(state)
+        }
+
+        let workerPath = Bundle.main.path(forResource: "odysseus-app", ofType: "sh") ?? ""
+        if workerPath.isEmpty {
+            applyState(AppState(
+                state: .error, port: workerPort, pid: 0, url: "",
+                message: "Bundled worker script missing — was the .app built correctly?"
+            ))
+            return
+        }
+        worker = Worker(path: workerPath, installDir: workerInstallDir, port: workerPort)
+        do {
+            try worker.start()
+        } catch {
+            applyState(AppState(
+                state: .error, port: workerPort, pid: 0, url: "",
+                message: "Could not start worker: \(error.localizedDescription)"
+            ))
+        }
+
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(handleWorkerExit),
+            name: .workerDidExit, object: nil
+        )
+    }
+
+    private func applyState(_ state: AppState) {
+        currentState = state
+        statusItem.button?.title = state.state.menuBarTitle
+        statusItem.button?.toolTip = "Odysseus: \(state.message)"
+        statusMenuItem.title = state.message
+        portMenuItem.title = state.url.isEmpty ? "" : "URL: \(state.url)"
+
+        // The user can open the browser as soon as the server is up.
+        let canOpen = (state.state == .running) && !state.url.isEmpty
+        openMenuItem.isEnabled = canOpen
+
+        // Surface errors as a notification so the user doesn't have to
+        // click the menu bar item to find out something is wrong.
+        if state.state == .error {
+            let n = NSUserNotification()
+            n.title = "Odysseus"
+            n.subtitle = "Server failed to start"
+            n.informativeText = state.message
+            NSUserNotificationCenter.default.deliver(n)
+        }
+    }
+
+    @objc private func openInBrowser() {
+        guard let urlStr = currentState?.url, !urlStr.isEmpty,
+              let url = URL(string: urlStr) else { return }
+        // Prefer an app-style window in a Chromium browser if available.
+        for browser in ["Google Chrome", "Microsoft Edge", "Brave Browser", "Chromium"] {
+            let path = "/Applications/\(browser).app"
+            if FileManager.default.fileExists(atPath: path) {
+                let task = Process()
+                task.executableURL = URL(fileURLWithPath: path)
+                task.arguments = ["--app=\(urlStr)", "--new-window"]
+                try? task.run()
+                return
+            }
+        }
+        NSWorkspace.shared.open(url)
+    }
+
+    @objc private func openInTerminal() {
+        // Spawn Terminal with a prefilled command. Useful when the
+        // first-run venv setup needs to run interactively (brew prompts,
+        // TCC consent, etc.) — Terminal inherits the user's TCC consents
+        // for ~/Desktop, ~/Documents, etc., which the launchd agent
+        // doesn't.
+        let script = """
+        tell application "Terminal"
+          do script "cd '\(workerInstallDir)' && ./odysseus.sh --launch=native"
+          activate
+        end tell
+        """
+        if let apple = NSAppleScript(source: script) {
+            var err: NSDictionary?
+            _ = apple.executeAndReturnError(&err)
+        }
+    }
+
+    @objc private func revealLog() {
+        let appSupport = (NSHomeDirectory() as NSString)
+            .appendingPathComponent("Library/Application Support/Odysseus")
+        let url = URL(fileURLWithPath: appSupport)
+        // Create the dir if the worker hasn't yet, so the user sees
+        // a Finder window they can navigate rather than nothing.
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        NSWorkspace.shared.activateFileViewerSelecting([url])
+    }
+
+    @objc private func handleWorkerExit() {
+        // Worker died. Update the menu bar to reflect the state file
+        // (which the worker writes on its way out). If the worker
+        // died without writing a "stopped" state, the last read may
+        // still show "running" — re-read to be sure.
+        if let final = watcher.last, final.state == .stopped { return }
+        // Give the worker a beat to write its exit state, then re-read.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            guard let self = self else { return }
+            // Re-read the state file directly in case DispatchSource
+            // missed a final write.
+            let appSupport = (NSHomeDirectory() as NSString)
+                .appendingPathComponent("Library/Application Support/Odysseus")
+            let path = URL(fileURLWithPath: appSupport).appendingPathComponent("state.json")
+            if let data = try? Data(contentsOf: path),
+               let s = try? JSONDecoder().decode(AppState.self, from: data) {
+                self.applyState(s)
+            }
+        }
+    }
+
+    @objc private func quit() {
+        NSApp.terminate(nil)
+    }
+
+    // ── Proper Cmd-Q + SIGTERM handling ─────────────────────────────────
+    // Two paths trigger shutdown:
+    //   1. Cmd-Q → applicationShouldTerminate
+    //   2. SIGTERM (kill from another terminal) → DispatchSource signal
+    // Both should SIGTERM the worker, wait for it, then exit the host.
+    // The .terminateLater / reply(toApplicationShouldTerminate:) dance
+    // is the official way for path 1; for path 2 we just call NSApp.terminate
+    // which routes through the same code.
+    private var terminateRequested = false
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        if terminateRequested { return .terminateNow }
+        terminateRequested = true
+        worker?.terminate(gracefulSeconds: 5.0) {
+            NSApp.reply(toApplicationShouldTerminate: true)
+        }
+        return .terminateLater
+    }
+
+    // SIGTERM from outside the run loop (kill from another terminal,
+    // a parent process dying) — Cocoa doesn't always turn those into
+    // applicationShouldTerminate, especially for accessory apps. Hook
+    // the signal directly via DispatchSource so the worker always
+    // gets a clean shutdown pass.
+    private var sigtermSource: DispatchSourceSignal?
+    func installSignalHandlers() {
+        signal(SIGTERM, SIG_IGN)
+        signal(SIGINT, SIG_IGN)
+        let src = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .main)
+        src.setEventHandler { [weak self] in
+            guard let self = self else { return }
+            if !self.terminateRequested {
+                self.terminateRequested = true
+                self.worker?.terminate(gracefulSeconds: 5.0) {
+                    NSApp.terminate(nil)
+                }
+            } else {
+                NSApp.terminate(nil)
+            }
+        }
+        src.resume()
+        sigtermSource = src
+        let intSrc = DispatchSource.makeSignalSource(signal: SIGINT, queue: .main)
+        intSrc.setEventHandler { [weak self] in
+            self?.worker?.terminate(gracefulSeconds: 2.0) { NSApp.terminate(nil) }
+        }
+        intSrc.resume()
+    }
+}
+
+// MARK: - main
+
+// Parse --install-dir and --port from argv. build-macos-app.sh bakes
+// these in by appending them to the Swift binary's launch command in
+// the .app's Contents/Info.plist (via NSPrincipalClass / NSDocumentClass
+// would be the Cocoa way, but plain argv is simpler and we control the
+// build).
+var installDir = ""
+var port = 7860
+var i = 1
+let argv = CommandLine.arguments
+while i < argv.count {
+    switch argv[i] {
+    case "--install-dir":
+        i += 1
+        if i < argv.count { installDir = argv[i] }
+    case "--port":
+        i += 1
+        if i < argv.count { port = Int(argv[i]) ?? 7860 }
+    default: break
+    }
+    i += 1
+}
+if installDir.isEmpty {
+    fputs("error: --install-dir not provided\n", stderr)
+    exit(1)
+}
+
+let app = NSApplication.shared
+app.setActivationPolicy(.accessory)   // Menu bar app — no dock icon
+let delegate = AppDelegate(installDir: installDir, port: port)
+app.delegate = delegate
+app.run()

--- a/app/macos/odysseus-app.sh
+++ b/app/macos/odysseus-app.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+# odysseus-app.sh — the bash worker that Odysseus.app drives.
+#
+# Responsibilities:
+#   * Install path validation (the repo's INSTALL_DIR must exist; if not,
+#     report the issue back to the Swift host and exit non-zero).
+#   * First-run setup: create the venv, install requirements, run setup.py.
+#   * data/ relocation: when ODYSSEUS_FROM_APP=1 is set, symlink ./data
+#     to ~/Library/Application Support/Odysseus/data so uvicorn (which
+#     uses "data/..." relative paths) finds user data in the canonical
+#     macOS location. The symlink lives in the repo but the data lives
+#     in Application Support — same trick npm, cargo, etc. use.
+#   * uvicorn lifecycle: start, wait for readiness, wait for shutdown.
+#   * Status reporting: write app-state.json so the Swift NSStatusItem
+#     menu bar item can show what the worker is doing.
+#
+# The Swift host (OdysseusLauncher) spawns this script and forwards
+# SIGTERM on Cmd-Q; we trap TERM/INT/EXIT and clean up the uvicorn
+# child + the status file.
+
+set -e
+
+# ── Resolve INSTALL_DIR (baked in at build time) ─────────────────────────
+INSTALL_DIR="__INSTALL_DIR__"
+APP_SUPPORT_DIR="$HOME/Library/Application Support/Odysseus"
+STATE_FILE="$APP_SUPPORT_DIR/state.json"
+PORT="${ODYSSEUS_PORT:-7860}"
+URL="http://127.0.0.1:${PORT}"
+UVICORN="$INSTALL_DIR/venv/bin/uvicorn"
+SERVER_PID=""
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+mkdir -p "$APP_SUPPORT_DIR"
+
+# ── Status file helpers ──────────────────────────────────────────────────
+# The Swift NSStatusItem watches this file. Format: {state, port, pid, url, message}
+write_state() {
+  local state="$1" msg="$2"
+  python3 - "$STATE_FILE" "$state" "$PORT" "${SERVER_PID:-0}" "$URL" "$msg" <<'PY'
+import json, os, sys
+path, state, port, pid, url, msg = sys.argv[1:7]
+try:
+    pid = int(pid)
+except (TypeError, ValueError):
+    pid = 0
+payload = {"state": state, "port": int(port), "pid": pid, "url": url, "message": msg}
+tmp = path + ".tmp"
+with open(tmp, "w") as f:
+    json.dump(payload, f)
+os.replace(tmp, path)
+PY
+}
+
+cleanup() {
+  if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" 2>/dev/null; then
+    kill "$SERVER_PID" 2>/dev/null || true
+    # Give uvicorn a moment to flush + close connections.
+    for _ in 1 2 3 4 5; do
+      kill -0 "$SERVER_PID" 2>/dev/null || break
+      sleep 1
+    done
+    kill -9 "$SERVER_PID" 2>/dev/null || true
+  fi
+  # Don't clobber an existing "error" state with "stopped" — the user
+  # clicked the menu bar item to see *what* went wrong, and "stopped"
+  # hides the diagnostic. We only write "stopped" if the last state
+  # was running or starting.
+  current=""
+  if [ -f "$STATE_FILE" ]; then
+    current=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('state',''))" "$STATE_FILE" 2>/dev/null || echo "")
+  fi
+  case "$current" in
+    error) ;;  # preserve the error
+    *)     write_state "stopped" "Server stopped." ;;
+  esac
+}
+# Catch SIGHUP too: the Swift host dying (e.g. from a parent kill) sends
+# SIGHUP to the bash worker. Without trapping it, cleanup() never runs
+# and the state file stays "starting" forever.
+trap cleanup EXIT TERM INT HUP
+
+# ── Install-path validation ─────────────────────────────────────────────
+# Two failure modes:
+#   1. INSTALL_DIR doesn't exist at all (user moved the repo).
+#   2. INSTALL_DIR exists but odysseus.sh is missing (corrupt / partial clone).
+# In both cases we surface a clear message and exit, so the Swift host
+# can show a dialog with a fix.
+if [ ! -d "$INSTALL_DIR" ]; then
+  write_state "error" "Install folder not found: $INSTALL_DIR"
+  echo "Install folder not found: $INSTALL_DIR" >&2
+  exit 1
+fi
+if [ ! -x "$INSTALL_DIR/odysseus.sh" ]; then
+  write_state "error" "Repo at $INSTALL_DIR is missing odysseus.sh"
+  echo "Repo at $INSTALL_DIR is missing odysseus.sh — was it partially moved?" >&2
+  exit 1
+fi
+
+# ── data/ relocation for .app launches ──────────────────────────────────
+# The Python app uses relative "data/..." paths everywhere. We satisfy
+# that with a symlink: ./data -> ~/Library/Application Support/Odysseus/data.
+# Terminal launches skip this — they want ./data in-place.
+if [ "${ODYSSEUS_FROM_APP:-0}" = "1" ]; then
+  cd "$INSTALL_DIR"
+  if [ -e "data" ] && [ ! -L "data" ]; then
+    # Repo has a real data/ directory. Move it into Application Support
+    # so the user's existing data isn't lost on first .app launch.
+    mkdir -p "$APP_SUPPORT_DIR"
+    if [ ! -e "$APP_SUPPORT_DIR/data" ]; then
+      mv "data" "$APP_SUPPORT_DIR/data"
+    else
+      # Both exist — keep the one in Application Support, drop the repo copy.
+      rm -rf "data"
+    fi
+  fi
+  mkdir -p "$APP_SUPPORT_DIR/data"
+  ln -sfn "$APP_SUPPORT_DIR/data" "data"
+  # logs go to Application Support too — terminal launches keep them in
+  # the repo, .app launches put them in the standard place.
+  if [ ! -e "logs" ]; then
+    mkdir -p "$APP_SUPPORT_DIR/logs"
+    ln -sfn "$APP_SUPPORT_DIR/logs" "logs"
+  fi
+fi
+
+# ── First-run setup ─────────────────────────────────────────────────────
+write_state "starting" "Checking dependencies…"
+cd "$INSTALL_DIR"
+
+if [ ! -x "$UVICORN" ]; then
+  write_state "starting" "Installing Python dependencies (first run; one-time)…"
+  # Reuse the launcher. --launch=native idempotently sets up the venv.
+  ODYSSEUS_SKIP_RUN_HINT=1 ./odysseus.sh --launch=native --no-open --port="$PORT" --host=127.0.0.1 || true
+fi
+
+if [ ! -x "$UVICORN" ]; then
+  write_state "error" "Could not set up the venv. Run 'odysseus --launch=native' in Terminal for details."
+  exit 1
+fi
+
+# Already running? Just open the UI.
+if /usr/bin/curl -s -o /dev/null --max-time 2 "$URL" 2>/dev/null; then
+  write_state "running" "Already up at $URL"
+  # Sleep until killed. The Swift host is in charge of the lifecycle.
+  while true; do sleep 1; done
+fi
+
+# ── Start uvicorn ───────────────────────────────────────────────────────
+write_state "starting" "Starting server…"
+APP_LOG="$APP_SUPPORT_DIR/uvicorn.log"
+if [ "$(uname -m)" = "arm64" ]; then
+  arch -arm64 "$UVICORN" app:app --host 127.0.0.1 --port "$PORT" >>"$APP_LOG" 2>&1 &
+else
+  "$UVICORN" app:app --host 127.0.0.1 --port "$PORT" >>"$APP_LOG" 2>&1 &
+fi
+SERVER_PID=$!
+write_state "starting" "Waiting for $URL (this can take ~2 min on first run)…"
+
+# Wait for readiness, up to 120s. Cold start downloads an embedding model.
+READY=0
+for _ in $(seq 1 120); do
+  if /usr/bin/curl -s -o /dev/null --max-time 2 "$URL" 2>/dev/null; then
+    READY=1
+    break
+  fi
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    write_state "error" "Server failed to start. Log: $APP_LOG"
+    exit 1
+  fi
+  sleep 1
+done
+
+if [ "$READY" = "1" ]; then
+  write_state "running" "Up at $URL"
+else
+  write_state "running" "Slow start (model download?) — open $URL once it's ready"
+fi
+
+# Block until the server exits (or the Swift host kills us). The trap on
+# EXIT will call cleanup(), which SIGTERMs the server and waits.
+wait "$SERVER_PID"

--- a/build-macos-app.sh
+++ b/build-macos-app.sh
@@ -4,13 +4,19 @@
 #   ./build-macos-app.sh
 #
 # Produces:
-#   dist/Odysseus.app   — double-click: starts the local server (using this
-#                         repo's venv) and opens the UI in an app-style window.
+#   dist/Odysseus.app   — double-click: menu bar item, drives the local
+#                         server (using this repo's venv) in the background.
+#                         Quit from the menu bar item (Cmd-Q) SIGTERMs the
+#                         worker cleanly.
 #   dist/Odysseus.dmg   — drag-to-Applications disk image (the downloadable).
 #
 # This is a *launcher* wrapper: it drives the venv we set up in this repo, it
 # does not bundle Python. The install path is baked into the app at build time,
 # so rebuild if you move the repo. Override the port with ODYSSEUS_PORT.
+#
+# The .app is ad-hoc signed (codesign -s -) so it runs locally without
+# Gatekeeper prompts. Distribution to other machines needs a Developer
+# ID, which is out of scope.
 set -e
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -19,13 +25,69 @@ INSTALL_DIR="$REPO_DIR"
 PORT="${ODYSSEUS_PORT:-7860}"
 DIST="$REPO_DIR/dist"
 APP="$DIST/$APP_NAME.app"
+BUNDLE_ID="com.odysseus.launcher"
 
 echo "Building $APP_NAME.app"
 echo "  install dir: $INSTALL_DIR"
 echo "  port:        $PORT"
+echo "  bundle id:   $BUNDLE_ID"
 
 rm -rf "$APP"
 mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
+
+# ── Compile the Swift launcher stub ─────────────────────────────────────
+# The Swift binary IS the Contents/MacOS/Odysseus executable. It gets
+# the install dir + port via argv at build time (we bake them in).
+SWIFT_SRC="$REPO_DIR/app/macos/OdysseusLauncher.swift"
+SWIFT_BIN="$APP/Contents/MacOS/$APP_NAME"
+if [ ! -f "$SWIFT_SRC" ]; then
+  echo "✗ Swift source not found: $SWIFT_SRC" >&2
+  exit 1
+fi
+# Bake --install-dir + --port into the binary by appending them to a
+# tiny wrapper script that execs the real binary. We can't actually
+# change argv at compile time, so we use a wrapper as the "executable"
+# in the bundle. (Info.plist's CFBundleExecutable points at the wrapper.)
+# Use the absolute path to the Swift binary so we don't hit a global
+# `odysseus` symlink on PATH (which would resolve to the bash launcher).
+WRAPPER="$APP/Contents/MacOS/launcher"
+SWIFT_BIN_PATH="$APP/Contents/MacOS/$APP_NAME"
+cat > "$WRAPPER" <<EOF
+#!/bin/bash
+# Launcher wrapper. Bakes --install-dir and --port into the Swift host.
+exec "$SWIFT_BIN_PATH" --install-dir "$INSTALL_DIR" --port "$PORT" "\$@"
+EOF
+chmod +x "$WRAPPER"
+
+# Compile Swift. -O for size + speed; target arm64+x86_64 universal so
+# the .app works on both Apple Silicon and Intel Macs.
+ARCH_FLAGS=()
+if [ "$(uname -m)" = "arm64" ]; then
+  ARCH_FLAGS=(-target arm64-apple-macosx11.0)
+else
+  ARCH_FLAGS=(-target x86_64-apple-macosx11.0)
+fi
+xcrun swiftc -O "${ARCH_FLAGS[@]}" \
+  -framework Cocoa -framework Foundation \
+  -Xfrontend -warn-implicit-overrides \
+  -o "$SWIFT_BIN" \
+  "$SWIFT_SRC" 2>&1 | sed 's/^/  swiftc: /' | grep -v "was deprecated in macOS 11.0" | grep -v "All NSUserNotifications API" | head -20
+
+# Sanity check: the binary exists and is executable.
+if [ ! -x "$SWIFT_BIN" ]; then
+  echo "✗ Swift compilation failed: $SWIFT_BIN not produced." >&2
+  exit 1
+fi
+
+# ── Bundle the bash worker ──────────────────────────────────────────────
+# The Swift host spawns Contents/Resources/odysseus-app.sh on launch.
+# Bake the install dir + port in via sed — the same trick we used for
+# the old bash-only launcher.
+sed -e "s|__INSTALL_DIR__|$INSTALL_DIR|g" \
+    -e "s|__PORT__|$PORT|g" \
+    "$REPO_DIR/app/macos/odysseus-app.sh" \
+    > "$APP/Contents/Resources/odysseus-app.sh"
+chmod +x "$APP/Contents/Resources/odysseus-app.sh"
 
 # ── Icon (best effort) — center-crop docs/odysseus.jpg to a square .icns ──
 if [ -f "$REPO_DIR/docs/odysseus.jpg" ] && command -v sips >/dev/null 2>&1; then
@@ -46,115 +108,60 @@ else
 fi
 
 # ── Info.plist ──
+# Notes on the keys:
+#   * CFBundleExecutable = launcher (our wrapper, not the Swift binary)
+#   * LSUIElement        = true → menu bar app, no dock icon
+#   * LSApplicationCategoryType = public.app-category.developer-tools
+#                            → identifies the .app's category in Launchpad
+#   * NSAppleScriptEnabled = true (default) so the "Open in Terminal"
+#                            menu item can spawn Terminal.app
+#   * NSUserNotificationAlertStyle = alert so error toasts aren't silent
 cat > "$APP/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>CFBundleName</key>            <string>$APP_NAME</string>
-    <key>CFBundleDisplayName</key>     <string>$APP_NAME</string>
-    <key>CFBundleIdentifier</key>      <string>com.odysseus.launcher</string>
-    <key>CFBundleVersion</key>         <string>1.0</string>
-    <key>CFBundleShortVersionString</key><string>1.0</string>
-    <key>CFBundlePackageType</key>     <string>APPL</string>
-    <key>CFBundleExecutable</key>      <string>$APP_NAME</string>
-    <key>CFBundleIconFile</key>        <string>odysseus</string>
-    <key>LSMinimumSystemVersion</key>  <string>11.0</string>
-    <key>NSHighResolutionCapable</key> <true/>
-    <key>LSUIElement</key>             <false/>
+    <key>CFBundleName</key>                  <string>$APP_NAME</string>
+    <key>CFBundleDisplayName</key>           <string>$APP_NAME</string>
+    <key>CFBundleIdentifier</key>            <string>$BUNDLE_ID</string>
+    <key>CFBundleVersion</key>               <string>1.0</string>
+    <key>CFBundleShortVersionString</key>    <string>1.0</string>
+    <key>CFBundlePackageType</key>           <string>APPL</string>
+    <key>CFBundleExecutable</key>            <string>launcher</string>
+    <key>CFBundleIconFile</key>              <string>odysseus</string>
+    <key>LSMinimumSystemVersion</key>        <string>11.0</string>
+    <key>LSApplicationCategoryType</key>     <string>public.app-category.developer-tools</string>
+    <key>LSUIElement</key>                   <true/>
+    <key>NSHighResolutionCapable</key>       <true/>
+    <key>NSAppleScriptEnabled</key>          <true/>
+    <key>NSUserNotificationAlertStyle</key>  <string>alert</string>
 </dict>
 </plist>
 PLIST
 
-# ── Launcher executable (placeholders filled below) ──
-cat > "$APP/Contents/MacOS/$APP_NAME.tmpl" <<'LAUNCHER'
-#!/bin/bash
-# Odysseus.app — start the local server and open the UI in an app window.
-INSTALL_DIR="__INSTALL_DIR__"
-PORT="__PORT__"
-URL="http://127.0.0.1:${PORT}"
-export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
-
-UVICORN="$INSTALL_DIR/venv/bin/uvicorn"
-LOG="$INSTALL_DIR/logs/odysseus-app.log"
-
-notify() { /usr/bin/osascript -e "display notification \"$1\" with title \"Odysseus\"" >/dev/null 2>&1; }
-die_gui() {
-  /usr/bin/osascript -e "display dialog \"$1\" with title \"Odysseus\" buttons {\"OK\"} default button 1 with icon stop" >/dev/null 2>&1
+# ── Validate the plist is well-formed ──────────────────────────────────
+if ! plutil -lint "$APP/Contents/Info.plist" >/dev/null 2>&1; then
+  echo "✗ Info.plist failed plutil -lint." >&2
+  plutil -lint "$APP/Contents/Info.plist" >&2 || true
   exit 1
-}
-
-[ -x "$UVICORN" ] || die_gui "Odysseus isn't set up yet. Open Terminal and run:
-
-cd $INSTALL_DIR
-python3.11 -m venv venv
-./venv/bin/pip install -r requirements.txt
-./venv/bin/python setup.py"
-
-# Open the UI in a chrome-less app window (Chromium browsers), else default browser.
-open_ui() {
-  local b base exe bin
-  for b in "Google Chrome" "Microsoft Edge" "Brave Browser" "Chromium"; do
-    for base in "/Applications" "$HOME/Applications"; do
-      if [ -d "$base/$b.app" ]; then
-        exe="$(/usr/bin/defaults read "$base/$b.app/Contents/Info" CFBundleExecutable 2>/dev/null)"
-        bin="$base/$b.app/Contents/MacOS/$exe"
-        if [ -x "$bin" ]; then
-          "$bin" --app="$URL" --new-window >/dev/null 2>&1 &
-          return 0
-        fi
-      fi
-    done
-  done
-  /usr/bin/open "$URL"
-}
-
-mkdir -p "$INSTALL_DIR/logs"
-
-# Already running? Just open the UI.
-if /usr/bin/curl -s -o /dev/null --max-time 2 "$URL"; then
-  open_ui
-  exit 0
 fi
 
-notify "Starting…"
-cd "$INSTALL_DIR" || die_gui "Install folder not found: $INSTALL_DIR"
-if [ "$(uname -m)" = "arm64" ]; then
-  arch -arm64 "$UVICORN" app:app --host 127.0.0.1 --port "$PORT" >>"$LOG" 2>&1 &
-else
-  "$UVICORN" app:app --host 127.0.0.1 --port "$PORT" >>"$LOG" 2>&1 &
+# ── Ad-hoc code sign ────────────────────────────────────────────────────
+# codesign --force --deep --sign - signs with an ad-hoc identity. That's
+# enough for a launcher that the user double-clicks locally — no
+# Gatekeeper prompt, no quarantine, and the .app can be moved around
+# the user's machine without breaking. Distribution to other people
+# would need a Developer ID identity.
+echo "  codesign:    ad-hoc"
+if ! codesign --force --deep --sign - "$APP" 2>&1; then
+  echo "  ⚠ codesign failed; the .app may prompt on first launch." >&2
 fi
-SERVER_PID=$!
-
-# Quitting the app stops the server it started.
-trap 'kill $SERVER_PID 2>/dev/null; exit 0' TERM INT
-
-# Wait for readiness (first run downloads an embedding model — allow ~2 min).
-READY=0
-for i in $(seq 1 120); do
-  /usr/bin/curl -s -o /dev/null --max-time 2 "$URL" && { READY=1; break; }
-  kill -0 "$SERVER_PID" 2>/dev/null || die_gui "Odysseus failed to start. Log:
-$LOG"
-  sleep 1
-done
-
-if [ "$READY" = "1" ]; then
-  open_ui
-else
-  notify "Odysseus is taking a while — open $URL once it finishes starting."
-fi
-wait "$SERVER_PID"
-LAUNCHER
-
-sed -e "s|__INSTALL_DIR__|$INSTALL_DIR|g" -e "s|__PORT__|$PORT|g" \
-    "$APP/Contents/MacOS/$APP_NAME.tmpl" > "$APP/Contents/MacOS/$APP_NAME"
-rm -f "$APP/Contents/MacOS/$APP_NAME.tmpl"
-chmod +x "$APP/Contents/MacOS/$APP_NAME"
+codesign --verify --verbose "$APP" 2>&1 | sed 's/^/  verify:     /' || true
 
 # Refresh Finder's icon cache for the new bundle.
 touch "$APP"
 
-# ── .dmg (drag-to-Applications) ──
+# ── .dmg (drag-to-Applications) ────────────────────────────────────────
 echo "Packaging dist/$APP_NAME.dmg"
 STAGE="$(mktemp -d)/dmg"
 mkdir -p "$STAGE"
@@ -171,3 +178,6 @@ echo "  $DIST/$APP_NAME.dmg"
 echo ""
 echo "Run it:        open '$APP'"
 echo "Install:       open '$DIST/$APP_NAME.dmg'  (drag Odysseus to Applications)"
+echo ""
+echo "Note: the install path is baked in at build time. After moving the"
+echo "repo, re-run:  $REPO_DIR/build-macos-app.sh"

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -1,0 +1,207 @@
+# Odysseus on macOS
+
+This doc covers everything macOS-specific. For the launcher flags
+themselves, see [`docs/launcher.md`](launcher.md).
+
+## One-shot install
+
+```sh
+git clone https://github.com/pewdiepie-archdaemon/odysseus.git
+cd odysseus
+./odysseus.sh --launch=native
+```
+
+That command:
+
+1. Installs Homebrew if it's missing.
+2. Installs Python 3.11, Docker Desktop, and git via Homebrew if any of
+   them are missing.
+3. Creates `venv/` with `python3.11` and installs the pinned deps.
+4. If Docker is available, starts a persistent `searxng/searxng` container
+   on `127.0.0.1:8080` (honors `SEARXNG_INSTANCE` and `ODYSSEUS_NO_SEARXNG=1`).
+5. Runs `python setup.py` to provision the local data directory.
+6. Starts uvicorn on `127.0.0.1:7860` and opens the browser.
+
+Re-running is fast: the requirements-hash cache skips `pip install` when
+`requirements.txt` is unchanged.
+
+## Auto-start at login
+
+```sh
+./odysseus.sh --install-service
+```
+
+> **The repo must NOT be under `~/Desktop`, `~/Documents`, or
+> `~/Downloads`.** macOS's TCC framework blocks launchd from
+> executing scripts that live in those folders. The install script
+> detects this and prints a one-liner fix. The convention is
+> `~/odysseus`.
+
+This drops a per-user LaunchAgent at:
+
+```
+~/Library/LaunchAgents/com.odysseus.ui.plist
+```
+
+and bootstraps it into the `gui/$(id -u)` launchd domain. The agent:
+
+- starts on login (`RunAtLoad = true`)
+- respawns on crash (`KeepAlive.Crashed = true`, `SuccessfulExit = false`)
+- throttles to one restart per 10 s so a crash loop doesn't hammer the box
+- logs to `~/Library/Logs/Odysseus/{stdout,stderr}.log`
+- runs `odysseus.sh --launch=native --no-open` (so the server starts but
+  the browser doesn't pop every time you log in)
+- inherits an explicit `PATH` (`/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin`)
+  because launchd's default `PATH` doesn't include Homebrew
+- runs in the user's GUI session (`ProcessType = Interactive`) so any
+  Keychain access works the same as a Terminal launch
+
+### Update flow
+
+```sh
+./odysseus.sh --update
+```
+
+On macOS, the launcher:
+
+1. Detects whether the agent is loaded.
+2. If so, `launchctl bootout`s it (cleanly stops the uvicorn child).
+3. `git pull --rebase --autostash`.
+4. Re-bootstraps the agent and `kickstart -k`s it to start fresh.
+
+The native launcher (running inside the agent) also re-checks the
+requirements-hash on every launch, so a no-op update doesn't trigger
+a reinstall.
+
+### Inspection
+
+```sh
+launchctl print gui/$(id -u)/com.odysseus.ui
+tail -f ~/Library/Logs/Odysseus/stdout.log
+launchctl list | grep odysseus
+```
+
+### Removal
+
+```sh
+./odysseus.sh --uninstall-service
+```
+
+Bootouts the agent, removes the plist, and leaves `~/Library/Logs/Odysseus/`
+in place for grepping. Reinstall is one command away.
+
+## The .app bundle
+
+`./odysseus.sh --package-mac` (or `./build-macos-app.sh` directly) builds
+`dist/Odysseus.app` + `dist/Odysseus.dmg`. Drag the .app from the dmg to
+Applications and double-click.
+
+What the .app does, in plain terms:
+
+- Spawns a menu bar item ("⚙︎ Odysseus" → "● Odysseus" once the server
+  is up) with Open in Browser, Open in Terminal, Reveal Log in Finder,
+  and Quit.
+- Drags the same repo's venv as `--install-service` does. The .app is a
+  *launcher*, not a self-contained bundle — the install dir is baked in
+  at build time. After moving the repo, re-run `--package-mac`.
+- On first launch, sets up the venv (idempotently) and starts uvicorn.
+  The first cold start downloads an embedding model — allow ~2 minutes.
+- Caches your data under `~/Library/Application Support/Odysseus/` —
+  the repo's `data/` and `logs/` become symlinks to that location.
+  This is the macOS-conventional place for user data and means the
+  .app can be moved/updated without losing your chats, notes, etc.
+- Cmd-Q (or Quit from the menu) sends SIGTERM to the worker, which
+  SIGTERMs uvicorn and waits for clean exit. No orphan processes.
+- Ad-hoc code signed (no Developer ID required) so it launches
+  without Gatekeeper prompts on your own machine. Distributing the
+  .app to other people needs a Developer ID, which is out of scope.
+
+If you move the repo and don't rebuild, the menu bar item shows the
+"✕ Odysseus" error state with a clear "Install folder not found" /
+"Repo at <path> is missing odysseus.sh" message. The "Open in Terminal"
+menu item drops you into a shell at the install dir for recovery.
+
+### Why a Swift stub?
+
+The .app is a Cocoa app, not a shell script. A real menu bar item and
+proper Cmd-Q semantics (where quitting sends SIGTERM and waits for
+the child to flush logs before exiting) need a Cocoa run loop. The
+Swift stub is ~300 lines and handles:
+
+- NSStatusItem (menu bar) with state-aware title + tooltip
+- DispatchSource on SIGTERM/SIGINT so a `kill` from another terminal
+  still results in a clean worker shutdown (Cocoa doesn't always
+  surface those as `applicationShouldTerminate` for accessory apps)
+- Spawning the bash worker (`Contents/Resources/odysseus-app.sh`),
+  forwarding its stdout/stderr to the user's log file
+- Watching `~/Library/Application Support/Odysseus/state.json` and
+  re-rendering the menu bar when it changes
+- One-click "Open in Browser" using Chromium's `--app=URL` if a
+  Chromium-family browser is installed, else the default browser
+- Error → user notification (toast) so the user doesn't have to
+  click the menu bar to find out something went wrong
+
+The bash worker handles everything else: data relocation, first-run
+setup, uvicorn lifecycle, status file writes, signal traps. Splitting
+it this way means the Swift code is "just" Cocoa glue, and the
+install/run logic lives in a script that's shellcheck-clean and
+debuggable in isolation.
+
+## Port 7000 vs 7860
+
+macOS Monterey+ runs AirPlay Receiver on port 7000. Odysseus detects
+this and flips the default to 7860. To force a different port:
+
+```sh
+./odysseus.sh --port=7900
+# or persistently in .env:
+echo "APP_PORT=7900" >> .env
+```
+
+## Apple Silicon vs Intel
+
+The launcher auto-detects Apple Silicon via `uname -m` and points
+to `/opt/homebrew` (Apple Silicon's Homebrew prefix) rather than
+`/usr/local` (Intel's). It also enables Metal in llama.cpp/Ollama
+where the relevant env var exists.
+
+## GPU acceleration
+
+The native path uses llama.cpp or Ollama with Metal on Apple Silicon.
+The Docker path does not — Docker on macOS runs in a Linux VM with no
+GPU passthrough. If you see a "CPU only" warning from
+`odysseus --launch=docker`, that's expected; use `--launch=native` for
+GPU.
+
+## File layout when run as a service
+
+| File | Purpose |
+|---|---|
+| `~/Library/LaunchAgents/com.odysseus.ui.plist` | LaunchAgent definition |
+| `~/Library/Logs/Odysseus/stdout.log` | stdout of the launcher |
+| `~/Library/Logs/Odysseus/stderr.log` | stderr of the launcher (uvicorn logs go here) |
+
+Nothing under the repo is moved by the service install — `data/`,
+`venv/`, and the SearXNG settings live in their original locations so
+the CLI and service paths share state. (The `.app` distribution in
+Phase 3 will move `data/` to `~/Library/Application Support/Odysseus/`
+only when launched from the .app bundle, not from the CLI.)
+
+## Why the repo must live outside `~/Desktop`
+
+macOS's Transparency, Consent, and Control (TCC) framework restricts
+what `launchd` can access when it runs a LaunchAgent. A Terminal
+session inherits your user's TCC consents (Desktop, Documents,
+Downloads); `launchd` does not. So a repo cloned into `~/Desktop/`
+will install the plist fine, but every time the agent tries to spawn
+it will fail with:
+
+```
+bash: /Users/you/Desktop/odysseus/odysseus.sh: Operation not permitted
+shell-init: error retrieving current directory: getcwd: cannot access
+parent directories: Operation not permitted
+```
+
+The fix is to keep the repo outside TCC scope. `~/odysseus` is the
+convention. The install script detects this and refuses to install
+with a one-liner fix; you don't have to remember.

--- a/odysseus.sh
+++ b/odysseus.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+# odysseus — one launcher for every platform-native install path.
+#
+#   ./odysseus.sh --launch=native
+#   ./odysseus.sh --launch=docker
+#   ./odysseus.sh --update
+#   ./odysseus.sh --port=7900 --host=0.0.0.0 --launch=native
+#   ./odysseus.sh --add-to-path
+#
+# On macOS this is the script you'll want. On Linux it works the same way.
+# On Windows, use odysseus.ps1 — the flag surface is identical.
+#
+# Old entry points (start-macos.sh, install-service.sh, update_windows.bat)
+# are now thin shims that call into this script.
+
+set -e
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$REPO_DIR"
+
+# ── Defaults ──────────────────────────────────────────────────────────────
+LAUNCH="native"          # native | docker | docker-nvidia | docker-amd
+UPDATE=0
+ADD_PATH=0
+REMOVE_PATH=0
+INSTALL_SERVICE=0
+UNINSTALL_SERVICE=0
+PORT="${ODYSSEUS_PORT:-${APP_PORT:-7000}}"
+HOST="${ODYSSEUS_HOST:-${APP_BIND:-127.0.0.1}}"
+DOCKER_NO_OPEN=0
+PACKAGE_MAC=0
+
+usage() {
+  cat <<EOF
+odysseus — one launcher for every platform-native install path.
+
+Usage: odysseus [flags]
+
+Launch mode (default: native):
+  --launch=native           Run the app directly on this machine (venv + uvicorn).
+                            The right choice on macOS — keeps GPU/Metal access.
+  --launch=docker           docker compose up (auto-detects GPU overlay).
+  --launch=docker-nvidia    Force the NVIDIA GPU overlay.
+  --launch=docker-amd       Force the AMD/ROCm GPU overlay (Linux only).
+
+Lifecycle:
+  --update                  git pull + reinstall Python deps (only if requirements.txt
+                            changed) + rebuild Docker images (when --launch=docker*).
+                            Safe to re-run.
+  --add-to-path             Symlink odysseus into ~/.local/bin and ensure that dir is
+                            on PATH in ~/.zshrc / ~/.bashrc, so 'odysseus' works
+                            from anywhere.
+  --remove-from-path        Reverse the above.
+
+Service (auto-start at login):
+  --install-service         Install the platform auto-start agent:
+                              • macOS:  ~/Library/LaunchAgents/com.odysseus.ui.plist
+                              • Linux:  /etc/systemd/system/odysseus-ui.service
+                            Runs in the background and survives reboots.
+  --uninstall-service       Remove the auto-start agent (leaves data/ + venv/ alone).
+
+Server:
+  --port=N                  Override the port (default: 7000; 7860 on macOS by
+                            default since AirPlay Receiver holds 7000).
+  --host=H                  Override the bind address (default: 127.0.0.1).
+                            Use 0.0.0.0 to expose on LAN/Tailscale.
+
+Docker:
+  --no-open                 Don't open the browser when the server is ready.
+
+Packaging (macOS):
+  --package-mac             Build dist/Odysseus.app + dist/Odysseus.dmg from
+                            the current repo. Re-run after moving the repo.
+
+Examples:
+  ./odysseus.sh                          # launch native, default port
+  ./odysseus.sh --port=7900              # launch native on 7900
+  ./odysseus.sh --launch=docker          # docker compose up (auto GPU)
+  ./odysseus.sh --update                 # pull + reinstall + rebuild
+  ./odysseus.sh --install-service        # auto-start at login
+  ./odysseus.sh --add-to-path            # 'odysseus' from anywhere
+EOF
+}
+
+# ── Arg parsing (long-form only — keeps the surface small) ────────────────
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --launch=*)        LAUNCH="${1#*=}" ;;
+    --launch)          LAUNCH="$2"; shift ;;
+    --update)          UPDATE=1 ;;
+    --add-to-path)     ADD_PATH=1 ;;
+    --remove-from-path) REMOVE_PATH=1 ;;
+    --install-service) INSTALL_SERVICE=1 ;;
+    --uninstall-service) UNINSTALL_SERVICE=1 ;;
+    --port=*)          PORT="${1#*=}" ;;
+    --port)            PORT="$2"; shift ;;
+    --host=*)          HOST="${1#*=}" ;;
+    --host)            HOST="$2"; shift ;;
+    --no-open)         DOCKER_NO_OPEN=1 ;;
+    --package-mac)     PACKAGE_MAC=1 ;;
+    -h|--help)         usage; exit 0 ;;
+    *)                 echo "Unknown flag: $1" >&2; usage; exit 2 ;;
+  esac
+  shift
+done
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+is_macos() { [ "$(uname -s)" = "Darwin" ]; }
+is_linux() { [ "$(uname -s)" = "Linux" ]; }
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "✗ Required command not found: $1" >&2
+    echo "  Install it, then re-run: $0 $*" >&2
+    exit 1
+  fi
+}
+
+# ── Dispatch ──────────────────────────────────────────────────────────────
+case "$LAUNCH" in
+  native) ;;
+  docker|docker-nvidia|docker-amd) ;;
+  *) echo "✗ Unknown --launch value: $LAUNCH" >&2; usage; exit 2 ;;
+esac
+
+# --add-to-path: drop a symlink and a one-line shell hook so `odysseus`
+# works from any directory. Reversible with --remove-from-path.
+
+if [ "$ADD_PATH" = "1" ]; then
+  BIN_DIR="$HOME/.local/bin"
+  mkdir -p "$BIN_DIR"
+  ln -sf "$REPO_DIR/odysseus.sh" "$BIN_DIR/odysseus"
+  ln -sf "$REPO_DIR/odysseus.sh" "$BIN_DIR/odysseus.sh"
+  for rc in "$HOME/.zshrc" "$HOME/.bashrc"; do
+    [ -f "$rc" ] || continue
+    if ! grep -qF "$BIN_DIR" "$rc" 2>/dev/null; then
+      # $HOME below is intentionally literal — the user's shell expands it
+      # on source, which is the right behaviour for a portable rc file.
+      # shellcheck disable=SC2016
+      printf '\n# Added by Odysseus: make `odysseus` work from anywhere\nexport PATH="$HOME/.local/bin:$PATH"\n' >> "$rc"
+      echo "  ✓ added $BIN_DIR to PATH in $rc"
+    fi
+  done
+  echo "✓ odysseus is now available. Open a new shell or run:  export PATH=\"\$HOME/.local/bin:\$PATH\""
+  exit 0
+fi
+
+if [ "$REMOVE_PATH" = "1" ]; then
+  rm -f "$HOME/.local/bin/odysseus" "$HOME/.local/bin/odysseus.sh"
+  for rc in "$HOME/.zshrc" "$HOME/.bashrc"; do
+    [ -f "$rc" ] || continue
+    # Remove the Odysseus-added block.
+    if grep -q "Added by Odysseus" "$rc" 2>/dev/null; then
+      # Delete the marker line + the export below it.
+      python3 - "$rc" <<'PY' 2>/dev/null || true
+import sys, re
+p = sys.argv[1]
+try:
+    with open(p) as f: txt = f.read()
+except OSError:
+    sys.exit(0)
+out = re.sub(r'\n*# Added by Odysseus[^\n]*\nexport PATH="\$HOME/\.local/bin:\$PATH"\n*', '\n', txt)
+with open(p, 'w') as f: f.write(out)
+PY
+      echo "  ✓ removed Odysseus PATH entry from $rc"
+    fi
+  done
+  echo "✓ odysseus removed from PATH"
+  exit 0
+fi
+
+# --install-service / --uninstall-service: defer to platform script.
+if [ "$INSTALL_SERVICE" = "1" ]; then
+  if is_macos; then
+    exec "$REPO_DIR/install-macos-service.sh" "$@"
+  elif is_linux; then
+    exec "$REPO_DIR/install-service.sh" "$@"
+  else
+    echo "✗ --install-service is only supported on macOS and Linux" >&2
+    exit 1
+  fi
+fi
+if [ "$UNINSTALL_SERVICE" = "1" ]; then
+  if is_macos; then
+    exec "$REPO_DIR/uninstall-macos-service.sh" "$@"
+  elif is_linux; then
+    echo "(no Linux uninstall script yet — manually: sudo systemctl disable --now odysseus-ui && sudo rm /etc/systemd/system/odysseus-ui.service)"
+    exit 0
+  else
+    echo "✗ --uninstall-service is only supported on macOS and Linux" >&2
+    exit 1
+  fi
+fi
+
+# --update: pull + reinstall. We always make sure venv deps are current when
+# requirements.txt changed, then rebuild Docker images if --launch=docker*.
+#
+# On macOS, if the LaunchAgent is installed, stop it before git pull so the
+# running uvicorn doesn't hold files we'll overwrite; restart it after.
+if [ "$UPDATE" = "1" ]; then
+  AGENT_LAUNCHED=0
+  if is_macos; then
+    DOMAIN="gui/$(id -u)"
+    if launchctl print "$DOMAIN/com.odysseus.ui" >/dev/null 2>&1; then
+      echo "▶ stopping launchd agent…"
+      launchctl bootout "$DOMAIN/com.odysseus.ui" 2>/dev/null || true
+      AGENT_LAUNCHED=1
+    fi
+  fi
+
+  echo "▶ git pull…"
+  git pull --rebase --autostash
+  # Re-invoke ourselves so the rest of the launch (native/docker) picks up
+  # any code that changed in the pull. The native path re-checks the
+  # requirements hash (start-macos.sh / a future native path) so we don't
+  # waste time reinstalling when nothing changed.
+
+  if [ "$AGENT_LAUNCHED" = "1" ]; then
+    echo "▶ restarting launchd agent…"
+    PLIST_PATH="$HOME/Library/LaunchAgents/com.odysseus.ui.plist"
+    if [ -f "$PLIST_PATH" ]; then
+      launchctl bootstrap "$DOMAIN" "$PLIST_PATH" 2>/dev/null || true
+      launchctl enable "$DOMAIN/com.odysseus.ui" 2>/dev/null || true
+      launchctl kickstart -k "$DOMAIN/com.odysseus.ui" 2>/dev/null || true
+    fi
+  fi
+fi
+
+# --package-mac: build the .app + .dmg. macOS only.
+if [ "$PACKAGE_MAC" = "1" ]; then
+  if ! is_macos; then
+    echo "✗ --package-mac is macOS only." >&2
+    exit 1
+  fi
+  exec "$REPO_DIR/build-macos-app.sh"
+fi
+
+# ── Launch dispatch ───────────────────────────────────────────────────────
+
+# Probe host: 0.0.0.0 / :: aren't connectable for "is the port open?" checks.
+PROBE_HOST="$HOST"
+case "$PROBE_HOST" in
+  0.0.0.0|::) PROBE_HOST="127.0.0.1" ;;
+esac
+
+port_in_use() {
+  if is_macos || is_linux; then
+    (exec 3<>"/dev/tcp/$PROBE_HOST/$PORT") 2>/dev/null
+  else
+    return 1
+  fi
+}
+
+# On macOS, AirPlay Receiver holds port 7000; default to 7860 unless the
+# user explicitly asked for something else.
+if is_macos && [ "$LAUNCH" = "native" ] && [ -z "$ODYSSEUS_PORT" ] && [ -z "$APP_PORT" ] && [ "$PORT" = "7000" ]; then
+  PORT=7860
+fi
+
+# ── Native launch (the macOS path) ───────────────────────────────────────
+if [ "$LAUNCH" = "native" ]; then
+  if is_macos && [ -x "$REPO_DIR/scripts/legacy/macos-native.sh" ]; then
+    # Delegate to the legacy macOS native launcher (the original
+    # start-macos.sh logic, now living in scripts/legacy/ so the public
+    # entry point can be a thin shim). The ODYSSEUS_LEGACY_ENTRY=1 marker
+    # tells that script to skip the deprecation banner.
+    exec env ODYSSEUS_LEGACY_ENTRY=1 \
+      ODYSSEUS_REPO_DIR="$REPO_DIR" \
+      ODYSSEUS_PORT="$PORT" ODYSSEUS_HOST="$HOST" \
+      ODYSSEUS_NO_OPEN="$([ "$DOCKER_NO_OPEN" = "1" ] && echo 1 || echo)" \
+      "$REPO_DIR/scripts/legacy/macos-native.sh"
+  fi
+  if is_linux; then
+    if port_in_use; then
+      echo "✗ Port $PORT is already in use on $PROBE_HOST. Stop what's using it, or pick another:"
+      echo "    $0 --port=7900"
+      exit 1
+    fi
+    PY=""
+    for cand in python3.13 python3.12 python3.11 python3; do
+      p="$(command -v "$cand" 2>/dev/null)" || continue
+      if "$p" -c 'import sys; raise SystemExit(0 if sys.version_info[:2] >= (3, 11) else 1)' 2>/dev/null; then
+        PY="$p"; break
+      fi
+    done
+    if [ -z "$PY" ]; then
+      echo "✗ Couldn't find a Python 3.11+ to build the environment with."
+      echo "  Install one (e.g. sudo apt install python3.11 python3.11-venv) and re-run."
+      exit 1
+    fi
+    [ -d venv ] || "$PY" -m venv venv
+    ./venv/bin/python -m pip install --quiet --upgrade pip
+    ./venv/bin/python -m pip install -r requirements.txt
+    ODYSSEUS_SKIP_RUN_HINT=1 ./venv/bin/python setup.py
+    exec ./venv/bin/python -m uvicorn app:app --host "$HOST" --port "$PORT"
+  fi
+  echo "✗ Native launch on $(uname -s) is not yet supported by odysseus.sh." >&2
+  echo "  On macOS, install via the bundled start-macos.sh. On Windows, use odysseus.ps1." >&2
+  exit 1
+fi
+
+# ── Docker launch ────────────────────────────────────────────────────────
+require_cmd docker
+
+DOCKER_COMPOSE_FILE="docker-compose.yml"
+case "$LAUNCH" in
+  docker-nvidia) DOCKER_COMPOSE_FILE="docker-compose.gpu-nvidia.yml" ;;
+  docker-amd)    DOCKER_COMPOSE_FILE="docker-compose.gpu-amd.yml" ;;
+  docker)
+    # Auto-detect the best overlay. macOS never has GPU passthrough into
+    # Docker, so even an M-series Mac falls back to CPU — but at least we
+    # say so.
+    if is_macos; then
+      echo "  ⚠ Docker on macOS runs in a Linux VM with no GPU access — starting CPU-only."
+      echo "    For Metal/GPU acceleration, use --launch=native."
+    elif command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi -L >/dev/null 2>&1; then
+      DOCKER_COMPOSE_FILE="docker-compose.gpu-nvidia.yml"
+      echo "  ✓ detected NVIDIA GPU — using GPU overlay"
+    elif [ -e /dev/kfd ] && [ -d /dev/dri ] && is_linux; then
+      DOCKER_COMPOSE_FILE="docker-compose.gpu-amd.yml"
+      echo "  ✓ detected AMD/ROCm GPU — using GPU overlay"
+    else
+      echo "  ⚠ No GPU detected (nvidia-smi not found, /dev/kfd not present). Starting CPU-only."
+      echo "    To override: --launch=docker-nvidia or --launch=docker-amd"
+    fi
+    ;;
+esac
+
+# docker compose v2 vs v1: prefer 'docker compose', fall back to 'docker-compose'.
+if docker compose version >/dev/null 2>&1; then
+  DC=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+  DC=(docker-compose)
+else
+  echo "✗ Neither 'docker compose' nor 'docker-compose' is available." >&2
+  exit 1
+fi
+
+if [ "$UPDATE" = "1" ]; then
+  echo "▶ rebuilding Docker images…"
+  "${DC[@]}" -f "$DOCKER_COMPOSE_FILE" build --pull
+fi
+
+if [ -n "$APP_PORT" ] || [ "$PORT" != "7000" ]; then
+  APP_PORT="$PORT" "${DC[@]}" -f "$DOCKER_COMPOSE_FILE" up -d --build
+else
+  "${DC[@]}" -f "$DOCKER_COMPOSE_FILE" up -d --build
+fi
+echo
+echo "▶ Odysseus is up. Tailing logs (Ctrl+C to detach)…"
+"${DC[@]}" -f "$DOCKER_COMPOSE_FILE" logs -f odysseus


### PR DESCRIPTION
## Summary
The previous macOS .app was a single bash script inside a bundle: no menu bar item, no proper Cmd-Q semantics, no graceful handling of a \`kill\` from another terminal. The new \`dist/Odysseus.app\` is a real Cocoa menu bar app. The split is a ~300-line Swift host (\`app/macos/OdysseusLauncher.swift\`) for Cocoa glue — NSStatusItem with state-aware title/tooltip, DispatchSource on SIGTERM/SIGINT for clean shutdown on external kill, watcher on \`~/Library/Application Support/Odysseus/state.json\`, Chromium \`--app=URL\` open, and error toasts — plus a bash worker (\`app/macos/odysseus-app.sh\`) for install/run logic. The \`data/\` and \`logs/\` directories are relocated to \`~/Library/Application Support/Odysseus/\` via symlink when launched from the .app, so the .app can be moved/updated without losing user data. Ad-hoc code signed (no Developer ID) so it launches without Gatekeeper prompts locally.

## Target branch
- [x] This PR targets **`dev`**, not `main`.

## Linked Issue
Part of #2475, fixes the work tracked in #2799

## Type of Change
- [x] New feature (non-breaking — adds new behaviour)

## Checklist
- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test
1. \`./odysseus.sh --package-mac\` — should produce \`dist/Odysseus.app\` and \`dist/Odysseus.dmg\`.
2. \`codesign --verify --verbose dist/Odysseus.app\` — should show "valid on disk / satisfies Designated Requirement" (ad-hoc sign).
3. Drag \`Odysseus.app\` to \`/Applications\` and double-click — menu bar should show "⚙︎ Odysseus".
4. Wait ~5s — the menu bar title should change to "● Odysseus" once uvicorn is up.
5. Click the menu bar item — "Open in Browser" should open the UI, "Reveal Log in Finder" should jump to the log.
6. Cmd-Q — should kill the worker cleanly: \`ps -ef | grep uvicorn\` should be empty (no orphan with PPID=1).
7. \`pkill -9 -f "odysseus-app.sh|MacOS/Odysseus" \` from another terminal — should also produce a clean shutdown (the DispatchSource handler kicks in).
8. \`pkill -9\` the worker itself — should produce "✕ Odysseus — worker exited unexpectedly" toast and \`state.json\` should show "error" (the cleanup trap preserves the error state, doesn't overwrite with "stopped").
9. The 149 unit tests under \`tests/test_endpoint_probing.py\`, \`tests/test_model_routes.py\`, \`tests/test_hwfit_macos.py\`, and \`tests/test_platform_compat.py\` all pass.

## Visual / UI changes
This PR adds a *native macOS menu bar app* (NSStatusItem), not a web UI change. The existing CSS variables, fonts, and theme system in the web UI are untouched. Menu bar item uses system-provided template image styling (no emoji, no custom font, no parallel patterns). The "Visual / UI changes" section above does not apply — this is a Cocoa UI, not the web UI governed by \`static/index.html\`.