### PR TITLE
fix(windows): detect per-user Git for Windows bash under %LocalAppData%\Programs\Git

### DIFF
--- a/core/platform_compat.py
+++ b/core/platform_compat.py
@@ -191,6 +191,8 @@ def _windows_bash_fallbacks() -> List[str]:
         base = os.environ.get(env_name)
         if base:
             roots.append(ntpath.join(base, "Git"))
+            if env_name == "LocalAppData":
+                roots.append(ntpath.join(base, "Programs", "Git"))
     roots.extend(_WINDOWS_BASH_DEFAULT_ROOTS)
 
     paths: List[str] = []

--- a/tests/test_platform_compat.py
+++ b/tests/test_platform_compat.py
@@ -47,6 +47,20 @@ def test_find_bash_checks_local_app_data_git_install(monkeypatch):
     assert platform_compat.find_bash() == expected
 
 
+def test_find_bash_checks_local_app_data_programs_git_install(monkeypatch):
+    _reset_bash_cache(monkeypatch)
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+    monkeypatch.setattr(platform_compat.shutil, "which", lambda _name: None)
+    for env_name in platform_compat._WINDOWS_BASH_ROOT_ENV_VARS:
+        monkeypatch.delenv(env_name, raising=False)
+    monkeypatch.setenv("LocalAppData", r"C:\Users\alice\AppData\Local")
+
+    expected = r"C:\Users\alice\AppData\Local\Programs\Git\bin\bash.exe"
+    monkeypatch.setattr(platform_compat.os.path, "exists", lambda path: path == expected)
+
+    assert platform_compat.find_bash() == expected
+
+
 def test_find_bash_skips_windows_wsl_stub(monkeypatch):
     _reset_bash_cache(monkeypatch)
     monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)


### PR DESCRIPTION
## Summary

`find_bash()` on Windows correctly rejects the Microsoft Store WSL `bash.exe` alias stub, then falls back to probing known Git for Windows install roots. That fallback only checked `%LocalAppData%\Git`, so per-user installs of Git for Windows (winget, or the official installer in "for me only" / non-admin mode) — which land in `%LocalAppData%\Programs\Git` — were never found. As a result the Cookbook refused local downloads/serves with "needs Git Bash (bash.exe) on PATH" even though Git for Windows was installed. This adds `%LocalAppData%\Programs\Git` to the per-user fallback roots.


## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #3735

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Windows host with Git for Windows installed per-user (winget `Git.Git`, or the official installer in "for me only" mode), so bash lives at `%LocalAppData%\Programs\Git\bin\bash.exe`, and with no other `bash` on PATH except the Microsoft Store WSL alias (`%LocalAppData%\Microsoft\WindowsApps\bash.exe`).
2. **Before the fix:** `python -c "from core.platform_compat import find_bash; print(find_bash())"` prints `None`, and starting a local Cookbook download fails with `Cookbook LOCAL execution on Windows needs Git Bash (bash.exe) on PATH.`
3. **After the fix:** the same command prints `...\AppData\Local\Programs\Git\bin\bash.exe`, and the local Cookbook download runs (the Git Bash error is gone).
4. Unit tests: `python -m pytest tests/test_platform_compat.py -k find_bash` → 4 passed (including the new `test_find_bash_checks_local_app_data_programs_git_install`). `python -m py_compile core/platform_compat.py` → OK.

- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

