### PR TITLE
test: add fire_and_forget to API chat webhook stub

### DIFF
--- a/tests/test_api_chat_security.py
+++ b/tests/test_api_chat_security.py
@@ -219,6 +219,9 @@ class _WebhookManager:
     async def fire(self, event, payload):
         return None
 
+    def fire_and_forget(self, event, payload):
+        return None
+
 
 def _install_sync_chat_stubs(monkeypatch):
     # FastAPI checks for python_multipart at import time when Form is used;


### PR DESCRIPTION
## Summary

Adds `fire_and_forget()` to the local `_WebhookManager` test stub used by `tests/test_api_chat_security.py`.

PR #4336 changed chat webhook emission to use `webhook_manager.fire_and_forget(...)`. The real `WebhookManager` already has this method, but the test stub did not, causing two API chat security tests to fail on current `dev`.

## Target branch

* [x] This PR targets **`dev`**

## Linked Issue

Fixes #4380

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
-  [ ] Documentation only
-  [x] CI / tooling / configuration

## Checklist

- [X] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [X] This PR targets `dev`
- [X] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [X] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Validate Python syntax:

   ```
   python3 -m py_compile tests/test_api_chat_security.py
   ```

2. Run the focused failing tests:

   ```
   python3 -m pytest -q tests/test_api_chat_security.py::test_api_chat_direct_base_url_allows_mocked_public_endpoint tests/test_api_chat_security.py::test_api_chat_fallback_trusts_configured_local_endpoint
   ```

3. Validate diff formatting:

   ```
   git diff --check
   ```

Expected result:

```
   2 passed
```

## Visual / UI changes — REQUIRED if you touched anything that renders

- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

N/A - no UI, CSS, HTML, SVG, `static/js/`, or rendered output changed.

### Screenshots / clips

N/A - no visual or UI changes.