### PR TITLE
feat(local-llm-router): foundation settings and runtime (1/6)

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -34,3 +34,8 @@ PyMuPDF
 # [all]/Azure/audio extras (cloud + heavy). Pinned to a release >30 days old per
 # the dependency-age discussion in issue #485.
 markitdown[docx,pptx,xlsx,xls]==0.1.5
+
+# Auto (Local LLMs) — per-message routing across local Ollama models.
+# Install via Cookbook → Packages or: pip install 'local-llm-router[ollama]'
+# 0.4.2+ required for preset tier_slots (complex / complex_alt agent-chat split).
+local-llm-router[ollama]>=0.4.2

--- a/src/constants.py
+++ b/src/constants.py
@@ -3,6 +3,8 @@
 import os
 
 APP_VERSION = "1.0.0"
+# Bump when local/dev behavior changes so you can confirm reload (shown in UI + /api/version).
+BUILD_STAMP = "auto-route-mode-v1"
 
 # Base paths
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__))) + "/"
@@ -67,6 +69,11 @@ MAX_DIFF_LINES = 400            # cap for edit_file unified-diff display
 MAX_CONTEXT_MESSAGES = 90
 REQUEST_TIMEOUT = 20
 OPENAI_COMPAT_PATH = "/v1/chat/completions"
+
+# Session sentinel for Auto (Local LLMs). Stored value must stay stable.
+LOCAL_LLM_ROUTER_AUTO_MODEL_ID = "__auto_stack__"
+LOCAL_LLM_ROUTER_NAME = "Local-LLM-Router"
+AUTO_SELECT_LABEL = "Auto (Local LLMs)"
 
 # Environment variables with defaults
 DEFAULT_HOST = os.getenv("LLM_HOST", "localhost")

--- a/src/local_llm_router_runtime.py
+++ b/src/local_llm_router_runtime.py
@@ -1,0 +1,29 @@
+"""Lazy-load the local-llm-router PyPI package."""
+
+from __future__ import annotations
+
+from src.constants import LOCAL_LLM_ROUTER_NAME
+
+LOCAL_LLM_ROUTER_PIP = "local-llm-router[ollama]"
+LOCAL_LLM_ROUTER_MISSING = (
+    f"{LOCAL_LLM_ROUTER_NAME} is not installed. "
+    f"Install with `pip install '{LOCAL_LLM_ROUTER_PIP}'` or use Install in the model picker."
+)
+
+
+def load_local_llm_router():
+    """Return the local_llm_router module, or raise a user-facing setup hint."""
+    for mod_name in ("local_llm_router", "split_stack"):
+        try:
+            return __import__(mod_name)
+        except ImportError:
+            continue
+    raise RuntimeError(LOCAL_LLM_ROUTER_MISSING)
+
+
+def local_llm_router_available() -> bool:
+    try:
+        load_local_llm_router()
+        return True
+    except RuntimeError:
+        return False

--- a/src/settings.py
+++ b/src/settings.py
@@ -132,6 +132,10 @@ DEFAULT_SETTINGS = {
     "utility_model_fallbacks": [],
     "teacher_model": "",
     "teacher_enabled": False,
+    # Local-LLM-Router — Auto (Local LLMs) routing (see local_llm_router_routing.py)
+    "local_llm_router_vram_gb": 0,  # 0 = detect via hwfit
+    "local_llm_router_quant": "qat",
+    "local_llm_router_models": [],
     # Skills: minimum self-reported confidence for an auto-written (LLM-authored)
     # DRAFT skill to be injected into the agent prompt. Published skills always
     # qualify. Keeps low-confidence auto-skills out of context until they're
@@ -213,9 +217,22 @@ def save_settings(settings: dict):
     _invalidate_caches()
 
 
+_LLR_SETTING_LEGACY = {
+    "local_llm_router_vram_gb": "auto_stack_vram_gb",
+    "local_llm_router_quant": "auto_stack_quant",
+    "local_llm_router_models": "auto_stack_models",
+}
+
+
 def get_setting(key: str, default: Any = None) -> Any:
     """Read a single setting value."""
-    return load_settings().get(key, default)
+    settings = load_settings()
+    if key in settings:
+        return settings.get(key, default)
+    legacy = _LLR_SETTING_LEGACY.get(key)
+    if legacy is not None:
+        return settings.get(legacy, default)
+    return settings.get(key, default)
 
 
 def is_setting_overridden(key: str) -> bool:

--- a/tests/test_local_llm_router_privileges.py
+++ b/tests/test_local_llm_router_privileges.py
@@ -1,0 +1,15 @@
+from src.local_llm_router_routing import is_local_llm_router_auto_model, is_local_llm_router_auto_session
+from src.constants import LOCAL_LLM_ROUTER_AUTO_MODEL_ID
+
+
+def test_local_llm_router_model_constant():
+    assert LOCAL_LLM_ROUTER_AUTO_MODEL_ID == "__auto_stack__"
+    assert is_local_llm_router_auto_model(LOCAL_LLM_ROUTER_AUTO_MODEL_ID)
+
+
+def test_local_llm_router_session_by_model_only():
+    class Sess:
+        model = LOCAL_LLM_ROUTER_AUTO_MODEL_ID
+
+    assert is_local_llm_router_auto_session(Sess()) is True
+    assert is_local_llm_router_auto_session(Sess(), require_enabled=True) is True

--- a/tests/test_local_llm_router_runtime.py
+++ b/tests/test_local_llm_router_runtime.py
@@ -1,0 +1,29 @@
+import builtins
+
+import pytest
+
+from src.constants import LOCAL_LLM_ROUTER_AUTO_MODEL_ID
+from src.local_llm_router_runtime import LOCAL_LLM_ROUTER_MISSING, load_local_llm_router
+
+
+def _block_router_import(monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name in ("local_llm_router", "split_stack"):
+            raise ImportError(f"No module named {name}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+
+def test_missing_dependency_error_is_user_actionable(monkeypatch):
+    _block_router_import(monkeypatch)
+    with pytest.raises(RuntimeError) as exc:
+        load_local_llm_router()
+    assert str(exc.value) == LOCAL_LLM_ROUTER_MISSING
+    assert "Local-LLM-Router" in str(exc.value)
+
+
+def test_LOCAL_LLM_ROUTER_AUTO_MODEL_ID_constant():
+    assert LOCAL_LLM_ROUTER_AUTO_MODEL_ID == "__auto_stack__"


### PR DESCRIPTION
﻿## Summary

Adds the Local LLM Router foundation: optional \local-llm-router[ollama]\ dependency, Auto sentinel constants and BUILD_STAMP in \src/constants.py\, settings keys with legacy \uto_stack_*\ aliases, and runtime privilege helpers.

**Slice scope:** requirements-optional.txt, src/constants.py, src/settings.py, src/local_llm_router_runtime.py, tests/test_local_llm_router_runtime.py, tests/test_local_llm_router_privileges.py (~103 lines vs dev).

of

## Target branch

- [x] This PR targets **dev**, not main. All PRs land in dev; main is curated by the maintainer at each release. If your PR is on main by accident, click "Edit" on this PR and change the base.

## Linked Issue

Part

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [x] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets dev
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (docker compose up or uvicorn app:app) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. \pip install -r requirements-optional.txt\ (or Cookbook package install).\n2. \pytest tests/test_local_llm_router_runtime.py tests/test_local_llm_router_privileges.py\" -IssueLine 

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any static/js/ module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (--red, --fg, --bg, --card, --border, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in static/index.html) or plain text.
  - Monospaced font (Fira Code) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

N/A for this slice (backend-only).
