### PR TITLE
fix(chat): Expand user chat bubble edit textbox width

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -2001,7 +2001,7 @@ body.bg-pattern-sparkles {
       border: 1px solid var(--bubble-border, var(--border));
       border-radius: 18px 18px 0 18px;
       align-self: flex-end;
-      width: fit-content;
+      width: 85%;
       max-width: 85%;
       min-width: 80px;
       word-wrap: break-word;

--- a/static/style.css
+++ b/static/style.css
@@ -2001,12 +2001,15 @@ body.bg-pattern-sparkles {
       border: 1px solid var(--bubble-border, var(--border));
       border-radius: 18px 18px 0 18px;
       align-self: flex-end;
-      width: 85%;
+      width: fit-content;
       max-width: 85%;
       min-width: 80px;
       word-wrap: break-word;
       overflow-wrap: break-word;
       overflow: hidden;
+    }
+    .msg-user:has(textarea) {
+      width: 85%;
     }
     .msg-ai {
       align-items: flex-start;


### PR DESCRIPTION
## Summary

Fixed an issue where the user chat edit textbox was too small when editing messages. This change updates the user bubble width to be consistent with the AI chat bubble behavior, ensuring a uniform editing experience across both.

I basically just changed the CSS of `.msg-user` from `width: fit-content` to `width: 85%` which is the same value as `.msg-ai`.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #3962

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Start a new chat
2. Send a prompt
3. Click the edit icon on the user prompt

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [x] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

<img width="795" height="392" alt="image" src="https://github.com/user-attachments/assets/c086e0b0-9fb3-41ef-92f1-bbf9040c3e26" />

