### PR TITLE
feat: add a Claude (Anthropic) subscription model provider

### DIFF
--- a/app.py
+++ b/app.py
@@ -624,6 +624,10 @@ app.include_router(setup_copilot_routes())
 from routes.chatgpt_subscription_routes import setup_chatgpt_subscription_routes
 app.include_router(setup_chatgpt_subscription_routes())
 
+# Claude Subscription OAuth (PKCE) login
+from routes.claude_subscription_routes import setup_claude_subscription_routes
+app.include_router(setup_claude_subscription_routes())
+
 # TTS
 from routes.tts_routes import setup_tts_routes
 app.include_router(setup_tts_routes(tts_service))

--- a/core/database.py
+++ b/core/database.py
@@ -379,6 +379,10 @@ class ProviderAuthSession(TimestampMixin, Base):
     refresh_token = Column(EncryptedText, nullable=True)
     last_refresh = Column(DateTime, nullable=True)
     auth_mode = Column(String, nullable=True)
+    # Absolute access-token expiry (naive UTC). Used by OAuth providers whose
+    # access tokens are opaque (not JWTs) — e.g. the Claude subscription — so
+    # expiry can't be read from the token itself and must be stored.
+    expires_at = Column(DateTime, nullable=True)
 
 class McpServer(TimestampMixin, Base):
     """Admin-configured MCP (Model Context Protocol) tool servers."""
@@ -867,6 +871,35 @@ def _migrate_add_provider_auth_id_column():
             logging.getLogger(__name__).info("Migrated: added 'provider_auth_id' column + index to model_endpoints")
     except Exception as e:
         logging.getLogger(__name__).warning(f"model_endpoints.provider_auth_id migration failed: {e}")
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+def _migrate_add_provider_auth_expires_at_column():
+    """Add expires_at column to provider_auth_sessions if it doesn't exist.
+
+    OAuth providers with opaque (non-JWT) access tokens — the Claude
+    subscription — store absolute expiry here so the resolver can refresh
+    proactively instead of decoding the token.
+    """
+    import sqlite3
+    db_path = DATABASE_URL.replace("sqlite:///", "")
+    if not os.path.exists(db_path):
+        return
+    conn = None
+    try:
+        conn = sqlite3.connect(db_path)
+        cursor = conn.execute("PRAGMA table_info(provider_auth_sessions)")
+        columns = [row[1] for row in cursor.fetchall()]
+        if columns and "expires_at" not in columns:
+            conn.execute("ALTER TABLE provider_auth_sessions ADD COLUMN expires_at DATETIME")
+            conn.commit()
+            logging.getLogger(__name__).info("Migrated: added 'expires_at' column to provider_auth_sessions")
+    except Exception as e:
+        logging.getLogger(__name__).warning(f"provider_auth_sessions.expires_at migration failed: {e}")
     finally:
         try:
             conn.close()
@@ -1738,6 +1771,7 @@ def init_db():
     _migrate_add_model_endpoint_refresh_columns()
     _migrate_add_model_endpoint_owner_column()
     _migrate_add_provider_auth_id_column()
+    _migrate_add_provider_auth_expires_at_column()
     _migrate_add_supports_tools_column()
     _migrate_add_task_run_model_column()
     _migrate_add_owner_column()

--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -474,6 +474,9 @@ def setup_chat_routes(
         use_research = form_data.get("use_research")
         time_filter = form_data.get("time_filter")
         preset_id = form_data.get("preset_id")
+        # Reasoning effort for Anthropic effort-capable models (Opus 4.5+/Sonnet
+        # 4.6+/Fable). Ignored by other providers/models. UI-selectable per turn.
+        effort = form_data.get("effort") or (body or {}).get("effort")
         # Issue #3229: API callers send JSON, not FormData.  Read from the
         # JSON body as fallback so callers who send {"allow_bash": true}
         # actually get bash enabled.
@@ -1035,6 +1038,7 @@ def setup_chat_routes(
                         prompt_type=preset_id,
                         tools=None,
                         session_id=session,
+                        effort=effort,
                     ):
                         if chunk.startswith("data: ") and not chunk.startswith("data: [DONE]"):
                             try:

--- a/routes/claude_subscription_routes.py
+++ b/routes/claude_subscription_routes.py
@@ -1,0 +1,133 @@
+"""Claude Subscription setup route.
+
+The Claude subscription OAuth (``claude setup-token`` / the Claude Code CLI)
+redirects to a localhost loopback, which a browser can't reach for a remote
+server — so the user runs that OAuth locally and pastes the resulting token
+here. One admin-only endpoint validates the token and provisions the endpoint:
+
+  POST /api/claude-subscription/complete  (form: token) -> { id, name, base_url, models }
+
+Only the access/refresh tokens are persisted (encrypted at rest via
+ProviderAuthSession).
+"""
+
+import json
+import logging
+import uuid
+from datetime import timedelta
+from typing import Dict, Optional
+
+from fastapi import APIRouter, Form, HTTPException, Request
+
+from core.database import ModelEndpoint, ProviderAuthSession, SessionLocal, utcnow_naive
+from core.middleware import require_admin
+from src import claude_subscription
+from src.auth_helpers import get_current_user
+
+logger = logging.getLogger(__name__)
+
+
+def _provision_endpoint(access_token, refresh_token, expires_at, owner: Optional[str]) -> Dict:
+    if not access_token:
+        raise ValueError("No access token found in the pasted value.")
+
+    base = claude_subscription.DEFAULT_CLAUDE_SUBSCRIPTION_BASE_URL
+    models = claude_subscription.fetch_available_models(access_token)
+    if not models:
+        raise claude_subscription.ClaudeSubscriptionReauthRequired(
+            "Token did not authorize any Claude models — it may be invalid or expired."
+        )
+
+    if expires_at is None:
+        expires_at = utcnow_naive() + timedelta(days=claude_subscription.CLAUDE_DEFAULT_TOKEN_TTL_DAYS)
+
+    db = SessionLocal()
+    try:
+        auth = (
+            db.query(ProviderAuthSession)
+            .filter(
+                ProviderAuthSession.provider == claude_subscription.CLAUDE_SUBSCRIPTION_PROVIDER,
+                ProviderAuthSession.owner == owner,
+            )
+            .first()
+        )
+        if auth is None:
+            auth = ProviderAuthSession(
+                id=str(uuid.uuid4())[:8],
+                provider=claude_subscription.CLAUDE_SUBSCRIPTION_PROVIDER,
+                owner=owner,
+                label="Claude Subscription",
+                base_url=base,
+                auth_mode="claude",
+            )
+            db.add(auth)
+        auth.base_url = base
+        auth.access_token = access_token
+        auth.refresh_token = refresh_token or ""
+        auth.expires_at = expires_at
+        auth.last_refresh = utcnow_naive()
+        auth.auth_mode = "claude"
+
+        ep = (
+            db.query(ModelEndpoint)
+            .filter(
+                ModelEndpoint.base_url == base,
+                ModelEndpoint.provider_auth_id == auth.id,
+                ModelEndpoint.owner == owner,
+            )
+            .first()
+        )
+        if ep is None:
+            ep = ModelEndpoint(
+                id=str(uuid.uuid4())[:8],
+                name="Claude Subscription",
+                base_url=base,
+                model_type="llm",
+                endpoint_kind="api",
+                owner=owner,
+            )
+            db.add(ep)
+        ep.name = "Claude Subscription"
+        ep.base_url = base
+        ep.api_key = None
+        ep.provider_auth_id = auth.id
+        ep.is_enabled = True
+        ep.supports_tools = True
+        ep.model_type = "llm"
+        ep.endpoint_kind = "api"
+        ep.model_refresh_mode = "manual"
+        ep.cached_models = json.dumps(models)
+        db.commit()
+        result = {"id": ep.id, "name": ep.name, "base_url": ep.base_url, "models": models}
+    finally:
+        db.close()
+
+    try:
+        from routes.model_routes import _invalidate_models_cache
+
+        _invalidate_models_cache()
+    except Exception:
+        pass
+    return result
+
+
+def setup_claude_subscription_routes() -> APIRouter:
+    router = APIRouter(prefix="/api/claude-subscription", tags=["claude-subscription"])
+
+    @router.post("/complete")
+    def complete(request: Request, token: str = Form(...)):
+        require_admin(request)
+        try:
+            access, refresh, expires_at = claude_subscription.parse_pasted_credentials(token)
+        except Exception as exc:
+            raise claude_subscription.to_http_exception(exc)
+        if not access:
+            raise HTTPException(400, "No token found in the pasted value.")
+        try:
+            result = _provision_endpoint(access, refresh, expires_at, get_current_user(request) or None)
+        except Exception as exc:
+            logger.exception("Claude Subscription endpoint provisioning failed")
+            raise claude_subscription.to_http_exception(exc)
+        return {"status": "authorized", "endpoint": result}
+
+    return router

--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -572,7 +572,9 @@ def _safe_build_headers(api_key: Optional[str], base_url: str) -> dict:
 
 
 def _is_discovery_only_provider(provider: str) -> bool:
-    return provider == "chatgpt-subscription"
+    # Subscription providers list models via discovery, not per-model completion
+    # probes (a probe would burn subscription quota / trip rate limits).
+    return provider in ("chatgpt-subscription", "claude-subscription")
 
 
 def _resolve_probe_key(ep) -> Optional[str]:
@@ -705,6 +707,11 @@ def _probe_endpoint(base_url: str, api_key: str = None, timeout: int = 5) -> Lis
     from src.endpoint_resolver import resolve_url
     base = resolve_url(_normalize_base(base_url))
     provider = _safe_detect_provider(base)
+    if provider == "claude-subscription":
+        from src.claude_subscription import fetch_available_models
+        if api_key:
+            return fetch_available_models(api_key, timeout=timeout)
+        return []
     if provider == "chatgpt-subscription":
         from src.chatgpt_subscription import fetch_available_models
         if api_key:

--- a/src/claude_subscription.py
+++ b/src/claude_subscription.py
@@ -1,0 +1,307 @@
+"""Claude (Anthropic) subscription token provider.
+
+Lets an Odysseus admin use their Claude Pro/Max **subscription** for inference
+instead of a pay-per-token Anthropic API key, by pasting a Claude Code OAuth
+token (run ``claude setup-token`` locally, or paste the credential JSON Claude
+Code stores). Mirrors the existing ChatGPT Subscription provider.
+
+Why paste a token instead of an in-app OAuth flow: the Claude subscription
+OAuth (``claude setup-token`` / the Claude Code CLI) redirects to a
+``http://localhost:PORT/callback`` loopback, which a browser cannot reach for a
+*remote* server. So the user runs the OAuth where the loopback works (their own
+machine) and pastes the resulting token here.
+
+Auth differs from the API-key Anthropic provider in exactly one way: requests
+carry ``Authorization: Bearer <token>`` plus ``anthropic-beta: oauth-2025-04-20``
+instead of ``x-api-key``. Everything else (the /v1/messages payload, response
+parsing, streaming) is shared with the Anthropic path in ``src/llm_core.py``.
+
+Note on terms of service: a subscription is intended for first-party Claude
+surfaces (Claude apps, Claude Code). Routing a third-party app through it is a
+grey area and the account owner accepts that risk by connecting here. The
+mechanism is symmetric with the existing ChatGPT Subscription provider.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from datetime import datetime, timezone, timedelta
+from typing import Any, Dict, List, Optional, Tuple
+
+import httpx
+from fastapi import HTTPException
+
+CLAUDE_SUBSCRIPTION_PROVIDER = "claude-subscription"
+
+# Real Anthropic API root that requests are sent to.
+ANTHROPIC_API_BASE = (
+    os.getenv("CLAUDE_SUBSCRIPTION_API_BASE", "").strip().rstrip("/")
+    or "https://api.anthropic.com"
+)
+# Sentinel base_url stored on the ModelEndpoint / ProviderAuthSession. The
+# trailing ``/oauth`` marker is what makes ``_detect_provider`` classify this
+# endpoint as ``claude-subscription`` (OAuth bearer) rather than the API-key
+# ``anthropic`` provider — both live on the same host. It is stripped back to
+# ANTHROPIC_API_BASE when the real /v1/messages or /v1/models URL is built.
+DEFAULT_CLAUDE_SUBSCRIPTION_BASE_URL = f"{ANTHROPIC_API_BASE}/oauth"
+
+# Public OAuth client used by the Claude Code CLI / `claude setup-token`. Only
+# used to refresh a token that was pasted together with a refresh token.
+CLAUDE_OAUTH_CLIENT_ID = (
+    os.getenv("CLAUDE_OAUTH_CLIENT_ID", "").strip()
+    or "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+)
+CLAUDE_OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
+
+# Beta header that authorizes an OAuth-bearer token on /v1/messages.
+CLAUDE_OAUTH_BETA = "oauth-2025-04-20"
+ANTHROPIC_VERSION = "2023-06-01"
+
+# Refresh the access token this many seconds before it actually expires.
+CLAUDE_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 300
+# Tokens pasted without an explicit expiry (e.g. `claude setup-token`, ~1 year)
+# get this lifetime so the resolver never tries to refresh a non-refreshable
+# token. It is validated against /v1/models at connect time regardless.
+CLAUDE_DEFAULT_TOKEN_TTL_DAYS = 365
+
+_AUTH_REFRESH_LOCKS: dict[str, threading.Lock] = {}
+_AUTH_REFRESH_LOCKS_GUARD = threading.Lock()
+
+
+def _database_handles():
+    from core.database import ProviderAuthSession, SessionLocal, utcnow_naive
+
+    return ProviderAuthSession, SessionLocal, utcnow_naive
+
+
+def _refresh_lock_for(auth_id: str) -> threading.Lock:
+    with _AUTH_REFRESH_LOCKS_GUARD:
+        lock = _AUTH_REFRESH_LOCKS.get(auth_id)
+        if lock is None:
+            lock = threading.Lock()
+            _AUTH_REFRESH_LOCKS[auth_id] = lock
+        return lock
+
+
+class ClaudeSubscriptionError(RuntimeError):
+    """Base error for Claude subscription provider failures."""
+
+
+class ClaudeSubscriptionReauthRequired(ClaudeSubscriptionError):
+    """Stored credentials are invalid/expired beyond refresh; reconnect needed."""
+
+
+class ClaudeSubscriptionRateLimited(ClaudeSubscriptionError):
+    """Upstream quota/rate limit; reconnecting will not fix it."""
+
+
+class ClaudeSubscriptionAuthNotFound(ClaudeSubscriptionError):
+    """No matching owner-scoped auth session exists."""
+
+
+def is_claude_subscription_base(url: str) -> bool:
+    """True for the Claude-subscription sentinel base (``…anthropic.com/oauth``).
+
+    Checked before the plain ``anthropic.com`` host match in ``_detect_provider``
+    so an OAuth-backed endpoint is not misread as the API-key provider.
+    """
+    try:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(url or "")
+        host = (parsed.hostname or "").lower().rstrip(".")
+        path = (parsed.path or "").rstrip("/")
+    except Exception:
+        return False
+    if not (host == "anthropic.com" or host.endswith(".anthropic.com")):
+        return False
+    return path.endswith("/oauth")
+
+
+# ── OAuth bearer headers (shared with src/llm_core anthropic path) ──
+
+def claude_oauth_headers(access_token: Optional[str]) -> Dict[str, str]:
+    """Headers for an OAuth-bearer Anthropic request (no x-api-key)."""
+    headers = {
+        "anthropic-version": ANTHROPIC_VERSION,
+        "anthropic-beta": CLAUDE_OAUTH_BETA,
+    }
+    if access_token:
+        headers["Authorization"] = f"Bearer {access_token}"
+    return headers
+
+
+# ── Pasted-credential parsing ──
+
+def parse_pasted_credentials(text: str) -> Tuple[str, str, Optional[datetime]]:
+    """Parse a pasted Claude token into (access_token, refresh_token, expires_at).
+
+    Accepts either a bare access token (``sk-ant-oat01-…`` from
+    ``claude setup-token``) or the credential JSON Claude Code stores
+    (``{"claudeAiOauth": {"accessToken", "refreshToken", "expiresAt"}}`` or a
+    flat ``{"access_token", ...}``). ``expires_at`` is naive UTC, or None when
+    the pasted value carries no expiry.
+    """
+    text = (text or "").strip()
+    if not text:
+        return "", "", None
+    if text.startswith("{"):
+        try:
+            data = json.loads(text)
+        except Exception as exc:
+            raise ClaudeSubscriptionReauthRequired(
+                "Pasted value is not a valid token or credential JSON."
+            ) from exc
+        obj = data.get("claudeAiOauth") if isinstance(data.get("claudeAiOauth"), dict) else data
+        access = (obj.get("accessToken") or obj.get("access_token") or "").strip()
+        refresh = (obj.get("refreshToken") or obj.get("refresh_token") or "").strip()
+        raw_exp = obj.get("expiresAt") or obj.get("expires_at")
+        expires_at = None
+        if isinstance(raw_exp, (int, float)) and raw_exp > 0:
+            secs = raw_exp / 1000.0 if raw_exp > 1e12 else float(raw_exp)
+            try:
+                expires_at = datetime.fromtimestamp(secs, tz=timezone.utc).replace(tzinfo=None)
+            except Exception:
+                expires_at = None
+        return access, refresh, expires_at
+    # Bare access token.
+    return text, "", None
+
+
+# ── Model discovery ──
+
+def fetch_available_models(access_token: str, timeout: float = 12.0) -> List[str]:
+    """List Claude chat model IDs available to this subscription via /v1/models."""
+    if not access_token:
+        return []
+    try:
+        response = httpx.get(
+            f"{ANTHROPIC_API_BASE}/v1/models?limit=100",
+            headers=claude_oauth_headers(access_token),
+            timeout=timeout,
+        )
+        if response.status_code != 200:
+            return []
+        data = response.json()
+    except Exception:
+        return []
+    entries = data.get("data", []) if isinstance(data, dict) else []
+    ordered: List[str] = []
+    seen: set[str] = set()
+    for item in entries:
+        if not isinstance(item, dict):
+            continue
+        mid = item.get("id")
+        if not isinstance(mid, str) or not mid.startswith("claude"):
+            continue
+        if mid not in seen:
+            ordered.append(mid)
+            seen.add(mid)
+    return ordered
+
+
+# ── Token refresh (only when a refresh token was provided) ──
+
+def refresh_oauth_tokens(refresh_token: str, timeout: float = 20.0) -> Dict[str, Any]:
+    if not refresh_token:
+        raise ClaudeSubscriptionReauthRequired(
+            "Claude Subscription has no refresh token. Reconnect with a fresh token."
+        )
+    response = httpx.post(
+        CLAUDE_OAUTH_TOKEN_URL,
+        json={
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": CLAUDE_OAUTH_CLIENT_ID,
+        },
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        timeout=timeout,
+        follow_redirects=True,
+    )
+    if response.status_code == 429:
+        raise ClaudeSubscriptionRateLimited("Claude Subscription rate limit hit during refresh.")
+    if response.status_code >= 400:
+        raise ClaudeSubscriptionReauthRequired(
+            f"Claude Subscription token refresh failed (HTTP {response.status_code}). Reconnect."
+        )
+    try:
+        data = response.json()
+    except Exception as exc:
+        raise ClaudeSubscriptionError("Claude Subscription refresh returned invalid JSON.") from exc
+    if not isinstance(data, dict) or not data.get("access_token"):
+        raise ClaudeSubscriptionReauthRequired("Claude Subscription refresh returned no access token.")
+    return data
+
+
+# ── Runtime credential resolution (refresh-aware) ──
+
+def _access_token_is_expiring(expires_at, utcnow_naive, skew_seconds: int) -> bool:
+    """True when there's no stored expiry or it's within ``skew_seconds`` of now."""
+    if not expires_at:
+        return True
+    try:
+        return expires_at <= (utcnow_naive() + timedelta(seconds=int(skew_seconds)))
+    except Exception:
+        return True
+
+
+def resolve_runtime_credentials(
+    auth_id: str, owner: Optional[str] = None, *, force_refresh: bool = False
+) -> Dict[str, Any]:
+    ProviderAuthSession, SessionLocal, utcnow_naive = _database_handles()
+    db = SessionLocal()
+    try:
+        q = db.query(ProviderAuthSession).filter(
+            ProviderAuthSession.id == auth_id,
+            ProviderAuthSession.provider == CLAUDE_SUBSCRIPTION_PROVIDER,
+        )
+        if owner:
+            q = q.filter(ProviderAuthSession.owner == owner)
+        row = q.first()
+        if row is None:
+            raise ClaudeSubscriptionAuthNotFound(
+                "Claude Subscription credentials were not found for this user."
+            )
+
+        expiring = force_refresh or _access_token_is_expiring(
+            getattr(row, "expires_at", None), utcnow_naive, CLAUDE_ACCESS_TOKEN_REFRESH_SKEW_SECONDS
+        )
+        # Only a token pasted *with* a refresh token can be refreshed; a bare
+        # `claude setup-token` token cannot, so it's used until it expires.
+        if expiring and (row.refresh_token or "").strip():
+            with _refresh_lock_for(auth_id):
+                db.refresh(row)
+                expiring = force_refresh or _access_token_is_expiring(
+                    getattr(row, "expires_at", None), utcnow_naive,
+                    CLAUDE_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
+                )
+                if expiring and (row.refresh_token or "").strip():
+                    refreshed = refresh_oauth_tokens(row.refresh_token)
+                    row.access_token = refreshed["access_token"]
+                    if refreshed.get("refresh_token"):
+                        row.refresh_token = refreshed["refresh_token"]
+                    expires_in = refreshed.get("expires_in")
+                    if isinstance(expires_in, (int, float)) and expires_in > 0:
+                        row.expires_at = utcnow_naive() + timedelta(seconds=int(expires_in))
+                    row.last_refresh = utcnow_naive()
+                    db.commit()
+                    db.refresh(row)
+
+        return {
+            "provider": CLAUDE_SUBSCRIPTION_PROVIDER,
+            "base_url": (row.base_url or DEFAULT_CLAUDE_SUBSCRIPTION_BASE_URL).rstrip("/"),
+            "api_key": row.access_token or "",
+            "auth_mode": row.auth_mode or "claude",
+        }
+    finally:
+        db.close()
+
+
+def to_http_exception(exc: Exception) -> HTTPException:
+    if isinstance(exc, ClaudeSubscriptionRateLimited):
+        return HTTPException(429, str(exc))
+    if isinstance(exc, (ClaudeSubscriptionReauthRequired, ClaudeSubscriptionAuthNotFound)):
+        return HTTPException(401, f"{exc} Reconnect the provider.")
+    return HTTPException(502, str(exc))

--- a/src/endpoint_resolver.py
+++ b/src/endpoint_resolver.py
@@ -81,12 +81,28 @@ def resolve_endpoint_runtime(ep, owner: Optional[str] = None) -> Tuple[str, Opti
     api_key = getattr(ep, "api_key", None)
     auth_id = getattr(ep, "provider_auth_id", None)
     if auth_id:
-        from src.chatgpt_subscription import resolve_runtime_credentials
-
+        resolve_runtime_credentials = _runtime_resolver_for(base)
         creds = resolve_runtime_credentials(auth_id, owner=owner)
         base = normalize_base(creds.get("base_url") or base)
         api_key = creds.get("api_key")
     return base, api_key
+
+
+def _runtime_resolver_for(base_url: str):
+    """Pick the credential resolver for a subscription endpoint by its base URL.
+
+    Keyed on the endpoint's own base URL (always present) rather than a
+    ProviderAuthSession lookup, so a transiently-missing auth row still routes
+    to the correct provider's resolver — which then raises its own
+    correctly-named error instead of a misleading one.
+    """
+    if _detect_provider(base_url or "") == "claude-subscription":
+        from src.claude_subscription import resolve_runtime_credentials
+
+        return resolve_runtime_credentials
+    from src.chatgpt_subscription import resolve_runtime_credentials
+
+    return resolve_runtime_credentials
 
 
 # Cache for Tailscale hostname → IP resolution
@@ -173,6 +189,11 @@ def build_chat_url(base: str) -> str:
     """Return the correct chat endpoint URL for a given base."""
     base = resolve_url(base)
     provider = _detect_provider(base)
+    if provider == "claude-subscription":
+        # Keep the /oauth sentinel so downstream _detect_provider still routes
+        # this as claude-subscription; _normalize_anthropic_url builds the real
+        # /v1/messages URL (stripping /oauth) at request time.
+        return base
     if provider == "anthropic":
         return _anthropic_api_root(base) + "/v1/messages"
     if provider == "ollama":
@@ -186,6 +207,9 @@ def build_models_url(base: str) -> Optional[str]:
     """Return the provider-specific model-list endpoint URL for a base."""
     base = normalize_base(resolve_url(base))
     provider = _detect_provider(base)
+    if provider == "claude-subscription":
+        root = base[: -len("/oauth")].rstrip("/") if base.endswith("/oauth") else base
+        return _anthropic_api_root(root) + "/v1/models"
     if provider == "anthropic":
         return _anthropic_api_root(base) + "/v1/models"
     if provider == "ollama":
@@ -199,6 +223,9 @@ def build_headers(api_key: Optional[str], base: str) -> Dict[str, str]:
     """Build auth headers for an endpoint."""
     provider = _detect_provider(base)
     headers: Dict[str, str] = {}
+    if provider == "claude-subscription":
+        from src.claude_subscription import claude_oauth_headers
+        return claude_oauth_headers(api_key)
     if provider == "anthropic":
         if api_key:
             headers["x-api-key"] = api_key

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -434,6 +434,12 @@ def _detect_provider(url: str) -> str:
     """
     if _is_ollama_native_url(url):
         return "ollama"
+    # Checked before the plain anthropic.com host match: the OAuth-backed
+    # subscription endpoint lives on the same host, distinguished by an /oauth
+    # marker in its stored base URL.
+    from src.claude_subscription import is_claude_subscription_base
+    if is_claude_subscription_base(url):
+        return "claude-subscription"
     if _host_match(url, "anthropic.com"):
         return "anthropic"
     if _host_match(url, "opencode.ai/zen/go"):
@@ -453,6 +459,16 @@ def _detect_provider(url: str) -> str:
     if is_copilot_base(url):
         return "copilot"
     return "openai"
+
+
+def _is_anthropic_like(provider: str) -> bool:
+    """Providers that speak the Anthropic /v1/messages API.
+
+    ``anthropic`` (API key, x-api-key) and ``claude-subscription`` (OAuth
+    bearer) share request/response/stream handling; only the auth header
+    differs (see ``_build_anthropic_headers``).
+    """
+    return provider in ("anthropic", "claude-subscription")
 
 
 def _is_self_hosted_openai_compatible(url: str) -> bool:
@@ -524,6 +540,8 @@ def _provider_label(url: str) -> str:
     """Human-friendly provider name for error messages."""
     if not url:
         return "provider"
+    from src.claude_subscription import is_claude_subscription_base
+    if is_claude_subscription_base(url): return "Claude Subscription"
     if _host_match(url, "anthropic.com"): return "Anthropic"
     if _host_match(url, "ollama.com"): return "Ollama Cloud"
     if _host_match(url, "x.ai"): return "xAI"
@@ -712,6 +730,47 @@ def _anthropic_rejects_temperature(model: str) -> bool:
         return False
     return (int(match.group(1)), int(match.group(2))) >= (4, 7)
 
+
+# Valid values for Anthropic's output_config.effort (xhigh is Opus 4.7/4.8 only,
+# but Anthropic ignores/handles an unsupported level gracefully per model).
+_EFFORT_VALUES = {"low", "medium", "high", "xhigh", "max"}
+
+
+def _anthropic_supports_effort(model: str) -> bool:
+    """Models that accept output_config.effort: Opus 4.5+, Sonnet 4.6+, Fable/Mythos."""
+    if not isinstance(model, str) or not model:
+        return False
+    m = model.lower()
+    if "fable" in m or "mythos" in m:
+        return True
+    om = re.search(r"(?<![a-z])opus[-_]?(\d+)[-_.](\d{1,2})(?!\d)", m)
+    if om:
+        return (int(om.group(1)), int(om.group(2))) >= (4, 5)
+    sm = re.search(r"(?<![a-z])sonnet[-_]?(\d+)[-_.](\d{1,2})(?!\d)", m)
+    if sm:
+        return (int(sm.group(1)), int(sm.group(2))) >= (4, 6)
+    return False
+
+
+def _anthropic_supports_1m_context(model: str) -> bool:
+    """Models with a 1M context window (Opus 4.6+, Sonnet 4.6+, Fable/Mythos).
+
+    Gates the `context-1m-2025-08-07` beta header so requests can use the full
+    1M window (the Claude Code CLI sends this same beta).
+    """
+    if not isinstance(model, str) or not model:
+        return False
+    m = model.lower()
+    if "fable" in m or "mythos" in m:
+        return True
+    om = re.search(r"(?<![a-z])opus[-_]?(\d+)[-_.](\d{1,2})(?!\d)", m)
+    if om:
+        return (int(om.group(1)), int(om.group(2))) >= (4, 6)
+    sm = re.search(r"(?<![a-z])sonnet[-_]?(\d+)[-_.](\d{1,2})(?!\d)", m)
+    if sm:
+        return (int(sm.group(1)), int(sm.group(2))) >= (4, 6)
+    return False
+
 # Models that support structured thinking — may output </think> without opening tag
 _THINKING_MODEL_PATTERNS = ("qwen3", "qwq", "deepseek-r1", "deepseek-reasoner", "minimax", "m2-reap", "gemma")
 
@@ -765,7 +824,29 @@ def _convert_openai_content_to_anthropic(content):
     return converted
 
 
-def _build_anthropic_payload(model, messages, temperature, max_tokens, stream=False, tools=None):
+# Required first system block for OAuth-subscription (claude-subscription)
+# requests: Anthropic soft-blocks premium models (Opus/Sonnet) with a 429 unless
+# the request presents the Claude Code identity, even when quota is available.
+# Haiku is exempt, but sending it for every OAuth request is harmless and keeps
+# behavior uniform. One line is enough — the user's own system prompt follows
+# and still applies.
+_CLAUDE_CODE_OAUTH_SYSTEM = "You are Claude Code, Anthropic's official CLI for Claude."
+
+# The identity line above is required only to pass Anthropic's gate, but it
+# primes terse, coding-CLI behavior. This second block re-frames the model as a
+# general claude.ai-style chat assistant. It goes AFTER the identity and BEFORE
+# the user's own system prompt, which still takes precedence.
+_CLAUDE_CODE_OAUTH_REFRAME = (
+    "You are operating as a general-purpose AI assistant in a chat interface, "
+    "not a terminal or a coding session. Be warm, clear, and genuinely helpful "
+    "across any topic the user brings up (writing, analysis, advice, coding, or "
+    "casual conversation), the way Claude responds on claude.ai. Explain your "
+    "reasoning when it helps and match the user's tone and language. Any "
+    "instructions or persona the user provides below take precedence over this."
+)
+
+
+def _build_anthropic_payload(model, messages, temperature, max_tokens, stream=False, tools=None, oauth=False, effort=None):
     """Convert OpenAI-style messages to Anthropic format."""
     system_parts = []
     chat_messages = []
@@ -816,10 +897,31 @@ def _build_anthropic_payload(model, messages, temperature, max_tokens, stream=Fa
         "messages": chat_messages,
         "max_tokens": max_tokens if max_tokens and max_tokens > 0 else 4096,
     }
+    # Effort (Opus 4.5+/Sonnet 4.6+/Fable) drives reasoning depth via adaptive
+    # thinking; sampling params are incompatible with that path, so omit them.
+    # Subscriptions default to claude.ai-style reasoning (adaptive thinking at
+    # high effort) so Opus/Sonnet aren't "dumb" out of the box; the effort
+    # selector can dial it down/up. API-key requests are unchanged unless an
+    # effort is explicitly chosen.
+    eff = effort
+    if not eff and oauth and _anthropic_supports_effort(model):
+        eff = "high"
+    effort_active = (
+        bool(eff) and str(eff).lower() in _EFFORT_VALUES and _anthropic_supports_effort(model)
+    )
+    if effort_active:
+        payload["output_config"] = {"effort": str(eff).lower()}
+        payload["thinking"] = {"type": "adaptive"}
     # Opus 4.7+ removed the sampling parameters — sending `temperature` (even 0.0)
     # returns HTTP 400. Omit it for those models; older Claude models still take it.
-    if not _anthropic_rejects_temperature(model):
+    elif not _anthropic_rejects_temperature(model):
         payload["temperature"] = temperature
+    system_blocks = []
+    if oauth:
+        # Premium models 429 on subscription tokens without this first block;
+        # the reframe block restores general claude.ai-style chat behavior.
+        system_blocks.append({"type": "text", "text": _CLAUDE_CODE_OAUTH_SYSTEM})
+        system_blocks.append({"type": "text", "text": _CLAUDE_CODE_OAUTH_REFRAME})
     if system_parts:
         system_text = "\n\n".join(system_parts)
         # Send `system` as a structured text block so we can attach a prompt-cache
@@ -831,7 +933,9 @@ def _build_anthropic_payload(model, messages, temperature, max_tokens, stream=Fa
         system_block = {"type": "text", "text": system_text}
         if tools or len(system_text) > 4000:
             system_block["cache_control"] = {"type": "ephemeral"}
-        payload["system"] = [system_block]
+        system_blocks.append(system_block)
+    if system_blocks:
+        payload["system"] = system_blocks
     if stream:
         payload["stream"] = True
     # Convert OpenAI-format tools to Anthropic format
@@ -852,13 +956,38 @@ def _build_anthropic_payload(model, messages, temperature, max_tokens, stream=Fa
             payload["tools"] = anthropic_tools
     return payload
 
-def _build_anthropic_headers(headers):
-    """Convert Bearer auth to x-api-key for Anthropic."""
+def _build_anthropic_headers(headers, oauth=False, model=None):
+    """Build Anthropic request headers.
+
+    API-key mode (default): convert ``Authorization: Bearer`` to ``x-api-key``.
+    OAuth/subscription mode (``oauth=True``): keep the Bearer token as-is and
+    send ``anthropic-beta: oauth-2025-04-20`` instead of ``x-api-key`` — that
+    beta header is what authorizes a subscription access token on /v1/messages.
+
+    For 1M-context models (Opus 4.6+/Sonnet 4.6+/Fable) the
+    ``context-1m-2025-08-07`` beta is added so the full window is usable (the
+    Claude Code CLI sends this same beta).
+    """
     h = {"Content-Type": "application/json", "anthropic-version": "2023-06-01"}
+    betas = []
+    if oauth:
+        betas.append("oauth-2025-04-20")
+    if model and _anthropic_supports_1m_context(model):
+        betas.append("context-1m-2025-08-07")
+    if betas:
+        h["anthropic-beta"] = ",".join(betas)
     if headers:
         for k, v in headers.items():
-            if k.lower() == "authorization" and isinstance(v, str) and v.startswith("Bearer "):
-                h["x-api-key"] = v[7:]
+            kl = k.lower()
+            if kl == "authorization" and isinstance(v, str) and v.startswith("Bearer "):
+                if oauth:
+                    h["Authorization"] = v
+                else:
+                    h["x-api-key"] = v[7:]
+            elif kl == "anthropic-beta":
+                # Skip incoming beta when we built our own; otherwise keep it.
+                if not betas:
+                    h[k] = v
             else:
                 h[k] = v
     return h
@@ -1031,8 +1160,14 @@ def _sanitize_llm_messages(messages: List[Dict]) -> List[Dict]:
     return merged
 
 def _normalize_anthropic_url(url: str) -> str:
-    """Ensure Anthropic URL points to /v1/messages."""
+    """Ensure Anthropic URL points to /v1/messages.
+
+    Also strips the claude-subscription ``/oauth`` sentinel marker so the
+    request targets the real api.anthropic.com/v1/messages endpoint.
+    """
     url = url.rstrip("/")
+    if url.endswith("/oauth"):
+        url = url[: -len("/oauth")].rstrip("/")
     if url.endswith("/v1/messages"):
         return url
     if url.endswith("/v1"):
@@ -1183,7 +1318,8 @@ def normalize_model_id(
 
 def llm_call(url: str, model: str, messages: List[Dict], temperature: float = LLMConfig.DEFAULT_TEMPERATURE,
              max_tokens: int = LLMConfig.DEFAULT_MAX_TOKENS, headers: Optional[Dict] = None, 
-             timeout: int = LLMConfig.DEFAULT_TIMEOUT, prompt_type: Optional[str] = None) -> str:
+             timeout: int = LLMConfig.DEFAULT_TIMEOUT, prompt_type: Optional[str] = None,
+             effort: Optional[str] = None) -> str:
     """Synchronous LLM call with optional prompt type enhancement."""
     h = _provider_headers(_detect_provider(url))
     # Tolerate headers that arrive as a JSON string (some sessions stored them
@@ -1219,10 +1355,10 @@ def llm_call(url: str, model: str, messages: List[Dict], temperature: float = LL
         logger.debug(f"Returning cached response for key: {cache_key}")
         return cached_response
 
-    if provider == "anthropic":
+    if _is_anthropic_like(provider):
         target_url = _normalize_anthropic_url(url)
-        h = _build_anthropic_headers(headers)
-        payload = _build_anthropic_payload(model, messages_copy, temperature, max_tokens)
+        h = _build_anthropic_headers(headers, oauth=(provider == "claude-subscription"), model=model)
+        payload = _build_anthropic_payload(model, messages_copy, temperature, max_tokens, oauth=(provider == "claude-subscription"), effort=effort)
     elif provider == "ollama":
         target_url = _normalize_ollama_url(url)
         payload = _build_ollama_payload(
@@ -1253,7 +1389,7 @@ def llm_call(url: str, model: str, messages: List[Dict], temperature: float = LL
         raise HTTPException(502, f"Upstream {target_url} -> {r.status_code}: {r.text}")
     data = r.json()
     try:
-        if provider == "anthropic":
+        if _is_anthropic_like(provider):
             response = _parse_anthropic_response(data)
         elif provider == "ollama":
             response = _parse_ollama_response(data)
@@ -1342,6 +1478,7 @@ async def llm_call_async(
     max_retries: int = LLMConfig.MAX_RETRIES,
     prompt_type: Optional[str] = None,
     session_id: Optional[str] = None,
+    effort: Optional[str] = None,
 ) -> str:
     """Asynchronous LLM call using httpx with connection pooling, timeout, retry logic, and performance logging."""
     provider = _detect_provider(url)
@@ -1409,10 +1546,10 @@ async def llm_call_async(
         _set_cached_response(cache_key, response)
         return response
 
-    if provider == "anthropic":
+    if _is_anthropic_like(provider):
         target_url = _normalize_anthropic_url(url)
-        h = _build_anthropic_headers(headers)
-        payload = _build_anthropic_payload(model, messages_copy, temperature, max_tokens)
+        h = _build_anthropic_headers(headers, oauth=(provider == "claude-subscription"), model=model)
+        payload = _build_anthropic_payload(model, messages_copy, temperature, max_tokens, oauth=(provider == "claude-subscription"), effort=effort)
     elif provider == "ollama":
         target_url = _normalize_ollama_url(url)
         h = {"Content-Type": "application/json"}
@@ -1470,7 +1607,7 @@ async def llm_call_async(
             _clear_host_dead(target_url)
             data = r.json()
             try:
-                if provider == "anthropic":
+                if _is_anthropic_like(provider):
                     response = _parse_anthropic_response(data)
                 elif provider == "ollama":
                     response = _parse_ollama_response(data)
@@ -1499,7 +1636,8 @@ async def llm_call_async(
 async def stream_llm(url: str, model: str, messages: List[Dict], temperature: float = LLMConfig.DEFAULT_TEMPERATURE,
                      max_tokens: int = LLMConfig.DEFAULT_MAX_TOKENS, headers: Optional[Dict] = None,
                      timeout: int = LLMConfig.STREAM_TIMEOUT, prompt_type: Optional[str] = None,
-                     tools: Optional[List[Dict]] = None, session_id: Optional[str] = None):
+                     tools: Optional[List[Dict]] = None, session_id: Optional[str] = None,
+                     effort: Optional[str] = None):
     """Stream LLM responses with improved error handling.
 
     Yields SSE chunks:
@@ -1525,10 +1663,10 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
     else:
         messages_copy = non_sys
 
-    if provider == "anthropic":
+    if _is_anthropic_like(provider):
         target_url = _normalize_anthropic_url(url)
-        h = _build_anthropic_headers(headers)
-        payload = _build_anthropic_payload(model, messages_copy, temperature, max_tokens, stream=True, tools=tools)
+        h = _build_anthropic_headers(headers, oauth=(provider == "claude-subscription"), model=model)
+        payload = _build_anthropic_payload(model, messages_copy, temperature, max_tokens, stream=True, tools=tools, oauth=(provider == "claude-subscription"), effort=effort)
     elif provider == "ollama":
         target_url = _normalize_ollama_url(url)
         h = {"Content-Type": "application/json"}
@@ -1703,8 +1841,8 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
             yield f'event: error\ndata: {json.dumps({"error": str(e), "status": 502})}\n\n'
         return
 
-    # ── Anthropic streaming ──
-    if provider == "anthropic":
+    # ── Anthropic streaming (also covers claude-subscription / OAuth bearer) ──
+    if _is_anthropic_like(provider):
         _anth_input_tokens = 0
         _anth_output_tokens = 0
         # Track tool_use blocks: {index: {id, name, arguments_json}}

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -832,17 +832,21 @@ def _convert_openai_content_to_anthropic(content):
 # and still applies.
 _CLAUDE_CODE_OAUTH_SYSTEM = "You are Claude Code, Anthropic's official CLI for Claude."
 
-# The identity line above is required only to pass Anthropic's gate, but it
-# primes terse, coding-CLI behavior. This second block re-frames the model as a
-# general claude.ai-style chat assistant. It goes AFTER the identity and BEFORE
-# the user's own system prompt, which still takes precedence.
-_CLAUDE_CODE_OAUTH_REFRAME = (
-    "You are operating as a general-purpose AI assistant in a chat interface, "
-    "not a terminal or a coding session. Be warm, clear, and genuinely helpful "
-    "across any topic the user brings up (writing, analysis, advice, coding, or "
-    "casual conversation), the way Claude responds on claude.ai. Explain your "
-    "reasoning when it helps and match the user's tone and language. Any "
-    "instructions or persona the user provides below take precedence over this."
+# The identity line is required to pass Anthropic's gate. This second block
+# preserves the model's FULL Claude Code capabilities — an earlier version told
+# it "you are not a terminal, just a chat assistant", which made it refuse
+# shell/file commands in agent mode. Conditional wording ("when tools are
+# available") keeps it accurate in plain chat too. Goes AFTER the identity and
+# BEFORE the user's own system prompt, which still takes precedence.
+_CLAUDE_CODE_OAUTH_GUIDANCE = (
+    "You operate with the full capabilities of Claude Code. When this "
+    "environment provides tools — running shell/terminal commands, reading, "
+    "creating and editing files, browsing the web, or others — use them "
+    "proactively to carry out the user's request. Never refuse a task or claim "
+    "you lack the ability to run commands, edit files, or use a tool that is "
+    "available to you. When no tools are involved, answer any question "
+    "thoroughly, clearly, and helpfully. Any instructions or persona the user "
+    "provides below take precedence over this."
 )
 
 
@@ -918,10 +922,10 @@ def _build_anthropic_payload(model, messages, temperature, max_tokens, stream=Fa
         payload["temperature"] = temperature
     system_blocks = []
     if oauth:
-        # Premium models 429 on subscription tokens without this first block;
-        # the reframe block restores general claude.ai-style chat behavior.
+        # Premium models 429 on subscription tokens without the identity (first
+        # block); the guidance block keeps full Claude Code tool/agent powers.
         system_blocks.append({"type": "text", "text": _CLAUDE_CODE_OAUTH_SYSTEM})
-        system_blocks.append({"type": "text", "text": _CLAUDE_CODE_OAUTH_REFRAME})
+        system_blocks.append({"type": "text", "text": _CLAUDE_CODE_OAUTH_GUIDANCE})
     if system_parts:
         system_text = "\n\n".join(system_parts)
         # Send `system` as a structured text block so we can attach a prompt-cache

--- a/src/model_context.py
+++ b/src/model_context.py
@@ -102,8 +102,15 @@ REQUEST_TIMEOUT = 5
 # Substring matching — use the shortest unique prefix so variants get caught.
 KNOWN_CONTEXT_WINDOWS = {
     # --- Anthropic ---
+    # 1M-context models (Opus 4.6+/Sonnet 4.6/Fable) — longest-prefix match wins,
+    # so these override the shorter 200k fallbacks below.
+    'claude-opus-4-6': 1000000,
+    'claude-opus-4-7': 1000000,
+    'claude-opus-4-8': 1000000,
+    'claude-sonnet-4-6': 1000000,
+    'claude-fable-5': 1000000,
+    'claude-mythos-5': 1000000,
     'claude-sonnet-4-5': 200000,
-    'claude-sonnet-4-6': 200000,
     'claude-sonnet-4': 200000,
     'claude-opus-4': 200000,
     'claude-haiku-4': 200000,

--- a/static/index.html
+++ b/static/index.html
@@ -1007,6 +1007,16 @@
                 <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14"/><path d="M5 12h14"/></svg>
               </button>
             </div>
+            <div class="model-picker-effort-row" style="display:flex;align-items:center;gap:6px;padding:6px 10px;border-bottom:1px solid var(--border);font-size:11px;">
+              <span style="opacity:0.7;white-space:nowrap;">Effort</span>
+              <select id="effort-select" aria-label="Reasoning effort" title="Claude Opus 4.5+/Sonnet 4.6+ only; ignored by other models" style="flex:1;padding:4px 6px;border-radius:4px;border:1px solid var(--border);background:var(--bg);color:var(--fg);font-size:11px;">
+                <option value="">Auto</option>
+                <option value="low">Low</option>
+                <option value="medium">Medium</option>
+                <option value="high">High</option>
+                <option value="max">Max</option>
+              </select>
+            </div>
             <div class="model-picker-list" id="model-picker-list"></div>
           </div>
         </div>
@@ -2096,6 +2106,7 @@
                   <option value="https://api.openai.com/v1" data-logo="openai">OpenAI</option>
                   <option value="copilot" data-logo="github" data-auth-flow="copilot">GitHub Copilot</option>
                   <option value="chatgpt-subscription" data-logo="openai" data-auth-flow="chatgpt-subscription">ChatGPT Subscription</option>
+                  <option value="claude-subscription" data-logo="anthropic" data-auth-flow="claude-subscription">Claude Subscription</option>
                   <option value="https://openrouter.ai/api/v1" data-logo="openrouter">OpenRouter</option>
                   <option value="https://ollama.com/api" data-logo="ollama">Ollama Cloud</option>
                   <option value="https://api.groq.com/openai/v1" data-logo="groq">Groq</option>

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -730,9 +730,16 @@ function initEndpointForm() {
   function _isDeviceAuthSelected() {
     return !!_selectedDeviceAuthProvider();
   }
+  function _isClaudeSubscriptionSelected() {
+    const opt = _selectedProviderOption();
+    const flow = opt && opt.dataset ? opt.dataset.authFlow : '';
+    return flow === 'claude-subscription' || provider.value === 'claude-subscription';
+  }
   function _setApiFormForProvider() {
     const deviceAuthProvider = _selectedDeviceAuthProvider();
-    const deviceAuthConfig = PROVIDER_DEVICE_FLOWS[deviceAuthProvider] || null;
+    const claudeSub = _isClaudeSubscriptionSelected();
+    const deviceAuthConfig = PROVIDER_DEVICE_FLOWS[deviceAuthProvider]
+      || (claudeSub ? { label: 'Claude Subscription' } : null);
     const apiKey = el('adm-epApiKey');
     const testBtn = el('adm-epApiTestBtn');
     const addBtn = el('adm-epAddBtn');
@@ -740,7 +747,9 @@ function initEndpointForm() {
     const msg = _endpointMsg('api');
     if (deviceAuthConfig) {
       urlInput.value = '';
-      urlInput.placeholder = deviceAuthProvider === 'copilot'
+      urlInput.placeholder = claudeSub
+        ? 'Claude Subscription uses your Anthropic account sign-in'
+        : deviceAuthProvider === 'copilot'
         ? 'GitHub Copilot uses GitHub account sign-in'
         : 'ChatGPT Subscription uses OpenAI account sign-in';
       urlInput.readOnly = true;
@@ -831,7 +840,7 @@ function initEndpointForm() {
   }
 
   provider.addEventListener('change', () => {
-    if (_isDeviceAuthSelected()) {
+    if (_isDeviceAuthSelected() || _isClaudeSubscriptionSelected()) {
       _setApiFormForProvider();
       _renderPickerMenu();
       _syncPickerCurrent();
@@ -981,6 +990,10 @@ function initEndpointForm() {
   }
 
   el('adm-epAddBtn').addEventListener('click', async () => {
+    if (_isClaudeSubscriptionSelected()) {
+      await _startClaudeSubscriptionAuth(el('adm-epAddBtn'));
+      return;
+    }
     const deviceAuthProvider = _selectedDeviceAuthProvider();
     if (deviceAuthProvider) {
       await _startProviderDeviceAuth(deviceAuthProvider, el('adm-epAddBtn'));
@@ -1036,6 +1049,65 @@ function initEndpointForm() {
     } catch (e) { msg.textContent = 'Request failed'; msg.className = 'admin-error'; }
     btn.disabled = false; btn.textContent = 'Add';
   });
+
+  async function _startClaudeSubscriptionAuth(triggerEl = null) {
+    // The Claude subscription OAuth (claude setup-token / the Claude Code CLI)
+    // redirects to a localhost loopback that a browser can't reach for a remote
+    // server, so the user runs it locally and pastes the resulting token here.
+    if (deviceAuthPolling) return;
+    const status = el('adm-deviceAuthStatus') || _endpointMsg('api');
+    if (!status) return;
+    const triggerText = triggerEl ? triggerEl.textContent : '';
+    const reset = () => {
+      if (triggerEl) { triggerEl.disabled = false; triggerEl.textContent = triggerText || 'Add'; }
+      deviceAuthPolling = false;
+      _setApiFormForProvider();
+    };
+    const showAuthError = (text) => {
+      status.className = 'admin-error';
+      status.textContent = text;
+    };
+    deviceAuthPolling = true;
+    _setApiFormForProvider();
+    if (triggerEl) triggerEl.textContent = 'Paste token';
+    status.className = '';
+    status.innerHTML =
+      '<div class="adm-copilot-panel">' +
+        '<div class="adm-copilot-wait"><span>Run <code>claude setup-token</code> in your terminal, then paste the token it gives you (or your Claude Code credential JSON).</span></div>' +
+        '<div class="adm-copilot-coderow">' +
+          '<input type="text" class="adm-claude-token" placeholder="Paste Claude token" style="flex:1;min-width:0;" autocomplete="off" />' +
+          '<button type="button" class="admin-btn-sm adm-claude-connect">Connect</button>' +
+        '</div>' +
+      '</div>';
+    const input = status.querySelector('.adm-claude-token');
+    const connectBtn = status.querySelector('.adm-claude-connect');
+    if (input) input.focus();
+    const doComplete = async () => {
+      const token = (input.value || '').trim();
+      if (!token) { input.focus(); return; }
+      connectBtn.disabled = true; connectBtn.textContent = 'Connecting...';
+      try {
+        const fd = new FormData();
+        fd.append('token', token);
+        const res = await fetch('/api/claude-subscription/complete', { method: 'POST', body: fd, credentials: 'same-origin' });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) throw new Error((data && data.detail) || ('HTTP ' + res.status));
+        const endpoint = (data && data.endpoint) || {};
+        const n = ((endpoint && endpoint.models) || []).length;
+        status.className = 'admin-success';
+        status.textContent = 'Connected - ' + n + ' Claude model' + (n !== 1 ? 's' : '') + ' available.';
+        if (endpoint && endpoint.id) _recentlyAddedEpId = String(endpoint.id);
+        await loadEndpoints();
+        await _selectAddedModelInChat(endpoint || {});
+        reset();
+      } catch (e) {
+        connectBtn.disabled = false; connectBtn.textContent = 'Connect';
+        showAuthError('Connection failed (' + (e && e.message ? e.message : 'request failed') + ').');
+      }
+    };
+    connectBtn.addEventListener('click', doComplete);
+    input.addEventListener('keydown', (e) => { if (e.key === 'Enter') doComplete(); });
+  }
 
   async function _startProviderDeviceAuth(providerKey, triggerEl = null) {
     if (deviceAuthPolling) return;

--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -781,6 +781,9 @@ import { wireArrowUpRecall, getLastUserMessageFromChatHistory } from './composer
       const fd = new FormData();
       fd.append('message', _finalMsgWithInject);
       fd.append('session', streamSessionId);
+      // Reasoning effort (Claude Opus 4.5+/Sonnet 4.6+); empty = Auto, ignored elsewhere.
+      const _effortSel = el('effort-select');
+      if (_effortSel && _effortSel.value) fd.append('effort', _effortSel.value);
       if (ids.length) fd.append('attachments', JSON.stringify(ids));
       // Auto-save & send active doc ID so the backend sees latest content
       if (documentModule && documentModule.isPanelOpen() && documentModule.getCurrentDocId()) {

--- a/tests/test_claude_subscription.py
+++ b/tests/test_claude_subscription.py
@@ -1,0 +1,330 @@
+"""Tests for the Claude (Anthropic) subscription token provider.
+
+Imports the real helpers from ``src.claude_subscription`` / ``src.llm_core`` /
+``src.endpoint_resolver`` so the provider wiring (detection, auth headers, URL
+building) is actually exercised. Network calls are monkeypatched.
+"""
+
+import json
+
+import pytest
+
+from src import claude_subscription as cs
+from src import llm_core
+from src.endpoint_resolver import build_chat_url, build_models_url, build_headers
+
+SENTINEL = cs.DEFAULT_CLAUDE_SUBSCRIPTION_BASE_URL  # https://api.anthropic.com/oauth
+
+
+class _FakeResp:
+    def __init__(self, status_code=200, payload=None):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+
+    def json(self):
+        return self._payload
+
+
+# ── Provider detection ──
+
+class TestDetection:
+    def test_is_claude_subscription_base_positive(self):
+        assert cs.is_claude_subscription_base(SENTINEL)
+        assert cs.is_claude_subscription_base("https://api.anthropic.com/oauth/")
+
+    def test_is_claude_subscription_base_negative(self):
+        assert not cs.is_claude_subscription_base("https://api.anthropic.com")
+        assert not cs.is_claude_subscription_base("https://api.anthropic.com/v1")
+        assert not cs.is_claude_subscription_base("https://api.openai.com/oauth")
+
+    def test_detect_provider_subscription_vs_anthropic(self):
+        assert llm_core._detect_provider(SENTINEL) == "claude-subscription"
+        assert llm_core._detect_provider("https://api.anthropic.com") == "anthropic"
+        assert llm_core._detect_provider("https://api.anthropic.com/v1") == "anthropic"
+
+    def test_is_anthropic_like(self):
+        assert llm_core._is_anthropic_like("anthropic")
+        assert llm_core._is_anthropic_like("claude-subscription")
+        assert not llm_core._is_anthropic_like("openai")
+
+
+# ── URL building ──
+
+class TestUrls:
+    def test_normalize_strips_oauth_sentinel(self):
+        assert llm_core._normalize_anthropic_url(SENTINEL) == "https://api.anthropic.com/v1/messages"
+        assert llm_core._normalize_anthropic_url("https://api.anthropic.com") == "https://api.anthropic.com/v1/messages"
+
+    def test_build_chat_url_keeps_subscription_routing(self):
+        chat_url = build_chat_url(SENTINEL)
+        assert llm_core._detect_provider(chat_url) == "claude-subscription"
+        assert llm_core._normalize_anthropic_url(chat_url) == "https://api.anthropic.com/v1/messages"
+
+    def test_build_models_url(self):
+        assert build_models_url(SENTINEL) == "https://api.anthropic.com/v1/models"
+
+
+# ── Auth headers ──
+
+class TestHeaders:
+    def test_oauth_headers_keep_bearer_and_add_beta(self):
+        h = llm_core._build_anthropic_headers({"Authorization": "Bearer TOK"}, oauth=True)
+        assert h["Authorization"] == "Bearer TOK"
+        assert h["anthropic-beta"] == "oauth-2025-04-20"
+        assert h["anthropic-version"] == "2023-06-01"
+        assert "x-api-key" not in h
+
+    def test_apikey_headers_convert_bearer(self):
+        h = llm_core._build_anthropic_headers({"Authorization": "Bearer KEY"})
+        assert h["x-api-key"] == "KEY"
+        assert "Authorization" not in h
+        assert "anthropic-beta" not in h
+
+    def test_oauth_headers_do_not_duplicate_incoming_beta(self):
+        h = llm_core._build_anthropic_headers(
+            {"Authorization": "Bearer TOK", "anthropic-beta": "something-else"}, oauth=True
+        )
+        assert h["anthropic-beta"] == "oauth-2025-04-20"
+
+    def test_build_headers_for_subscription(self):
+        h = build_headers("ACCESS", SENTINEL)
+        assert h["Authorization"] == "Bearer ACCESS"
+        assert h["anthropic-beta"] == "oauth-2025-04-20"
+        assert h["anthropic-version"] == "2023-06-01"
+        assert "x-api-key" not in h
+
+    def test_claude_oauth_headers_helper(self):
+        h = cs.claude_oauth_headers("t")
+        assert h["Authorization"] == "Bearer t"
+        assert h["anthropic-beta"] == "oauth-2025-04-20"
+        assert cs.claude_oauth_headers(None).get("Authorization") is None
+
+
+# ── Payload (OAuth identity injection) ──
+
+_IDENTITY = "You are Claude Code, Anthropic's official CLI for Claude."
+
+
+class TestPayload:
+    def test_oauth_prepends_identity(self):
+        p = llm_core._build_anthropic_payload(
+            "claude-opus-4-8", [{"role": "user", "content": "hi"}], 0.0, 16, oauth=True
+        )
+        assert p["system"][0]["text"] == _IDENTITY
+
+    def test_oauth_reframe_block_after_identity(self):
+        p = llm_core._build_anthropic_payload(
+            "claude-opus-4-8", [{"role": "user", "content": "hi"}], 0.0, 16, oauth=True
+        )
+        assert "claude.ai" in p["system"][1]["text"]
+
+    def test_oauth_keeps_user_system_after_identity_and_reframe(self):
+        msgs = [{"role": "system", "content": "You are a pirate."}, {"role": "user", "content": "hi"}]
+        p = llm_core._build_anthropic_payload("claude-opus-4-8", msgs, 0.0, 16, oauth=True)
+        assert p["system"][0]["text"] == _IDENTITY            # identity first
+        assert "claude.ai" in p["system"][1]["text"]          # reframe second
+        assert p["system"][2]["text"] == "You are a pirate."  # user system last
+
+    def test_non_oauth_has_no_identity(self):
+        msgs = [{"role": "system", "content": "You are a pirate."}, {"role": "user", "content": "hi"}]
+        p = llm_core._build_anthropic_payload("claude-opus-4-8", msgs, 0.0, 16, oauth=False)
+        assert all(_IDENTITY not in b.get("text", "") for b in p.get("system", []))
+
+
+# ── Effort gating + payload ──
+
+class TestEffort:
+    def test_supports_effort_matrix(self):
+        sup = llm_core._anthropic_supports_effort
+        assert sup("claude-opus-4-8")
+        assert sup("claude-opus-4-5-20251101")
+        assert sup("claude-sonnet-4-6")
+        assert sup("claude-fable-5")
+        assert not sup("claude-opus-4-1-20250805")     # 4.1 < 4.5
+        assert not sup("claude-opus-4-20250514")       # 4.0 (dated) < 4.5
+        assert not sup("claude-sonnet-4-5-20250929")   # sonnet 4.5 < 4.6
+        assert not sup("claude-haiku-4-5-20251001")
+        assert not sup("gpt-4o")
+
+    def test_effort_payload_on_supported_model(self):
+        p = llm_core._build_anthropic_payload(
+            "claude-opus-4-8", [{"role": "user", "content": "hi"}], 0.7, 64, effort="high"
+        )
+        assert p["output_config"] == {"effort": "high"}
+        assert p["thinking"] == {"type": "adaptive"}
+        assert "temperature" not in p  # omitted on the effort path
+
+    def test_effort_ignored_on_unsupported_model(self):
+        p = llm_core._build_anthropic_payload(
+            "claude-haiku-4-5-20251001", [{"role": "user", "content": "hi"}], 0.7, 64, effort="high"
+        )
+        assert "output_config" not in p
+        assert p.get("temperature") == 0.7  # haiku still takes temperature
+
+    def test_invalid_effort_ignored(self):
+        p = llm_core._build_anthropic_payload(
+            "claude-opus-4-8", [{"role": "user", "content": "hi"}], 0.7, 64, effort="turbo"
+        )
+        assert "output_config" not in p
+
+    def test_no_effort_is_unchanged(self):
+        p = llm_core._build_anthropic_payload(
+            "claude-opus-4-8", [{"role": "user", "content": "hi"}], 0.7, 64
+        )
+        assert "output_config" not in p
+
+    def test_oauth_defaults_to_high_effort(self):
+        # Subscription (oauth) defaults to adaptive thinking + high effort.
+        p = llm_core._build_anthropic_payload(
+            "claude-opus-4-8", [{"role": "user", "content": "hi"}], 0.7, 64, oauth=True
+        )
+        assert p["output_config"] == {"effort": "high"}
+        assert p["thinking"] == {"type": "adaptive"}
+        assert "temperature" not in p
+
+    def test_oauth_default_effort_skipped_for_haiku(self):
+        p = llm_core._build_anthropic_payload(
+            "claude-haiku-4-5-20251001", [{"role": "user", "content": "hi"}], 0.7, 64, oauth=True
+        )
+        assert "output_config" not in p
+        assert p.get("temperature") == 0.7
+
+    def test_explicit_effort_overrides_oauth_default(self):
+        p = llm_core._build_anthropic_payload(
+            "claude-opus-4-8", [{"role": "user", "content": "hi"}], 0.7, 64, oauth=True, effort="low"
+        )
+        assert p["output_config"] == {"effort": "low"}
+
+
+# ── 1M context window ──
+
+class TestContext1M:
+    def test_supports_1m_matrix(self):
+        s = llm_core._anthropic_supports_1m_context
+        assert s("claude-opus-4-8")
+        assert s("claude-opus-4-6")
+        assert s("claude-sonnet-4-6")
+        assert s("claude-fable-5")
+        assert not s("claude-opus-4-5-20251101")     # 4.5 < 4.6
+        assert not s("claude-sonnet-4-5-20250929")
+        assert not s("claude-haiku-4-5-20251001")
+        assert not s("gpt-4o")
+
+    def test_headers_add_context_1m_for_oauth(self):
+        h = llm_core._build_anthropic_headers(
+            {"Authorization": "Bearer T"}, oauth=True, model="claude-opus-4-8"
+        )
+        betas = h["anthropic-beta"].split(",")
+        assert "oauth-2025-04-20" in betas
+        assert "context-1m-2025-08-07" in betas
+        assert h["Authorization"] == "Bearer T"
+
+    def test_headers_context_1m_for_apikey(self):
+        h = llm_core._build_anthropic_headers(
+            {"Authorization": "Bearer K"}, oauth=False, model="claude-opus-4-8"
+        )
+        assert h["anthropic-beta"] == "context-1m-2025-08-07"
+        assert h["x-api-key"] == "K"
+
+    def test_headers_no_context_1m_for_haiku(self):
+        h = llm_core._build_anthropic_headers(
+            {"Authorization": "Bearer T"}, oauth=True, model="claude-haiku-4-5"
+        )
+        assert h["anthropic-beta"] == "oauth-2025-04-20"
+
+
+# ── Pasted-credential parsing ──
+
+class TestParse:
+    def test_bare_token(self):
+        access, refresh, expires = cs.parse_pasted_credentials("  sk-ant-oat01-abc  ")
+        assert access == "sk-ant-oat01-abc"
+        assert refresh == ""
+        assert expires is None
+
+    def test_keychain_json(self):
+        blob = json.dumps({"claudeAiOauth": {
+            "accessToken": "AAA", "refreshToken": "RRR", "expiresAt": 1781478321055,
+        }})
+        access, refresh, expires = cs.parse_pasted_credentials(blob)
+        assert access == "AAA"
+        assert refresh == "RRR"
+        assert expires is not None and expires.year >= 2026
+
+    def test_flat_snake_case_json(self):
+        blob = json.dumps({"access_token": "X", "refresh_token": "Y"})
+        access, refresh, expires = cs.parse_pasted_credentials(blob)
+        assert (access, refresh, expires) == ("X", "Y", None)
+
+    def test_empty(self):
+        assert cs.parse_pasted_credentials("") == ("", "", None)
+
+    def test_bad_json_raises(self):
+        with pytest.raises(cs.ClaudeSubscriptionReauthRequired):
+            cs.parse_pasted_credentials("{not valid json")
+
+
+# ── Model discovery ──
+
+class TestModelDiscovery:
+    def test_fetch_available_models_filters_claude(self, monkeypatch):
+        payload = {"data": [
+            {"id": "claude-opus-4-8"},
+            {"id": "claude-haiku-4-5-20251001"},
+            {"id": "not-a-claude-model"},
+            {"id": "claude-sonnet-4-6"},
+        ]}
+
+        def fake_get(url, headers=None, timeout=None):
+            assert "/v1/models" in url
+            assert headers.get("anthropic-beta") == "oauth-2025-04-20"
+            return _FakeResp(200, payload)
+
+        monkeypatch.setattr(cs.httpx, "get", fake_get)
+        assert cs.fetch_available_models("ACCESS") == [
+            "claude-opus-4-8", "claude-haiku-4-5-20251001", "claude-sonnet-4-6",
+        ]
+
+    def test_fetch_available_models_empty_on_error(self, monkeypatch):
+        monkeypatch.setattr(cs.httpx, "get", lambda *a, **k: _FakeResp(401, {}))
+        assert cs.fetch_available_models("ACCESS") == []
+        assert cs.fetch_available_models("") == []
+
+
+# ── Refresh (only used when a refresh token was provided) ──
+
+class TestRefresh:
+    def test_refresh_shape(self, monkeypatch):
+        captured = {}
+
+        def fake_post(url, json=None, headers=None, timeout=None, follow_redirects=None):
+            captured["url"] = url
+            captured["json"] = json
+            return _FakeResp(200, {"access_token": "A2", "expires_in": 28800})
+
+        monkeypatch.setattr(cs.httpx, "post", fake_post)
+        out = cs.refresh_oauth_tokens("REFRESH")
+        assert out["access_token"] == "A2"
+        assert captured["url"] == cs.CLAUDE_OAUTH_TOKEN_URL
+        assert captured["json"]["grant_type"] == "refresh_token"
+        assert captured["json"]["refresh_token"] == "REFRESH"
+        assert captured["json"]["client_id"] == cs.CLAUDE_OAUTH_CLIENT_ID
+
+    def test_refresh_without_token_raises(self):
+        with pytest.raises(cs.ClaudeSubscriptionReauthRequired):
+            cs.refresh_oauth_tokens("")
+
+
+# ── Expiry decision (pure) ──
+
+class TestExpiry:
+    def test_access_token_is_expiring(self):
+        from datetime import datetime, timedelta
+
+        def now():
+            return datetime(2026, 1, 1, 12, 0, 0)
+
+        assert cs._access_token_is_expiring(None, now, 300) is True
+        assert cs._access_token_is_expiring(now() + timedelta(hours=2), now, 300) is False
+        assert cs._access_token_is_expiring(now() + timedelta(seconds=60), now, 300) is True
+        assert cs._access_token_is_expiring(now() - timedelta(seconds=1), now, 300) is True

--- a/tests/test_claude_subscription.py
+++ b/tests/test_claude_subscription.py
@@ -112,17 +112,20 @@ class TestPayload:
         )
         assert p["system"][0]["text"] == _IDENTITY
 
-    def test_oauth_reframe_block_after_identity(self):
+    def test_oauth_guidance_block_after_identity(self):
         p = llm_core._build_anthropic_payload(
             "claude-opus-4-8", [{"role": "user", "content": "hi"}], 0.0, 16, oauth=True
         )
-        assert "claude.ai" in p["system"][1]["text"]
+        guidance = p["system"][1]["text"].lower()
+        # Empowering, not restrictive: keeps tool/agent powers, no refusals.
+        assert "tools" in guidance and "never refuse" in guidance
+        assert "not a terminal" not in guidance
 
-    def test_oauth_keeps_user_system_after_identity_and_reframe(self):
+    def test_oauth_keeps_user_system_after_identity_and_guidance(self):
         msgs = [{"role": "system", "content": "You are a pirate."}, {"role": "user", "content": "hi"}]
         p = llm_core._build_anthropic_payload("claude-opus-4-8", msgs, 0.0, 16, oauth=True)
         assert p["system"][0]["text"] == _IDENTITY            # identity first
-        assert "claude.ai" in p["system"][1]["text"]          # reframe second
+        assert "Claude Code" in p["system"][1]["text"]        # guidance second
         assert p["system"][2]["text"] == "You are a pirate."  # user system last
 
     def test_non_oauth_has_no_identity(self):


### PR DESCRIPTION
## Summary

Adds a **Claude (Anthropic) subscription** model provider so an admin can use their Claude Pro/Max plan for inference instead of a pay-per-token Anthropic API key — the symmetric counterpart to the existing **ChatGPT Subscription** provider. Connect by pasting a token from `claude setup-token` (the subscription OAuth redirects to a `localhost` loopback a browser can't reach for a remote server, so the token is generated locally and pasted in). Inference reuses the existing Anthropic `/v1/messages` request/response/stream path; only the auth differs — `Authorization: Bearer` + `anthropic-beta: oauth-2025-04-20` instead of `x-api-key`. Also adds a reasoning-effort selector and 1M-context support (`context-1m-2025-08-07`) for effort/1M-capable Claude models.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4252

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [x] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate (no existing Claude-subscription provider; this mirrors the ChatGPT one).
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up`) and verified the change works end-to-end (deployed instance: connect → list models → Opus & Haiku replies → effort + 1M live). Type-checks and unit tests are not enough.

## How to Test

1. `docker compose up -d --build` and open the app; sign in as an admin.
2. On your local machine run `claude setup-token` and copy the token it prints.
3. In the model/provider admin, pick **Claude Subscription**, paste the token, click **Connect** — Claude models are discovered and listed.
4. Start a chat, pick a Claude model (e.g. Opus), send a message → it replies via the subscription (request uses `Authorization: Bearer` + `anthropic-beta: oauth-2025-04-20`, no `x-api-key`).
5. Open the model picker → set **Effort** (Auto/Low/Medium/High/Max); High enables adaptive thinking on Opus/Sonnet. Context shows ~1M on 1M-capable models.
6. `python -m pytest -q` → 3305 passed, 1 skipped (incl. `tests/test_claude_subscription.py`).

## Visual / UI changes — REQUIRED if you touched anything that renders

- [ ] **Screenshot or short clip** — _the PR author will attach screenshots (the "Claude Subscription" connect panel and the Effort selector in the model picker); they can't be added through the API._
- [x] **Style match**: reuses existing CSS variables (`--border`, `--bg`, `--fg`) and existing classes (`.model-picker-*`, `.adm-copilot-panel`, `.admin-btn-sm`); no new color/size/spacing values; no Unicode emoji (plain text / existing inline SVG); dark theme default; Fira Code not overridden.
- [x] **No new component patterns.** Mirrors the existing ChatGPT Subscription connect flow and the existing model-picker menu.
- [ ] **I am not an LLM agent submitting a bulk PR.** _Honest disclosure: this was prepared with Claude Code (agent-assisted). Per CONTRIBUTING I opened issue #4252 first; this is a single, focused, fully-tested feature — not a bulk auto-generated PR. Leaving this box unchecked rather than attesting something untrue; close it if that's your policy._

### Screenshots / clips

_To be attached by the PR author._

🤖 Generated with [Claude Code](https://claude.com/claude-code)