### PR TITLE
deep-research: communicate max_rounds to the LLM in the stop prompt

### DIFF
--- a/src/deep_research.py
+++ b/src/deep_research.py
@@ -107,13 +107,15 @@ You are deciding whether a research report is comprehensive enough.
 **Current report:**
 {report}
 
-**Rounds completed:** {round_num}
+**Rounds completed:** {round_num} / {max_rounds}
 
 Based on the report so far, do we have enough information to answer the question \
 comprehensively?  Consider:
 - Are the key aspects of the question addressed?
 - Are there obvious gaps or unanswered sub-questions?
 - Is the evidence sufficient and from multiple sources?
+- The user has allocated {max_rounds} rounds for this research — if there are still \
+unexplored aspects, use the remaining rounds to investigate them.
 
 Reply with ONLY "YES" or "NO" followed by a brief one-sentence reason.
 Example: "YES — The report covers all major aspects with evidence from multiple sources."
@@ -698,6 +700,7 @@ class DeepResearcher:
             question=question,
             report=report,
             round_num=round_num,
+            max_rounds=self.max_rounds,
         )
 
         try:

--- a/src/task_scheduler.py
+++ b/src/task_scheduler.py
@@ -1708,11 +1708,13 @@ class TaskScheduler:
         extraction_timeout = int(get_setting("research_extraction_timeout_seconds", 90) or 90)
         extraction_concurrency = int(get_setting("research_extraction_concurrency", 3) or 3)
 
+        effective_rounds = 8
         researcher = DeepResearcher(
             llm_endpoint=endpoint_url,
             llm_model=model,
             llm_headers=headers,
-            max_rounds=8,
+            max_rounds=effective_rounds,
+            min_rounds=min(3, effective_rounds),
             max_time=600,  # 10 min for scheduled research
             max_report_tokens=max_tokens,
             extraction_timeout=extraction_timeout,


### PR DESCRIPTION
## Summary

The deep research STOP_PROMPT tells the LLM the current round number but not the user's max_rounds budget. Without this context, the LLM stops at round 2-3 for moderately simple questions even when the user configured 4+ rounds. The fix adds max_rounds to the stop prompt so the LLM can factor the intended research depth into its decision.

Also ensures scheduled research tasks pass min_rounds explicitly so they respect the same floor as interactive research.

## Linked Issue

Fixes #2863

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Open Deep Research panel
2. Set Rounds to 4+
3. Launch research on a moderately complex question
4. Verify the LLM continues past round 2-3 and uses the full allocated budget