### PR TITLE
fix(agent): quarantine pre-tool prose from persisted round history

### DIFF
--- a/routes/chat_helpers.py
+++ b/routes/chat_helpers.py
@@ -961,6 +961,9 @@ def select_saved_body(
     all ungrounded pre-tool prose sanitizes to "", which must persist as empty
     rather than fall back to the raw pre-tool prose; only a genuinely absent
     sanitized body (None, e.g. a non-agentic turn) falls back to ``full_response``.
+    ``teacher_clean`` carries the same distinction: a teacher takeover that
+    sanitizes to "" persists as an empty teacher segment (the student segment
+    alone) rather than falling back to the raw ``post_metrics_deltas``.
     """
     if clean_body is not None:
         student = clean_body
@@ -970,6 +973,12 @@ def select_saved_body(
         return full_response
     if teacher_clean:
         return (student + "\n\n" + teacher_clean) if student else teacher_clean
+    if teacher_clean is not None:
+        # Teacher sanitized to empty ("") — present but contributes no segment,
+        # so persist just the student segment rather than falling back to the raw
+        # post-metrics deltas (which carry the teacher's pre-tool prose). Mirrors
+        # the outer/student presence semantics above (RaresKeY finding).
+        return student
     return student + post_metrics_deltas
 
 

--- a/routes/chat_helpers.py
+++ b/routes/chat_helpers.py
@@ -929,6 +929,50 @@ def clean_thinking_for_save(content: str, metadata: dict | None = None) -> tuple
     return content, md
 
 
+def select_saved_body(
+    clean_body: str | None,
+    post_metrics_deltas: str,
+    full_response: str,
+    *,
+    teacher_clean: str | None = None,
+    pre_metrics_raw: str | None = None,
+) -> str:
+    """Body to persist for an agentic turn (#3992 / PR #4015 review).
+
+    The saved body is the STUDENT segment followed by the TEACHER segment (when an
+    inline teacher takeover ran). Each segment is sanitized — the quarantined
+    pre-tool prose (#3992) must not appear in either.
+
+    - Student segment: ``clean_body`` (join of round_texts, carried in the agent
+      loop's metrics event) when the student used tools; otherwise its raw answer
+      ``pre_metrics_raw`` (the visible deltas streamed BEFORE the outer metrics
+      event — no tools means no pre-tool prose to strip).
+    - Teacher segment: ``teacher_clean`` (the teacher's OWN sanitized body, set when
+      the teacher ran a tool-backed turn whose nested ``stream_agent_loop`` emits
+      its own metrics + clean_response) when present; otherwise the raw
+      ``post_metrics_deltas`` (a no-tool teacher's visible correction). Preferring
+      ``teacher_clean`` keeps the teacher's fabricated pre-tool guess out of the
+      saved body (#3992 finding #4).
+
+    Non-agentic / no-metrics turns (no student segment) keep the raw accumulation.
+
+    ``clean_body`` distinguishes "sanitized to empty" ("") from "no sanitized
+    value" (None) — see RaresKeY finding #5. A tool turn whose visible text was
+    all ungrounded pre-tool prose sanitizes to "", which must persist as empty
+    rather than fall back to the raw pre-tool prose; only a genuinely absent
+    sanitized body (None, e.g. a non-agentic turn) falls back to ``full_response``.
+    """
+    if clean_body is not None:
+        student = clean_body
+    elif pre_metrics_raw is not None:
+        student = pre_metrics_raw
+    else:
+        return full_response
+    if teacher_clean:
+        return (student + "\n\n" + teacher_clean) if student else teacher_clean
+    return student + post_metrics_deltas
+
+
 def save_assistant_response(
     sess,
     session_manager,

--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -38,6 +38,7 @@ from routes.chat_helpers import (
     save_assistant_response,
     run_post_response_tasks,
     clean_thinking_for_save,
+    select_saved_body,
     _enforce_chat_privileges,
 )
 from src.action_intents import classify_tool_intent as _classify_tool_intent
@@ -1252,6 +1253,26 @@ def setup_chat_routes(
                 _answered_by = None  # set if the selected model failed and a fallback answered
                 _requested_model = sess.model
                 _actual_model = None
+                # Sanitized canonical body from agent_loop's metrics event. On an
+                # agentic turn the raw delta accumulation still carries the
+                # quarantined pre-tool prose (#3992); the saved/replayed/exported
+                # body must use this instead of full_response.
+                _clean_body = None
+                # Visible deltas streamed AFTER the outer metrics event (e.g. an
+                # inline teacher takeover) are not in _clean_body — accumulate them
+                # so the saved body keeps them (#3992 / PR #4015 review).
+                _post_clean_deltas = ""
+                # Set once the OUTER turn's metrics event arrives; gates the
+                # post-metrics delta accumulation and snapshots the student's raw
+                # answer (for a no-tool student, which has no clean_response).
+                _outer_metrics_seen = False
+                _pre_metrics_raw = None
+                # A tool-using teacher takeover runs a nested stream_agent_loop that
+                # emits its OWN metrics + clean_response (forwarded teacher=True).
+                # Capture that sanitized teacher body so the saved body uses it
+                # instead of the raw post-metrics deltas, which carry the teacher's
+                # own pre-tool prose (#3992 finding #4).
+                _teacher_clean = None
                 try:
                     from src.settings import get_setting
                     from src.agent_tools import MAX_AGENT_ROUNDS as _DEFAULT_ROUNDS
@@ -1300,6 +1321,11 @@ def setup_chat_routes(
                                     # them out of the saved reply (same as chat mode).
                                     if not data.get("thinking"):
                                         full_response += data["delta"]
+                                        # A delta seen after the outer metrics event
+                                        # is post-answer (teacher takeover) — keep it
+                                        # for the saved body.
+                                        if _outer_metrics_seen:
+                                            _post_clean_deltas += data["delta"]
                                         _stream_set(session, partial=full_response)
                                     yield chunk
                                 elif data.get("type") == "web_sources":
@@ -1332,19 +1358,54 @@ def setup_chat_routes(
                                     data["requested_model"] = _requested_model
                                     yield f'data: {json.dumps(data)}\n\n'
                                 elif data.get("type") == "metrics":
-                                    last_metrics = data.get("data", {})
-                                    _reported_model = last_metrics.get("model")
-                                    last_metrics["requested_model"] = last_metrics.get("requested_model") or _requested_model
-                                    last_metrics["model"] = _reported_model or _actual_model or _answered_by or _requested_model
-                                    yield f'data: {json.dumps({"type": "metrics", "data": last_metrics})}\n\n'
+                                    _metrics_data = data.get("data", {})
+                                    # Pull the sanitized body out of the metrics
+                                    # payload — it's for persistence only, not the
+                                    # client, and shouldn't bloat the SSE.
+                                    _metrics_clean = _metrics_data.pop("clean_response", None)
+                                    if data.get("teacher"):
+                                        # Nested teacher run's metrics — must NOT
+                                        # clobber the outer turn's sanitized body or
+                                        # metrics. Keep its sanitized answer as the
+                                        # teacher segment (#3992 finding #4); forward
+                                        # untouched (clean_response already popped).
+                                        if _metrics_clean:
+                                            _teacher_clean = _metrics_clean
+                                        yield f'data: {json.dumps(data)}\n\n'
+                                    else:
+                                        last_metrics = _metrics_data
+                                        # Preserve an empty sanitized body ("")
+                                        # as a real value (RaresKeY finding #5) —
+                                        # only a missing key (None) keeps the
+                                        # prior _clean_body.
+                                        if _metrics_clean is not None:
+                                            _clean_body = _metrics_clean
+                                        # Mark the outer-turn boundary and snapshot
+                                        # the student's raw answer so a no-tool
+                                        # student (no clean_response) still has a
+                                        # student segment before any teacher takeover.
+                                        _outer_metrics_seen = True
+                                        _pre_metrics_raw = full_response
+                                        _reported_model = last_metrics.get("model")
+                                        last_metrics["requested_model"] = last_metrics.get("requested_model") or _requested_model
+                                        last_metrics["model"] = _reported_model or _actual_model or _answered_by or _requested_model
+                                        yield f'data: {json.dumps({"type": "metrics", "data": last_metrics})}\n\n'
                             except json.JSONDecodeError:
                                 yield chunk
                         elif chunk.startswith("event: "):
                             yield chunk
                         elif chunk == "data: [DONE]\n\n":
                             if full_response:
+                                # Persist/replay/export the sanitized body when the
+                                # agent loop emitted one (#3992); fall back to the
+                                # raw accumulation for non-agentic or empty cases.
+                                _save_body = select_saved_body(
+                                    _clean_body, _post_clean_deltas, full_response,
+                                    teacher_clean=_teacher_clean,
+                                    pre_metrics_raw=_pre_metrics_raw,
+                                )
                                 _saved_id = save_assistant_response(
-                                    sess, session_manager, session, full_response, last_metrics,
+                                    sess, session_manager, session, _save_body, last_metrics,
                                     character_name=ctx.preset.character_name,
                                     web_sources=web_sources,
                                     rag_sources=ctx.rag_sources,
@@ -1354,7 +1415,7 @@ def setup_chat_routes(
                                 if _saved_id:
                                     yield f'data: {json.dumps({"type": "message_saved", "id": _saved_id})}\n\n'
                                 run_post_response_tasks(
-                                    sess, session_manager, session, message, full_response,
+                                    sess, session_manager, session, message, _save_body,
                                     last_metrics, ctx.uprefs, memory_manager, memory_vector, webhook_manager,
                                     incognito=incognito, compare_mode=compare_mode,
                                     character_name=ctx.preset.character_name,

--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -1369,7 +1369,14 @@ def setup_chat_routes(
                                         # metrics. Keep its sanitized answer as the
                                         # teacher segment (#3992 finding #4); forward
                                         # untouched (clean_response already popped).
-                                        if _metrics_clean:
+                                        # Preserve an empty sanitized teacher body ("")
+                                        # as a real value the same way the outer path
+                                        # does (RaresKeY finding): a teacher whose
+                                        # visible text was all pre-tool prose sanitizes
+                                        # to "" and must not fall back to the raw
+                                        # post-metrics deltas; only a missing key (None)
+                                        # leaves _teacher_clean unset.
+                                        if _metrics_clean is not None:
                                             _teacher_clean = _metrics_clean
                                         yield f'data: {json.dumps(data)}\n\n'
                                     else:

--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -2499,6 +2499,11 @@ async def stream_agent_loop(
     for round_num in range(1, max_rounds + 1):
         round_response = ""
         round_reasoning = ""  # reasoning_content deltas (DeepSeek-thinking, vLLM --reasoning-parser)
+        # When set, the persisted text for this round (round_texts) is this value
+        # instead of the model's raw prose — used by the force-answer grace
+        # synthesis, whose final answer lands only in full_response, not the
+        # round's streamed prose.
+        _round_text_override = None
         native_tool_calls = []  # populated if model uses function calling
         # Reset doc streaming state per round
         _doc_acc = ""
@@ -2826,12 +2831,18 @@ async def stream_agent_loop(
                 if _synth:
                     yield f'data: {json.dumps({"delta": _synth})}\n\n'
                     full_response += _synth
+                    # The synthesized answer is the real content for this round,
+                    # but it never entered round_response, so persist it as this
+                    # round's text (otherwise it's lost from the reload bubbles
+                    # and the sanitized saved body).
+                    _round_text_override = _synth
                 else:
                     _fb = ("I gathered some search results but couldn't pull a clean "
                            "answer together. Want me to try a more specific question, "
                            "or summarize what I did find?")
                     yield f'data: {json.dumps({"delta": _fb})}\n\n'
                     full_response += _fb
+                    _round_text_override = _fb
 
         # ── Fallback: auto-create document if model dumped large code in chat ──
         # If no create_document tool was used, check for big code blocks in text
@@ -2872,7 +2883,22 @@ async def stream_agent_loop(
         # persisted text either — otherwise it streams once and then disappears
         # on reload (#3222 follow-up).
         cleaned_round = strip_tool_blocks(round_response, skip_fenced=(_is_api_model and not used_native and not guide_only)).strip()
-        round_texts.append(cleaned_round)
+        if _round_text_override is not None:
+            # Force-answer grace synthesis: the synthesized answer is the round's
+            # real text (round_response held only the discarded tool call).
+            round_texts.append(_round_text_override)
+        elif tool_blocks:
+            # This round resolved to an executable tool call, so any prose the
+            # model emitted before it is pre-tool / ungrounded — the grounded
+            # answer only arrives in a later round once the real tool result is
+            # fed back. Persisting that prose makes the agentic reload
+            # reconstruction (chatRenderer.js replays round_texts per round)
+            # show a guessed/fabricated answer in its own bubble next to the
+            # real one (#3992). Quarantine the visible prose, but keep <think>
+            # blocks so the thinking section still renders on reload.
+            round_texts.append("".join(_THINK_RE.findall(cleaned_round)).strip())
+        else:
+            round_texts.append(cleaned_round)
 
         if not tool_blocks:
             # ── Completion verifier (mechanism 3a) ────────────────────
@@ -3237,6 +3263,21 @@ async def stream_agent_loop(
                     yield 'data: ' + json.dumps({"delta": _auq_delta}) + '\n\n'
                 _pending_ask_user_event = _auq
                 _awaiting_user = True
+                # ask_user ENDS the turn, so this round is terminal: its prose is
+                # the assistant's actual message to the user, NOT pre-tool /
+                # ungrounded prose — there is no later grounded round to supersede
+                # it. The #3992 tool-round quarantine above blanked round_texts to
+                # <think>-only, and reload reconstruction (chatRenderer.js) reads
+                # round_texts, so the question vanished on reload. Restore this
+                # round's visible prose and make sure the question itself persists.
+                if round_texts:
+                    _terminal_text = cleaned_round
+                    if _auq_q and _auq_q not in _terminal_text:
+                        _terminal_text = (
+                            (_terminal_text + "\n\n" + _auq_q).strip()
+                            if _terminal_text.strip() else _auq_q
+                        )
+                    round_texts[-1] = _terminal_text
 
             # update_plan: agent wrote back to the plan (ticked a step / revised).
             # Push it to the frontend so the stored plan + docked window update
@@ -3460,6 +3501,24 @@ async def stream_agent_loop(
         backend_prefill_tps=backend_prefill_tps,
     )
     metrics["requested_model"] = requested_model
+    # Sanitized canonical body for the chat route to persist on agentic turns.
+    # The route otherwise saves the raw delta accumulation, which still carries
+    # the quarantined pre-tool prose (#3992) — that body is replayed to the model
+    # and fed to export/webhook/extraction. round_texts already holds the per-
+    # round sanitized text (incl. the terminal ask_user question and the grace-
+    # synthesis answer), so the saved body is their join. Only emitted for
+    # agentic turns; direct chat keeps full_response untouched.
+    #
+    # Emit clean_response even when the join is "" (RaresKeY review finding #5):
+    # a tool turn whose only visible text was ungrounded pre-tool prose sanitizes
+    # to empty. That "" is a real sanitized result, so the route must persist it
+    # (empty), not fall back to the raw pre-tool prose. The consumer distinguishes
+    # "sanitized to empty" ("") from "no sanitized value" (key absent) via
+    # `is not None`, so the presence of the key — not its truthiness — matters.
+    if tool_events:
+        metrics["clean_response"] = "\n\n".join(
+            t for t in round_texts if t and t.strip()
+        )
     yield f"data: {json.dumps({'type': 'metrics', 'data': metrics})}\n\n"
 
     # Teacher-escalation: inline takeover visible in the chat stream.

--- a/tests/test_agent_pre_tool_prose.py
+++ b/tests/test_agent_pre_tool_prose.py
@@ -1,0 +1,505 @@
+"""Issue #3992 — the agent must not persist pre-tool prose as a final answer.
+
+When a single assistant round emits prose AND an executable tool call, the
+prose precedes the real tool result, so it is *ungrounded*: the grounded answer
+only arrives in a later round after the tool output is fed back. `stream_agent_loop`
+used to append that pre-tool prose to `round_texts` unconditionally
+(`src/agent_loop.py`), and `round_texts` is exactly what `chatRenderer.js`'s
+agentic multi-bubble reconstruction replays on reload — so a guessed/fabricated
+answer rendered as its own bubble right next to the real, tool-grounded answer.
+
+The fix quarantines the visible pre-tool prose for any round that resolved to an
+executable tool call, while preserving `<think>` blocks (so the thinking section
+still renders on reload). Rounds with no tool call keep their prose unchanged.
+
+These tests drive the real `stream_agent_loop` end-to-end with a mocked LLM
+stream (mirroring tests/test_fenced_example_not_executed_for_native_models.py)
+and assert on the `round_texts` carried in the final metrics event — the same
+artifact the reporter's fake-stream probe inspected.
+"""
+import asyncio
+import json
+
+import src.agent_loop as al
+
+
+def _collect(gen):
+    async def _run():
+        return [c async for c in gen]
+    return asyncio.run(_run())
+
+
+def _events(chunks):
+    out = []
+    for c in chunks:
+        if c.startswith("data: ") and not c.startswith("data: [DONE]"):
+            try:
+                out.append(json.loads(c[6:]))
+            except Exception:
+                pass
+    return out
+
+
+def _round_texts(events):
+    for e in events:
+        if e.get("type") == "metrics":
+            return e.get("data", {}).get("round_texts")
+    return None
+
+
+def _patch_common(monkeypatch, exec_calls):
+    monkeypatch.setattr(al, "get_setting", lambda key, default=None: default, raising=False)
+    monkeypatch.setattr(al, "get_mcp_manager", lambda: None, raising=False)
+    monkeypatch.setattr(al, "estimate_tokens", lambda *a, **k: 10, raising=False)
+
+    async def _fake_exec(block, *a, **k):
+        exec_calls.append(block)
+        return ("bash", {"output": "Real A and Real B", "exit_code": 0})
+    monkeypatch.setattr(al, "execute_tool_block", _fake_exec, raising=False)
+
+
+def _run_loop(monkeypatch, model, round1_deltas, round2_text="The real inbox has 2 emails: Real A and Real B.",
+              max_rounds=3, endpoint_url="http://192.168.1.50:8000/v1"):
+    """Drive stream_agent_loop: round 1 streams `round1_deltas`, round 2 (and
+    later) streams a plain grounded answer with no tool call so the loop ends.
+    Defaults to a non-native model/host so the fenced tool channel is active."""
+    call_count = {"n": 0}
+
+    async def _fake_stream(_candidates, messages, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            for d in round1_deltas:
+                yield f'data: {json.dumps({"delta": d})}\n\n'
+            yield "data: [DONE]\n\n"
+        else:
+            yield f'data: {json.dumps({"delta": round2_text})}\n\n'
+            yield "data: [DONE]\n\n"
+
+    monkeypatch.setattr(al, "stream_llm_with_fallback", _fake_stream, raising=False)
+
+    gen = al.stream_agent_loop(
+        endpoint_url, model,
+        [{"role": "user", "content": "List my latest emails."}],
+        max_rounds=max_rounds,
+        relevant_tools={"bash"},
+    )
+    return _events(_collect(gen))
+
+
+# ---------------------------------------------------------------------------
+# 1. Pre-tool prose (a fabricated answer) emitted in the same round as an
+#    executable tool call must NOT survive in round_texts; the later
+#    tool-grounded answer must.
+# ---------------------------------------------------------------------------
+def test_pre_tool_prose_not_persisted_when_round_has_tool_call(monkeypatch):
+    exec_calls = []
+    _patch_common(monkeypatch, exec_calls)
+    round1 = (
+        "Here are your latest emails:\n\n"
+        "| From | Subject |\n|---|---|\n| Alice | FAKE-GUESSED-ROW |\n\n"
+        "```bash\necho fetch-inbox\n```"
+    )
+    events = _run_loop(monkeypatch, "llama-2-7b-chat", [round1])
+
+    assert len(exec_calls) == 1, f"the fenced tool call should have executed: {exec_calls}"
+    rt = _round_texts(events)
+    assert rt is not None, "metrics should carry round_texts when tools ran"
+    # The fabricated pre-tool answer must not be persisted in any round slot.
+    assert all("FAKE-GUESSED-ROW" not in t for t in rt), rt
+    # The real, tool-grounded answer survives.
+    assert any("Real A and Real B" in t for t in rt), rt
+
+
+# ---------------------------------------------------------------------------
+# 2. <think> reasoning in a quarantined tool round is preserved (so the
+#    thinking section still renders on reload), but the ungrounded prose is not.
+# ---------------------------------------------------------------------------
+def test_think_blocks_preserved_in_quarantined_tool_round(monkeypatch):
+    exec_calls = []
+    _patch_common(monkeypatch, exec_calls)
+    round1 = (
+        "<think>I should fetch the inbox before answering.</think>"
+        "Your inbox has FAKE-GUESSED-ANSWER.\n\n"
+        "```bash\necho fetch-inbox\n```"
+    )
+    events = _run_loop(monkeypatch, "llama-2-7b-chat", [round1])
+
+    assert len(exec_calls) == 1, exec_calls
+    rt = _round_texts(events)
+    assert rt is not None and rt, rt
+    first = rt[0]
+    assert "I should fetch the inbox" in first, f"think block should be kept: {first!r}"
+    assert "FAKE-GUESSED-ANSWER" not in first, f"ungrounded prose should be dropped: {first!r}"
+
+
+# ---------------------------------------------------------------------------
+# 2b. Multiple/interleaved <think> blocks in a quarantined tool round: every
+#     think block is kept, and every stretch of ungrounded prose between/around
+#     them is dropped.
+# ---------------------------------------------------------------------------
+def test_interleaved_think_blocks_all_kept_prose_all_dropped(monkeypatch):
+    exec_calls = []
+    _patch_common(monkeypatch, exec_calls)
+    round1 = (
+        "<think>First, decide.</think>"
+        "FAKE-PROSE-A in the middle.\n"
+        "<think>Now fetch.</think>"
+        "FAKE-PROSE-B at the end.\n\n"
+        "```bash\necho fetch-inbox\n```"
+    )
+    events = _run_loop(monkeypatch, "llama-2-7b-chat", [round1])
+
+    assert len(exec_calls) == 1, exec_calls
+    rt = _round_texts(events)
+    assert rt is not None and rt, rt
+    first = rt[0]
+    assert "First, decide." in first and "Now fetch." in first, f"all think blocks kept: {first!r}"
+    assert "FAKE-PROSE-A" not in first and "FAKE-PROSE-B" not in first, f"all prose dropped: {first!r}"
+
+
+# ---------------------------------------------------------------------------
+# 3. A round with no tool call keeps its prose verbatim (regression): the
+#    grounded answer that arrives after the tool result is preserved in full.
+# ---------------------------------------------------------------------------
+def test_prose_kept_in_round_without_tool_call(monkeypatch):
+    exec_calls = []
+    _patch_common(monkeypatch, exec_calls)
+    round1 = "Let me look that up.\n\n```bash\necho fetch-inbox\n```"
+    events = _run_loop(
+        monkeypatch, "llama-2-7b-chat", [round1],
+        round2_text="Grounded answer: KEEP-THIS-FULL-TEXT from the real result.",
+    )
+
+    assert len(exec_calls) == 1, exec_calls
+    rt = _round_texts(events)
+    assert rt is not None, rt
+    assert any("KEEP-THIS-FULL-TEXT" in t for t in rt), rt
+
+
+# ---------------------------------------------------------------------------
+# 4. Terminal ask_user round (RaresKeY review on PR #4015): ask_user ENDS the
+#    turn, so its round is terminal — there is no later grounded round to
+#    supersede the prose. The blanket tool-round quarantine wrongly blanked it,
+#    and reload reconstruction reads round_texts, so the question disappeared on
+#    reload. The terminal round's question (and visible prose) must survive in
+#    round_texts.
+# ---------------------------------------------------------------------------
+def test_terminal_ask_user_question_survives_in_round_texts(monkeypatch):
+    exec_calls = []
+
+    monkeypatch.setattr(al, "get_setting", lambda key, default=None: default, raising=False)
+    monkeypatch.setattr(al, "get_mcp_manager", lambda: None, raising=False)
+    monkeypatch.setattr(al, "estimate_tokens", lambda *a, **k: 10, raising=False)
+
+    async def _fake_exec(block, *a, **k):
+        exec_calls.append(block)
+        if getattr(block, "tool_type", None) == "ask_user":
+            return "ask_user: which inbox", {
+                "ask_user": {
+                    "question": "ASK-QUESTION-KEEPME which inbox should I check?",
+                    "options": [{"label": "Work"}, {"label": "Personal"}],
+                    "multi": False,
+                },
+                "output": "Asked the user. Awaiting their selection.",
+                "exit_code": 0,
+            }
+        return ("bash", {"output": "ignored", "exit_code": 0})
+
+    monkeypatch.setattr(al, "execute_tool_block", _fake_exec, raising=False)
+
+    round1 = (
+        "I can do that, but I need one detail first.\n\n"
+        '```ask_user\n{"question": "ASK-QUESTION-KEEPME which inbox should I check?", '
+        '"options": [{"label": "Work"}, {"label": "Personal"}]}\n```'
+    )
+    events = _run_loop(monkeypatch, "llama-2-7b-chat", [round1])
+
+    assert len(exec_calls) == 1, f"ask_user should have executed once: {exec_calls}"
+    rt = _round_texts(events)
+    assert rt is not None and rt, f"metrics should carry round_texts: {rt}"
+    # The terminal ask_user question must persist so it renders on reload.
+    assert any("ASK-QUESTION-KEEPME" in t for t in rt), f"ask_user question lost on reload: {rt}"
+
+
+def _clean_response(events):
+    for e in events:
+        if e.get("type") == "metrics":
+            return e.get("data", {}).get("clean_response")
+    return None
+
+
+def _accumulated_deltas(events):
+    """Mirror the chat route: concatenate every non-thinking delta the way
+    routes/chat_routes.py builds the saved `full_response`."""
+    out = ""
+    for e in events:
+        if "delta" in e and not e.get("thinking"):
+            out += e["delta"]
+    return out
+
+
+# ---------------------------------------------------------------------------
+# 5. Gap A (RaresKeY review on PR #4015): quarantining only round_texts is not
+#    enough — the chat route saves the delta-accumulated full_response as the
+#    canonical assistant message, which is replayed to the model and fed to
+#    export/webhook/extraction. That saved body must ALSO drop the fabricated
+#    pre-tool prose while keeping the grounded answer. agent_loop now emits a
+#    sanitized `clean_response` in the metrics event for the route to save.
+# ---------------------------------------------------------------------------
+def test_clean_response_excludes_pre_tool_prose_for_saved_body(monkeypatch):
+    exec_calls = []
+    _patch_common(monkeypatch, exec_calls)
+    round1 = (
+        "Here are your latest emails:\n\n"
+        "| From | Subject |\n|---|---|\n| Alice | FAKE-GUESSED-ROW |\n\n"
+        "```bash\necho fetch-inbox\n```"
+    )
+    events = _run_loop(monkeypatch, "llama-2-7b-chat", [round1])
+
+    assert len(exec_calls) == 1, exec_calls
+    # The raw delta accumulation (what the route used to save) DOES carry the
+    # fabricated answer — this is the bug surface.
+    assert "FAKE-GUESSED-ROW" in _accumulated_deltas(events)
+    # The sanitized body the route will actually save must NOT.
+    clean = _clean_response(events)
+    assert clean is not None, "metrics should carry clean_response on an agentic turn"
+    assert "FAKE-GUESSED-ROW" not in clean, f"saved body still has fabricated prose: {clean!r}"
+    assert "Real A and Real B" in clean, f"grounded answer missing from saved body: {clean!r}"
+
+
+# ---------------------------------------------------------------------------
+# 5b. Gap A — grace synthesis: when the model burns its budget and writes no
+#     final prose, agent_loop synthesizes the answer (force-answer path) and
+#     adds it only to full_response, NOT round_texts. clean_response must still
+#     include that synthesized answer (else join(round_texts) would lose it).
+# ---------------------------------------------------------------------------
+def test_clean_response_keeps_grace_synthesis_answer(monkeypatch):
+    exec_calls = []
+
+    monkeypatch.setattr(al, "get_setting", lambda key, default=None: default, raising=False)
+    monkeypatch.setattr(al, "get_mcp_manager", lambda: None, raising=False)
+    monkeypatch.setattr(al, "estimate_tokens", lambda *a, **k: 10, raising=False)
+
+    async def _fake_exec(block, *a, **k):
+        exec_calls.append(block)
+        return ("bash", {"output": "raw data rows", "exit_code": 0})
+    monkeypatch.setattr(al, "execute_tool_block", _fake_exec, raising=False)
+
+    async def _fake_synth(*a, **k):
+        return "SYNTH-FINAL-ANSWER assembled from the gathered data."
+    monkeypatch.setattr("src.llm_core.llm_call_async", _fake_synth, raising=False)
+
+    # Every round emits the SAME tool call and no final prose. After enough
+    # identical no-progress rounds the loop-breaker trips and forces one
+    # tool-free round, where the grace synthesis salvages a final answer.
+    _step_delta = "```bash\necho step\n```"
+
+    async def _fake_stream(_candidates, messages, **kwargs):
+        yield f'data: {json.dumps({"delta": _step_delta})}\n\n'
+        yield "data: [DONE]\n\n"
+
+    monkeypatch.setattr(al, "stream_llm_with_fallback", _fake_stream, raising=False)
+    gen = al.stream_agent_loop(
+        "http://192.168.1.50:8000/v1", "llama-2-7b-chat",
+        [{"role": "user", "content": "Summarize my inbox."}],
+        max_rounds=8, relevant_tools={"bash"},
+    )
+    events = _events(_collect(gen))
+    clean = _clean_response(events)
+    assert clean is not None, "metrics should carry clean_response on an agentic turn"
+    assert "SYNTH-FINAL-ANSWER" in clean, f"grace-synthesized answer missing: {clean!r}"
+
+
+def _route_saved_body(events):
+    """Mirror routes/chat_routes.py agent-mode save accumulation, delegating the
+    final body choice to the real production helper: accumulate full_response
+    from visible deltas, capture clean_response from the metrics event, then
+    accumulate the visible deltas that arrive AFTER it (the inline teacher
+    takeover) — these are absent from clean_response."""
+    from routes.chat_helpers import select_saved_body
+    full, clean, post, teacher_clean, pre_raw = "", None, "", None, None
+    outer_seen = False
+    for e in events:
+        if e.get("type") == "metrics":
+            md_clean = e.get("data", {}).get("clean_response")
+            if e.get("teacher"):
+                # Nested teacher metrics — don't clobber the outer clean body.
+                if md_clean:
+                    teacher_clean = md_clean
+            else:
+                # Mirror the route: an empty sanitized body ("") is a real value
+                # (finding #5); only an absent key (None) keeps the prior clean.
+                if md_clean is not None:
+                    clean = md_clean
+                outer_seen = True
+                pre_raw = full
+        elif "delta" in e and not e.get("thinking"):
+            full += e["delta"]
+            # Mirror the route guard: only deltas after the outer metrics event
+            # are post-answer (teacher takeover).
+            if outer_seen:
+                post += e["delta"]
+    return select_saved_body(
+        clean, post, full, teacher_clean=teacher_clean, pre_metrics_raw=pre_raw
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. Gap C (RaresKeY review on PR #4015): an inline teacher takeover streams a
+#    visible correction AFTER the metrics event, so it is not in clean_response.
+#    The saved body must still carry the teacher's answer (it is the real final
+#    assistant output) while keeping the pre-tool prose excluded.
+# ---------------------------------------------------------------------------
+def test_teacher_takeover_survives_in_saved_body(monkeypatch):
+    exec_calls = []
+    _patch_common(monkeypatch, exec_calls)
+
+    async def _fake_teacher(*a, **k):
+        yield 'data: ' + json.dumps(
+            {"delta": "TEACHER-FIX-USE-THIS — the real total is 43."}
+        ) + '\n\n'
+
+    monkeypatch.setattr(
+        "src.teacher_escalation.run_teacher_inline", _fake_teacher, raising=False
+    )
+
+    round1 = (
+        "Quick guess: FAKE-PRE-TOOL total is 999.\n\n"
+        "```bash\necho compute\n```"
+    )
+    events = _run_loop(monkeypatch, "llama-2-7b-chat", [round1])
+
+    # The teacher delta is emitted after the metrics event (post-answer takeover).
+    assert any("TEACHER-FIX-USE-THIS" in e.get("delta", "") for e in events), \
+        "teacher takeover should stream as a visible delta"
+
+    body = _route_saved_body(events)
+    assert "TEACHER-FIX-USE-THIS" in body, f"teacher takeover lost from saved body: {body!r}"
+    assert "FAKE-PRE-TOOL" not in body, f"pre-tool prose leaked into saved body: {body!r}"
+
+
+# ---------------------------------------------------------------------------
+# 5c. Empty sanitized turn (RaresKeY review on PR #4015, finding #5): a
+#     tool-using round emits ONLY ungrounded pre-tool prose and the turn then
+#     ends with no grounded final answer, so the sanitized body is "". agent_loop
+#     must STILL emit clean_response (as "") so the route can distinguish
+#     "sanitized to empty" from "no sanitized value" — otherwise the route's
+#     fallback persists the raw pre-tool prose. The saved body must be empty,
+#     NOT the fabricated pre-tool answer.
+# ---------------------------------------------------------------------------
+def test_empty_sanitized_tool_turn_saves_empty_not_raw_pretool_prose(monkeypatch):
+    exec_calls = []
+    _patch_common(monkeypatch, exec_calls)
+    round1 = "FAKE-ONLY-PRETOOL answer: 999.\n\n```bash\necho compute\n```"
+    # The follow-up round produces no final prose, so nothing grounded is written.
+    events = _run_loop(monkeypatch, "llama-2-7b-chat", [round1], round2_text="")
+
+    assert len(exec_calls) == 1, exec_calls
+    # The raw delta accumulation still carries the fabricated pre-tool answer.
+    assert "FAKE-ONLY-PRETOOL" in _accumulated_deltas(events)
+    # agent_loop must emit clean_response even though it sanitized to empty.
+    clean = _clean_response(events)
+    assert clean == "", f"empty-sanitized tool turn must emit clean_response='', got {clean!r}"
+    # The body the route persists must be the (empty) sanitized body, not raw.
+    body = _route_saved_body(events)
+    assert "FAKE-ONLY-PRETOOL" not in body, f"raw pre-tool prose leaked into saved body: {body!r}"
+    assert body == "", f"saved body should be empty, got {body!r}"
+
+
+def _route_outer_metrics(events):
+    """Mirror the route's last_metrics selection: only the outer (non-teacher)
+    metrics event is persisted; a nested teacher metrics must not replace it."""
+    last = None
+    for e in events:
+        if e.get("type") == "metrics" and not e.get("teacher"):
+            last = e.get("data", {})
+    return last
+
+
+# ---------------------------------------------------------------------------
+# 7. Gap D (RaresKeY review on PR #4015, finding #4): when the inline teacher
+#    takeover ITSELF runs a tool-backed turn, its nested stream_agent_loop emits
+#    its OWN metrics event carrying clean_response, forwarded with teacher=True.
+#    The outer route must NOT let that nested metrics clobber the student's
+#    sanitized body or the outer turn's metrics — and must use the teacher's
+#    sanitized clean_response as the teacher segment, not the raw deltas (which
+#    carry the teacher's own pre-tool prose). Saved body = student answer +
+#    teacher grounded answer, each once, with no pre-tool prose from either.
+# ---------------------------------------------------------------------------
+def test_tool_using_teacher_takeover_keeps_both_sanitized_segments(monkeypatch):
+    exec_calls = []
+    _patch_common(monkeypatch, exec_calls)
+
+    async def _fake_teacher(*a, **k):
+        # Mirrors run_teacher_inline forwarding a tool-using teacher run: the
+        # teacher streams its own pre-tool prose, then emits its nested metrics
+        # with a sanitized clean_response — all tagged teacher=True
+        # (src/teacher_escalation.py sets payload["teacher"] = True on each).
+        yield 'data: ' + json.dumps(
+            {"delta": "TEACHER-PRETOOL guess: 111.", "teacher": True}
+        ) + '\n\n'
+        yield 'data: ' + json.dumps(
+            {"type": "metrics", "teacher": True,
+             "data": {"clean_response": "TEACHER-GROUNDED real total is 43."}}
+        ) + '\n\n'
+
+    monkeypatch.setattr(
+        "src.teacher_escalation.run_teacher_inline", _fake_teacher, raising=False
+    )
+
+    round1 = "STUDENT-PRETOOL guess: 999.\n\n```bash\necho compute\n```"
+    events = _run_loop(
+        monkeypatch, "llama-2-7b-chat", [round1],
+        round2_text="STUDENT-GROUNDED answer: Real A and Real B.",
+    )
+
+    body = _route_saved_body(events)
+    # Student's sanitized grounded answer survives (not clobbered by the nested
+    # teacher metrics).
+    assert "STUDENT-GROUNDED" in body, f"student answer dropped: {body!r}"
+    # Teacher's sanitized grounded answer present, exactly once (no duplication).
+    assert body.count("TEACHER-GROUNDED") == 1, \
+        f"teacher answer missing/duplicated: {body!r}"
+    # No pre-tool prose from EITHER student or teacher.
+    assert "STUDENT-PRETOOL" not in body, f"student pre-tool prose leaked: {body!r}"
+    assert "TEACHER-PRETOOL" not in body, f"teacher pre-tool prose leaked: {body!r}"
+
+    # The persisted metrics describe the OUTER turn, not the nested teacher run.
+    outer = _route_outer_metrics(events)
+    assert outer is not None and "round_texts" in outer, \
+        f"outer-turn metrics lost to nested teacher metrics: {outer!r}"
+
+
+# ---------------------------------------------------------------------------
+# 8. Gap D, no-tool student variant (fresh-context review of finding #4): a
+#    student that answers WITHOUT tools emits no clean_response, so _clean_body
+#    is None. A tool-using teacher takeover must still contribute its sanitized
+#    answer (not its raw pre-tool prose), and the student's raw answer is kept.
+# ---------------------------------------------------------------------------
+def test_no_tool_student_then_tool_using_teacher_excludes_teacher_pretool(monkeypatch):
+    exec_calls = []
+    _patch_common(monkeypatch, exec_calls)
+
+    async def _fake_teacher(*a, **k):
+        yield 'data: ' + json.dumps(
+            {"delta": "TEACHER-PRETOOL guess: 111.", "teacher": True}
+        ) + '\n\n'
+        yield 'data: ' + json.dumps(
+            {"type": "metrics", "teacher": True,
+             "data": {"clean_response": "TEACHER-GROUNDED real total is 43."}}
+        ) + '\n\n'
+
+    monkeypatch.setattr(
+        "src.teacher_escalation.run_teacher_inline", _fake_teacher, raising=False
+    )
+
+    # Student gives up with no tool call → one round, no clean_response.
+    events = _run_loop(
+        monkeypatch, "llama-2-7b-chat", ["STUDENT-NOTOOL I cannot compute that."]
+    )
+
+    body = _route_saved_body(events)
+    assert "STUDENT-NOTOOL" in body, f"student raw answer dropped: {body!r}"
+    assert body.count("TEACHER-GROUNDED") == 1, \
+        f"teacher answer missing/duplicated: {body!r}"
+    assert "TEACHER-PRETOOL" not in body, f"teacher pre-tool prose leaked: {body!r}"

--- a/tests/test_chat_helpers.py
+++ b/tests/test_chat_helpers.py
@@ -475,3 +475,25 @@ def test_select_saved_body_distinguishes_empty_sanitized_from_absent():
     # Empty student + a teacher takeover: keep the teacher segment alone, with no
     # leading blank line from concatenating onto an empty student.
     assert select_saved_body("", "", "RAW", teacher_clean="TEACHER-ANSWER", pre_metrics_raw="RAW") == "TEACHER-ANSWER"
+
+
+def test_select_saved_body_empty_teacher_clean_drops_raw_teacher_prose():
+    # RaresKeY follow-up: the teacher path must mirror the student presence
+    # semantics. A tool-using teacher takeover whose visible text was all
+    # pre-tool prose sanitizes to teacher_clean == "". That empty-but-present
+    # teacher segment must persist as empty (the student segment alone), never
+    # falling back to the raw post-metrics deltas that still carry the teacher's
+    # pre-tool prose.
+    student = "STUDENT grounded answer."
+    raw_teacher_deltas = "\n\nTEACHER-RAW pre-tool guess: 999."
+    body = select_saved_body(
+        student, raw_teacher_deltas, "full", teacher_clean="", pre_metrics_raw=student
+    )
+    assert body == student, f"empty teacher segment not preserved: {body!r}"
+    assert "TEACHER-RAW pre-tool guess" not in body, f"raw teacher pre-tool prose leaked: {body!r}"
+    # A genuinely absent teacher (None) still appends the raw post-metrics deltas
+    # (a no-tool teacher's visible correction has no clean_response to prefer).
+    assert (
+        select_saved_body(student, raw_teacher_deltas, "full", teacher_clean=None)
+        == student + raw_teacher_deltas
+    )

--- a/tests/test_chat_helpers.py
+++ b/tests/test_chat_helpers.py
@@ -435,3 +435,43 @@ async def test_build_chat_context_keeps_cookie_user_owner_scope(monkeypatch):
         "preface_owner": "bob",
         "compact_owner": "bob",
     }
+
+
+# ---------------------------------------------------------------------------
+# select_saved_body — PR #4015 review (RaresKeY finding #3): the agentic save
+# path uses the sanitized clean_response, but an inline teacher takeover streams
+# its visible correction AFTER the metrics event, so that text is absent from
+# clean_response. It must still be persisted (it is real, user-visible final
+# assistant output) — otherwise reload/replay/export silently drop the teacher's
+# answer. Pre-tool prose must stay excluded.
+# ---------------------------------------------------------------------------
+from routes.chat_helpers import select_saved_body
+
+
+def test_select_saved_body_appends_post_metrics_teacher_takeover():
+    clean = "The grounded answer is 42."
+    teacher = "\n\n[Teacher] Correction: the real total is 43. USE-THIS."
+    full = "FAKE pre-tool guess: 999.\n\n" + clean + teacher
+    body = select_saved_body(clean, teacher, full)
+    assert "USE-THIS" in body, f"teacher takeover dropped from saved body: {body!r}"
+    assert "FAKE pre-tool guess" not in body, f"pre-tool prose leaked back in: {body!r}"
+
+
+def test_select_saved_body_falls_back_to_full_response_without_clean_body():
+    # Non-agentic / direct chat: no clean_response emitted (None) → keep raw body.
+    assert select_saved_body(None, "", "plain direct answer") == "plain direct answer"
+
+
+def test_select_saved_body_distinguishes_empty_sanitized_from_absent():
+    # RaresKeY finding #5: a tool turn whose visible text was all pre-tool prose
+    # sanitizes to "". That "" is a real sanitized result (nothing grounded to
+    # keep), NOT "no sanitized value" — it must be persisted as empty, never
+    # falling back to the raw pre-tool prose.
+    assert select_saved_body("", "", "RAW-PRETOOL guess", pre_metrics_raw="RAW-PRETOOL guess") == ""
+    # Only a genuinely absent sanitized body (None) falls back to the raw answer.
+    assert select_saved_body(None, "", "plain direct answer", pre_metrics_raw=None) == "plain direct answer"
+    # No-tool student (no clean_response → None) still persists its raw answer.
+    assert select_saved_body(None, "", "RAW", pre_metrics_raw="STUDENT-NOTOOL answer") == "STUDENT-NOTOOL answer"
+    # Empty student + a teacher takeover: keep the teacher segment alone, with no
+    # leading blank line from concatenating onto an empty student.
+    assert select_saved_body("", "", "RAW", teacher_clean="TEACHER-ANSWER", pre_metrics_raw="RAW") == "TEACHER-ANSWER"


### PR DESCRIPTION
## Summary

When a single assistant round emits prose **and** an executable tool call, the prose precedes the real tool result and is therefore ungrounded — the grounded answer only arrives in a later round once the tool output is fed back. `stream_agent_loop` appended that pre-tool prose to `round_texts` unconditionally, and `round_texts` is exactly what `chatRenderer.js` replays per round when it reconstructs an agentic turn on reload. The result was a guessed/fabricated answer rendered in its own bubble next to the real, tool-grounded answer — most visible with `list_emails` / search / calendar / file tools, where round 1 shows a made-up answer and a later round shows the contradictory real one. This change quarantines the visible pre-tool prose for any round that resolved to an executable tool call, while keeping `<think>` blocks so the thinking section still renders on reload.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3992

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app end-to-end — see the honest note below.

> **Verification note (honest):** this is a backend-only change to persisted round metadata with **no UI/render surface**, so there is nothing visual to screenshot. Rather than only type-checking, I drove the **real `stream_agent_loop`** end-to-end with a mocked LLM stream — the same fake-stream method the reporter used to probe `round_texts` — asserting on the actual `round_texts` carried in the metrics event (not a stub). I did **not** spin the full Docker/uvicorn app against a live local model emitting pre-tool prose; if you'd like that confirmed in the running app, the steps below reproduce it.

## How to Test

Automated (deterministic, no model needed):

```
python -m pytest tests/test_agent_pre_tool_prose.py -v
```

Full suite: `python -m pytest` → 3270 passed, 1 skipped on this branch.

In the running app (optional manual confirmation):

1. Use Agent mode with a fenced-tool local model that emits prose **and** an executable tool call in the same round (e.g. `gemma`/`llama` via Ollama). Ask something that needs a tool result, like "list my latest emails".
2. Let the model write a prose answer **before** a fenced `list_emails` call, let the tool run, and let it continue into the grounded answer.
3. Reload the conversation. **Before:** the first-round guessed prose renders as its own AI bubble next to the real answer. **After:** only the tool-grounded answer remains; the ungrounded pre-tool prose is gone (its `<think>` reasoning, if any, still shows in the thinking section).

## Visual / UI changes — REQUIRED if you touched anything that renders

**N/A — no rendering changes.** This PR only changes `src/agent_loop.py` (which strings get persisted into `round_texts`) plus a new test. No CSS/HTML/SVG/`static/js/` module is touched; `chatRenderer.js` is unchanged. The reload reconstruction simply replays the now-quarantined `round_texts`.
