### PR TITLE
feat(local-llm-router): chat and agent wiring (3/6) — merge after #4020

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -34,3 +34,8 @@ PyMuPDF
 # [all]/Azure/audio extras (cloud + heavy). Pinned to a release >30 days old per
 # the dependency-age discussion in issue #485.
 markitdown[docx,pptx,xlsx,xls]==0.1.5
+
+# Auto (Local LLMs) — per-message routing across local Ollama models.
+# Install via Cookbook → Packages or: pip install 'local-llm-router[ollama]'
+# 0.4.2+ required for preset tier_slots (complex / complex_alt agent-chat split).
+local-llm-router[ollama]>=0.4.2

--- a/routes/chat_helpers.py
+++ b/routes/chat_helpers.py
@@ -13,6 +13,13 @@ from core.database import SessionLocal
 from core.database import Session as DBSession, ModelEndpoint
 from src.llm_core import normalize_model_id
 from src.endpoint_resolver import normalize_base
+from src.constants import LOCAL_LLM_ROUTER_AUTO_MODEL_ID
+from src.local_llm_router_routing import (
+    LocalLlmRouterNotReady,
+    is_local_llm_router_active,
+    is_local_llm_router_auto_model,
+    resolve_local_llm_router,
+)
 from src.context_compactor import maybe_compact, trim_for_context
 from src.auth_helpers import get_current_user
 from src.prompt_security import untrusted_context_message
@@ -100,7 +107,10 @@ def _enforce_chat_privileges(request, sess) -> None:
     allowed = allowed_raw if isinstance(allowed_raw, list) else []
     restricted = bool(privs.get("allowed_models_restricted")) or bool(allowed)
     if restricted and sess.model and sess.model not in allowed:
-        raise HTTPException(403, f"Your account is not allowed to use model '{sess.model}'.")
+        if sess.model == LOCAL_LLM_ROUTER_AUTO_MODEL_ID:
+            pass
+        else:
+            raise HTTPException(403, f"Your account is not allowed to use model '{sess.model}'.")
 
     cap = int(privs.get("max_messages_per_day") or 0)
     if cap <= 0:
@@ -159,9 +169,26 @@ async def auto_name_session(session_manager, sess):
             return
 
         owner = getattr(sess, "owner", None)
-        t_url, t_model, t_headers = resolve_task_endpoint(
-            sess.endpoint_url, sess.model, sess.headers, owner=owner,
-        )
+        if is_local_llm_router_auto_model(sess.model):
+            if not is_local_llm_router_active(sess):
+                logger.debug("[auto-name] Auto (Local LLMs) inactive, skipping")
+                return
+            try:
+                res = resolve_local_llm_router(
+                    prompt=first_msg or "New chat",
+                    endpoint_url=sess.endpoint_url,
+                    headers=sess.headers,
+                    owner=owner,
+                    mode="chat",
+                )
+                t_url, t_model, t_headers = res.endpoint_url, res.model, res.headers
+            except (LocalLlmRouterNotReady, ValueError, RuntimeError) as exc:
+                logger.debug("[auto-name] Auto (Local LLMs) resolve failed, skipping: %s", exc)
+                return
+        else:
+            t_url, t_model, t_headers = resolve_task_endpoint(
+                sess.endpoint_url, sess.model, sess.headers, owner=owner,
+            )
         if not t_model:
             logger.debug("[auto-name] No model provided, skipping")
             return
@@ -604,13 +631,14 @@ async def build_chat_context(
 
     # Normalize model ID. Prefer cached endpoint models so group chat does not
     # re-hit slow local /models endpoints on every participant turn.
-    norm = _normalize_model_id_from_cache(sess) or normalize_model_id(
-        sess.endpoint_url,
-        sess.model,
-        owner=getattr(sess, "owner", None),
-    )
-    if norm:
-        sess.model = norm
+    if not is_local_llm_router_auto_model(getattr(sess, "model", None)):
+        norm = _normalize_model_id_from_cache(sess) or normalize_model_id(
+            sess.endpoint_url,
+            sess.model,
+            owner=getattr(sess, "owner", None),
+        )
+        if norm:
+            sess.model = norm
 
     # Build messages
     messages = preface + sess.get_context_messages()
@@ -879,9 +907,16 @@ def save_assistant_response(
 
     requested_model = _model_value(md.get("requested_model") or md.get("selected_model") or getattr(sess, "model", ""))
     actual_model = _model_value(md.get("model") or md.get("actual_model") or requested_model)
+    resolved_model = _model_value(md.get("resolved_model") or "")
     if requested_model:
         md["requested_model"] = requested_model
-    if actual_model:
+    if is_local_llm_router_auto_model(sess.model):
+        if resolved_model and not is_local_llm_router_auto_model(resolved_model):
+            md["resolved_model"] = resolved_model
+        elif actual_model and not is_local_llm_router_auto_model(actual_model):
+            md["resolved_model"] = actual_model
+        md["model"] = sess.model
+    elif actual_model:
         md["model"] = actual_model
     if character_name:
         md["character_name"] = character_name

--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -41,6 +41,16 @@ from routes.chat_helpers import (
 )
 from src.action_intents import classify_tool_intent as _classify_tool_intent
 from src.tool_policy import build_effective_tool_policy
+from src.local_llm_router_routing import (
+    LocalLlmRouterNotReady,
+    check_local_llm_router_ready,
+    is_local_llm_router_active,
+    is_local_llm_router_auto_model,
+    resolve_local_llm_router,
+    local_llm_router_fallback_candidates,
+)
+from src.local_llm_router_runtime import LOCAL_LLM_ROUTER_MISSING, local_llm_router_available
+from src.constants import AUTO_SELECT_LABEL
 
 logger = logging.getLogger(__name__)
 
@@ -549,7 +559,8 @@ def setup_chat_routes(
             # the first cached model off the matching endpoint so the
             # upstream isn't called with model="" (which surfaces as a
             # generic 401/503).
-            _recover_empty_session_model(sess, session, owner=owner)
+            if not is_local_llm_router_auto_model(getattr(sess, "model", None)):
+                _recover_empty_session_model(sess, session, owner=owner)
             if not getattr(sess, "model", "").strip():
                 raise HTTPException(
                     400,
@@ -569,6 +580,15 @@ def setup_chat_routes(
         # Admins always have full privileges via get_privileges (returns
         # ADMIN_PRIVILEGES wholesale) so this is a no-op for them.
         _enforce_chat_privileges(request, sess)
+
+        if is_local_llm_router_active(sess) and not local_llm_router_available():
+            raise HTTPException(503, LOCAL_LLM_ROUTER_MISSING)
+
+        if is_local_llm_router_active(sess):
+            try:
+                check_local_llm_router_ready(sess.endpoint_url or "", owner=owner)
+            except LocalLlmRouterNotReady as exc:
+                raise HTTPException(400, str(exc)) from exc
 
         # Ensure session has auth headers
         resolve_session_auth(sess, session, owner=get_current_user(request))
@@ -956,6 +976,13 @@ def setup_chat_routes(
 
             full_response = ""
             last_metrics = None
+            _local_llm_router = (
+                is_local_llm_router_active(sess)
+                and not do_research
+                and not compare_mode
+                and chat_mode in ("chat", "agent")
+            )
+            _llr_res = None
 
             # Configured fallback chain for the default chat model. Tried in
             # order if the session's primary model fails before producing
@@ -966,9 +993,36 @@ def setup_chat_routes(
             except Exception:
                 _fallback_candidates = []
 
+            if _local_llm_router:
+                try:
+                    _llr_res = resolve_local_llm_router(
+                        prompt=message or "",
+                        endpoint_url=sess.endpoint_url,
+                        headers=sess.headers,
+                        owner=_user,
+                        mode=chat_mode if chat_mode in ("chat", "agent") else "chat",
+                    )
+                except Exception as exc:
+                    yield f'data: {json.dumps({"delta": f"Auto (Local LLMs): {exc}"})}\n\n'
+                    yield "data: [DONE]\n\n"
+                    _active_streams.pop(session, None)
+                    return
+
             # Send model name early so the frontend can show it during streaming
             _model_suffix = "Research" if effective_do_research else None
-            _model_info = {"type": "model_info", "model": sess.model}
+            if _llr_res:
+                _display_model = _llr_res.model
+                _model_info = {
+                    "type": "model_info",
+                    "model": _display_model,
+                    "requested_model": sess.model,
+                    "local_llm_router": True,
+                    "tier": _llr_res.tier,
+                    "mode_label": AUTO_SELECT_LABEL,
+                    "route_reasons": list(_llr_res.route_reasons),
+                }
+            else:
+                _model_info = {"type": "model_info", "model": sess.model}
             if _model_suffix:
                 _model_info["suffix"] = _model_suffix
             if ctx.preset.character_name:
@@ -1021,7 +1075,17 @@ def setup_chat_routes(
                 _actual_model = None
                 # ── Chat mode: call stream_llm directly, NO tools, NO document access ──
                 try:
-                    _chat_candidates = [(sess.endpoint_url, sess.model, sess.headers)] + _fallback_candidates
+                    if _llr_res:
+                        _chat_candidates = [
+                            (_llr_res.endpoint_url, _llr_res.model, _llr_res.headers),
+                        ] + local_llm_router_fallback_candidates(
+                            _llr_res,
+                            endpoint_url=sess.endpoint_url,
+                            headers=sess.headers,
+                            owner=_user,
+                        )
+                    else:
+                        _chat_candidates = [(sess.endpoint_url, sess.model, sess.headers)] + _fallback_candidates
                     async for chunk in stream_llm_with_fallback(
                         _chat_candidates,
                         messages,
@@ -1063,7 +1127,10 @@ def setup_chat_routes(
                                     last_metrics = data.get("data", {})
                                     _reported_model = last_metrics.get("model")
                                     last_metrics["requested_model"] = _requested_model
-                                    last_metrics["model"] = _reported_model or _actual_model or _answered_by or _requested_model
+                                    _resolved = _reported_model or _actual_model or _answered_by
+                                    last_metrics["model"] = _resolved or _display_model or _requested_model
+                                    if _llr_res and _resolved:
+                                        last_metrics["resolved_model"] = _resolved
                                     if ctx.context_length and last_metrics.get("input_tokens"):
                                         pct = min(round((last_metrics["input_tokens"] / ctx.context_length) * 100, 1), 100.0)
                                         last_metrics["context_percent"] = pct
@@ -1180,10 +1247,12 @@ def setup_chat_routes(
                         disabled_tools=disabled_tools if disabled_tools else None,
                         tool_policy=tool_policy,
                         owner=_user,
-                        fallbacks=_fallback_candidates,
+                        fallbacks=[] if _local_llm_router else _fallback_candidates,
                         plan_mode=plan_mode,
                         approved_plan=approved_plan or None,
                         workspace=workspace or None,
+                        local_llm_router_active=_local_llm_router,
+                        local_llm_router_anchor_url=sess.endpoint_url,
                     ):
                         if chunk.startswith("data: ") and not chunk.startswith("data: [DONE]"):
                             try:
@@ -1206,6 +1275,8 @@ def setup_chat_routes(
                                     "rounds_exhausted",
                                     "ask_user",
                                     "plan_update",
+                                    "model_info",
+                                    "model_resolved",
                                 ):
                                     if data.get("type") == "agent_step":
                                         _agent_rounds = max(_agent_rounds, data.get("round", 1))
@@ -1229,7 +1300,10 @@ def setup_chat_routes(
                                     last_metrics = data.get("data", {})
                                     _reported_model = last_metrics.get("model")
                                     last_metrics["requested_model"] = last_metrics.get("requested_model") or _requested_model
-                                    last_metrics["model"] = _reported_model or _actual_model or _answered_by or _requested_model
+                                    _resolved = _reported_model or _actual_model or _answered_by
+                                    last_metrics["model"] = _resolved or _display_model or _requested_model
+                                    if _llr_res and _resolved:
+                                        last_metrics["resolved_model"] = _resolved
                                     yield f'data: {json.dumps({"type": "metrics", "data": last_metrics})}\n\n'
                             except json.JSONDecodeError:
                                 yield chunk

--- a/routes/session_routes.py
+++ b/routes/session_routes.py
@@ -453,6 +453,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
         name: str = Form(None), folder: str = Form(None),
         model: str = Form(None), endpoint_url: str = Form(None),
         endpoint_id: str = Form(None),
+        skip_validation: str = Form(None),
     ):
         _verify_session_owner(request, sid)
         try:
@@ -476,19 +477,23 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
             finally:
                 db.close()
         # Switch model/endpoint mid-session
-        if model is not None and endpoint_url is not None:
+        if model is not None:
+            from src.local_llm_router_routing import is_local_llm_router_auto_model
+
             user = get_current_user(request)
-            _reject_raw_endpoint_url_for_non_admin(request, user, endpoint_id, endpoint_url)
+            ep_id = (endpoint_id or "").strip() if endpoint_id is not None else ""
+            resolved_url = (endpoint_url or "").strip() if endpoint_url is not None else ""
             endpoint_api_key = ""
             endpoint_base_url = ""
-            if endpoint_id:
+
+            if ep_id:
                 from core.database import ModelEndpoint
                 from src.auth_helpers import owner_filter
                 from src.endpoint_resolver import build_chat_url, normalize_base
                 _db = SessionLocal()
                 try:
                     q = _db.query(ModelEndpoint).filter(
-                        ModelEndpoint.id == endpoint_id,
+                        ModelEndpoint.id == ep_id,
                         ModelEndpoint.is_enabled == True,
                     )
                     if user:
@@ -498,11 +503,30 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
                         raise HTTPException(400, "Model endpoint no longer exists")
                     endpoint_base_url = ep.base_url or ""
                     endpoint_api_key = ep.api_key or ""
-                    endpoint_url = build_chat_url(normalize_base(endpoint_base_url))
+                    resolved_url = build_chat_url(normalize_base(endpoint_base_url))
                 finally:
                     _db.close()
+            elif resolved_url:
+                _reject_raw_endpoint_url_for_non_admin(
+                    request, user, ep_id, resolved_url
+                )
+            elif is_local_llm_router_auto_model(model):
+                raise HTTPException(
+                    400,
+                    "Auto (Local LLMs) needs a registered local endpoint. "
+                    "Refresh endpoints in Settings, then pick Auto again.",
+                )
+            else:
+                raise HTTPException(
+                    400,
+                    "endpoint_id is required to switch models on this account.",
+                )
+
+            if not resolved_url:
+                raise HTTPException(400, "Could not resolve endpoint URL for model switch")
+
             session.model = model
-            session.endpoint_url = endpoint_url
+            session.endpoint_url = resolved_url
             # Update auth headers from the endpoint's stored API key
             if endpoint_api_key:
                 from src.endpoint_resolver import build_headers
@@ -515,14 +539,16 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
                 db_session = db.query(DbSession).filter(DbSession.id == sid).first()
                 if db_session:
                     db_session.model = model
-                    db_session.endpoint_url = endpoint_url
+                    db_session.endpoint_url = resolved_url
                     db_session.headers = session.headers or {}
                     db_session.updated_at = datetime.utcnow()
                     db.commit()
             finally:
                 db.close()
             result["model"] = model
-            result["endpoint_url"] = endpoint_url
+            result["endpoint_url"] = resolved_url
+            if ep_id:
+                result["endpoint_id"] = ep_id
         return result
     
     @router.post("/session/{sid}/inject_messages")

--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -1734,6 +1734,8 @@ async def stream_agent_loop(
     tool_policy: Optional[ToolPolicy] = None,
     workspace: Optional[str] = None,
     _is_teacher_run: bool = False,
+    local_llm_router_active: bool = False,
+    local_llm_router_anchor_url: Optional[str] = None,
 ) -> AsyncGenerator[str, None]:
     """Streaming agent loop generator.
 
@@ -2115,6 +2117,7 @@ async def stream_agent_loop(
     # using tools — i.e. it was cut off, not finished. Drives a "Continue" event
     # so the user can resume instead of the turn silently stalling.
     _exhausted_rounds = False
+    _anchor_url = local_llm_router_anchor_url or endpoint_url
 
     for round_num in range(1, max_rounds + 1):
         round_response = ""
@@ -2129,6 +2132,50 @@ async def stream_agent_loop(
         # fenced block closes we advance this so the next iteration can
         # detect a SUBSEQUENT block in the same round.
         _doc_scan_from = 0
+
+        _round_stack_fb = list(fallbacks or [])
+        if local_llm_router_active:
+            from src.local_llm_router_routing import (
+                resolve_local_llm_router,
+                local_llm_router_fallback_candidates,
+            )
+            try:
+                _route_prompt = _extract_last_user_message(messages) or ""
+                _llr_res = resolve_local_llm_router(
+                    prompt=_route_prompt,
+                    endpoint_url=_anchor_url,
+                    headers=headers,
+                    owner=owner,
+                    mode="agent",
+                )
+                endpoint_url = _llr_res.endpoint_url
+                model = _llr_res.model
+                headers = _llr_res.headers
+                _model_lc = (model or "").lower()
+                _is_ollama_native = _is_ollama_native_url(endpoint_url or "")
+                _ollama_openai_compat = _is_ollama_openai_compat_url(endpoint_url or "")
+                _model_no_tools = any(kw in _model_lc for kw in ("deepseek-r1",))
+                _model_supports_tools = any(kw in _model_lc for kw in (
+                    "gpt-4", "gpt-5", "gpt-o", "claude", "gemini", "gemma",
+                    "qwen3", "qwen2.5", "mixtral", "mistral", "llama-3.1", "llama-3.2",
+                    "llama-3.3", "llama-4", "minimax", "kimi", "yi-", "phi-3", "phi-4",
+                    "command-r", "glm-4", "internlm", "hermes", "deepseek-v", "deepseek-chat",
+                ))
+                if _is_ollama_native or _ollama_openai_compat or _model_no_tools:
+                    _is_api_model = False
+                else:
+                    _is_api_model = any(h in endpoint_url for h in _API_HOSTS) or _model_supports_tools
+                _round_stack_fb = local_llm_router_fallback_candidates(
+                    _llr_res,
+                    endpoint_url=_anchor_url,
+                    headers=headers,
+                    owner=owner,
+                )
+                from src.constants import AUTO_SELECT_LABEL, LOCAL_LLM_ROUTER_AUTO_MODEL_ID
+                yield f'data: {json.dumps({"type": "model_resolved", "model": model, "requested_model": LOCAL_LLM_ROUTER_AUTO_MODEL_ID, "tier": _llr_res.tier, "round": round_num, "local_llm_router": True, "mode_label": AUTO_SELECT_LABEL, "route_reasons": list(_llr_res.route_reasons)})}\n\n'
+            except Exception as _llr_err:
+                yield f'event: error\ndata: {json.dumps({"error": f"Auto (Local LLMs): {_llr_err}"})}\n\n'
+                break
 
         # Merge native tool schemas with MCP tool schemas, filtering out
         # Only send function schemas for API models (OpenAI, Anthropic, etc.).
@@ -2175,7 +2222,7 @@ async def stream_agent_loop(
         # Primary target + any configured fallback models. stream_llm_with_fallback
         # only switches on a pre-content failure, so streamed output is never
         # duplicated; the dead-host cooldown keeps repeat primary attempts cheap.
-        _candidates = [(endpoint_url, model, headers)] + list(fallbacks or [])
+        _candidates = [(endpoint_url, model, headers)] + list(_round_stack_fb)
         # stream_llm enforces a per-read INACTIVITY timeout (httpx read=timeout),
         # which kills a wedged/silent endpoint. This wall-clock deadline is the
         # complementary cap for the rare stream that trickles bytes forever and

--- a/src/constants.py
+++ b/src/constants.py
@@ -3,6 +3,8 @@
 import os
 
 APP_VERSION = "1.0.0"
+# Bump when local/dev behavior changes so you can confirm reload (shown in UI + /api/version).
+BUILD_STAMP = "auto-route-mode-v1"
 
 # Base paths
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__))) + "/"
@@ -67,6 +69,11 @@ MAX_DIFF_LINES = 400            # cap for edit_file unified-diff display
 MAX_CONTEXT_MESSAGES = 90
 REQUEST_TIMEOUT = 20
 OPENAI_COMPAT_PATH = "/v1/chat/completions"
+
+# Session sentinel for Auto (Local LLMs). Stored value must stay stable.
+LOCAL_LLM_ROUTER_AUTO_MODEL_ID = "__auto_stack__"
+LOCAL_LLM_ROUTER_NAME = "Local-LLM-Router"
+AUTO_SELECT_LABEL = "Auto (Local LLMs)"
 
 # Environment variables with defaults
 DEFAULT_HOST = os.getenv("LLM_HOST", "localhost")

--- a/src/local_llm_router_routing.py
+++ b/src/local_llm_router_routing.py
@@ -1,0 +1,521 @@
+"""Local-LLM-Router — Auto (Local LLMs) per-message routing."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any
+
+from src.constants import AUTO_SELECT_LABEL, LOCAL_LLM_ROUTER_AUTO_MODEL_ID
+from src.endpoint_resolver import (
+    _endpoint_enabled_models,
+    build_chat_url,
+    build_headers,
+    normalize_base,
+)
+from src.local_llm_router_runtime import load_local_llm_router, local_llm_router_available
+from src.settings import get_setting
+from src.teacher_escalation import is_self_hosted
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class LocalLlmRouterResolution:
+    endpoint_url: str
+    model: str
+    headers: dict
+    tier: str
+    route_reasons: tuple[str, ...]
+    pool: tuple[str, ...]
+
+
+def is_local_llm_router_auto_model(model: str | None) -> bool:
+    return (model or "").strip() == LOCAL_LLM_ROUTER_AUTO_MODEL_ID
+
+
+def is_local_llm_router_auto_session(sess, *, require_enabled: bool = False) -> bool:
+    return is_local_llm_router_auto_model(getattr(sess, "model", None))
+
+
+def is_local_llm_router_active(sess) -> bool:
+    if not is_local_llm_router_auto_session(sess):
+        return False
+    if not is_self_hosted(getattr(sess, "endpoint_url", "") or ""):
+        return False
+    return True
+
+
+def _match_tag(requested: str, models: list[str]) -> str | None:
+    if not requested or not models:
+        return None
+    if requested in models:
+        return requested
+    req_base = os.path.basename(requested.rstrip("/")).lower()
+    for mid in models:
+        if mid.lower() == requested.lower():
+            return mid
+        if os.path.basename(mid.rstrip("/")).lower() == req_base:
+            return mid
+    return None
+
+
+def _load_endpoint(*, endpoint_url: str, owner: str | None):
+    from core.database import ModelEndpoint, SessionLocal
+    from src.auth_helpers import owner_filter
+
+    session_base = normalize_base(endpoint_url or "")
+    if not session_base:
+        return None
+    db = SessionLocal()
+    try:
+        q = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True)
+        if owner:
+            q = owner_filter(q, ModelEndpoint, owner)
+        for ep in q.all():
+            try:
+                if normalize_base(ep.base_url or "") == session_base:
+                    return ep
+            except Exception:
+                continue
+        return None
+    finally:
+        db.close()
+
+
+def installed_tags_for_endpoint(
+    endpoint_url: str,
+    *,
+    owner: str | None = None,
+) -> list[str]:
+    ep = _load_endpoint(endpoint_url=endpoint_url, owner=owner)
+    if ep is None:
+        return []
+    return list(_endpoint_enabled_models(ep))
+
+
+class LocalLlmRouterNotReady(ValueError):
+    """Auto (Local LLMs) cannot route — missing endpoint models or pool too small."""
+
+    def __init__(self, message: str, *, code: str = "not_ready"):
+        self.code = code
+        super().__init__(message)
+
+
+def check_local_llm_router_ready(
+    endpoint_url: str,
+    *,
+    owner: str | None = None,
+) -> None:
+    if not (endpoint_url or "").strip():
+        raise LocalLlmRouterNotReady(
+            "Auto (Local LLMs) needs a local endpoint. "
+            "Add Ollama (or another local server) in Settings or Cookbook, then try again.",
+            code="no_endpoint",
+        )
+    installed = installed_tags_for_endpoint(endpoint_url, owner=owner)
+    if not installed:
+        raise LocalLlmRouterNotReady(
+            "No models are installed on your local endpoint yet. "
+            "Open Cookbook to pull at least 2 models, then refresh endpoints.",
+            code="no_models",
+        )
+    if len(installed) < 2:
+        only = installed[0]
+        raise LocalLlmRouterNotReady(
+            f"Auto (Local LLMs) needs at least 2 local models to route between; "
+            f"you have {len(installed)} ({only}). Open Cookbook to add another model.",
+            code="insufficient_models",
+        )
+
+
+def resolve_model_on_endpoint(
+    model_tag: str,
+    *,
+    endpoint_url: str,
+    headers: dict | None,
+    owner: str | None = None,
+) -> tuple[str, str, dict]:
+    ep = _load_endpoint(endpoint_url=endpoint_url, owner=owner)
+    if ep is None:
+        raise ValueError(f"No enabled endpoint matches {endpoint_url!r}")
+    enabled = _endpoint_enabled_models(ep)
+    matched = _match_tag(model_tag, enabled)
+    if not matched:
+        raise ValueError(
+            f"Model {model_tag!r} not found on endpoint {getattr(ep, 'name', endpoint_url)!r}. "
+            f"Installed: {', '.join(enabled[:8])}{'...' if len(enabled) > 8 else ''}"
+        )
+    base = normalize_base(ep.base_url)
+    chat_url = build_chat_url(base)
+    hdrs = build_headers(ep.api_key, base)
+    if headers:
+        hdrs.update(headers)
+    return chat_url, matched, hdrs
+
+
+def _vram_gb_from_hwfit(system: dict) -> float:
+    groups = system.get("gpu_groups") or []
+    if groups:
+        each = groups[0].get("vram_each")
+        if each:
+            return float(each)
+    gpus = system.get("gpus") or []
+    if gpus:
+        return max(float(g.get("vram_gb") or 0) for g in gpus)
+    return float(system.get("gpu_vram_gb") or 0)
+
+
+def _vram_detection_info() -> tuple[int, str]:
+    """Return (vram_gb, source) where source is manual | hwfit | fallback."""
+    manual = int(get_setting("local_llm_router_vram_gb", 0) or 0)
+    if manual > 0:
+        return manual, "manual"
+    try:
+        from services.hwfit.hardware import detect_system
+        system = detect_system() or {}
+        vram = _vram_gb_from_hwfit(system)
+        if vram > 0:
+            gb = max(8, int(round(vram)))
+            logger.info(
+                "[local_llm_router] hwfit vram=%s GB (gpu=%s) -> profile %s",
+                gb,
+                system.get("gpu_name"),
+                load_local_llm_router().profile_for_vram_gb(gb),
+            )
+            return gb, "hwfit"
+    except Exception as exc:
+        logger.debug("local_llm_router vram detect failed: %s", exc)
+    logger.warning("[local_llm_router] hwfit detect failed; falling back to 16 GB profile")
+    return 16, "fallback"
+
+
+def _detect_vram_gb() -> int:
+    gb, _ = _vram_detection_info()
+    return gb
+
+
+def _llr_quant() -> str:
+    return str(get_setting("local_llm_router_quant", "qat") or "qat").strip() or "qat"
+
+
+def _desired_stack(vram_gb: int, quant: str) -> list[str]:
+    router = load_local_llm_router()
+    profile = router.profile_for_vram_gb(vram_gb)
+    override = get_setting("local_llm_router_models", []) or []
+    if isinstance(override, list) and override:
+        return [str(m).strip() for m in override if str(m).strip()]
+    return list(router.recommended_models(profile, quant=quant))
+
+
+def _resolve_pool_against_installed(
+    desired: list[str],
+    installed: list[str],
+) -> tuple[list[str], list[str], str | None]:
+    """Match LLR session/poc stack resolution: recommended order, honest fallbacks."""
+    try:
+        from local_llm_router.poc_models import resolve_stack_against_pool
+
+        pool, missing, note = resolve_stack_against_pool(desired, installed)
+        return list(pool), list(missing), note
+    except Exception:
+        installed_set = set(installed)
+        pool = [name for name in desired if name in installed_set]
+        missing = [name for name in desired if name not in installed_set]
+        note = None
+        if len(pool) < 2 and len(installed) >= 2:
+            pool = list(installed)
+            note = (
+                f"Recommended stack not fully installed ({', '.join(desired)}). "
+                f"Using installed models: {', '.join(pool)}"
+            )
+        return pool, missing, note
+
+
+def _rebind_tier_slot(
+    tag: str | None,
+    pool: list[str],
+    *,
+    router: Any,
+    profile: str,
+) -> str | None:
+    if not tag or not pool:
+        return None
+    matched = _match_tag(tag, pool)
+    if matched:
+        return matched
+    try:
+        registry = router.load_registry(profile=profile)
+        target_w = router.model_weight(tag, registry)
+        ranked = sorted(
+            pool,
+            key=lambda name: (
+                abs(router.model_weight(name, registry) - target_w),
+                router.model_weight(name, registry),
+            ),
+        )
+        return ranked[0] if ranked else None
+    except Exception:
+        return pool[0]
+
+
+def _rebind_tier_map(
+    tiers: Any,
+    pool: list[str],
+    *,
+    router: Any,
+    profile: str,
+) -> Any:
+    """Map LLR preset tier_slots onto the installed pool (exact tag or closest weight)."""
+    from local_llm_router.models import TierMap
+
+    if not pool:
+        return tiers
+
+    simple = _rebind_tier_slot(tiers.simple, pool, router=router, profile=profile) or pool[0]
+    medium = _rebind_tier_slot(tiers.medium, pool, router=router, profile=profile) or simple
+    complex_model = _rebind_tier_slot(tiers.complex, pool, router=router, profile=profile) or medium
+    reasoning = _rebind_tier_slot(tiers.reasoning, pool, router=router, profile=profile) or complex_model
+    code = _rebind_tier_slot(getattr(tiers, "code", None), pool, router=router, profile=profile)
+    complex_alt = _rebind_tier_slot(
+        getattr(tiers, "complex_alt", None),
+        pool,
+        router=router,
+        profile=profile,
+    )
+    if complex_alt == complex_model:
+        complex_alt = None
+    return TierMap(
+        simple=simple,
+        medium=medium,
+        complex=complex_model,
+        reasoning=reasoning,
+        code=code,
+        complex_alt=complex_alt,
+    )
+
+
+def _build_llr_session(
+    installed: list[str],
+    *,
+    vram_gb: int | None = None,
+    quant: str | None = None,
+) -> dict[str, Any]:
+    """Build pool + tier ladder the same way LLR presets expect."""
+    router = load_local_llm_router()
+    vram = vram_gb if vram_gb is not None else _detect_vram_gb()
+    quant_mode = quant if quant is not None else _llr_quant()
+    profile = router.profile_for_vram_gb(vram)
+    override = get_setting("local_llm_router_models", []) or []
+    desired = _desired_stack(vram, quant_mode)
+    pool, missing, note = _resolve_pool_against_installed(desired, installed)
+
+    if isinstance(override, list) and override:
+        tiers = router.assign_tiers(pool)
+    else:
+        preset_tiers = router.assign_recommended_tiers(profile, quant=quant_mode)
+        tiers = _rebind_tier_map(preset_tiers, pool, router=router, profile=profile)
+
+    warnings: list[str] = []
+    try:
+        warnings = list(router.validate_tier_map(tiers, pool, profile=profile))
+    except Exception:
+        pass
+    if note:
+        warnings.insert(0, note)
+
+    return {
+        "profile": profile,
+        "vram_gb": vram,
+        "quant": quant_mode,
+        "desired": desired,
+        "pool": pool,
+        "missing": missing,
+        "tiers": tiers,
+        "warnings": warnings,
+        "note": note,
+    }
+
+
+def _configure_llr_from_installed(
+    installed: list[str],
+    *,
+    vram_gb: int | None = None,
+    quant: str | None = None,
+) -> dict[str, Any]:
+    ctx = _build_llr_session(installed, vram_gb=vram_gb, quant=quant)
+    router = load_local_llm_router()
+    router.configure(
+        vram_gb=ctx["vram_gb"],
+        quant=ctx["quant"],
+        models=list(ctx["pool"]),
+        tiers=ctx["tiers"],
+    )
+    return ctx
+
+
+def describe_local_llm_router_status(
+    endpoint_url: str,
+    *,
+    owner: str | None = None,
+) -> dict:
+    """Read-only Auto (Local LLMs) snapshot for the UI — no prompt, no routing."""
+    from src.local_llm_router_runtime import LOCAL_LLM_ROUTER_MISSING, local_llm_router_available
+
+    quant = _llr_quant()
+    vram_gb, vram_source = _vram_detection_info()
+    status: dict = {
+        "ready": False,
+        "code": "ok",
+        "message": "",
+        "router_available": local_llm_router_available(),
+        "vram_gb": vram_gb,
+        "vram_source": vram_source,
+        "profile": None,
+        "quant": quant,
+        "recommended": [],
+        "installed": [],
+        "pool": [],
+        "missing_pulls": [],
+        "tier_slots": {},
+        "stack_warnings": [],
+    }
+
+    if not status["router_available"]:
+        status["code"] = "router_missing"
+        status["message"] = LOCAL_LLM_ROUTER_MISSING
+        return status
+
+    try:
+        router = load_local_llm_router()
+        status["profile"] = router.profile_for_vram_gb(vram_gb)
+        status["recommended"] = _desired_stack(vram_gb, quant)
+    except Exception as exc:
+        status["code"] = "router_missing"
+        status["message"] = str(exc)
+        return status
+
+    url = (endpoint_url or "").strip()
+    if not url:
+        status["code"] = "no_endpoint"
+        status["message"] = (
+            "Auto (Local LLMs) needs a local endpoint. "
+            "Add Ollama (or another local server) in Settings or Cookbook, then try again."
+        )
+        return status
+
+    installed = installed_tags_for_endpoint(url, owner=owner)
+    status["installed"] = installed
+    status["missing_pulls"] = [m for m in status["recommended"] if m not in installed]
+
+    try:
+        check_local_llm_router_ready(url, owner=owner)
+    except LocalLlmRouterNotReady as exc:
+        status["code"] = exc.code
+        status["message"] = str(exc)
+        return status
+
+    try:
+        ctx = _build_llr_session(installed, vram_gb=vram_gb, quant=quant)
+        status["pool"] = ctx["pool"]
+        status["missing_pulls"] = ctx["missing"]
+        status["stack_warnings"] = ctx["warnings"]
+        router = load_local_llm_router()
+        status["tier_slots"] = router.describe_tiers(ctx["tiers"])
+        if len(ctx["pool"]) < 2:
+            raise LocalLlmRouterNotReady(
+                f"Auto (Local LLMs) needs 2+ installed models on your local endpoint; found {len(ctx['pool'])}. "
+                "Open Cookbook to add models, then refresh endpoints.",
+                code="insufficient_models",
+            )
+        status["ready"] = True
+        status["code"] = "ok"
+        status["message"] = ""
+    except LocalLlmRouterNotReady as exc:
+        status["code"] = exc.code
+        status["message"] = str(exc)
+
+    return status
+
+
+def build_model_pool(
+    endpoint_url: str,
+    *,
+    owner: str | None = None,
+) -> list[str]:
+    check_local_llm_router_ready(endpoint_url, owner=owner)
+    installed = installed_tags_for_endpoint(endpoint_url, owner=owner)
+    ctx = _build_llr_session(installed)
+    pool = ctx["pool"]
+    if len(pool) < 2:
+        raise LocalLlmRouterNotReady(
+            f"Auto (Local LLMs) needs 2+ installed models on your local endpoint; found {len(pool)}. "
+            "Open Cookbook to add models, then refresh endpoints.",
+            code="insufficient_models",
+        )
+    return pool
+
+
+def resolve_local_llm_router(
+    *,
+    prompt: str,
+    endpoint_url: str,
+    headers: dict | None,
+    owner: str | None = None,
+    mode: str,
+) -> LocalLlmRouterResolution:
+    installed = installed_tags_for_endpoint(endpoint_url, owner=owner)
+    ctx = _configure_llr_from_installed(installed)
+    pool = ctx["pool"]
+    router = load_local_llm_router()
+    decision = router.explain(prompt, mode=mode)
+    tier = decision.tier
+    tag = decision.model
+    reasons = tuple(decision.reasons)
+    url, model, hdrs = resolve_model_on_endpoint(
+        tag,
+        endpoint_url=endpoint_url,
+        headers=headers,
+        owner=owner,
+    )
+    logger.info(
+        "[local_llm_router] tier=%s model=%s mode=%s reasons=%s pool=%s",
+        tier,
+        model,
+        mode,
+        "; ".join(reasons),
+        ",".join(pool),
+    )
+    return LocalLlmRouterResolution(
+        endpoint_url=url,
+        model=model,
+        headers=hdrs,
+        tier=str(getattr(tier, "value", tier)),
+        route_reasons=reasons,
+        pool=tuple(pool),
+    )
+
+
+def local_llm_router_fallback_candidates(
+    resolution: LocalLlmRouterResolution,
+    *,
+    endpoint_url: str,
+    headers: dict | None,
+    owner: str | None = None,
+) -> list[tuple[str, str, dict]]:
+    out: list[tuple[str, str, dict]] = []
+    for tag in resolution.pool:
+        if tag == resolution.model:
+            continue
+        try:
+            url, model, hdrs = resolve_model_on_endpoint(
+                tag,
+                endpoint_url=endpoint_url,
+                headers=headers,
+                owner=owner,
+            )
+            out.append((url, model, hdrs))
+        except ValueError:
+            continue
+    return out

--- a/src/local_llm_router_runtime.py
+++ b/src/local_llm_router_runtime.py
@@ -1,0 +1,29 @@
+"""Lazy-load the local-llm-router PyPI package."""
+
+from __future__ import annotations
+
+from src.constants import LOCAL_LLM_ROUTER_NAME
+
+LOCAL_LLM_ROUTER_PIP = "local-llm-router[ollama]"
+LOCAL_LLM_ROUTER_MISSING = (
+    f"{LOCAL_LLM_ROUTER_NAME} is not installed. "
+    f"Install with `pip install '{LOCAL_LLM_ROUTER_PIP}'` or use Install in the model picker."
+)
+
+
+def load_local_llm_router():
+    """Return the local_llm_router module, or raise a user-facing setup hint."""
+    for mod_name in ("local_llm_router", "split_stack"):
+        try:
+            return __import__(mod_name)
+        except ImportError:
+            continue
+    raise RuntimeError(LOCAL_LLM_ROUTER_MISSING)
+
+
+def local_llm_router_available() -> bool:
+    try:
+        load_local_llm_router()
+        return True
+    except RuntimeError:
+        return False

--- a/src/settings.py
+++ b/src/settings.py
@@ -132,6 +132,10 @@ DEFAULT_SETTINGS = {
     "utility_model_fallbacks": [],
     "teacher_model": "",
     "teacher_enabled": False,
+    # Local-LLM-Router — Auto (Local LLMs) routing (see local_llm_router_routing.py)
+    "local_llm_router_vram_gb": 0,  # 0 = detect via hwfit
+    "local_llm_router_quant": "qat",
+    "local_llm_router_models": [],
     # Skills: minimum self-reported confidence for an auto-written (LLM-authored)
     # DRAFT skill to be injected into the agent prompt. Published skills always
     # qualify. Keeps low-confidence auto-skills out of context until they're
@@ -213,9 +217,22 @@ def save_settings(settings: dict):
     _invalidate_caches()
 
 
+_LLR_SETTING_LEGACY = {
+    "local_llm_router_vram_gb": "auto_stack_vram_gb",
+    "local_llm_router_quant": "auto_stack_quant",
+    "local_llm_router_models": "auto_stack_models",
+}
+
+
 def get_setting(key: str, default: Any = None) -> Any:
     """Read a single setting value."""
-    return load_settings().get(key, default)
+    settings = load_settings()
+    if key in settings:
+        return settings.get(key, default)
+    legacy = _LLR_SETTING_LEGACY.get(key)
+    if legacy is not None:
+        return settings.get(legacy, default)
+    return settings.get(key, default)
 
 
 def is_setting_overridden(key: str) -> bool:

--- a/src/task_endpoint.py
+++ b/src/task_endpoint.py
@@ -3,6 +3,35 @@
 from src.endpoint_resolver import resolve_endpoint
 
 
+def _resolve_local_llm_router_fallback(
+    endpoint_url,
+    model,
+    headers,
+    *,
+    owner=None,
+    prompt: str = "background utility task",
+):
+    """Map Auto (Local LLMs) sentinel to a concrete local model for background LLM calls."""
+    from src.local_llm_router_routing import (
+        is_local_llm_router_auto_model,
+        resolve_local_llm_router,
+    )
+
+    if not is_local_llm_router_auto_model(model) or not (endpoint_url or "").strip():
+        return endpoint_url, model, headers
+    try:
+        res = resolve_local_llm_router(
+            prompt=prompt,
+            endpoint_url=endpoint_url,
+            headers=headers,
+            owner=owner,
+            mode="chat",
+        )
+        return res.endpoint_url, res.model, res.headers
+    except Exception:
+        return endpoint_url, model, headers
+
+
 def resolve_task_endpoint(fallback_url=None, fallback_model=None, fallback_headers=None, owner=None):
     """Return (endpoint_url, model, headers) for background tasks.
 
@@ -10,4 +39,7 @@ def resolve_task_endpoint(fallback_url=None, fallback_model=None, fallback_heade
     Falls back to the provided values when the setting is empty or the
     endpoint cannot be resolved.
     """
-    return resolve_endpoint("task", fallback_url, fallback_model, fallback_headers, owner=owner)
+    url, model, headers = resolve_endpoint(
+        "task", fallback_url, fallback_model, fallback_headers, owner=owner,
+    )
+    return _resolve_local_llm_router_fallback(url, model, headers, owner=owner)

--- a/tests/test_local_llm_router_agent_round.py
+++ b/tests/test_local_llm_router_agent_round.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+def test_agent_loop_emits_local_llm_router_model_resolved():
+    source = Path("src/agent_loop.py").read_text(encoding="utf-8")
+
+    assert "local_llm_router_active" in source
+    assert "resolve_local_llm_router" in source
+    assert '"local_llm_router": True' in source
+    assert 'mode="agent"' in source

--- a/tests/test_local_llm_router_chat_context.py
+++ b/tests/test_local_llm_router_chat_context.py
@@ -1,0 +1,8 @@
+from types import SimpleNamespace
+
+from src.local_llm_router_routing import is_local_llm_router_auto_model
+
+
+def test_local_llm_router_skips_normalization_path():
+    sess = SimpleNamespace(model="__auto_stack__", endpoint_url="http://127.0.0.1:11434")
+    assert is_local_llm_router_auto_model(sess.model)

--- a/tests/test_local_llm_router_privileges.py
+++ b/tests/test_local_llm_router_privileges.py
@@ -1,0 +1,15 @@
+from src.local_llm_router_routing import is_local_llm_router_auto_model, is_local_llm_router_auto_session
+from src.constants import LOCAL_LLM_ROUTER_AUTO_MODEL_ID
+
+
+def test_local_llm_router_model_constant():
+    assert LOCAL_LLM_ROUTER_AUTO_MODEL_ID == "__auto_stack__"
+    assert is_local_llm_router_auto_model(LOCAL_LLM_ROUTER_AUTO_MODEL_ID)
+
+
+def test_local_llm_router_session_by_model_only():
+    class Sess:
+        model = LOCAL_LLM_ROUTER_AUTO_MODEL_ID
+
+    assert is_local_llm_router_auto_session(Sess()) is True
+    assert is_local_llm_router_auto_session(Sess(), require_enabled=True) is True

--- a/tests/test_local_llm_router_routing.py
+++ b/tests/test_local_llm_router_routing.py
@@ -1,0 +1,305 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.local_llm_router_routing import (
+    LocalLlmRouterNotReady,
+    LocalLlmRouterResolution,
+    build_model_pool,
+    check_local_llm_router_ready,
+    describe_local_llm_router_status,
+    is_local_llm_router_auto_model,
+    resolve_local_llm_router,
+    resolve_model_on_endpoint,
+)
+from src.constants import LOCAL_LLM_ROUTER_AUTO_MODEL_ID as CONST_ID
+
+
+def test_is_local_llm_router_auto_model():
+    assert is_local_llm_router_auto_model(CONST_ID)
+    assert not is_local_llm_router_auto_model("qwen3:8b")
+
+
+@patch("src.local_llm_router_routing.resolve_model_on_endpoint")
+@patch("src.local_llm_router_routing._configure_llr_from_installed")
+@patch("src.local_llm_router_routing.load_local_llm_router")
+def test_resolve_local_llm_router_passes_mode_and_reasons(mock_load_ss, mock_configure, mock_resolve):
+    mock_configure.return_value = {"pool": ["gemma4:e4b", "qwen3:8b"]}
+    decision = MagicMock()
+    decision.tier = MagicMock(value="simple")
+    decision.model = "gemma4:e4b"
+    decision.reasons = ("mode=agent", "keyword/heuristic scoring → tier simple")
+    router = MagicMock()
+    router.explain.return_value = decision
+    mock_load_ss.return_value = router
+    mock_resolve.return_value = ("http://127.0.0.1:11434/api/chat", "gemma4:e4b", {})
+
+    res = resolve_local_llm_router(
+        prompt="Reply with exactly: pong",
+        endpoint_url="http://127.0.0.1:11434",
+        headers={},
+        mode="agent",
+    )
+
+    mock_configure.assert_called_once()
+    router.explain.assert_called_once_with("Reply with exactly: pong", mode="agent")
+    assert isinstance(res, LocalLlmRouterResolution)
+    assert res.model == "gemma4:e4b"
+    assert res.route_reasons == ("mode=agent", "keyword/heuristic scoring → tier simple")
+
+
+@patch("src.local_llm_router_routing._load_endpoint")
+def test_resolve_model_on_endpoint_scoped(mock_load):
+    ep = MagicMock()
+    ep.base_url = "http://127.0.0.1:11434"
+    ep.name = "Ollama"
+    ep.api_key = ""
+    mock_load.return_value = ep
+    with patch("src.local_llm_router_routing._endpoint_enabled_models", return_value=["gemma4:e4b", "qwen3:8b"]):
+        with patch("src.local_llm_router_routing.build_chat_url", return_value="http://127.0.0.1:11434/api/chat"):
+            with patch("src.local_llm_router_routing.build_headers", return_value={"Authorization": "Bearer x"}):
+                url, model, headers = resolve_model_on_endpoint(
+                    "qwen3:8b",
+                    endpoint_url="http://127.0.0.1:11434",
+                    headers={"X-Test": "1"},
+                    owner=None,
+                )
+    assert model == "qwen3:8b"
+    assert "11434" in url
+    assert headers.get("X-Test") == "1"
+
+
+@patch("src.local_llm_router_routing.get_setting")
+@patch("src.local_llm_router_routing.load_local_llm_router")
+@patch("src.local_llm_router_routing.installed_tags_for_endpoint")
+def test_build_model_pool_intersection(mock_installed, mock_load_ss, mock_setting):
+    mock_installed.return_value = ["gemma4:e4b", "qwen3:8b", "qwen3:14b"]
+    mock_setting.side_effect = lambda key, default=None: {
+        "local_llm_router_vram_gb": 16,
+        "local_llm_router_quant": "qat",
+        "local_llm_router_models": [],
+    }.get(key, default)
+    ss = MagicMock()
+    ss.recommended_models.return_value = ["gemma4:e4b", "qwen3:8b", "qwen3:14b", "deepseek-r1:8b"]
+    mock_load_ss.return_value = ss
+    pool = build_model_pool("http://127.0.0.1:11434")
+    assert "gemma4:e4b" in pool
+    assert len(pool) >= 2
+
+
+@patch("src.local_llm_router_routing.get_setting")
+@patch("src.local_llm_router_routing.load_local_llm_router")
+@patch("src.local_llm_router_routing.installed_tags_for_endpoint")
+def test_build_model_pool_falls_back_to_installed_only(mock_installed, mock_load_ss, mock_setting):
+    mock_installed.return_value = ["qwen3:8b", "qwen3:14b", "llama3.2:3b"]
+    mock_setting.side_effect = lambda key, default=None: {
+        "local_llm_router_vram_gb": 16,
+        "local_llm_router_quant": "qat",
+        "local_llm_router_models": [],
+    }.get(key, default)
+    ss = MagicMock()
+    ss.recommended_models.return_value = ["gemma4:e4b", "qwen3:8b"]
+    mock_load_ss.return_value = ss
+    pool = build_model_pool("http://127.0.0.1:11434")
+    assert set(pool) == {"qwen3:8b", "qwen3:14b", "llama3.2:3b"}
+    assert len(pool) == 3
+
+
+@patch("src.local_llm_router_routing.installed_tags_for_endpoint")
+def test_check_local_llm_router_ready_no_models(mock_installed):
+    mock_installed.return_value = []
+    with pytest.raises(LocalLlmRouterNotReady) as exc:
+        check_local_llm_router_ready("http://127.0.0.1:11434/v1")
+    assert exc.value.code == "no_models"
+    assert "Cookbook" in str(exc.value)
+
+
+@patch("src.local_llm_router_routing.installed_tags_for_endpoint")
+def test_check_local_llm_router_ready_one_model(mock_installed):
+    mock_installed.return_value = ["qwen3:8b"]
+    with pytest.raises(LocalLlmRouterNotReady) as exc:
+        check_local_llm_router_ready("http://127.0.0.1:11434/v1")
+    assert exc.value.code == "insufficient_models"
+    assert "qwen3:8b" in str(exc.value)
+
+
+def test_check_local_llm_router_ready_no_endpoint():
+    with pytest.raises(LocalLlmRouterNotReady) as exc:
+        check_local_llm_router_ready("")
+    assert exc.value.code == "no_endpoint"
+
+
+@patch("src.local_llm_router_runtime.local_llm_router_available", return_value=True)
+@patch("src.local_llm_router_routing.get_setting")
+@patch("src.local_llm_router_routing.load_local_llm_router")
+@patch("src.local_llm_router_routing.installed_tags_for_endpoint")
+@patch("src.local_llm_router_routing.build_model_pool")
+def test_describe_local_llm_router_status_ready(
+    mock_pool, mock_installed, mock_load_ss, mock_setting, _mock_avail,
+):
+    mock_installed.return_value = ["gemma4:e4b", "qwen3:8b", "qwen3:14b"]
+    mock_pool.return_value = ["gemma4:e4b", "qwen3:8b"]
+    mock_setting.side_effect = lambda key, default=None: {
+        "local_llm_router_vram_gb": 16,
+        "local_llm_router_quant": "qat",
+        "local_llm_router_models": [],
+    }.get(key, default)
+    ss = MagicMock()
+    ss.profile_for_vram_gb.return_value = "medium"
+    ss.recommended_models.return_value = ["gemma4:e4b", "qwen3:8b", "deepseek-r1:8b"]
+    mock_load_ss.return_value = ss
+
+    status = describe_local_llm_router_status("http://127.0.0.1:11434")
+
+    assert status["ready"] is True
+    assert status["vram_gb"] == 16
+    assert status["profile"] == "medium"
+    assert status["pool"] == ["gemma4:e4b", "qwen3:8b"]
+    assert "deepseek-r1:8b" in status["missing_pulls"]
+
+
+@patch("src.local_llm_router_runtime.local_llm_router_available", return_value=False)
+def test_describe_local_llm_router_status_router_missing(_mock_avail):
+    status = describe_local_llm_router_status("http://127.0.0.1:11434")
+    assert status["ready"] is False
+    assert status["code"] == "router_missing"
+
+
+@patch("src.local_llm_router_runtime.local_llm_router_available", return_value=True)
+@patch("src.local_llm_router_routing.get_setting")
+@patch("src.local_llm_router_routing.load_local_llm_router")
+@patch("src.local_llm_router_routing.installed_tags_for_endpoint")
+def test_describe_local_llm_router_status_insufficient_models(
+    mock_installed, mock_load_ss, mock_setting, _mock_avail,
+):
+    mock_installed.return_value = ["qwen3:8b"]
+    mock_setting.side_effect = lambda key, default=None: {
+        "local_llm_router_vram_gb": 16,
+        "local_llm_router_quant": "qat",
+        "local_llm_router_models": [],
+    }.get(key, default)
+    ss = MagicMock()
+    ss.profile_for_vram_gb.return_value = "medium"
+    ss.recommended_models.return_value = ["gemma4:e4b", "qwen3:8b"]
+    mock_load_ss.return_value = ss
+
+    status = describe_local_llm_router_status("http://127.0.0.1:11434")
+
+    assert status["ready"] is False
+    assert status["code"] == "insufficient_models"
+    assert status["installed"] == ["qwen3:8b"]
+
+
+def test_vram_gb_from_hwfit_uses_per_gpu_not_total():
+    from src.local_llm_router_routing import _vram_gb_from_hwfit
+
+    # 2x 8 GB: total 16 but Ollama uses one card → 8 GB tier
+    system = {
+        "gpu_vram_gb": 16.0,
+        "gpu_groups": [
+            {"vram_each": 8.0, "count": 2, "vram_total": 16.0},
+        ],
+    }
+    assert _vram_gb_from_hwfit(system) == 8.0
+
+
+def test_match_tag_no_fuzzy_cross_model():
+    from src.local_llm_router_routing import _match_tag
+
+    assert _match_tag("gemma4:e4b", ["qwen3:8b", "qwen3:14b"]) is None
+    assert _match_tag("qwen3:8b", ["qwen3:8b", "qwen3:14b"]) == "qwen3:8b"
+
+
+@patch("src.local_llm_router_routing.resolve_local_llm_router")
+def test_resolve_task_endpoint_concrete_auto_stack(mock_resolve_stack):
+    from src.local_llm_router_routing import LocalLlmRouterResolution
+    from src.constants import LOCAL_LLM_ROUTER_AUTO_MODEL_ID
+    from src.task_endpoint import _resolve_local_llm_router_fallback
+
+    mock_resolve_stack.return_value = LocalLlmRouterResolution(
+        endpoint_url="http://127.0.0.1:11434/api/chat",
+        model="gemma4:e4b",
+        headers={},
+        tier="simple",
+        route_reasons=("mode=chat",),
+        pool=("gemma4:e4b", "qwen3:8b"),
+    )
+    url, model, headers = _resolve_local_llm_router_fallback(
+        "http://127.0.0.1:11434/v1",
+        LOCAL_LLM_ROUTER_AUTO_MODEL_ID,
+        {},
+    )
+    assert model == "gemma4:e4b"
+    assert "11434" in url
+
+
+def test_resolve_task_endpoint_passthrough_non_auto():
+    from src.task_endpoint import _resolve_local_llm_router_fallback
+
+    url, model, headers = _resolve_local_llm_router_fallback(
+        "http://127.0.0.1:11434/v1",
+        "qwen3:8b",
+        {"X": "1"},
+    )
+    assert model == "qwen3:8b"
+    assert headers == {"X": "1"}
+
+
+def test_build_llr_session_16gb_preset_tiers_and_pool_order():
+    from src.local_llm_router_routing import _build_llr_session
+
+    installed = [
+        "gemma4:e4b",
+        "qwen3.5:9b",
+        "qwen3.6:35b-a3b",
+        "qwen3:14b",
+        "qwen2.5-coder:14b",
+        "deepseek-r1:8b",
+    ]
+    ctx = _build_llr_session(installed, vram_gb=16, quant="qat")
+
+    assert ctx["profile"] == "workstation_16gb"
+    assert ctx["pool"] == [
+        "gemma4:e4b",
+        "qwen3.5:9b",
+        "qwen3.6:35b-a3b",
+        "qwen3:14b",
+        "qwen2.5-coder:14b",
+        "deepseek-r1:8b",
+    ]
+    assert ctx["tiers"].complex == "qwen3.6:35b-a3b"
+    assert ctx["tiers"].complex_alt == "qwen3:14b"
+    assert ctx["tiers"].code == "qwen2.5-coder:14b"
+
+
+@patch("src.local_llm_router_routing.get_setting")
+@patch("src.local_llm_router_routing.installed_tags_for_endpoint")
+def test_configure_uses_llr_preset_complex_and_complex_alt(mock_installed, mock_setting):
+    from src.local_llm_router_routing import _configure_llr_from_installed
+    from src.local_llm_router_runtime import load_local_llm_router
+
+    mock_setting.side_effect = lambda key, default=None: {
+        "local_llm_router_vram_gb": 16,
+        "local_llm_router_quant": "qat",
+        "local_llm_router_models": [],
+    }.get(key, default)
+    installed = [
+        "gemma4:e4b",
+        "qwen3.5:9b",
+        "qwen3.6:35b-a3b",
+        "qwen3:14b",
+        "qwen2.5-coder:14b",
+        "deepseek-r1:8b",
+    ]
+    mock_installed.return_value = installed
+
+    _configure_llr_from_installed(installed)
+    session = load_local_llm_router().get_session()
+    assert session.tiers.complex == "qwen3.6:35b-a3b"
+    assert session.tiers.complex_alt == "qwen3:14b"
+
+    router = load_local_llm_router()
+    agent = router.explain("architecture tradeoffs", hint="design", mode="agent")
+    chat = router.explain("architecture tradeoffs", hint="design", mode="chat")
+    assert agent.model == "qwen3.6:35b-a3b"
+    assert chat.model == "qwen3:14b"

--- a/tests/test_local_llm_router_runtime.py
+++ b/tests/test_local_llm_router_runtime.py
@@ -1,0 +1,29 @@
+import builtins
+
+import pytest
+
+from src.constants import LOCAL_LLM_ROUTER_AUTO_MODEL_ID
+from src.local_llm_router_runtime import LOCAL_LLM_ROUTER_MISSING, load_local_llm_router
+
+
+def _block_router_import(monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name in ("local_llm_router", "split_stack"):
+            raise ImportError(f"No module named {name}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+
+def test_missing_dependency_error_is_user_actionable(monkeypatch):
+    _block_router_import(monkeypatch)
+    with pytest.raises(RuntimeError) as exc:
+        load_local_llm_router()
+    assert str(exc.value) == LOCAL_LLM_ROUTER_MISSING
+    assert "Local-LLM-Router" in str(exc.value)
+
+
+def test_LOCAL_LLM_ROUTER_AUTO_MODEL_ID_constant():
+    assert LOCAL_LLM_ROUTER_AUTO_MODEL_ID == "__auto_stack__"


### PR DESCRIPTION
﻿## Summary
Wires LLR into chat, session, agent loop, and task endpoint.

**Slice scope:** routes/chat_helpers.py, chat_routes.py, session_routes.py, src/agent_loop.py, task_endpoint.py + agent/chat tests (~260/+28 lines).

**Merge order:** Draft — merge after #4020.

Part of #3073.

## How to Test
pytest tests/test_local_llm_router_agent_round.py tests/test_local_llm_router_chat_context.py
