### PR TITLE
fix(contacts): unfold RFC 6350 folded lines when parsing vCards

### DIFF
--- a/routes/contacts_routes.py
+++ b/routes/contacts_routes.py
@@ -147,6 +147,12 @@ def _parse_vcards(text: str) -> List[Dict]:
         if not block.strip():
             continue
         contact = {"name": "", "emails": [], "phones": [], "uid": ""}
+        # RFC 6350 ss3.2 line unfolding: a CRLF (or LF) followed by a single
+        # space or tab continues the previous line. Without unfolding, a folded
+        # value (a long EMAIL, TEL, or FN, which Apple/iCloud/Google routinely
+        # fold at ~75 chars) is split across physical lines and the continuation
+        # is silently dropped, truncating the value.
+        block = re.sub(r"\r?\n[ \t]", "", block)
         for line in block.split("\n"):
             line = line.strip()
             # Strip an optional RFC 6350 group prefix (e.g. "item1.EMAIL;...")

--- a/tests/test_vcard_unfold.py
+++ b/tests/test_vcard_unfold.py
@@ -1,0 +1,28 @@
+"""_parse_vcards must unfold RFC 6350 folded lines.
+
+A long property value is folded by inserting a line break + a single space/tab.
+The parser split on newlines without unfolding, so a folded EMAIL/TEL/FN was
+truncated at the fold and the continuation (which does not start with a property
+name) was dropped.
+"""
+from routes.contacts_routes import _parse_vcards
+
+
+def test_folded_email_is_unfolded():
+    vcf = "BEGIN:VCARD\nFN:Test\nEMAIL:verylongmailbox-part1\n part2@example.com\nEND:VCARD\n"
+    contacts = _parse_vcards(vcf)
+    assert contacts[0]["emails"] == ["verylongmailbox-part1part2@example.com"]
+
+
+def test_folded_email_crlf_and_tab():
+    vcf = "BEGIN:VCARD\r\nFN:Test\r\nEMAIL:abc\r\n\tdef@example.com\r\nEND:VCARD\r\n"
+    contacts = _parse_vcards(vcf)
+    assert contacts[0]["emails"] == ["abcdef@example.com"]
+
+
+def test_unfolded_vcard_still_parses():
+    vcf = "BEGIN:VCARD\nFN:Jane Doe\nEMAIL:jane@example.com\nTEL:+15551234567\nEND:VCARD\n"
+    contacts = _parse_vcards(vcf)
+    assert contacts[0]["name"] == "Jane Doe"
+    assert contacts[0]["emails"] == ["jane@example.com"]
+    assert contacts[0]["phones"] == ["+15551234567"]


### PR DESCRIPTION
## Summary

`_parse_vcards` split each vCard block on newlines without RFC 6350 unfolding. Per RFC 6350 section 3.2 a long value is folded by inserting a line break followed by a single space or tab; the continuation line does not start with a property name, so the parser dropped it and truncated the value. Apple/iCloud/Google fold long `EMAIL`, `TEL`, and `FN` values at ~75 chars, so imported contacts lost the tail of those fields. This unfolds before splitting into logical lines.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3905

## Type of Change

- [x] Bug fix (non-breaking, fixes a confirmed issue)
- [ ] New feature (non-breaking, adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Details

```python
block = re.sub(r"\r?\n[ \t]", "", block)   # RFC 6350 line unfolding
for line in block.split("\n"):
    ...
```

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) and this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above, no unrelated refactors or whitespace churn.

## How to Test

```
python -m pytest tests/test_vcard_unfold.py -q   # 3 passed
python -m py_compile routes/contacts_routes.py   # ok
```

Tests cover a folded email (space continuation), a folded email (CRLF + tab), and an unfolded sanity case. Verified the folded cases fail against current `dev`.

## Visual / UI changes

None, backend parser only.
