### PR TITLE
fix(cookbook): stop Ollama runner from executing the install one-liner

### DIFF
--- a/routes/cookbook_helpers.py
+++ b/routes/cookbook_helpers.py
@@ -531,6 +531,18 @@ def _bash_squote(v: str) -> str:
     return v.replace("'", "'\\''")
 
 
+# Shown by generated runner scripts when the ollama binary is missing on the
+# target host. Must stay free of backticks/$( ) and be emitted single-quoted:
+# an earlier version wrapped the install one-liner in backticks inside a
+# double-quoted echo, which bash executed as command substitution and ran the
+# system-wide installer (including on remote SSH hosts) instead of printing
+# the hint.
+OLLAMA_MISSING_HINT = (
+    "ERROR: Ollama not found on this server. Install it from "
+    "https://ollama.com/download or run: curl -fsSL https://ollama.com/install.sh | sh"
+)
+
+
 # Allow-list of binaries permitted as the leading token of `req.cmd` for /api/model/serve.
 # Anything else is rejected before the cmd is interpolated into a tmux/PowerShell wrapper.
 _SERVE_CMD_ALLOWLIST = {

--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 from routes.cookbook_helpers import (
     _SESSION_ID_RE, _validate_repo_id, _validate_serve_model_id, _validate_include, _validate_token,
     _validate_local_dir, _validate_gpus, _shell_path,
-    _ps_squote, _bash_squote, _validate_serve_cmd, _parse_serve_phase,
+    _ps_squote, _bash_squote, _validate_serve_cmd, _parse_serve_phase, OLLAMA_MISSING_HINT,
     _safe_env_prefix, _local_tooling_path_export, _append_serve_preflight_exit_lines,
     _append_serve_exit_code_lines, _append_llama_cpp_linux_accel_build_lines, _cached_model_scan_script,
     _ollama_bind_from_cmd, _pip_install_fallback_chain, _pip_install_no_cache,
@@ -1443,7 +1443,10 @@ def setup_cookbook_routes() -> APIRouter:
                 runner_lines.append('  exec 3<&-; exec 3>&-')
                 runner_lines.append('done')
                 runner_lines.append('if ! command -v ollama &>/dev/null; then')
-                runner_lines.append('  echo "ERROR: Ollama not found on this server. Install it from https://ollama.com/download or `curl -fsSL https://ollama.com/install.sh | sh`."')
+                # Single-quoted on purpose: backticks inside a double-quoted
+                # echo are command substitution, and this line used to run the
+                # curl|sh installer on the target host instead of printing it.
+                runner_lines.append(f"  echo '{_bash_squote(OLLAMA_MISSING_HINT)}'")
                 runner_lines.append('  echo')
                 runner_lines.append('  echo "=== Process exited with code 127 ==="')
                 runner_lines.append('  exec bash -i')

--- a/tests/test_ollama_runner_hint.py
+++ b/tests/test_ollama_runner_hint.py
@@ -1,0 +1,57 @@
+"""The generated Ollama runner must print the install hint, not execute it.
+
+The runner script emitted by /api/model/serve contained:
+
+    echo "ERROR: Ollama not found ... or `curl -fsSL .../install.sh | sh`."
+
+Backticks inside double quotes are bash command substitution, so on any host
+without ollama the script downloaded and ran the system-wide installer
+(including remote SSH serve targets) instead of printing the hint. The hint
+now lives in OLLAMA_MISSING_HINT, contains no substitution tokens, and is
+emitted single-quoted.
+"""
+import os
+import shutil
+import subprocess
+
+import pytest
+
+from routes.cookbook_helpers import OLLAMA_MISSING_HINT, _bash_squote
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def test_hint_has_no_shell_expansion_tokens():
+    assert "`" not in OLLAMA_MISSING_HINT
+    assert "$(" not in OLLAMA_MISSING_HINT
+
+
+def test_hint_still_tells_the_user_how_to_install():
+    assert "https://ollama.com/download" in OLLAMA_MISSING_HINT
+    assert "install.sh" in OLLAMA_MISSING_HINT
+
+
+def test_no_runner_echo_line_uses_backticks_in_double_quotes():
+    # Source-level guard: generated-script echo lines must never carry
+    # backticks inside a double-quoted bash string again.
+    src = open(os.path.join(ROOT, "routes", "cookbook_routes.py"), encoding="utf-8").read()
+    offenders = [
+        line.strip()
+        for line in src.splitlines()
+        if "append(" in line and 'echo "' in line and "`" in line.split('echo "', 1)[1]
+    ]
+    assert offenders == []
+
+
+def test_single_quoted_echo_prints_hint_literally():
+    bash = shutil.which("bash")
+    if not bash:
+        pytest.skip("bash not available")
+    out = subprocess.run(
+        [bash, "-c", f"echo '{_bash_squote(OLLAMA_MISSING_HINT)}'"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert out.returncode == 0
+    assert out.stdout.strip() == OLLAMA_MISSING_HINT


### PR DESCRIPTION
## Summary

The bash runner script generated for Cookbook serves printed the missing-ollama hint like this:

```bash
echo "ERROR: Ollama not found on this server. Install it from https://ollama.com/download or `curl -fsSL https://ollama.com/install.sh | sh`."
```

Backticks inside double quotes are command substitution, so on any serve target where `ollama` is absent the script did not print the hint, it downloaded and executed the system-wide installer, including on remote SSH hosts. Ironically `_validate_serve_cmd` rejects backticks in user-supplied commands for exactly this reason; the app's own generated script never passes through that validator.

This PR moves the hint text into `OLLAMA_MISSING_HINT` in `cookbook_helpers.py` (rewritten with no substitution tokens) and emits it single-quoted via the existing `_bash_squote` helper, so nothing inside the message can ever expand. Tests pin all three layers: the constant contains no backticks or `$(`, no generated `echo "..."` line in `cookbook_routes.py` carries backticks inside the double quotes, and an actual `bash -c` run prints the line byte-for-byte instead of executing anything.

## Linked Issue

Fixes #3816

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / code quality
- [ ] Other (describe below)

## Checklist

- [x] I searched existing PRs and issues to avoid duplicates
- [x] My code follows the existing style of the project
- [x] I added tests that prove my fix is effective (or explain below why not)
- [ ] I ran the app end-to-end and verified the affected flow works
- [x] New and existing unit tests pass locally with my changes
- [ ] I am not an LLM/agent submitting a bulk PR

## How to Test

1. `python -m pytest tests/test_ollama_runner_hint.py -v` (4 tests, one of them runs the echo through real bash and asserts the output equals the hint).
2. Against current `dev` the test module fails at import (the constant does not exist) and the source-scan test catches the backticked echo line; with this patch all 4 pass.
3. Manual repro of the bug on `dev`: Cookbook, serve any Ollama model targeting a host without `ollama` installed, and watch the tmux pane run the installer before showing the error. With this patch the runner prints the hint and exits to the interactive shell as intended.

I verified the fix with pytest locally (fails before, passes after), ran the existing `tests/test_cookbook_helpers.py` suite alongside it, and ran `py_compile` on both touched modules. I did not run a full serve end-to-end, which is why that box is unchecked.
