### PR TITLE
feat(macos): Homebrew formula + symlink-aware REPO_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,18 @@ ODYSSEUS_HOST=0.0.0.0 ./start-macos.sh
 # then open http://<tailscale-ip>:7860
 ```
 
+#### Homebrew install (macOS)
+
+```bash
+brew install pewdiepie-archdaemon/tap/odysseus
+brew services start odysseus   # auto-start at login, restart on crash
+```
+
+The formula installs the repo to `libexec/`, symlinks `odysseus` +
+the helper commands into `bin/`, and writes a launchd plist under
+`brew services`. See [`docs/macos.md`](docs/macos.md#homebrew-install)
+for details and upgrade flow.
+
 The script also reads `.env` at startup, so `APP_BIND=0.0.0.0` and `APP_PORT`
 set there are picked up automatically without a command-line override each run.
 

--- a/app/macos/odysseus-app.sh
+++ b/app/macos/odysseus-app.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+# odysseus-app.sh — the bash worker that Odysseus.app drives.
+#
+# Responsibilities:
+#   * Install path validation (the repo's INSTALL_DIR must exist; if not,
+#     report the issue back to the Swift host and exit non-zero).
+#   * First-run setup: create the venv, install requirements, run setup.py.
+#   * data/ relocation: when ODYSSEUS_FROM_APP=1 is set, symlink ./data
+#     to ~/Library/Application Support/Odysseus/data so uvicorn (which
+#     uses "data/..." relative paths) finds user data in the canonical
+#     macOS location. The symlink lives in the repo but the data lives
+#     in Application Support — same trick npm, cargo, etc. use.
+#   * uvicorn lifecycle: start, wait for readiness, wait for shutdown.
+#   * Status reporting: write app-state.json so the Swift NSStatusItem
+#     menu bar item can show what the worker is doing.
+#
+# The Swift host (OdysseusLauncher) spawns this script and forwards
+# SIGTERM on Cmd-Q; we trap TERM/INT/EXIT and clean up the uvicorn
+# child + the status file.
+
+set -e
+
+# ── Resolve INSTALL_DIR (baked in at build time) ─────────────────────────
+INSTALL_DIR="__INSTALL_DIR__"
+APP_SUPPORT_DIR="$HOME/Library/Application Support/Odysseus"
+STATE_FILE="$APP_SUPPORT_DIR/state.json"
+PORT="${ODYSSEUS_PORT:-7860}"
+URL="http://127.0.0.1:${PORT}"
+UVICORN="$INSTALL_DIR/venv/bin/uvicorn"
+SERVER_PID=""
+
+# INSTALL_DIR may itself be a symlink (e.g. when installed via
+# Homebrew, the bin entry is a symlink into libexec). Follow it so
+# the venv + uvicorn are found at the real path.
+if [ -L "$INSTALL_DIR" ]; then
+  INSTALL_DIR="$(cd -P "$(dirname "$INSTALL_DIR")" && pwd)/$(basename "$INSTALL_DIR")"
+  # Re-resolve if the target is also a symlink (chained symlinks).
+  while [ -L "$INSTALL_DIR" ]; do
+    TARGET=$(readlink "$INSTALL_DIR")
+    [[ "$TARGET" == /* ]] && INSTALL_DIR="$TARGET" || INSTALL_DIR="$(dirname "$INSTALL_DIR")/$TARGET"
+  done
+fi
+UVICORN="$INSTALL_DIR/venv/bin/uvicorn"
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+mkdir -p "$APP_SUPPORT_DIR"
+
+# ── Status file helpers ──────────────────────────────────────────────────
+# The Swift NSStatusItem watches this file. Format: {state, port, pid, url, message}
+write_state() {
+  local state="$1" msg="$2"
+  python3 - "$STATE_FILE" "$state" "$PORT" "${SERVER_PID:-0}" "$URL" "$msg" <<'PY'
+import json, os, sys
+path, state, port, pid, url, msg = sys.argv[1:7]
+try:
+    pid = int(pid)
+except (TypeError, ValueError):
+    pid = 0
+payload = {"state": state, "port": int(port), "pid": pid, "url": url, "message": msg}
+tmp = path + ".tmp"
+with open(tmp, "w") as f:
+    json.dump(payload, f)
+os.replace(tmp, path)
+PY
+}
+
+cleanup() {
+  if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" 2>/dev/null; then
+    kill "$SERVER_PID" 2>/dev/null || true
+    # Give uvicorn a moment to flush + close connections.
+    for _ in 1 2 3 4 5; do
+      kill -0 "$SERVER_PID" 2>/dev/null || break
+      sleep 1
+    done
+    kill -9 "$SERVER_PID" 2>/dev/null || true
+  fi
+  # Don't clobber an existing "error" state with "stopped" — the user
+  # clicked the menu bar item to see *what* went wrong, and "stopped"
+  # hides the diagnostic. We only write "stopped" if the last state
+  # was running or starting.
+  current=""
+  if [ -f "$STATE_FILE" ]; then
+    current=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('state',''))" "$STATE_FILE" 2>/dev/null || echo "")
+  fi
+  case "$current" in
+    error) ;;  # preserve the error
+    *)     write_state "stopped" "Server stopped." ;;
+  esac
+}
+# Catch SIGHUP too: the Swift host dying (e.g. from a parent kill) sends
+# SIGHUP to the bash worker. Without trapping it, cleanup() never runs
+# and the state file stays "starting" forever.
+trap cleanup EXIT TERM INT HUP
+
+# ── Install-path validation ─────────────────────────────────────────────
+# Two failure modes:
+#   1. INSTALL_DIR doesn't exist at all (user moved the repo).
+#   2. INSTALL_DIR exists but odysseus.sh is missing (corrupt / partial clone).
+# In both cases we surface a clear message and exit, so the Swift host
+# can show a dialog with a fix.
+if [ ! -d "$INSTALL_DIR" ]; then
+  write_state "error" "Install folder not found: $INSTALL_DIR"
+  echo "Install folder not found: $INSTALL_DIR" >&2
+  exit 1
+fi
+if [ ! -x "$INSTALL_DIR/odysseus.sh" ]; then
+  write_state "error" "Repo at $INSTALL_DIR is missing odysseus.sh"
+  echo "Repo at $INSTALL_DIR is missing odysseus.sh — was it partially moved?" >&2
+  exit 1
+fi
+
+# ── data/ relocation for .app launches ──────────────────────────────────
+# The Python app uses relative "data/..." paths everywhere. We satisfy
+# that with a symlink: ./data -> ~/Library/Application Support/Odysseus/data.
+# Terminal launches skip this — they want ./data in-place.
+if [ "${ODYSSEUS_FROM_APP:-0}" = "1" ]; then
+  cd "$INSTALL_DIR"
+  if [ -e "data" ] && [ ! -L "data" ]; then
+    # Repo has a real data/ directory. Move it into Application Support
+    # so the user's existing data isn't lost on first .app launch.
+    mkdir -p "$APP_SUPPORT_DIR"
+    if [ ! -e "$APP_SUPPORT_DIR/data" ]; then
+      mv "data" "$APP_SUPPORT_DIR/data"
+    else
+      # Both exist — keep the one in Application Support, drop the repo copy.
+      rm -rf "data"
+    fi
+  fi
+  mkdir -p "$APP_SUPPORT_DIR/data"
+  ln -sfn "$APP_SUPPORT_DIR/data" "data"
+  # logs go to Application Support too — terminal launches keep them in
+  # the repo, .app launches put them in the standard place.
+  if [ ! -e "logs" ]; then
+    mkdir -p "$APP_SUPPORT_DIR/logs"
+    ln -sfn "$APP_SUPPORT_DIR/logs" "logs"
+  fi
+fi
+
+# ── First-run setup ─────────────────────────────────────────────────────
+write_state "starting" "Checking dependencies…"
+cd "$INSTALL_DIR"
+
+if [ ! -x "$UVICORN" ]; then
+  write_state "starting" "Installing Python dependencies (first run; one-time)…"
+  # Reuse the launcher. --launch=native idempotently sets up the venv.
+  ODYSSEUS_SKIP_RUN_HINT=1 ./odysseus.sh --launch=native --no-open --port="$PORT" --host=127.0.0.1 || true
+fi
+
+if [ ! -x "$UVICORN" ]; then
+  write_state "error" "Could not set up the venv. Run 'odysseus --launch=native' in Terminal for details."
+  exit 1
+fi
+
+# Already running? Just open the UI.
+if /usr/bin/curl -s -o /dev/null --max-time 2 "$URL" 2>/dev/null; then
+  write_state "running" "Already up at $URL"
+  # Sleep until killed. The Swift host is in charge of the lifecycle.
+  while true; do sleep 1; done
+fi
+
+# ── Start uvicorn ───────────────────────────────────────────────────────
+write_state "starting" "Starting server…"
+APP_LOG="$APP_SUPPORT_DIR/uvicorn.log"
+if [ "$(uname -m)" = "arm64" ]; then
+  arch -arm64 "$UVICORN" app:app --host 127.0.0.1 --port "$PORT" >>"$APP_LOG" 2>&1 &
+else
+  "$UVICORN" app:app --host 127.0.0.1 --port "$PORT" >>"$APP_LOG" 2>&1 &
+fi
+SERVER_PID=$!
+write_state "starting" "Waiting for $URL (this can take ~2 min on first run)…"
+
+# Wait for readiness, up to 120s. Cold start downloads an embedding model.
+READY=0
+for _ in $(seq 1 120); do
+  if /usr/bin/curl -s -o /dev/null --max-time 2 "$URL" 2>/dev/null; then
+    READY=1
+    break
+  fi
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    write_state "error" "Server failed to start. Log: $APP_LOG"
+    exit 1
+  fi
+  sleep 1
+done
+
+if [ "$READY" = "1" ]; then
+  write_state "running" "Up at $URL"
+else
+  write_state "running" "Slow start (model download?) — open $URL once it's ready"
+fi
+
+# Block until the server exits (or the Swift host kills us). The trap on
+# EXIT will call cleanup(), which SIGTERMs the server and waits.
+wait "$SERVER_PID"

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -1,0 +1,292 @@
+# Odysseus on macOS
+
+This doc covers everything macOS-specific. For the launcher flags
+themselves, see [`docs/launcher.md`](launcher.md).
+
+## One-shot install
+
+```sh
+git clone https://github.com/pewdiepie-archdaemon/odysseus.git
+cd odysseus
+./odysseus.sh --launch=native
+```
+
+That command:
+
+1. Installs Homebrew if it's missing.
+2. Installs Python 3.11, Docker Desktop, and git via Homebrew if any of
+   them are missing.
+3. Creates `venv/` with `python3.11` and installs the pinned deps.
+4. If Docker is available, starts a persistent `searxng/searxng` container
+   on `127.0.0.1:8080` (honors `SEARXNG_INSTANCE` and `ODYSSEUS_NO_SEARXNG=1`).
+5. Runs `python setup.py` to provision the local data directory.
+6. Starts uvicorn on `127.0.0.1:7860` and opens the browser.
+
+Re-running is fast: the requirements-hash cache skips `pip install` when
+`requirements.txt` is unchanged.
+
+## Auto-start at login
+
+```sh
+./odysseus.sh --install-service
+```
+
+> **The repo must NOT be under `~/Desktop`, `~/Documents`, or
+> `~/Downloads`.** macOS's TCC framework blocks launchd from
+> executing scripts that live in those folders. The install script
+> detects this and prints a one-liner fix. The convention is
+> `~/odysseus`.
+
+This drops a per-user LaunchAgent at:
+
+```
+~/Library/LaunchAgents/com.odysseus.ui.plist
+```
+
+and bootstraps it into the `gui/$(id -u)` launchd domain. The agent:
+
+- starts on login (`RunAtLoad = true`)
+- respawns on crash (`KeepAlive.Crashed = true`, `SuccessfulExit = false`)
+- throttles to one restart per 10 s so a crash loop doesn't hammer the box
+- logs to `~/Library/Logs/Odysseus/{stdout,stderr}.log`
+- runs `odysseus.sh --launch=native --no-open` (so the server starts but
+  the browser doesn't pop every time you log in)
+- inherits an explicit `PATH` (`/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin`)
+  because launchd's default `PATH` doesn't include Homebrew
+- runs in the user's GUI session (`ProcessType = Interactive`) so any
+  Keychain access works the same as a Terminal launch
+
+### Update flow
+
+```sh
+./odysseus.sh --update
+```
+
+On macOS, the launcher:
+
+1. Detects whether the agent is loaded.
+2. If so, `launchctl bootout`s it (cleanly stops the uvicorn child).
+3. `git pull --rebase --autostash`.
+4. Re-bootstraps the agent and `kickstart -k`s it to start fresh.
+
+The native launcher (running inside the agent) also re-checks the
+requirements-hash on every launch, so a no-op update doesn't trigger
+a reinstall.
+
+### Inspection
+
+```sh
+launchctl print gui/$(id -u)/com.odysseus.ui
+tail -f ~/Library/Logs/Odysseus/stdout.log
+launchctl list | grep odysseus
+```
+
+### Removal
+
+```sh
+./odysseus.sh --uninstall-service
+```
+
+Bootouts the agent, removes the plist, and leaves `~/Library/Logs/Odysseus/`
+in place for grepping. Reinstall is one command away.
+
+## The .app bundle
+
+`./odysseus.sh --package-mac` (or `./build-macos-app.sh` directly) builds
+`dist/Odysseus.app` + `dist/Odysseus.dmg`. Drag the .app from the dmg to
+Applications and double-click.
+
+What the .app does, in plain terms:
+
+- Spawns a menu bar item ("⚙︎ Odysseus" → "● Odysseus" once the server
+  is up) with Open in Browser, Open in Terminal, Reveal Log in Finder,
+  and Quit.
+- Drags the same repo's venv as `--install-service` does. The .app is a
+  *launcher*, not a self-contained bundle — the install dir is baked in
+  at build time. After moving the repo, re-run `--package-mac`.
+- On first launch, sets up the venv (idempotently) and starts uvicorn.
+  The first cold start downloads an embedding model — allow ~2 minutes.
+- Caches your data under `~/Library/Application Support/Odysseus/` —
+  the repo's `data/` and `logs/` become symlinks to that location.
+  This is the macOS-conventional place for user data and means the
+  .app can be moved/updated without losing your chats, notes, etc.
+- Cmd-Q (or Quit from the menu) sends SIGTERM to the worker, which
+  SIGTERMs uvicorn and waits for clean exit. No orphan processes.
+- Ad-hoc code signed (no Developer ID required) so it launches
+  without Gatekeeper prompts on your own machine. Distributing the
+  .app to other people needs a Developer ID, which is out of scope.
+
+If you move the repo and don't rebuild, the menu bar item shows the
+"✕ Odysseus" error state with a clear "Install folder not found" /
+"Repo at <path> is missing odysseus.sh" message. The "Open in Terminal"
+menu item drops you into a shell at the install dir for recovery.
+
+### Why a Swift stub?
+
+The .app is a Cocoa app, not a shell script. A real menu bar item and
+proper Cmd-Q semantics (where quitting sends SIGTERM and waits for
+the child to flush logs before exiting) need a Cocoa run loop. The
+Swift stub is ~300 lines and handles:
+
+- NSStatusItem (menu bar) with state-aware title + tooltip
+- DispatchSource on SIGTERM/SIGINT so a `kill` from another terminal
+  still results in a clean worker shutdown (Cocoa doesn't always
+  surface those as `applicationShouldTerminate` for accessory apps)
+- Spawning the bash worker (`Contents/Resources/odysseus-app.sh`),
+  forwarding its stdout/stderr to the user's log file
+- Watching `~/Library/Application Support/Odysseus/state.json` and
+  re-rendering the menu bar when it changes
+- One-click "Open in Browser" using Chromium's `--app=URL` if a
+  Chromium-family browser is installed, else the default browser
+- Error → user notification (toast) so the user doesn't have to
+  click the menu bar to find out something went wrong
+
+The bash worker handles everything else: data relocation, first-run
+setup, uvicorn lifecycle, status file writes, signal traps. Splitting
+it this way means the Swift code is "just" Cocoa glue, and the
+install/run logic lives in a script that's shellcheck-clean and
+debuggable in isolation.
+
+## Port 7000 vs 7860
+
+macOS Monterey+ runs AirPlay Receiver on port 7000. Odysseus detects
+this and flips the default to 7860. To force a different port:
+
+```sh
+./odysseus.sh --port=7900
+# or persistently in .env:
+echo "APP_PORT=7900" >> .env
+```
+
+## Apple Silicon vs Intel
+
+The launcher auto-detects Apple Silicon via `uname -m` and points
+to `/opt/homebrew` (Apple Silicon's Homebrew prefix) rather than
+`/usr/local` (Intel's). It also enables Metal in llama.cpp/Ollama
+where the relevant env var exists.
+
+## GPU acceleration
+
+The native path uses llama.cpp or Ollama with Metal on Apple Silicon.
+The Docker path does not — Docker on macOS runs in a Linux VM with no
+GPU passthrough. If you see a "CPU only" warning from
+`odysseus --launch=docker`, that's expected; use `--launch=native` for
+GPU.
+
+## File layout when run as a service
+
+| File | Purpose |
+|---|---|
+| `~/Library/LaunchAgents/com.odysseus.ui.plist` | LaunchAgent definition |
+| `~/Library/Logs/Odysseus/stdout.log` | stdout of the launcher |
+| `~/Library/Logs/Odysseus/stderr.log` | stderr of the launcher (uvicorn logs go here) |
+
+Nothing under the repo is moved by the service install — `data/`,
+`venv/`, and the SearXNG settings live in their original locations so
+the CLI and service paths share state. (The `.app` distribution in
+Phase 3 will move `data/` to `~/Library/Application Support/Odysseus/`
+only when launched from the .app bundle, not from the CLI.)
+
+## Why the repo must live outside `~/Desktop`
+
+macOS's Transparency, Consent, and Control (TCC) framework restricts
+what `launchd` can access when it runs a LaunchAgent. A Terminal
+session inherits your user's TCC consents (Desktop, Documents,
+Downloads); `launchd` does not. So a repo cloned into `~/Desktop/`
+will install the plist fine, but every time the agent tries to spawn
+it will fail with:
+
+```
+bash: /Users/you/Desktop/odysseus/odysseus.sh: Operation not permitted
+shell-init: error retrieving current directory: getcwd: cannot access
+parent directories: Operation not permitted
+```
+
+The fix is to keep the repo outside TCC scope. `~/odysseus` is the
+convention. The install script detects this and refuses to install
+with a one-liner fix; you don't have to remember.
+
+## Homebrew install
+
+The repo ships a Homebrew formula at `homebrew/odysseus.rb`. Once
+it's in a tap, the install is one command:
+
+```sh
+brew install pewdiepie-archdaemon/tap/odysseus
+```
+
+This installs the whole repo to `libexec/` and symlinks the entry
+points into `bin/`:
+
+| Path | Resolves to |
+|---|---|
+| `odysseus` | the launcher |
+| `odysseus-package` | the .app builder |
+| `odysseus-install-service` | the launchd installer |
+| `odysseus-uninstall-service` | the launchd uninstaller |
+
+The TCC scope problem doesn't apply here: the formula puts the repo
+under `/opt/homebrew/Cellar/odysseus/`, which is outside TCC's
+restricted folders.
+
+### First-time setup
+
+```sh
+brew services start odysseus   # auto-start at login, restart on crash
+odysseus --launch=native       # or just run it once
+```
+
+The first launch provisions a venv at `libexec/venv/` using
+Homebrew's `python@3.11`. Subsequent runs reuse the venv; the
+launcher's requirements-hash cache skips `pip install` when nothing
+changed.
+
+### Logs and data
+
+```
+/opt/homebrew/var/log/odysseus.log
+/opt/homebrew/var/log/odysseus-error.log
+~/Library/Logs/Odysseus/   (when also using --install-service or the .app)
+~/Library/Application Support/Odysseus/   (data + per-app state)
+```
+
+### Upgrade
+
+```sh
+brew update && brew upgrade odysseus
+odysseus --update            # re-resolves Python deps if requirements.txt changed
+```
+
+`brew upgrade` swaps the keg. `odysseus --update` (in the launcher)
+is also the right call for a `requirements.txt` change — the venv
+is keyed on its hash, so a no-op install is a no-op.
+
+### Setting up a tap
+
+The formula lives at `homebrew/odysseus.rb` in the main repo. To
+publish it as a tap, mirror it to a Homebrew tap repo:
+
+```sh
+git clone https://github.com/pewdiepie-archdaemon/homebrew-tap.git
+cp odysseus/homebrew/odysseus.rb homebrew-tap/Formula/odysseus.rb
+cd homebrew-tap && git add Formula/odysseus.rb && git commit -m "add odysseus" && git push
+```
+
+Until the formula's `url` and `sha256` are filled in (those need a
+real `v0.1.0` tag), the install is `brew install --HEAD` only.
+After a release:
+
+```sh
+brew install --build-from-source pewdiepie-archdaemon/tap/odysseus
+```
+
+### How it works
+
+The formula uses the `service do` block so `brew services start
+odysseus` writes a launchd plist that runs `odysseus
+--launch=native --no-open` from the libexec dir, keep-alive on
+crash, with logs to `/opt/homebrew/var/log/odysseus*.log`. The
+`bin/odysseus` symlink is followed by the launcher's symlink-aware
+`REPO_DIR` resolution — when launched via the symlink, the
+launcher follows the chain to the real `libexec/` dir so paths
+like `app.py` and the venv resolve correctly.

--- a/homebrew/odysseus.rb
+++ b/homebrew/odysseus.rb
@@ -1,0 +1,90 @@
+# typed: strict
+# frozen_string_literal: true
+
+# Homebrew formula for Odysseus — see docs/macos.md for usage.
+class Odysseus < Formula
+  desc "AI agent runtime with native Apple Silicon / Metal GPU support"
+  homepage "https://github.com/pewdiepie-archdaemon/odysseus"
+  # Tag a release, then `brew install --build-from-source` will pull
+  # a tarball. Until then, `brew install --HEAD` installs from `dev`.
+  url "https://github.com/pewdiepie-archdaemon/odysseus/archive/refs/tags/v0.1.0.tar.gz"
+  version "0.1.0"
+  # sha256 "FILL_AT_RELEASE_TIME"
+  license "MIT"
+  head "https://github.com/pewdiepie-archdaemon/odysseus.git", branch: "dev"
+
+  # macOS only. The launchd service + Metal GPU path don't apply on
+  # Linux; this formula only exists so the user can `brew install`
+  # rather than `git clone && ./odysseus.sh`. The repo also has a
+  # Linux systemd path that's not part of this formula.
+  depends_on xcode: ["15.0", :build]
+  depends_on :macos
+  depends_on "python@3.11"
+
+  def install
+    # Install the whole repo to libexec. The launcher resolves its
+    # own install dir from BASH_SOURCE and follows symlinks, so a
+    # `bin/odysseus → libexec/odysseus.sh` indirection is transparent.
+    libexec.install Dir["*"]
+
+    # Symlink the entry points into bin.
+    bin.install_symlink libexec/"odysseus.sh"                   => "odysseus"
+    bin.install_symlink libexec/"build-macos-app.sh"            => "odysseus-package"
+    bin.install_symlink libexec/"install-macos-service.sh"     => "odysseus-install-service"
+    bin.install_symlink libexec/"uninstall-macos-service.sh"   => "odysseus-uninstall-service"
+
+    # The .app worker needs to be findable. build-macos-app.sh
+    # also reads Swift source from app/macos/, so that dir is
+    # already at libexec/app/macos/.
+  end
+
+  # `brew services start odysseus` writes a launchd plist that runs
+  # `odysseus --launch=native --no-open` with our libexec as the
+  # working dir, keep-alive on crash. The TCC requirement (repo
+  # outside ~/Desktop etc.) is satisfied because libexec lives
+  # under /opt/homebrew/Cellar.
+  service do
+    run [opt_bin/"odysseus", "--launch=native", "--no-open"]
+    keep_alive true
+    working_dir opt_libexec
+    log_path var/"log/odysseus.log"
+    error_log_path var/"log/odysseus-error.log"
+  end
+
+  def caveats
+    <<~EOS
+      Odysseus has been installed. To get started:
+
+        brew services start odysseus   # auto-start at login, restart on crash
+        odysseus --launch=native       # ...or just run it once
+        odysseus --add-to-path         # install the `odysseus` symlink to ~/.local/bin
+
+      First launch provisions a Python venv at:
+        #{libexec}/venv/
+
+      User data lives at:
+        ~/Library/Application Support/Odysseus/
+
+      Logs:
+        #{var}/log/odysseus.log
+        #{var}/log/odysseus-error.log
+        ~/Library/Logs/Odysseus/   (if you also use the .app or --install-service)
+
+      To upgrade:
+        brew update && brew upgrade odysseus
+        odysseus --update            # pull + reinstall Python deps
+
+      To uninstall:
+        brew services stop odysseus
+        brew uninstall odysseus
+        rm -rf ~/Library/Application Support/Odysseus  # only if you want to wipe data
+    EOS
+  end
+
+  test do
+    # `--help` exits 0 and prints the launcher usage. We don't run
+    # the actual install + venv setup in `brew test` because that
+    # would touch the user's Homebrew prefix for real.
+    assert_match "odysseus — one launcher", shell_output("#{bin}/odysseus --help")
+  end
+end

--- a/install-macos-service.sh
+++ b/install-macos-service.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# install-macos-service.sh — install Odysseus as a per-user LaunchAgent
+# so it auto-starts at login and survives crashes.
+#
+#   ~/Library/LaunchAgents/com.odysseus.ui.plist
+#   /Users/USER/Library/Logs/Odysseus/{stdout,stderr}.log
+#
+# Run via:
+#   ./odysseus.sh --install-service
+# or directly:
+#   ./install-macos-service.sh
+#
+# Idempotent: re-running with the same path updates the plist in place
+# and reloads the agent.
+
+set -e
+
+# ── Resolve paths ──────────────────────────────────────────────────────────
+# Follow symlinks so that `brew install` symlinks (in /opt/homebrew/bin)
+# resolve back to the real libexec dir. Without this, the plist would
+# bake in the symlink path and break the moment Homebrew updates the
+# keg.
+SOURCE="${BASH_SOURCE[0]}"
+while [ -L "$SOURCE" ]; do
+  DIR=$(cd -P "$(dirname "$SOURCE")" && pwd)
+  SOURCE=$(readlink "$SOURCE")
+  [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+# Honor ODYSSEUS_REPO_DIR if set — useful when the user has symlinked
+# install-macos-service.sh into a different location (e.g. a non-TCC
+# wrapper script).
+REPO_DIR="${ODYSSEUS_REPO_DIR:-$SCRIPT_DIR}"
+
+LABEL="com.odysseus.ui"
+PLIST_PATH="$HOME/Library/LaunchAgents/${LABEL}.plist"
+LOG_DIR="$HOME/Library/Logs/Odysseus"
+STDOUT_LOG="$LOG_DIR/stdout.log"
+STDERR_LOG="$LOG_DIR/stderr.log"
+
+# Make sure we never trash an existing plist from a different repo path.
+EXISTING_PROG=""
+EXISTING_CWD=""
+if [ -f "$PLIST_PATH" ]; then
+  EXISTING_PROG=$(/usr/libexec/PlistBuddy -c "Print :ProgramArguments:0" "$PLIST_PATH" 2>/dev/null || true)
+  EXISTING_CWD=$(/usr/libexec/PlistBuddy -c "Print :WorkingDirectory" "$PLIST_PATH" 2>/dev/null || true)
+fi
+
+# Sanity: the path the launcher is going to call must exist, and Python 3.11+
+# must be reachable inside that environment. We don't try to *create* the
+# venv here — that's the launcher's job. We just fail loud if the venv is
+# missing so the user knows to run `odysseus --launch=native` first.
+if [ ! -x "$REPO_DIR/odysseus.sh" ]; then
+  echo "✗ odysseus.sh not found at $REPO_DIR/odysseus.sh" >&2
+  exit 1
+fi
+
+# ── TCC path check ────────────────────────────────────────────────────────
+# macOS's Transparency, Consent, and Control (TCC) framework restricts
+# what launchd can access when it runs a LaunchAgent. Files under
+# ~/Desktop/, ~/Documents/, and ~/Downloads/ are in TCC's "user data"
+# set, and launchd will get "Operation not permitted" when it tries to
+# exec a shell script living there. (A Terminal session has TCC consent
+# for these folders; the launchd process does not.) This means a repo
+# cloned into Desktop/ or Documents/ will install the plist fine but
+# the agent will refuse to spawn.
+#
+# The right answer is to keep the repo outside those folders — `~/odysseus`
+# is the convention. Detect and fail with a one-liner fix.
+case "$REPO_DIR" in
+  "$HOME"/Desktop/*|"$HOME"/Documents/*|"$HOME"/Downloads/*)
+    echo "✗ Repo path is under a TCC-protected folder: $REPO_DIR" >&2
+    echo "" >&2
+    echo "  launchd cannot execute scripts under ~/Desktop, ~/Documents," >&2
+    echo "  or ~/Downloads (macOS file-vault consent). The agent will" >&2
+    echo "  install but refuse to start." >&2
+    echo "" >&2
+    echo "  Move the repo out of the protected folder and re-run:" >&2
+    echo "" >&2
+    echo "    mv \"$REPO_DIR\" \"$HOME/odysseus\"" >&2
+    echo "    cd ~/odysseus" >&2
+    echo "    ./odysseus.sh --install-service" >&2
+    echo "" >&2
+    echo "  Or set ODYSSEUS_REPO_DIR= to a non-protected path." >&2
+    exit 1
+    ;;
+esac
+
+# ── Detect brew prefix for the embedded PATH ──────────────────────────────
+# launchd's default PATH is /usr/bin:/bin — no /opt/homebrew/bin, no
+# /usr/local/bin. The native launcher needs brew's python3.11 and the
+# `open` command lives in /usr/bin so that's fine, but `git` (used by
+# --update) and a few other tools need to be on PATH inside the agent.
+BREW_PREFIX=""
+if [ -x /opt/homebrew/bin/brew ]; then
+  BREW_PREFIX="/opt/homebrew"
+elif [ -x /usr/local/bin/brew ]; then
+  BREW_PREFIX="/usr/local"
+fi
+LAUNCHD_PATH="$BREW_PREFIX/bin:/usr/local/bin:/usr/bin:/bin"
+
+# ── Generate the plist ────────────────────────────────────────────────────
+mkdir -p "$(dirname "$PLIST_PATH")"
+mkdir -p "$LOG_DIR"
+
+cat > "$PLIST_PATH" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${LABEL}</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>${REPO_DIR}/odysseus.sh</string>
+        <string>--launch=native</string>
+        <string>--no-open</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>${REPO_DIR}</string>
+
+    <!-- Run at user login (and on demand via launchctl start). -->
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- Respawn on crash, but not on a clean exit. SuccessfulExit=false
+         means: relaunch on anything other than exit code 0. Crashed=true
+         is a synonym for "exit code != 0" but we keep both for clarity. -->
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+        <key>Crashed</key>
+        <true/>
+    </dict>
+
+    <!-- Don't spin in a tight crash loop. -->
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <!-- Logs. We append rather than truncate so the user can post-mortem. -->
+    <key>StandardOutPath</key>
+    <string>${STDOUT_LOG}</string>
+    <key>StandardErrorPath</key>
+    <string>${STDERR_LOG}</string>
+
+    <!-- Interactive = share the user's GUI session, so anything that needs
+         the keychain (e.g. secrets fetched from Keychain) works. -->
+    <key>ProcessType</key>
+    <string>Interactive</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>${LAUNCHD_PATH}</string>
+        <key>ODYSSEUS_SERVICE_MODE</key>
+        <string>launchd</string>
+    </dict>
+</dict>
+</plist>
+PLIST
+
+# ── Validate the plist is well-formed ─────────────────────────────────────
+if ! plutil -lint "$PLIST_PATH" >/dev/null 2>&1; then
+  echo "✗ plist failed plutil -lint; not loading." >&2
+  plutil -lint "$PLIST_PATH" >&2 || true
+  exit 1
+fi
+
+# ── Load (or reload) the agent ────────────────────────────────────────────
+# launchctl bootstrap is the modern API (macOS 10.11+); it cleanly handles
+# "already loaded" by unloading first.
+DOMAIN="gui/$(id -u)"
+
+# Clear any "disabled" override from a previous install. The per-user
+# launchd override db (~/Library/Preferences/com.apple.launchd.<UID>.plist
+# — or the in-memory version of it) can hold a `Disabled = true` entry
+# left behind by a prior --uninstall-service, a `launchctl disable` call,
+# or a botched install. If that entry is set, bootstrap will succeed
+# but the agent will refuse to spawn, surfacing as a silent
+# "Bootstrap failed: 5: Input/output error" on the *next* install attempt.
+# Always clear it before bootstrapping.
+launchctl enable "$DOMAIN/$LABEL" 2>/dev/null || true
+launchctl enable "system/$LABEL" 2>/dev/null || true
+
+if launchctl print "$DOMAIN/$LABEL" >/dev/null 2>&1; then
+  echo "▶ unloading existing agent (different path or update)…"
+  launchctl bootout "$DOMAIN/$LABEL" 2>/dev/null || true
+fi
+
+# Also nuke any old-style "loaded into the system domain" copy of the
+# same label — defensive, in case someone installed it manually with
+# `launchctl load -w` before this script existed.
+launchctl bootout "system/$LABEL" 2>/dev/null || true
+
+echo "▶ loading $LABEL into $DOMAIN…"
+if ! launchctl bootstrap "$DOMAIN" "$PLIST_PATH" 2>&1; then
+  echo "✗ launchctl bootstrap failed." >&2
+  exit 1
+fi
+
+# Re-enable in case the bootstrap above flipped the bit (it shouldn't,
+# but be defensive). enable is idempotent.
+launchctl enable "$DOMAIN/$LABEL" 2>/dev/null || true
+
+# Kick it once now so the user can see it's working without re-logging in.
+launchctl kickstart -k "$DOMAIN/$LABEL" 2>/dev/null || true
+
+echo
+echo "✓ Odysseus auto-start installed."
+echo "  plist:  $PLIST_PATH"
+echo "  logs:   $LOG_DIR/"
+echo "  status: launchctl print $DOMAIN/$LABEL"
+echo
+if [ -n "$EXISTING_PROG" ] && [ "$EXISTING_PROG" != "${REPO_DIR}/odysseus.sh" ]; then
+  echo "  ⚠ replaced previous install at: $EXISTING_PROG"
+fi
+if [ -n "$EXISTING_CWD" ] && [ "$EXISTING_CWD" != "$REPO_DIR" ]; then
+  echo "  ⚠ replaced previous WorkingDirectory: $EXISTING_CWD"
+fi
+echo
+echo "  Stop:   launchctl bootout $DOMAIN/$LABEL"
+echo "  Start:  launchctl bootstrap $DOMAIN $PLIST_PATH"
+echo "  Logs:   tail -f $STDOUT_LOG $STDERR_LOG"
+echo "  Remove: ./odysseus.sh --uninstall-service"

--- a/odysseus.sh
+++ b/odysseus.sh
@@ -1,0 +1,361 @@
+#!/usr/bin/env bash
+# odysseus — one launcher for every platform-native install path.
+#
+#   ./odysseus.sh --launch=native
+#   ./odysseus.sh --launch=docker
+#   ./odysseus.sh --update
+#   ./odysseus.sh --port=7900 --host=0.0.0.0 --launch=native
+#   ./odysseus.sh --add-to-path
+#
+# On macOS this is the script you'll want. On Linux it works the same way.
+# On Windows, use odysseus.ps1 — the flag surface is identical.
+#
+# Old entry points (start-macos.sh, install-service.sh, update_windows.bat)
+# are now thin shims that call into this script.
+
+set -e
+
+# Follow symlinks so that `odysseus` (a symlink in ~/.local/bin or
+# /opt/homebrew/bin) resolves to the real install dir. Without this,
+# the launcher would compute REPO_DIR as the symlink's directory
+# and fail to find app.py, the venv, etc.
+SOURCE="${BASH_SOURCE[0]}"
+while [ -L "$SOURCE" ]; do
+  DIR=$(cd -P "$(dirname "$SOURCE")" && pwd)
+  SOURCE=$(readlink "$SOURCE")
+  [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+REPO_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+cd "$REPO_DIR"
+
+# ── Defaults ──────────────────────────────────────────────────────────────
+LAUNCH="native"          # native | docker | docker-nvidia | docker-amd
+UPDATE=0
+ADD_PATH=0
+REMOVE_PATH=0
+INSTALL_SERVICE=0
+UNINSTALL_SERVICE=0
+PORT="${ODYSSEUS_PORT:-${APP_PORT:-7000}}"
+HOST="${ODYSSEUS_HOST:-${APP_BIND:-127.0.0.1}}"
+DOCKER_NO_OPEN=0
+PACKAGE_MAC=0
+
+usage() {
+  cat <<EOF
+odysseus — one launcher for every platform-native install path.
+
+Usage: odysseus [flags]
+
+Launch mode (default: native):
+  --launch=native           Run the app directly on this machine (venv + uvicorn).
+                            The right choice on macOS — keeps GPU/Metal access.
+  --launch=docker           docker compose up (auto-detects GPU overlay).
+  --launch=docker-nvidia    Force the NVIDIA GPU overlay.
+  --launch=docker-amd       Force the AMD/ROCm GPU overlay (Linux only).
+
+Lifecycle:
+  --update                  git pull + reinstall Python deps (only if requirements.txt
+                            changed) + rebuild Docker images (when --launch=docker*).
+                            Safe to re-run.
+  --add-to-path             Symlink odysseus into ~/.local/bin and ensure that dir is
+                            on PATH in ~/.zshrc / ~/.bashrc, so 'odysseus' works
+                            from anywhere.
+  --remove-from-path        Reverse the above.
+
+Service (auto-start at login):
+  --install-service         Install the platform auto-start agent:
+                              • macOS:  ~/Library/LaunchAgents/com.odysseus.ui.plist
+                              • Linux:  /etc/systemd/system/odysseus-ui.service
+                            Runs in the background and survives reboots.
+  --uninstall-service       Remove the auto-start agent (leaves data/ + venv/ alone).
+
+Server:
+  --port=N                  Override the port (default: 7000; 7860 on macOS by
+                            default since AirPlay Receiver holds 7000).
+  --host=H                  Override the bind address (default: 127.0.0.1).
+                            Use 0.0.0.0 to expose on LAN/Tailscale.
+
+Docker:
+  --no-open                 Don't open the browser when the server is ready.
+
+Packaging (macOS):
+  --package-mac             Build dist/Odysseus.app + dist/Odysseus.dmg from
+                            the current repo. Re-run after moving the repo.
+
+Examples:
+  ./odysseus.sh                          # launch native, default port
+  ./odysseus.sh --port=7900              # launch native on 7900
+  ./odysseus.sh --launch=docker          # docker compose up (auto GPU)
+  ./odysseus.sh --update                 # pull + reinstall + rebuild
+  ./odysseus.sh --install-service        # auto-start at login
+  ./odysseus.sh --add-to-path            # 'odysseus' from anywhere
+EOF
+}
+
+# ── Arg parsing (long-form only — keeps the surface small) ────────────────
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --launch=*)        LAUNCH="${1#*=}" ;;
+    --launch)          LAUNCH="$2"; shift ;;
+    --update)          UPDATE=1 ;;
+    --add-to-path)     ADD_PATH=1 ;;
+    --remove-from-path) REMOVE_PATH=1 ;;
+    --install-service) INSTALL_SERVICE=1 ;;
+    --uninstall-service) UNINSTALL_SERVICE=1 ;;
+    --port=*)          PORT="${1#*=}" ;;
+    --port)            PORT="$2"; shift ;;
+    --host=*)          HOST="${1#*=}" ;;
+    --host)            HOST="$2"; shift ;;
+    --no-open)         DOCKER_NO_OPEN=1 ;;
+    --package-mac)     PACKAGE_MAC=1 ;;
+    -h|--help)         usage; exit 0 ;;
+    *)                 echo "Unknown flag: $1" >&2; usage; exit 2 ;;
+  esac
+  shift
+done
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+is_macos() { [ "$(uname -s)" = "Darwin" ]; }
+is_linux() { [ "$(uname -s)" = "Linux" ]; }
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "✗ Required command not found: $1" >&2
+    echo "  Install it, then re-run: $0 $*" >&2
+    exit 1
+  fi
+}
+
+# ── Dispatch ──────────────────────────────────────────────────────────────
+case "$LAUNCH" in
+  native) ;;
+  docker|docker-nvidia|docker-amd) ;;
+  *) echo "✗ Unknown --launch value: $LAUNCH" >&2; usage; exit 2 ;;
+esac
+
+# --add-to-path: drop a symlink and a one-line shell hook so `odysseus`
+# works from any directory. Reversible with --remove-from-path.
+
+if [ "$ADD_PATH" = "1" ]; then
+  BIN_DIR="$HOME/.local/bin"
+  mkdir -p "$BIN_DIR"
+  ln -sf "$REPO_DIR/odysseus.sh" "$BIN_DIR/odysseus"
+  ln -sf "$REPO_DIR/odysseus.sh" "$BIN_DIR/odysseus.sh"
+  for rc in "$HOME/.zshrc" "$HOME/.bashrc"; do
+    [ -f "$rc" ] || continue
+    if ! grep -qF "$BIN_DIR" "$rc" 2>/dev/null; then
+      # $HOME below is intentionally literal — the user's shell expands it
+      # on source, which is the right behaviour for a portable rc file.
+      # shellcheck disable=SC2016
+      printf '\n# Added by Odysseus: make `odysseus` work from anywhere\nexport PATH="$HOME/.local/bin:$PATH"\n' >> "$rc"
+      echo "  ✓ added $BIN_DIR to PATH in $rc"
+    fi
+  done
+  echo "✓ odysseus is now available. Open a new shell or run:  export PATH=\"\$HOME/.local/bin:\$PATH\""
+  exit 0
+fi
+
+if [ "$REMOVE_PATH" = "1" ]; then
+  rm -f "$HOME/.local/bin/odysseus" "$HOME/.local/bin/odysseus.sh"
+  for rc in "$HOME/.zshrc" "$HOME/.bashrc"; do
+    [ -f "$rc" ] || continue
+    # Remove the Odysseus-added block.
+    if grep -q "Added by Odysseus" "$rc" 2>/dev/null; then
+      # Delete the marker line + the export below it.
+      python3 - "$rc" <<'PY' 2>/dev/null || true
+import sys, re
+p = sys.argv[1]
+try:
+    with open(p) as f: txt = f.read()
+except OSError:
+    sys.exit(0)
+out = re.sub(r'\n*# Added by Odysseus[^\n]*\nexport PATH="\$HOME/\.local/bin:\$PATH"\n*', '\n', txt)
+with open(p, 'w') as f: f.write(out)
+PY
+      echo "  ✓ removed Odysseus PATH entry from $rc"
+    fi
+  done
+  echo "✓ odysseus removed from PATH"
+  exit 0
+fi
+
+# --install-service / --uninstall-service: defer to platform script.
+if [ "$INSTALL_SERVICE" = "1" ]; then
+  if is_macos; then
+    exec "$REPO_DIR/install-macos-service.sh" "$@"
+  elif is_linux; then
+    exec "$REPO_DIR/install-service.sh" "$@"
+  else
+    echo "✗ --install-service is only supported on macOS and Linux" >&2
+    exit 1
+  fi
+fi
+if [ "$UNINSTALL_SERVICE" = "1" ]; then
+  if is_macos; then
+    exec "$REPO_DIR/uninstall-macos-service.sh" "$@"
+  elif is_linux; then
+    echo "(no Linux uninstall script yet — manually: sudo systemctl disable --now odysseus-ui && sudo rm /etc/systemd/system/odysseus-ui.service)"
+    exit 0
+  else
+    echo "✗ --uninstall-service is only supported on macOS and Linux" >&2
+    exit 1
+  fi
+fi
+
+# --update: pull + reinstall. We always make sure venv deps are current when
+# requirements.txt changed, then rebuild Docker images if --launch=docker*.
+#
+# On macOS, if the LaunchAgent is installed, stop it before git pull so the
+# running uvicorn doesn't hold files we'll overwrite; restart it after.
+if [ "$UPDATE" = "1" ]; then
+  AGENT_LAUNCHED=0
+  if is_macos; then
+    DOMAIN="gui/$(id -u)"
+    if launchctl print "$DOMAIN/com.odysseus.ui" >/dev/null 2>&1; then
+      echo "▶ stopping launchd agent…"
+      launchctl bootout "$DOMAIN/com.odysseus.ui" 2>/dev/null || true
+      AGENT_LAUNCHED=1
+    fi
+  fi
+
+  echo "▶ git pull…"
+  git pull --rebase --autostash
+  # Re-invoke ourselves so the rest of the launch (native/docker) picks up
+  # any code that changed in the pull. The native path re-checks the
+  # requirements hash (start-macos.sh / a future native path) so we don't
+  # waste time reinstalling when nothing changed.
+
+  if [ "$AGENT_LAUNCHED" = "1" ]; then
+    echo "▶ restarting launchd agent…"
+    PLIST_PATH="$HOME/Library/LaunchAgents/com.odysseus.ui.plist"
+    if [ -f "$PLIST_PATH" ]; then
+      launchctl bootstrap "$DOMAIN" "$PLIST_PATH" 2>/dev/null || true
+      launchctl enable "$DOMAIN/com.odysseus.ui" 2>/dev/null || true
+      launchctl kickstart -k "$DOMAIN/com.odysseus.ui" 2>/dev/null || true
+    fi
+  fi
+fi
+
+# --package-mac: build the .app + .dmg. macOS only.
+if [ "$PACKAGE_MAC" = "1" ]; then
+  if ! is_macos; then
+    echo "✗ --package-mac is macOS only." >&2
+    exit 1
+  fi
+  exec "$REPO_DIR/build-macos-app.sh"
+fi
+
+# ── Launch dispatch ───────────────────────────────────────────────────────
+
+# Probe host: 0.0.0.0 / :: aren't connectable for "is the port open?" checks.
+PROBE_HOST="$HOST"
+case "$PROBE_HOST" in
+  0.0.0.0|::) PROBE_HOST="127.0.0.1" ;;
+esac
+
+port_in_use() {
+  if is_macos || is_linux; then
+    (exec 3<>"/dev/tcp/$PROBE_HOST/$PORT") 2>/dev/null
+  else
+    return 1
+  fi
+}
+
+# On macOS, AirPlay Receiver holds port 7000; default to 7860 unless the
+# user explicitly asked for something else.
+if is_macos && [ "$LAUNCH" = "native" ] && [ -z "$ODYSSEUS_PORT" ] && [ -z "$APP_PORT" ] && [ "$PORT" = "7000" ]; then
+  PORT=7860
+fi
+
+# ── Native launch (the macOS path) ───────────────────────────────────────
+if [ "$LAUNCH" = "native" ]; then
+  if is_macos && [ -x "$REPO_DIR/scripts/legacy/macos-native.sh" ]; then
+    # Delegate to the legacy macOS native launcher (the original
+    # start-macos.sh logic, now living in scripts/legacy/ so the public
+    # entry point can be a thin shim). The ODYSSEUS_LEGACY_ENTRY=1 marker
+    # tells that script to skip the deprecation banner.
+    exec env ODYSSEUS_LEGACY_ENTRY=1 \
+      ODYSSEUS_REPO_DIR="$REPO_DIR" \
+      ODYSSEUS_PORT="$PORT" ODYSSEUS_HOST="$HOST" \
+      ODYSSEUS_NO_OPEN="$([ "$DOCKER_NO_OPEN" = "1" ] && echo 1 || echo)" \
+      "$REPO_DIR/scripts/legacy/macos-native.sh"
+  fi
+  if is_linux; then
+    if port_in_use; then
+      echo "✗ Port $PORT is already in use on $PROBE_HOST. Stop what's using it, or pick another:"
+      echo "    $0 --port=7900"
+      exit 1
+    fi
+    PY=""
+    for cand in python3.13 python3.12 python3.11 python3; do
+      p="$(command -v "$cand" 2>/dev/null)" || continue
+      if "$p" -c 'import sys; raise SystemExit(0 if sys.version_info[:2] >= (3, 11) else 1)' 2>/dev/null; then
+        PY="$p"; break
+      fi
+    done
+    if [ -z "$PY" ]; then
+      echo "✗ Couldn't find a Python 3.11+ to build the environment with."
+      echo "  Install one (e.g. sudo apt install python3.11 python3.11-venv) and re-run."
+      exit 1
+    fi
+    [ -d venv ] || "$PY" -m venv venv
+    ./venv/bin/python -m pip install --quiet --upgrade pip
+    ./venv/bin/python -m pip install -r requirements.txt
+    ODYSSEUS_SKIP_RUN_HINT=1 ./venv/bin/python setup.py
+    exec ./venv/bin/python -m uvicorn app:app --host "$HOST" --port "$PORT"
+  fi
+  echo "✗ Native launch on $(uname -s) is not yet supported by odysseus.sh." >&2
+  echo "  On macOS, install via the bundled start-macos.sh. On Windows, use odysseus.ps1." >&2
+  exit 1
+fi
+
+# ── Docker launch ────────────────────────────────────────────────────────
+require_cmd docker
+
+DOCKER_COMPOSE_FILE="docker-compose.yml"
+case "$LAUNCH" in
+  docker-nvidia) DOCKER_COMPOSE_FILE="docker-compose.gpu-nvidia.yml" ;;
+  docker-amd)    DOCKER_COMPOSE_FILE="docker-compose.gpu-amd.yml" ;;
+  docker)
+    # Auto-detect the best overlay. macOS never has GPU passthrough into
+    # Docker, so even an M-series Mac falls back to CPU — but at least we
+    # say so.
+    if is_macos; then
+      echo "  ⚠ Docker on macOS runs in a Linux VM with no GPU access — starting CPU-only."
+      echo "    For Metal/GPU acceleration, use --launch=native."
+    elif command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi -L >/dev/null 2>&1; then
+      DOCKER_COMPOSE_FILE="docker-compose.gpu-nvidia.yml"
+      echo "  ✓ detected NVIDIA GPU — using GPU overlay"
+    elif [ -e /dev/kfd ] && [ -d /dev/dri ] && is_linux; then
+      DOCKER_COMPOSE_FILE="docker-compose.gpu-amd.yml"
+      echo "  ✓ detected AMD/ROCm GPU — using GPU overlay"
+    else
+      echo "  ⚠ No GPU detected (nvidia-smi not found, /dev/kfd not present). Starting CPU-only."
+      echo "    To override: --launch=docker-nvidia or --launch=docker-amd"
+    fi
+    ;;
+esac
+
+# docker compose v2 vs v1: prefer 'docker compose', fall back to 'docker-compose'.
+if docker compose version >/dev/null 2>&1; then
+  DC=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+  DC=(docker-compose)
+else
+  echo "✗ Neither 'docker compose' nor 'docker-compose' is available." >&2
+  exit 1
+fi
+
+if [ "$UPDATE" = "1" ]; then
+  echo "▶ rebuilding Docker images…"
+  "${DC[@]}" -f "$DOCKER_COMPOSE_FILE" build --pull
+fi
+
+if [ -n "$APP_PORT" ] || [ "$PORT" != "7000" ]; then
+  APP_PORT="$PORT" "${DC[@]}" -f "$DOCKER_COMPOSE_FILE" up -d --build
+else
+  "${DC[@]}" -f "$DOCKER_COMPOSE_FILE" up -d --build
+fi
+echo
+echo "▶ Odysseus is up. Tailing logs (Ctrl+C to detach)…"
+"${DC[@]}" -f "$DOCKER_COMPOSE_FILE" logs -f odysseus


### PR DESCRIPTION
## Summary
Adds `homebrew/odysseus.rb` so users can `brew install pewdiepie-archdaemon/tap/odysseus` instead of cloning the repo. The formula installs the whole repo to `libexec/` and symlinks the entry points (`odysseus`, `odysseus-package`, `odysseus-install-service`, `odysseus-uninstall-service`) into `bin/`. The `service do` block wires `brew services start` to launchd, so a user can do `brew services start odysseus` and get the same auto-start-at-login UX as `./odysseus.sh --install-service` (Phase 2). Sidesteps the macOS TCC scope problem because the install lives under `/opt/homebrew/Cellar/`. Also fixes a latent bug in the launcher's `REPO_DIR` resolution: `odysseus.sh`, `install-macos-service.sh`, and `app/macos/odysseus-app.sh` now follow symlinks, so the launcher works whether invoked directly, via `~/.local/bin/odysseus`, or via `/opt/homebrew/bin/odysseus`.

## Target branch
- [x] This PR targets **`dev`**, not `main`.

## Linked Issue
Part of #2475, fixes the work tracked in #2800

## Type of Change
- [x] New feature (non-breaking — adds new behaviour)
- [x] Bug fix (the `REPO_DIR` resolution bug: when the launcher is invoked via a symlink in `~/.local/bin` or `/opt/homebrew/bin`, `REPO_DIR` previously resolved to the symlink's directory, breaking the `app.py` and venv lookup)

## Checklist
- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test
1. `brew style homebrew/odysseus.rb` — should pass with no offenses.
2. `brew tap-new pewdiepie-archdaemon/odysseus-test` and copy the formula into `Formula/`.
3. `brew install --build-from-source pewdiepie-archdaemon/odysseus-test/odysseus` — should install 864 files / 34 MB to `/opt/homebrew/Cellar/odysseus/0.1.0/`.
4. `ls -la /opt/homebrew/bin/odysseus` — should symlink to the keg.
5. `/opt/homebrew/bin/odysseus --help` — should print the unified launcher help (proves symlink-aware REPO_DIR works).
6. `/opt/homebrew/bin/odysseus-install-service` — should drop a valid plist that points at the real `libexec/odysseus.sh`, not the symlink path (proves the install script's symlink-aware REPO_DIR also works).
7. `brew test pewdiepie-archdaemon/odysseus-test/odysseus` — should pass (runs the `test do` block, which is `odysseus --help`).
8. `brew services start pewdiepie-archdaemon/odysseus-test/odysseus` — should bootstrap the launchd plist. `launchctl print gui/$(id -u)/homebrew.mxcl.odysseus-test` should show the agent running.
9. The 149 unit tests under `tests/test_endpoint_probing.py`, `tests/test_model_routes.py`, `tests/test_hwfit_macos.py`, and `tests/test_platform_compat.py` all pass. `shellcheck` is clean on every shell file touched.

## Visual / UI changes
N/A — no UI rendering changes.