### PR TITLE
fix(ollama): shape multimodal content for native Ollama Cloud vision

### DIFF
--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -340,6 +340,56 @@ def _ollama_normalize_tool_messages(messages: List[Dict]) -> List[Dict]:
     return out
 
 
+def _ollama_split_multimodal_content(content: List) -> Tuple[str, List[str]]:
+    """Split an OpenAI-style multimodal content array into native Ollama parts.
+
+    Returns ``(text, images)`` where ``text`` joins the text blocks and
+    ``images`` holds each image_url's raw base64 (the ``data:<type>;base64,``
+    prefix stripped). Native Ollama /api/chat carries images in a sibling
+    ``images`` array, not inline in ``content``. External (non-data) image URLs
+    are skipped — native Ollama only accepts base64/file images, so forwarding a
+    URL string would not render and only risks another unmarshal error.
+    """
+    texts: List[str] = []
+    images: List[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            if isinstance(block, str):
+                texts.append(block)
+            continue
+        if block.get("type") == "text":
+            texts.append(block.get("text") or "")
+        elif block.get("type") == "image_url":
+            url = (block.get("image_url") or {}).get("url", "")
+            if url.startswith("data:") and "," in url:
+                images.append(url.split(",", 1)[1])
+    return "\n".join(t for t in texts if t), images
+
+
+def _ollama_normalize_message_content(messages: List[Dict]) -> List[Dict]:
+    """Flatten OpenAI multimodal content arrays into native Ollama shape.
+
+    A vision turn arrives with ``content`` as an array of text / image_url
+    blocks. Native Ollama /api/chat wants ``content`` as a plain string plus a
+    sibling ``images`` array of base64; given the array it rejects the whole
+    request with HTTP 400 "cannot unmarshal array into Go struct field
+    ChatRequest.messages.content of type string". Convert on shallow copies,
+    leaving string-content messages untouched.
+    """
+    out: List[Dict] = []
+    for m in messages or []:
+        if not isinstance(m, dict) or not isinstance(m.get("content"), list):
+            out.append(m)
+            continue
+        text, images = _ollama_split_multimodal_content(m["content"])
+        nm = dict(m)
+        nm["content"] = text
+        if images:
+            nm["images"] = images
+        out.append(nm)
+    return out
+
+
 def _build_ollama_payload(
     model: str,
     messages: List[Dict],
@@ -362,7 +412,9 @@ def _build_ollama_payload(
     """
     payload: Dict = {
         "model": model,
-        "messages": _ollama_normalize_tool_messages(messages),
+        "messages": _ollama_normalize_message_content(
+            _ollama_normalize_tool_messages(messages)
+        ),
         "stream": stream,
     }
     options: Dict = {}

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -363,6 +363,14 @@ def _ollama_split_multimodal_content(content: List) -> Tuple[str, List[str]]:
             url = (block.get("image_url") or {}).get("url", "")
             if url.startswith("data:") and "," in url:
                 images.append(url.split(",", 1)[1])
+        else:
+            # Native Ollama /api/chat only carries text + base64 images; any other
+            # block type (e.g. audio) has no representation here and is dropped.
+            # Log it so a vanished attachment is debuggable rather than silent.
+            logger.debug(
+                "ollama: dropping unsupported content block type %r",
+                block.get("type"),
+            )
     return "\n".join(t for t in texts if t), images
 
 

--- a/tests/test_llm_core_ollama.py
+++ b/tests/test_llm_core_ollama.py
@@ -176,6 +176,50 @@ def test_ollama_payload_text_only_array_collapses_without_images_key():
     assert "images" not in msg
 
 
+def test_ollama_payload_drops_unsupported_content_block():
+    # A block native Ollama can't carry (e.g. audio) is dropped, not forwarded
+    # as an array (which would 400) nor mistaken for an image. Text survives.
+    msgs = [{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "hi"},
+            {"type": "audio", "audio": {"url": "data:audio/wav;base64,SND"}},
+        ],
+    }]
+    payload = llm_core._build_ollama_payload("m", msgs, temperature=0.0, max_tokens=0)
+    msg = payload["messages"][0]
+    assert msg["content"] == "hi"
+    assert "images" not in msg
+
+
+def test_ollama_payload_handles_tool_calls_and_multimodal_together():
+    # Tool-arg normalization and multimodal flattening compose without clobbering
+    # each other: a vision user turn and an assistant tool call in one request.
+    msgs = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "look"},
+                {"type": "image_url",
+                 "image_url": {"url": "data:image/png;base64,IMG"}},
+            ],
+        },
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{
+                "id": "c0", "type": "function",
+                "function": {"name": "app_api", "arguments": '{"a": 1}'},
+            }],
+        },
+    ]
+    payload = llm_core._build_ollama_payload("m", msgs, temperature=0.0, max_tokens=0)
+    user, asst = payload["messages"][0], payload["messages"][1]
+    assert user["content"] == "look"
+    assert user["images"] == ["IMG"]
+    assert asst["tool_calls"][0]["function"]["arguments"] == {"a": 1}
+
+
 def test_ollama_payload_tolerates_malformed_arguments():
     msgs = [{
         "role": "assistant",

--- a/tests/test_llm_core_ollama.py
+++ b/tests/test_llm_core_ollama.py
@@ -105,6 +105,77 @@ def test_ollama_payload_leaves_plain_messages_untouched():
     assert payload["messages"][0] == {"role": "user", "content": "hello"}
 
 
+# ---------------------------------------------------------------------------
+# Multimodal (vision) content shaping for native Ollama (issue #3313)
+#
+# A vision turn arrives as an OpenAI-style content *array*
+# ([{type:text,...}, {type:image_url, image_url:{url:"data:image/png;base64,XXX"}}]).
+# Native Ollama /api/chat wants `content` as a plain string with images carried
+# in a sibling `images` array of raw base64; given the array it 400s with
+# "cannot unmarshal array into Go struct field ChatRequest.messages.content of
+# type string", so _build_ollama_payload must flatten it.
+# ---------------------------------------------------------------------------
+
+def test_ollama_payload_flattens_multimodal_to_string_and_images():
+    msgs = [{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "What is in this image?"},
+            {"type": "image_url",
+             "image_url": {"url": "data:image/png;base64,AAAABBBB"}},
+        ],
+    }]
+    payload = llm_core._build_ollama_payload(
+        "qwen3-vl", msgs, temperature=0.0, max_tokens=0,
+    )
+    msg = payload["messages"][0]
+    # content must be a plain string, not the OpenAI array.
+    assert msg["content"] == "What is in this image?"
+    assert not isinstance(msg["content"], list)
+    # image moves to a sibling `images` array, data-URI prefix stripped.
+    assert msg["images"] == ["AAAABBBB"]
+
+
+def test_ollama_payload_joins_multiple_text_blocks_keeps_images():
+    msgs = [{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "first"},
+            {"type": "image_url",
+             "image_url": {"url": "data:image/jpeg;base64,IMG"}},
+            {"type": "text", "text": "second"},
+        ],
+    }]
+    payload = llm_core._build_ollama_payload("m", msgs, temperature=0.0, max_tokens=0)
+    msg = payload["messages"][0]
+    assert msg["content"] == "first\nsecond"
+    assert msg["images"] == ["IMG"]
+
+
+def test_ollama_payload_image_only_message_has_empty_content():
+    msgs = [{
+        "role": "user",
+        "content": [
+            {"type": "image_url",
+             "image_url": {"url": "data:image/webp;base64,ONLYIMG"}},
+        ],
+    }]
+    payload = llm_core._build_ollama_payload("m", msgs, temperature=0.0, max_tokens=0)
+    msg = payload["messages"][0]
+    assert msg["content"] == ""
+    assert msg["images"] == ["ONLYIMG"]
+
+
+def test_ollama_payload_text_only_array_collapses_without_images_key():
+    # A content array carrying only text collapses to a string; no images key is
+    # added (Ollama rejects an empty images array on some server versions).
+    msgs = [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
+    payload = llm_core._build_ollama_payload("m", msgs, temperature=0.0, max_tokens=0)
+    msg = payload["messages"][0]
+    assert msg["content"] == "hi"
+    assert "images" not in msg
+
+
 def test_ollama_payload_tolerates_malformed_arguments():
     msgs = [{
         "role": "assistant",


### PR DESCRIPTION
## Summary

Vision turns sent to **Ollama Cloud** (e.g. `qwen3-vl`) fail with:

```
Ollama Cloud returned HTTP 400: json: cannot unmarshal array into Go struct field ChatRequest.messages.content of type string
```

Native Ollama `/api/chat` expects message `content` to be a **string** with images carried in a sibling `images` array of base64. Odysseus forwarded the OpenAI-style multimodal `content` **array** (`[{type:text…}, {type:image_url…}]`) verbatim to the native endpoint, which the Go server rejects.

Fix: `_build_ollama_payload` now flattens multimodal content for the native path — join text blocks into `content`, move each `data:` image into `images` with the `data:<type>;base64,` prefix stripped. String-content messages and the existing tool-call normalization are untouched. External (non-data) image URLs are skipped since native Ollama only accepts base64/file images. This mirrors the existing Anthropic adapter (`_convert_openai_content_to_anthropic`), kept on the Ollama side as its own shape.

## Target branch

- [x] This PR targets `dev`, not `main`.

## Linked Issue

Fixes #3313

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app and verified the change works end-to-end. *(Backend-only payload builder; verified via the regression suite below rather than a live Ollama Cloud session.)*

## How to Test

Backend-only change to `_build_ollama_payload`; no UI surface touched.

1. `python -m pytest tests/test_llm_core_ollama.py` → **16 passed** (4 new regression tests: multimodal → string+images, multi-text join, image-only → empty content, text-only array collapse, no empty `images` key).
2. `python -m pytest -k "llm_core or ollama"` → **153 passed**.
3. `python -m py_compile src/llm_core.py` → OK.

To verify against a live endpoint: configure an Ollama Cloud vision model (e.g. `qwen3-vl`) and send a chat turn containing an image — before this fix the request returns HTTP 400 (`cannot unmarshal array … content of type string`); after it, the turn completes.

