### PR TITLE
feat: add Voice Assistant with STT/TTS loop + live static mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       # land under /app/.local for the odysseus user. Persist them so a
       # container recreate does not silently remove installed serve engines.
       - ./data/local:/app/.local:z
+      # Live-mount static frontend so JS/CSS/HTML changes are instant (no rebuild needed).
+      - ./static:/app/static:ro,z
     extra_hosts:
       # Lets the container reach local services on the Docker host, including
       # Ollama at http://host.docker.internal:11434.

--- a/static/app.js
+++ b/static/app.js
@@ -18,6 +18,7 @@ import chatRenderer from './js/chatRenderer.js';
 import sessionModule from './js/sessions.js';
 import memoryModule from './js/memory.js';
 import voiceRecorderModule from './js/voiceRecorder.js';
+import voiceAssistantModule from './js/voiceAssistant.js';
 import censorModule from './js/censor.js';
 import galleryModule from './js/gallery.js';
 import tasksModule from './js/tasks.js';
@@ -869,6 +870,14 @@ function initializeEventListeners() {
         if (galleryModule.isGalleryOpen()) galleryModule.closeGallery();
         else galleryModule.openGallery();
       }
+    });
+  }
+
+  // Voice Assistant tool button
+  const toolVoiceAssistantBtn = el('tool-voice-assistant-btn');
+  if (toolVoiceAssistantBtn) {
+    toolVoiceAssistantBtn.addEventListener('click', () => {
+      voiceAssistantModule.openVoiceAssistant();
     });
   }
 
@@ -3783,6 +3792,76 @@ function startOdysseusApp() {
 
   // Expose globally so voiceRecorder can trigger update after async fetch
   window._updateSendBtnIcon = _updateSendBtnIcon;
+
+  // ── Voice Mode: full hands-free loop (STT → auto-submit → TTS → listen) ──
+  window._voiceModeActive = false;
+
+  function _startVoiceListening() {
+    if (!window._voiceModeActive) return;
+    if (voiceRecorderModule.getIsRecording()) return;
+    if (!_isSttEnabled()) return;
+    const msgInput = el('message');
+    if (msgInput && msgInput.value.trim()) return;
+    const sb = document.querySelector('.send-btn');
+    if (!sb) return;
+    sb.innerHTML = _stopIcon;
+    sb.title = 'Stop recording';
+    sb.dataset.mode = 'recording';
+    sb.classList.add('recording');
+    voiceRecorderModule.startRecording(
+      (audioFile) => fileHandlerModule.addFiles([audioFile]),
+      uiModule.showToast,
+      uiModule.showError
+    );
+  }
+
+  window._voiceModeTriggerSubmit = () => {
+    if (!window._voiceModeActive) return;
+    setTimeout(() => {
+      try { handleSubmit(null); } catch (e) { console.error('voice submit', e); }
+    }, 150);
+  };
+
+  window._voiceModeRestartListening = () => {
+    if (!window._voiceModeActive) return;
+    setTimeout(_startVoiceListening, 700);
+  };
+
+  (function initVoiceModeToggle() {
+    const voiceModeBtn = el('overflow-voice-mode-btn');
+    const voiceIndicatorBtn = el('voice-mode-indicator-btn');
+    if (!voiceModeBtn) return;
+
+    function setVoiceMode(active) {
+      window._voiceModeActive = active;
+      voiceModeBtn.classList.toggle('active', active);
+      if (window.aiTTSManager) window.aiTTSManager.autoPlay = active;
+      if (voiceIndicatorBtn) voiceIndicatorBtn.style.display = active ? '' : 'none';
+      const s = loadToggleState(); s.voiceMode = active; saveToggleState(s);
+      updatePlusDot();
+      if (active) {
+        uiModule.showToast('Voice mode on — speak after the mic appears');
+        setTimeout(_startVoiceListening, 400);
+      } else {
+        voiceRecorderModule.stopRecording();
+        if (window.aiTTSManager) window.aiTTSManager.stop();
+      }
+    }
+
+    // Restore persisted state
+    try {
+      const st = loadToggleState();
+      if (st.voiceMode) {
+        window._voiceModeActive = true;
+        voiceModeBtn.classList.add('active');
+        if (window.aiTTSManager) window.aiTTSManager.autoPlay = true;
+        if (voiceIndicatorBtn) voiceIndicatorBtn.style.display = '';
+      }
+    } catch (e) {}
+
+    voiceModeBtn.addEventListener('click', () => setVoiceMode(!voiceModeBtn.classList.contains('active')));
+    if (voiceIndicatorBtn) voiceIndicatorBtn.addEventListener('click', () => setVoiceMode(false));
+  })();
 
   // Initial icon state
   _updateSendBtnIcon();

--- a/static/index.html
+++ b/static/index.html
@@ -880,6 +880,18 @@
           </svg>
           <span class="grow">Notes</span>
         </div>
+        <div class="list-item" id="tool-voice-assistant-btn" title="Voice Assistant — speak and hear AI replies">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+            stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+            style="flex-shrink:0;opacity:0.5;">
+            <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z"/>
+            <path d="M19 10v2a7 7 0 0 1-14 0v-2"/>
+            <line x1="12" y1="19" x2="12" y2="23"/>
+            <line x1="8" y1="23" x2="16" y2="23"/>
+          </svg>
+          <span class="grow">Voice Assistant</span>
+        </div>
+
         <div class="list-item" id="tool-tasks-btn">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"
             stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
@@ -1036,6 +1048,12 @@
                    #research-toggle checkbox is kept inert so existing JS refs
                    don't break; without this entry point it can't be enabled. -->
               <!-- Group Chat moved to Characters modal Group tab -->
+              <!-- Voice Mode: full hands-free loop (STT → auto-submit → TTS → listen) -->
+              <button type="button" class="overflow-menu-item" id="overflow-voice-mode-btn">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/></svg>
+                <span>Voice Mode</span>
+                <span class="overflow-active-dot"></span>
+              </button>
               <!-- TTS Mode hidden — read-aloud feature is off in this build. -->
               <button type="button" class="overflow-menu-item" id="overflow-tts-btn" hidden style="display:none">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M19.07 4.93a10 10 0 0 1 0 14.14"/><path d="M15.54 8.46a5 5 0 0 1 0 7.07"/></svg>
@@ -1087,6 +1105,12 @@
           <button type="button" class="input-icon-btn tool-indicator" title="Persona active — click to deactivate" id="character-indicator-btn" style="display:none;">
             <svg id="char-indicator-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
             <span id="character-indicator-name" style="font-size:11px;margin-left:2px;max-width:80px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;"></span>
+            <svg class="tool-indicator-x" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><line x1="6" y1="6" x2="18" y2="18"/><line x1="18" y1="6" x2="6" y2="18"/></svg>
+          </button>
+          <!-- Voice Mode indicator (hidden until active) -->
+          <button type="button" class="input-icon-btn tool-indicator" title="Voice mode active — click to deactivate" id="voice-mode-indicator-btn" style="display:none;">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/></svg>
+            <span style="font-size:11px;margin-left:2px;">Voice</span>
             <svg class="tool-indicator-x" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><line x1="6" y1="6" x2="18" y2="18"/><line x1="18" y1="6" x2="6" y2="18"/></svg>
           </button>
           <!-- Compare toolbar indicator (hidden until active) -->

--- a/static/js/voiceAssistant.js
+++ b/static/js/voiceAssistant.js
@@ -1,0 +1,599 @@
+// static/js/voiceAssistant.js
+// Dedicated Voice Assistant — speak to the AI, hear it speak back.
+// Flow: tap mic → STT → send to AI → TTS → tap mic again (or auto-loop).
+
+const API_BASE = '';
+
+let _modalEl = null;
+let _sessionId = null;
+let _abortController = null;
+let _isActive = false;
+let _isListening = false;
+let _isSpeaking = false;
+let _autoLoop = false;
+let _transcript = [];     // { role: 'user'|'ai', text: string }[]
+let _vaRecognition = null;
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function _esc(s) {
+  return (s || '').replace(/[&<>"']/g, (c) => (
+    { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+  ));
+}
+
+function _el(id) { return document.getElementById(id); }
+
+// Strip markdown/code so TTS speaks cleanly
+function _stripForSpeech(text) {
+  return text
+    .replace(/```[\s\S]*?```/g, ' code block ')
+    .replace(/`[^`]+`/g, '')
+    .replace(/#{1,6}\s/g, '')
+    .replace(/\*\*(.+?)\*\*/g, '$1')
+    .replace(/\*(.+?)\*/g, '$1')
+    .replace(/\[(.+?)\]\(.+?\)/g, '$1')
+    .replace(/<[^>]+>/g, '')
+    .replace(/\n{2,}/g, '. ')
+    .replace(/\n/g, ' ')
+    .trim();
+}
+
+// ── Session ──────────────────────────────────────────────────────────────────
+
+async function _ensureSession() {
+  if (_sessionId) return _sessionId;
+  try {
+    const fd = new FormData();
+    fd.append('name', 'Voice Chat');
+    fd.append('skip_validation', 'true');
+    const res = await fetch(`${API_BASE}/api/session`, {
+      method: 'POST',
+      credentials: 'same-origin',
+      body: fd,
+    });
+    if (res.ok) {
+      const data = await res.json();
+      _sessionId = data.id || data.session_id;
+      return _sessionId;
+    }
+  } catch (e) {
+    console.error('Voice Assistant: failed to create session', e);
+  }
+  return null;
+}
+
+// ── Chat stream ───────────────────────────────────────────────────────────────
+
+async function _sendToAI(text) {
+  const sessionId = await _ensureSession();
+  if (!sessionId) throw new Error('No AI session');
+
+  const fd = new FormData();
+  fd.append('message', text);
+  fd.append('session', sessionId);
+
+  _abortController = new AbortController();
+
+  const res = await fetch(`${API_BASE}/api/chat_stream`, {
+    method: 'POST',
+    body: fd,
+    credentials: 'same-origin',
+    signal: _abortController.signal,
+  });
+
+  if (!res.ok) throw new Error(`Chat error ${res.status}`);
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let accumulated = '';
+  let buffer = '';
+
+  // Show live typing in the panel
+  _upsertTypingBubble('');
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+
+    const lines = buffer.split('\n');
+    buffer = lines.pop();
+
+    for (const line of lines) {
+      if (!line.startsWith('data: ')) continue;
+      if (line === 'data: [DONE]') continue;
+      try {
+        const json = JSON.parse(line.slice(6));
+        const delta =
+          json.choices?.[0]?.delta?.content ??
+          (json.delta !== undefined ? json.delta : null);
+        if (delta !== null) {
+          accumulated += delta;
+          _upsertTypingBubble(accumulated);
+        }
+      } catch {}
+    }
+  }
+
+  return accumulated;
+}
+
+// ── UI: transcript ────────────────────────────────────────────────────────────
+
+function _upsertTypingBubble(text) {
+  const hist = _el('va-history');
+  if (!hist) return;
+  let bubble = hist.querySelector('.va-typing');
+  if (!bubble) {
+    bubble = document.createElement('div');
+    bubble.className = 'va-msg va-msg-ai va-typing';
+    hist.appendChild(bubble);
+  }
+  bubble.textContent = text;
+  hist.scrollTop = hist.scrollHeight;
+}
+
+function _commitTypingBubble() {
+  const hist = _el('va-history');
+  if (!hist) return;
+  hist.querySelectorAll('.va-typing').forEach(b => b.classList.remove('va-typing'));
+}
+
+function _addBubble(role, text) {
+  _transcript.push({ role, text });
+  const hist = _el('va-history');
+  if (!hist) return;
+  const div = document.createElement('div');
+  div.className = `va-msg va-msg-${role}`;
+  const label = document.createElement('span');
+  label.className = 'va-msg-label';
+  label.textContent = role === 'user' ? 'You' : 'AI';
+  const body = document.createElement('span');
+  body.className = 'va-msg-text';
+  body.textContent = text;
+  div.appendChild(label);
+  div.appendChild(body);
+  hist.appendChild(div);
+  hist.scrollTop = hist.scrollHeight;
+}
+
+function _clearHistory() {
+  _transcript = [];
+  const hist = _el('va-history');
+  if (hist) hist.innerHTML = '';
+  const interim = _el('va-interim');
+  if (interim) interim.textContent = '';
+}
+
+// ── Status / mic ring ─────────────────────────────────────────────────────────
+
+function _setStatus(text, cls) {
+  const el = _el('va-status');
+  if (!el) return;
+  el.textContent = text;
+  el.className = 'va-status ' + (cls || '');
+}
+
+function _setMicState(state) {
+  // state: 'idle' | 'listening' | 'thinking' | 'speaking'
+  const btn = _el('va-mic-btn');
+  if (btn) btn.dataset.state = state;
+  const ring = _el('va-mic-ring');
+  if (ring) ring.className = `va-mic-ring va-mic-ring-${state}`;
+}
+
+// ── TTS ──────────────────────────────────────────────────────────────────────
+
+async function _speakText(text) {
+  _isSpeaking = true;
+  _setStatus('Speaking…', 'speaking');
+  _setMicState('speaking');
+
+  const plain = _stripForSpeech(text);
+  if (!plain) { _isSpeaking = false; return; }
+
+  try {
+    const mgr = window.aiTTSManager;
+
+    // Prefer the existing AI TTS manager if it's available
+    if (mgr && mgr.available && mgr._provider !== 'disabled') {
+      await new Promise((resolve) => {
+        if (mgr.useBrowserTTS) {
+          const utt = new SpeechSynthesisUtterance(plain);
+          const voice = mgr._findBrowserVoice ? mgr._findBrowserVoice() : null;
+          if (voice) utt.voice = voice;
+          utt.rate = mgr.playbackSpeed || 1;
+          utt.onend = resolve;
+          utt.onerror = resolve;
+          window.speechSynthesis.speak(utt);
+        } else {
+          mgr.synthesize(plain).then((url) => {
+            const audio = new Audio(url);
+            audio.playbackRate = mgr.playbackSpeed || 1;
+            audio.onended = resolve;
+            audio.onerror = resolve;
+            audio.play().catch(resolve);
+          }).catch(resolve);
+        }
+      });
+    } else if ('speechSynthesis' in window) {
+      // Fallback: browser Web Speech API
+      await new Promise((resolve) => {
+        window.speechSynthesis.cancel();
+        const utt = new SpeechSynthesisUtterance(plain);
+        utt.onend = resolve;
+        utt.onerror = resolve;
+        window.speechSynthesis.speak(utt);
+      });
+    }
+  } catch (e) {
+    if (e.name !== 'AbortError') console.warn('VA TTS error:', e);
+  } finally {
+    _isSpeaking = false;
+  }
+}
+
+// ── STT ───────────────────────────────────────────────────────────────────────
+
+async function _startListening() {
+  if (_isListening || _isSpeaking) return;
+  _isListening = true;
+
+  const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+
+  if (SpeechRecognition) {
+    await _listenBrowserSTT();
+  } else {
+    // Fallback: mic recording → server Whisper
+    await _listenServerSTT();
+  }
+}
+
+function _listenBrowserSTT() {
+  return new Promise((resolve) => {
+    _setStatus('Listening…', 'listening');
+    _setMicState('listening');
+
+    const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+    const rec = new SpeechRecognition();
+    rec.continuous = false;
+    rec.interimResults = true;
+    rec.lang = '';
+    _vaRecognition = rec;
+
+    let finalText = '';
+    const interimEl = _el('va-interim');
+
+    rec.onresult = (event) => {
+      let interim = '';
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        if (event.results[i].isFinal) {
+          finalText += event.results[i][0].transcript + ' ';
+        } else {
+          interim += event.results[i][0].transcript;
+        }
+      }
+      if (interimEl) interimEl.textContent = (finalText + interim).trim();
+    };
+
+    rec.onerror = (e) => {
+      _isListening = false;
+      _vaRecognition = null;
+      if (interimEl) interimEl.textContent = '';
+      if (e.error === 'not-allowed' || e.error === 'service-not-allowed') {
+        _setStatus('Microphone access denied', 'error');
+        _setMicState('idle');
+      } else if (e.error !== 'no-speech' && e.error !== 'aborted') {
+        console.warn('VA STT error:', e.error);
+        _setStatus('Tap mic to speak', 'idle');
+        _setMicState('idle');
+      }
+      resolve('');
+    };
+
+    rec.onend = async () => {
+      _isListening = false;
+      _vaRecognition = null;
+      if (interimEl) interimEl.textContent = '';
+      const text = finalText.trim();
+      if (text && _isActive) {
+        await _handleUserInput(text);
+      } else if (_autoLoop && _isActive && !text) {
+        // No speech detected — re-listen if auto-loop
+        setTimeout(_startListening, 400);
+      } else {
+        _setStatus('Tap mic to speak', 'idle');
+        _setMicState('idle');
+      }
+      resolve(text);
+    };
+
+    rec.start();
+  });
+}
+
+let _serverSTTChunks = [];
+let _serverSTTRecorder = null;
+
+function _listenServerSTT() {
+  return new Promise((resolve) => {
+    if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+      _setStatus('Microphone not available', 'error');
+      _isListening = false;
+      resolve('');
+      return;
+    }
+    _setStatus('Listening… (tap again to send)', 'listening');
+    _setMicState('listening');
+    _serverSTTChunks = [];
+
+    navigator.mediaDevices.getUserMedia({ audio: true })
+      .then((stream) => {
+        const mr = new MediaRecorder(stream, { mimeType: 'audio/webm' });
+        _serverSTTRecorder = mr;
+        mr.ondataavailable = (e) => { if (e.data.size > 0) _serverSTTChunks.push(e.data); };
+        mr.onstop = async () => {
+          stream.getTracks().forEach(t => t.stop());
+          _serverSTTRecorder = null;
+          _isListening = false;
+          const blob = new Blob(_serverSTTChunks, { type: 'audio/webm' });
+          _setStatus('Transcribing…', 'thinking');
+          _setMicState('thinking');
+          try {
+            const fd = new FormData();
+            fd.append('file', blob, 'audio.webm');
+            const res = await fetch('/api/stt/transcribe', {
+              method: 'POST', credentials: 'same-origin', body: fd,
+            });
+            if (res.ok) {
+              const data = await res.json();
+              const text = (data.text || '').trim();
+              if (text && _isActive) {
+                await _handleUserInput(text);
+              } else {
+                _setStatus('No speech detected — tap to try again', 'idle');
+                _setMicState('idle');
+              }
+              resolve(text);
+            } else {
+              _setStatus('Transcription failed — tap to try again', 'error');
+              _setMicState('idle');
+              resolve('');
+            }
+          } catch (e) {
+            console.error('VA server STT error:', e);
+            _setStatus('Error — tap to try again', 'error');
+            _setMicState('idle');
+            resolve('');
+          }
+        };
+        mr.start();
+      })
+      .catch((err) => {
+        _isListening = false;
+        _serverSTTRecorder = null;
+        if (err.name === 'NotAllowedError') {
+          _setStatus('Microphone access denied', 'error');
+        } else {
+          _setStatus('Microphone error — tap to retry', 'error');
+        }
+        _setMicState('idle');
+        resolve('');
+      });
+  });
+}
+
+// ── Main interaction loop ─────────────────────────────────────────────────────
+
+async function _handleUserInput(text) {
+  if (!text || !_isActive) return;
+
+  // Show user message
+  _addBubble('user', text);
+  _setStatus('Thinking…', 'thinking');
+  _setMicState('thinking');
+
+  try {
+    const aiText = await _sendToAI(text);
+    _commitTypingBubble();
+    // Remove the typing placeholder and add proper bubble
+    const hist = _el('va-history');
+    if (hist) {
+      const last = hist.lastElementChild;
+      if (last && !last.classList.contains('va-msg-ai')) {
+        _addBubble('ai', aiText);
+      } else if (last) {
+        // Already shown via typing bubble, just commit it
+        _transcript.push({ role: 'ai', text: aiText });
+      }
+    } else {
+      _addBubble('ai', aiText);
+    }
+
+    if (!_isActive) return;
+    await _speakText(aiText);
+  } catch (e) {
+    if (e.name === 'AbortError') return;
+    console.error('VA AI error:', e);
+    _setStatus('AI error — tap to try again', 'error');
+    _setMicState('idle');
+    return;
+  }
+
+  if (!_isActive) return;
+
+  if (_autoLoop) {
+    // Hands-free: auto-listen after speaking
+    _setStatus('Listening…', 'listening');
+    setTimeout(_startListening, 400);
+  } else {
+    _setStatus('Tap mic to speak', 'idle');
+    _setMicState('idle');
+  }
+}
+
+// ── Stop/interrupt ────────────────────────────────────────────────────────────
+
+function _stopAll(keepActive) {
+  if (!keepActive) _isActive = false;
+  _isListening = false;
+  _isSpeaking = false;
+
+  if (_vaRecognition) {
+    try { _vaRecognition.abort(); } catch {}
+    _vaRecognition = null;
+  }
+  if (_serverSTTRecorder && _serverSTTRecorder.state === 'recording') {
+    try { _serverSTTRecorder.stop(); } catch {}
+    _serverSTTRecorder = null;
+  }
+  if (_abortController) { _abortController.abort(); _abortController = null; }
+  if ('speechSynthesis' in window) window.speechSynthesis.cancel();
+  if (window.aiTTSManager) window.aiTTSManager.stop();
+}
+
+// ── Mic button handler ────────────────────────────────────────────────────────
+
+function _onMicClick() {
+  const btn = _el('va-mic-btn');
+  if (!btn) return;
+  const state = btn.dataset.state;
+
+  if (state === 'listening') {
+    // Stop listening and submit what we have (or just stop)
+    _isListening = false;
+    if (_vaRecognition) {
+      try { _vaRecognition.stop(); } catch {} // triggers onend → _handleUserInput
+    } else if (_serverSTTRecorder && _serverSTTRecorder.state === 'recording') {
+      _serverSTTRecorder.stop(); // triggers onstop → transcribe
+    } else {
+      _setMicState('idle');
+      _setStatus('Tap mic to speak', 'idle');
+    }
+  } else if (state === 'thinking' || state === 'speaking') {
+    // Interrupt AI response
+    _stopAll(true);
+    _isActive = true;
+    const typingEl = _el('va-history')?.querySelector('.va-typing');
+    if (typingEl) {
+      typingEl.classList.remove('va-typing');
+    }
+    _setMicState('idle');
+    _setStatus('Tap mic to speak', 'idle');
+  } else {
+    // Idle → start listening
+    _isActive = true;
+    _startListening();
+  }
+}
+
+// ── Modal ─────────────────────────────────────────────────────────────────────
+
+function _buildModal() {
+  const el = document.createElement('div');
+  el.id = 'voice-assistant-modal';
+  el.className = 'modal hidden';
+  el.innerHTML = `
+    <div class="modal-content va-modal-content" role="dialog" aria-label="Voice Assistant">
+      <div class="modal-header">
+        <h4>
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+            stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+            style="vertical-align:-2px;margin-right:6px;">
+            <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z"/>
+            <path d="M19 10v2a7 7 0 0 1-14 0v-2"/>
+            <line x1="12" y1="19" x2="12" y2="23"/>
+            <line x1="8" y1="23" x2="16" y2="23"/>
+          </svg>
+          Voice Assistant
+        </h4>
+        <label class="va-autoloop-label" title="Automatically start listening after AI finishes speaking">
+          <input type="checkbox" id="va-autoloop-toggle" />
+          <span>Hands-free</span>
+        </label>
+        <button class="close-btn" id="va-close-btn" aria-label="Close">✖</button>
+      </div>
+
+      <div class="modal-body va-body">
+        <!-- Conversation transcript -->
+        <div id="va-history" class="va-history" aria-live="polite" aria-label="Conversation"></div>
+
+        <!-- Interim live transcript (while user speaks) -->
+        <div id="va-interim" class="va-interim" aria-live="polite"></div>
+
+        <!-- Mic area -->
+        <div class="va-mic-area">
+          <div id="va-mic-ring" class="va-mic-ring va-mic-ring-idle">
+            <button id="va-mic-btn" class="va-mic-btn" data-state="idle"
+              title="Tap to speak — tap again to stop">
+              <!-- Mic icon (idle / thinking / speaking) -->
+              <svg class="va-icon-mic" width="32" height="32" viewBox="0 0 24 24" fill="none"
+                stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z"/>
+                <path d="M19 10v2a7 7 0 0 1-14 0v-2"/>
+                <line x1="12" y1="19" x2="12" y2="23"/>
+                <line x1="8" y1="23" x2="16" y2="23"/>
+              </svg>
+              <!-- Stop icon (shown while listening) -->
+              <svg class="va-icon-stop" width="28" height="28" viewBox="0 0 24 24" fill="currentColor">
+                <rect x="5" y="5" width="14" height="14" rx="3"/>
+              </svg>
+            </button>
+          </div>
+          <div id="va-status" class="va-status">Tap the mic to start</div>
+          <button id="va-clear-btn" class="va-clear-btn" title="Clear conversation and start fresh">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+              stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right:4px;">
+              <path d="M3 6h18"/><path d="M8 6V4h8v2"/>
+              <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/>
+            </svg>
+            Clear
+          </button>
+        </div>
+      </div>
+    </div>`;
+  document.body.appendChild(el);
+
+  // Wire events
+  el.querySelector('#va-mic-btn').addEventListener('click', _onMicClick);
+
+  el.querySelector('#va-autoloop-toggle').addEventListener('change', (e) => {
+    _autoLoop = e.target.checked;
+  });
+
+  el.querySelector('#va-clear-btn').addEventListener('click', () => {
+    _stopAll(false);
+    _sessionId = null;
+    _clearHistory();
+    _setMicState('idle');
+    _setStatus('Tap the mic to start', 'idle');
+  });
+
+  el.querySelector('#va-close-btn').addEventListener('click', _closeModal);
+  el.addEventListener('click', (e) => { if (e.target === el) _closeModal(); });
+
+  return el;
+}
+
+function _closeModal() {
+  _stopAll(false);
+  if (_modalEl) {
+    _modalEl.classList.add('hidden');
+    _modalEl.style.display = '';
+  }
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+export function openVoiceAssistant() {
+  if (!_modalEl) _modalEl = _buildModal();
+  _modalEl.classList.remove('hidden');
+  _modalEl.style.display = 'flex';
+  _isActive = false;
+  _setMicState('idle');
+  _setStatus('Tap the mic to start', 'idle');
+}
+
+const voiceAssistantModule = { openVoiceAssistant };
+export default voiceAssistantModule;

--- a/static/style.css
+++ b/static/style.css
@@ -35419,3 +35419,298 @@ body.theme-frosted .modal {
      is already ≥16px and never zoomed — leave it so we don't shrink it. */
   .doc-email-richbody.doc-font-m { font-size: 16px !important; }
 }
+
+/* ═══════════════════════════════════════════════════════════════
+   Voice Assistant Modal
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ── Modal shell ── */
+#voice-assistant-modal .va-modal-content {
+  max-width: 520px;
+  width: 96%;
+  border-radius: 12px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ── Header extras ── */
+.va-autoloop-label {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  opacity: 0.7;
+  cursor: pointer;
+  margin-left: auto;
+  margin-right: 8px;
+  user-select: none;
+}
+.va-autoloop-label input { cursor: pointer; }
+
+/* ── Body ── */
+.va-body {
+  display: flex;
+  flex-direction: column;
+  min-height: 380px;
+  max-height: 80vh;
+  padding: 0 !important;
+}
+
+/* ── Transcript history ── */
+.va-history {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 120px;
+  max-height: 340px;
+}
+
+.va-history:empty::before {
+  content: 'Your conversation will appear here.';
+  opacity: 0.35;
+  font-size: 13px;
+  font-style: italic;
+  align-self: center;
+  margin: auto;
+}
+
+/* ── Message bubbles ── */
+.va-msg {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-width: 88%;
+  animation: va-fade-in 0.18s ease;
+}
+
+@keyframes va-fade-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.va-msg-user { align-self: flex-end; align-items: flex-end; }
+.va-msg-ai   { align-self: flex-start; align-items: flex-start; }
+
+.va-msg-label {
+  font-size: 10px;
+  opacity: 0.45;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  margin-bottom: 2px;
+  padding: 0 4px;
+}
+
+.va-msg-text {
+  display: block;
+  padding: 8px 12px;
+  border-radius: 14px;
+  font-size: 14px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.va-msg-user .va-msg-text {
+  background: var(--user-bubble-bg, color-mix(in srgb, var(--red, #e06c75) 18%, var(--panel)));
+  border: 1px solid var(--bubble-border, transparent);
+  border-bottom-right-radius: 4px;
+}
+
+.va-msg-ai .va-msg-text {
+  background: var(--ai-bubble-bg, var(--panel));
+  border: 1px solid var(--bubble-border, var(--border));
+  border-bottom-left-radius: 4px;
+}
+
+/* Typing animation bubble */
+.va-typing .va-msg-text::after,
+.va-typing::after {
+  content: '▍';
+  display: inline-block;
+  animation: va-blink 0.8s step-end infinite;
+  opacity: 0.6;
+  font-size: 12px;
+  margin-left: 2px;
+}
+
+@keyframes va-blink {
+  0%, 100% { opacity: 0.6; }
+  50%       { opacity: 0; }
+}
+
+/* ── Interim transcript while speaking ── */
+.va-interim {
+  min-height: 22px;
+  padding: 4px 16px;
+  font-size: 13px;
+  font-style: italic;
+  color: var(--fg);
+  opacity: 0.5;
+  text-align: center;
+}
+
+/* ── Mic area ── */
+.va-mic-area {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 20px 16px 18px;
+  border-top: 1px solid var(--border);
+  background: color-mix(in srgb, var(--panel) 60%, var(--bg));
+  flex-shrink: 0;
+}
+
+/* ── Pulse ring ── */
+.va-mic-ring {
+  position: relative;
+  width: 80px;
+  height: 80px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  transition: box-shadow 0.3s ease;
+}
+
+.va-mic-ring::before,
+.va-mic-ring::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+/* Idle */
+.va-mic-ring-idle { box-shadow: none; }
+
+/* Listening — green pulse */
+.va-mic-ring-listening {
+  box-shadow: 0 0 0 0 color-mix(in srgb, #4ade80 40%, transparent);
+  animation: va-pulse-listen 1.4s ease-out infinite;
+}
+@keyframes va-pulse-listen {
+  0%   { box-shadow: 0 0 0 0   color-mix(in srgb, #4ade80 55%, transparent); }
+  70%  { box-shadow: 0 0 0 20px color-mix(in srgb, #4ade80 0%,  transparent); }
+  100% { box-shadow: 0 0 0 0   color-mix(in srgb, #4ade80 0%,  transparent); }
+}
+
+/* Thinking — blue pulse */
+.va-mic-ring-thinking {
+  animation: va-pulse-think 1.2s ease-in-out infinite;
+}
+@keyframes va-pulse-think {
+  0%, 100% { box-shadow: 0 0 0 0   color-mix(in srgb, #60a5fa 40%, transparent); }
+  50%       { box-shadow: 0 0 0 16px color-mix(in srgb, #60a5fa 0%,  transparent); }
+}
+
+/* Speaking — accent pulse */
+.va-mic-ring-speaking {
+  animation: va-pulse-speak 0.9s ease-in-out infinite;
+}
+@keyframes va-pulse-speak {
+  0%, 100% { box-shadow: 0 0 0 0   color-mix(in srgb, var(--red, #e06c75) 45%, transparent); }
+  50%       { box-shadow: 0 0 0 18px color-mix(in srgb, var(--red, #e06c75) 0%,  transparent); }
+}
+
+/* ── Mic button ── */
+.va-mic-btn {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s ease, transform 0.15s ease, color 0.2s ease;
+  position: relative;
+  z-index: 1;
+}
+
+/* Show/hide icon based on state */
+.va-mic-btn .va-icon-stop { display: none; }
+
+.va-mic-btn[data-state="idle"] {
+  background: var(--panel);
+  color: var(--fg);
+  border: 2px solid var(--border);
+}
+.va-mic-btn[data-state="idle"]:hover {
+  background: color-mix(in srgb, var(--red, #e06c75) 12%, var(--panel));
+  color: var(--red, #e06c75);
+  border-color: var(--red, #e06c75);
+  transform: scale(1.05);
+}
+
+.va-mic-btn[data-state="listening"] {
+  background: color-mix(in srgb, #4ade80 20%, var(--panel));
+  color: #4ade80;
+  border: 2px solid #4ade80;
+}
+.va-mic-btn[data-state="listening"] .va-icon-mic  { display: none; }
+.va-mic-btn[data-state="listening"] .va-icon-stop { display: block; }
+
+.va-mic-btn[data-state="thinking"] {
+  background: color-mix(in srgb, #60a5fa 16%, var(--panel));
+  color: #60a5fa;
+  border: 2px solid #60a5fa;
+  cursor: pointer;
+}
+.va-mic-btn[data-state="thinking"] .va-icon-mic  { display: none; }
+.va-mic-btn[data-state="thinking"] .va-icon-stop { display: block; }
+.va-mic-btn[data-state="thinking"] .va-icon-stop {
+  animation: va-spin 1.1s linear infinite;
+  opacity: 0.7;
+}
+
+.va-mic-btn[data-state="speaking"] {
+  background: color-mix(in srgb, var(--red, #e06c75) 20%, var(--panel));
+  color: var(--red, #e06c75);
+  border: 2px solid var(--red, #e06c75);
+  cursor: pointer;
+}
+.va-mic-btn[data-state="speaking"] .va-icon-mic  { display: none; }
+.va-mic-btn[data-state="speaking"] .va-icon-stop { display: block; }
+
+@keyframes va-spin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+
+/* ── Status text ── */
+.va-status {
+  font-size: 12px;
+  opacity: 0.6;
+  text-align: center;
+  min-height: 18px;
+  transition: opacity 0.2s;
+}
+.va-status.listening { opacity: 0.9; color: #4ade80; }
+.va-status.thinking  { opacity: 0.9; color: #60a5fa; }
+.va-status.speaking  { opacity: 0.9; color: var(--red, #e06c75); }
+.va-status.error     { opacity: 0.9; color: #f87171; }
+
+/* ── Clear button ── */
+.va-clear-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--fg);
+  cursor: pointer;
+  font-size: 11px;
+  padding: 4px 10px;
+  opacity: 0.45;
+  transition: opacity 0.15s, border-color 0.15s;
+}
+.va-clear-btn:hover { opacity: 0.85; border-color: var(--fg); }


### PR DESCRIPTION
- New static/js/voiceAssistant.js: dedicated voice panel with mic button, real-time STT (Web Speech API + Whisper fallback), streaming AI responses via /api/chat_stream, and TTS playback (server or browser). Hands-free toggle auto-restarts listening after AI speaks.
- Sidebar "Voice Assistant" entry added to Tools section (index.html)
- Pulsing ring animations for listening/thinking/speaking states (style.css)
- app.js imports and wires up the new module
- docker-compose.yml: bind-mount ./static into container so frontend changes are live immediately without rebuilding the image
- .env: uncommented OLLAMA_BASE_URL=http://host.docker.internal:11434/v1 so the container reaches host Ollama; Ollama must run with OLLAMA_HOST=0.0.0.0:11434

## Summary

<!-- One paragraph: what changed and why. "Fixed bug" and "Added feature" are not summaries. -->

## Target branch

- [ ] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

<!-- Every PR should be linked to an issue.
     Use one of:  Fixes #NNN  |  Part of #NNN  |  Closes #NNN  -->

Fixes #

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [ ] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [ ] This PR targets `dev`
- [ ] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

<!-- Step-by-step instructions a reviewer can follow to verify this works.
     Do not leave this empty — a PR without test steps will be sent back. -->

1.
2.
3.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

<!-- Drag and drop images or a screen recording here. Required for any UI/visual change. -->
