### PR TITLE
feat(settings): add dynamic blurbs for settings tabs in the admin interface

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1337,7 +1337,7 @@
         </button>
         <button class="close-btn" aria-label="Close settings">✖</button>
       </div>
-      <div class="admin-toggle-sub" style="padding:0 12px 8px;opacity:0.6;font-size:11px;">Toggle on/off visibility of tools and modules across the interface.</div>
+      <div id="settings-tab-blurb" class="admin-toggle-sub" style="padding:0 12px 8px;opacity:0.6;font-size:11px;"></div>
       <div class="settings-layout">
         <div class="settings-sidebar">
           <!-- Section 1: AI plumbing (Add Models → AI Defaults → Search) -->

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -21,10 +21,34 @@ function safeRasterDataUrl(raw) {
 /* ── Tab switching ── */
 const ADMIN_TABS = new Set(['services', 'integrations', 'tools', 'users', 'system']);
 
+const SETTINGS_TAB_BLURBS = {
+  services: 'Connect local and cloud model endpoints for chat and images.',
+  ai: 'Default chat model, utility model, and related AI behavior.',
+  search: 'Search API used for web search and deep research.',
+  integrations: 'All external service connections in one place.',
+  email: 'Email writing style and links to account setup in Integrations.',
+  reminders: 'How fired note reminders are delivered (browser, email, ntfy).',
+  appearance: 'Toggle on/off visibility of tools and modules across the interface.',
+  shortcuts: 'Click a shortcut to rebind; press Escape to cancel.',
+  account: 'Profile, password, and two-factor authentication.',
+  tools: 'Enable or disable tools available to the AI agent.',
+  users: 'User accounts, open signup, and per-user privileges.',
+  system: 'Backup, import, tokens, webhooks, and server maintenance.',
+};
+
+function syncSettingsTabBlurb(tab) {
+  const blurb = el('settings-tab-blurb');
+  if (!blurb) return;
+  const text = SETTINGS_TAB_BLURBS[tab] || '';
+  blurb.textContent = text;
+  blurb.style.display = text ? '' : 'none';
+}
+
 function initTabs() {
   modalEl.querySelectorAll('[data-settings-tab]').forEach(btn => {
     btn.addEventListener('click', () => {
       const tab = btn.dataset.settingsTab;
+      syncSettingsTabBlurb(tab);
       // Lazy-init admin when first clicking an admin tab
       if (ADMIN_TABS.has(tab) && window.adminModule && typeof window.adminModule.open === 'function') {
         window.adminModule.open(tab);
@@ -5197,6 +5221,7 @@ export function open(tab) {
   }
   // Auto-init admin data if showing an admin tab
   const activeTab = tab || (modalEl.querySelector('[data-settings-tab].active') || {}).dataset?.settingsTab || 'services';
+  syncSettingsTabBlurb(activeTab);
   document.body.classList.toggle('settings-appearance-open', activeTab === 'appearance');
   syncAppearanceOpacity(activeTab === 'appearance');
   if (activeTab === 'ai') refreshAiModelEndpoints();


### PR DESCRIPTION
## Summary

The settings modal showed a static Appearance-only subtitle ("Toggle on/off visibility…") on every tab for all users. The subtitle is now driven by #settings-tab-blurb and updates per tab via SETTINGS_TAB_BLURBS in settings.js, so each panel shows context-appropriate help text (e.g. AI Defaults vs Appearance vs Account). No new styling or components. reuses the existing admin-toggle-sub element.

Fixes [Issue 3289](https://github.com/pewdiepie-archdaemon/odysseus/issues/3289)
and continuation of [PR 1060](https://github.com/pewdiepie-archdaemon/odysseus/pull/1060)

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #3289

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Start Odysseus locally
2. Log in and open settings
3. Switch to **AI Defaults** where subtitle should describe AI models, not visibility toggles
4. Switch to **Appearance** where subtitle should mention toggling visibility

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [x] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

![Appearance tab — visibility subtitle](https://github.com/user-attachments/assets/0e329e12-a9c2-4dd0-a49f-98af9c9bd8fa)

![AI Defaults tab — AI-specific subtitle](https://github.com/user-attachments/assets/8062f748-185f-485a-a086-c131691a1ab2)

