### PR TITLE
fix(backup): reject tarball entries that resolve outside the repo root

### DIFF
--- a/scripts/odysseus-backup
+++ b/scripts/odysseus-backup
@@ -154,7 +154,7 @@ def cmd_verify(args):
     try:
         with tarfile.open(path, "r:gz") as tar:
             members = tar.getmembers()
-            _validate_restore_members(members)
+            _validate_restore_members(members, _REPO_ROOT)
     except (tarfile.TarError, OSError) as e:
         fail(f"tarball is corrupt: {e}")
     emit({
@@ -166,8 +166,9 @@ def cmd_verify(args):
     }, args)
 
 
-def _validate_restore_members(members):
+def _validate_restore_members(members, root: Path):
     """Reject archive entries that can escape data/ during restore."""
+    resolved_root = root.resolve()
     for m in members:
         rel = PurePosixPath(m.name)
         if rel.is_absolute() or ".." in rel.parts:
@@ -178,6 +179,13 @@ def _validate_restore_members(members):
             fail(f"refusing tarball with link entry: {m.name!r}")
         if not (m.isdir() or m.isfile()):
             fail(f"refusing tarball with special file entry: {m.name!r}")
+        # Final defense: even if every textual check above were wrong, refuse
+        # to extract any entry whose resolved destination escapes `root`.
+        # Catches symlinked parent directories on disk and any other
+        # normalization surprise.
+        target = (root / rel).resolve()
+        if not (target == resolved_root or resolved_root in target.parents):
+            fail(f"refusing tarball entry that escapes root: {m.name!r}")
 
 
 def _extract_restore_members(tar, members, root: Path) -> None:
@@ -208,7 +216,7 @@ def cmd_restore(args):
     stash = None
     with tarfile.open(path, "r:gz") as tar:
         members = tar.getmembers()
-        _validate_restore_members(members)
+        _validate_restore_members(members, _REPO_ROOT)
         # Save a safety copy of current data/ before extracting.
         if _DATA_DIR.exists() or _DATA_DIR.is_symlink():
             stash = _REPO_ROOT / f"data.before-restore-{datetime.now().strftime('%Y%m%d-%H%M%S')}"

--- a/tests/test_backup_cli_security.py
+++ b/tests/test_backup_cli_security.py
@@ -124,3 +124,31 @@ def test_restore_extracts_regular_files_without_extractall(tmp_path, monkeypatch
     assert (repo / "data" / "nested" / "new.txt").read_text(encoding="utf-8") == "new"
     assert not (repo / "data" / "old.txt").exists()
     assert list(repo.glob("data.before-restore-*"))
+
+
+def test_restore_rejects_path_traversal_under_data(tmp_path, monkeypatch):
+    """A crafted entry like `data/../../escape.txt` must be refused.
+
+    The textual `parts[0] == "data"` check accepts the prefix, but the
+    resolved path escapes the repo root. The resolved-path check inside
+    `_validate_restore_members` is the final defense.
+    """
+    backup = _load_backup_cli()
+    repo = tmp_path / "repo"
+    data = repo / "data"
+    data.mkdir(parents=True)
+    _patch_repo(backup, monkeypatch, repo)
+
+    tar_path = tmp_path / "traversal.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as tar:
+        payload = b"pwned"
+        item = tarfile.TarInfo("data/../../escape.txt")
+        item.size = len(payload)
+        tar.addfile(item, io.BytesIO(payload))
+
+    with pytest.raises(SystemExit):
+        backup.cmd_restore(_restore_args(tar_path))
+
+    # Nothing must have been written outside the repo, and data/ must be intact.
+    assert not (tmp_path / "escape.txt").exists()
+    assert data.exists()


### PR DESCRIPTION
## Summary
`odysseus-backup restore` validates tarball entries by checking the textual prefix `rel.parts[0] == data`. A crafted entry like `data/../../escape.txt` passes that check but `(root / rel).resolve()` escapes the repo root.

This PR adds a final defense in `_validate_restore_members`: after the textual checks pass, resolve the target path and refuse the entry unless it equals the repo root or is a strict descendant of it. The check also catches symlinked parent directories on disk.

## What changed
- `scripts/odysseus-backup` — `_validate_restore_members(members, root)` now resolves each entry and refuses anything that escapes `root`. Both `cmd_restore` and `cmd_verify` are updated to pass `_REPO_ROOT`.
- `tests/test_backup_cli_security.py` — new test `test_restore_rejects_path_traversal_under_data` that builds a tarball with `data/../../escape.txt` and asserts `cmd_restore` refuses it.

## Test plan
`uv run pytest tests/test_backup_cli_security.py -v` → 6/6 PASS.