### PR TITLE
feat(settings): configurable chat_request_timeout_seconds

### DIFF
--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -591,6 +591,7 @@ def setup_auth_routes(auth_manager: AuthManager) -> APIRouter:
         _INT_RANGES = {
             "agent_max_rounds": (1, 200),
             "agent_max_tool_calls": (0, 1000),  # 0 = unlimited
+            "chat_request_timeout_seconds": (10, 1800),  # client request backstop
         }
         for key in DEFAULT_SETTINGS:
             if key not in body:

--- a/src/settings.py
+++ b/src/settings.py
@@ -111,6 +111,12 @@ DEFAULT_SETTINGS = {
     # `compute_input_token_budget` in src/context_budget.py.
     "agent_input_token_hard_max": 200_000,
     "agent_stream_timeout_seconds": 300,
+    # Client-side hard backstop (seconds) for a normal chat request before the
+    # browser aborts it. Raise it for slow local backends where a cold image-gen
+    # pipeline reload (~2 min) would otherwise be killed mid-warmup. Read by the
+    # frontend from /api/auth/settings; agent/research modes use their own longer
+    # timeout. Default matches the original hardcoded 120s.
+    "chat_request_timeout_seconds": 120,
     # Extra directory roots that read_file / write_file may access, in
     # addition to the built-in project data/ and system temp dirs. Each
     # entry is an absolute path. Sensitive subpaths (.ssh, .gnupg, shell

--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -26,7 +26,12 @@ import { createStreamRenderer } from './streamingRenderer.js';
 import { wireArrowUpRecall, getLastUserMessageFromChatHistory } from './composerArrowUpRecall.js';
 
   const RESEARCH_TIMEOUT_MS = 360000;
-  const DEFAULT_TIMEOUT_MS = 120000;
+  // Client-side hard backstop for a normal chat request. Overridable at runtime
+  // via the `chat_request_timeout_seconds` setting (Settings panel / manage_settings),
+  // loaded from /api/auth/settings in init() below. Defaults to dev's 120s; raise it
+  // for slow local backends where a cold image-gen reload (~2 min) would otherwise be
+  // aborted mid-warmup. The processing probe still catches a genuinely-offline endpoint.
+  let DEFAULT_TIMEOUT_MS = 120000;
   const RESEARCH_SVG = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>';
 
   let API_BASE = '';
@@ -179,6 +184,14 @@ import { wireArrowUpRecall, getLastUserMessageFromChatHistory } from './composer
    */
   export function init(apiBase) {
     API_BASE = apiBase;
+    // Load the configurable client request-timeout backstop (defaults to 120s).
+    fetch((apiBase || '') + '/api/auth/settings', { credentials: 'same-origin' })
+      .then(r => r.ok ? r.json() : null)
+      .then(s => {
+        const secs = s && Number(s.chat_request_timeout_seconds);
+        if (secs && secs > 0) DEFAULT_TIMEOUT_MS = secs * 1000;
+      })
+      .catch(() => {});
     initSlashCommands({ apiBase, isStreaming: () => isStreaming });
     // Initialize email inbox
     emailInbox.init(documentModule);


### PR DESCRIPTION
## Summary

The client-side hard timeout that aborts a chat request (`DEFAULT_TIMEOUT_MS` in `static/js/chat.js`) is a hardcoded 120s constant. On slow local backends a legitimate long request — e.g. a cold image-pipeline reload (~2 min) — gets aborted mid-flight, leaving the spinner stuck, with no way to tune it short of editing code. This PR makes it a real setting, `chat_request_timeout_seconds` (default **120s**, unchanged behavior), read by the frontend from `/api/auth/settings` at init, clamped 10–1800s, and adjustable from the Settings panel (and the `manage_settings` tool). Agent/research modes keep their own longer timeouts. Follows the existing `*_timeout_seconds` + `get_setting` + bounded-int convention (e.g. `agent_stream_timeout_seconds`, `research_run_timeout_seconds`).

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Part of #2615

## Type of Change

- [x] New feature (non-breaking — adds new behaviour)

## Checklist

- [x] I searched open issues and PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. With defaults, confirm behavior is unchanged (120s client backstop for normal chat mode).
2. In Settings (or via `manage_settings`, e.g. "set chat timeout to 300"), change the value; confirm `GET /api/auth/settings` returns `chat_request_timeout_seconds`.
3. Reload, send a chat message, and confirm the client abort backstop uses the configured value (agent/research modes still use their longer timeout).
4. Confirm an out-of-range value is clamped to 10–1800s on save.

## Visual / UI changes

No rendering changes. The only `static/js` edit is reading a numeric setting to drive an existing timeout constant — no DOM/CSS/layout changes.

- [x] No visual change.
