### PR TITLE
feat(ui): add a maximize/restore control to tool modals

### DIFF
--- a/static/js/modalManager.js
+++ b/static/js/modalManager.js
@@ -74,6 +74,90 @@ function _emitModalOpened(id, modal) {
   } catch (_) {}
 }
 
+// ── Maximize / restore — a header button on every tool modal ──
+// Lets any window be enlarged on demand, so windows can open at the normal
+// (dev-origin) size instead of one of them opening oversized.
+const _MAX_ICON = '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3H5a2 2 0 0 0-2 2v3"/><path d="M21 8V5a2 2 0 0 0-2-2h-3"/><path d="M3 16v3a2 2 0 0 0 2 2h3"/><path d="M16 21h3a2 2 0 0 0 2-2v-3"/></svg>';
+const _RESTORE_ICON = '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 9H5a2 2 0 0 1-2-2V5"/><path d="M15 9h4a2 2 0 0 0 2-2V5"/><path d="M9 15H5a2 2 0 0 0-2 2v2"/><path d="M15 15h4a2 2 0 0 1 2 2v2"/></svg>';
+const _MAX_PROPS = ['width', 'height', 'max-width', 'max-height'];
+
+function _toggleMaximize(content, btn) {
+  if (!content) return;
+  if (btn.dataset.state !== 'restore') {
+    // Save the current inline sizing so restore puts it back exactly.
+    const saved = {};
+    _MAX_PROPS.forEach((p) => { saved[p] = content.style.getPropertyValue(p); });
+    btn._odySaved = saved;
+    content.style.setProperty('width', '96%', 'important');
+    content.style.setProperty('height', '95%', 'important');
+    content.style.setProperty('max-width', '96%', 'important');
+    content.style.setProperty('max-height', '95%', 'important');
+    content.classList.add('modal-content-maximized');
+    btn.dataset.state = 'restore';
+    btn.innerHTML = _RESTORE_ICON;
+    btn.setAttribute('aria-label', 'Restore window');
+    btn.title = 'Restore';
+  } else {
+    const saved = btn._odySaved || {};
+    _MAX_PROPS.forEach((p) => {
+      content.style.removeProperty(p);
+      if (saved[p]) content.style.setProperty(p, saved[p]);
+    });
+    content.classList.remove('modal-content-maximized');
+    btn.dataset.state = 'maximize';
+    btn.innerHTML = _MAX_ICON;
+    btn.setAttribute('aria-label', 'Maximize window');
+    btn.title = 'Maximize';
+  }
+  const m = content.closest('.modal');
+  if (m) _bringToFront(m);
+}
+
+// Build a maximize/restore button wired to resize `content`. Shared by the
+// auto-injector (standard modals) and custom panels (e.g. notes).
+function _makeMaximizeButton(content) {
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'modal-maximize-btn';
+  btn.dataset.state = 'maximize';
+  btn.setAttribute('aria-label', 'Maximize window');
+  btn.title = 'Maximize';
+  btn.innerHTML = _MAX_ICON;
+  btn.style.flexShrink = '0';
+  btn.addEventListener('click', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    _toggleMaximize(content, btn);
+  });
+  // Don't let a click on the button start the header's drag (tileManager).
+  btn.addEventListener('mousedown', (e) => e.stopPropagation());
+  return btn;
+}
+
+/** Ensure a maximize button sits in `header` (before `beforeEl` or the close
+ * button) wired to resize `content`. Idempotent. Exported for custom panels. */
+export function injectMaximizeButton(header, content, beforeEl) {
+  if (!header || !content) return null;
+  // Skip if one already exists (e.g. usage ships its own).
+  if (header.querySelector('.modal-maximize-btn')) return null;
+  const btn = _makeMaximizeButton(content);
+  const anchor = beforeEl || header.querySelector('.close-btn, .modal-close, .modal-close-btn');
+  if (anchor && anchor.parentNode) anchor.parentNode.insertBefore(btn, anchor);
+  else header.appendChild(btn);
+  return btn;
+}
+
+// Standard modals: maximize the `.modal-content`, placed before the close button
+// (and after the minimize button injectMinimizeButton already inserted), so the
+// controls read minimize · maximize · close, grouped at the right.
+function _ensureMaximizeButton(modal) {
+  if (!modal) return;
+  const header = modal.querySelector('.modal-header');
+  const content = modal && modal.querySelector('.modal-content');
+  if (!header || !content) return;
+  injectMaximizeButton(header, content);
+}
+
 function _captureRestoreHeight(modal, state) {
   if (!modal || !state) return;
   const content = modal.querySelector('.modal-content');
@@ -1356,6 +1440,7 @@ export function injectMinimizeButton(modal, modalId) {
         minimize(modalId);
       }, true);
     }
+    _ensureMaximizeButton(modal);
     return;
   }
   const closeBtn = header.querySelector('.close-btn, .modal-close');
@@ -1386,6 +1471,8 @@ export function injectMinimizeButton(modal, modalId) {
   });
   if (closeBtn && closeBtn.parentNode) closeBtn.parentNode.insertBefore(btn, closeBtn);
   else header.appendChild(btn);
+  // After minimize is placed, add maximize between it and close → minimize · maximize · close.
+  _ensureMaximizeButton(modal);
 }
 
 // ── Auto-wire fallback for modals not explicitly registered ──
@@ -1549,4 +1636,4 @@ document.addEventListener('click', (e) => {
   }
 }, true);
 
-export default { register, unregister, isRegistered, isMinimized, minimize, restore, toggle, close, injectMinimizeButton };
+export default { register, unregister, isRegistered, isMinimized, minimize, restore, toggle, close, injectMinimizeButton, injectMaximizeButton };

--- a/static/js/notes.js
+++ b/static/js/notes.js
@@ -1146,6 +1146,7 @@ export function openPanel() {
         <span class="notes-header-btn-label">Toggle</span>
       </button>
       <button id="notes-minimize-btn" class="modal-minimize-btn" title="Minimize" aria-label="Minimize notes" style="position:relative;left:2px;"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.4" stroke-linecap="round" aria-hidden="true"><line x1="6" y1="18" x2="18" y2="18"/></svg></button>
+      <button id="notes-close-btn" class="close-btn" type="button" title="Close" aria-label="Close notes">✖</button>
     </div>
     <div class="notes-search-bar">
       <input type="text" id="notes-search" class="memory-search-input" placeholder="Search notes…" autocomplete="off" />
@@ -1208,6 +1209,19 @@ export function openPanel() {
     e.stopPropagation();
     closePanel('down');
   });
+  // Full close (the `_` button only minimizes/docks). Gives Notes the same
+  // minimize · maximize · close control set as every other tool window.
+  const closeBtnEl = document.getElementById('notes-close-btn');
+  if (closeBtnEl) closeBtnEl.addEventListener('click', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    closePanel();
+  });
+  // Maximize/restore, inserted between minimize and close. The pane is a centred
+  // floating panel, so the shared toggle resizes it just like the other modals.
+  try {
+    Modals.injectMaximizeButton(pane.querySelector('.notes-pane-header'), pane, closeBtnEl);
+  } catch (_) {}
   // Search
   const searchEl = document.getElementById('notes-search');
   if (searchEl) {

--- a/static/style.css
+++ b/static/style.css
@@ -825,6 +825,27 @@ body.bg-pattern-sparkles {
       transition: background 0.15s, color 0.15s;
     }
     .modal-minimize-btn:hover { background: var(--fg); color: var(--bg); }
+    /* Generic maximize/restore button injected into every tool modal's header by
+       modalManager (next to close). Mirrors .modal-minimize-btn. */
+    .modal-maximize-btn {
+      background: var(--bg);
+      color: var(--fg);
+      border: 1px solid var(--fg);
+      cursor: pointer;
+      width: 24px;
+      height: 24px;
+      padding: 0;
+      margin-left: 0;
+      margin-right: 4px;
+      line-height: 1;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 4px;
+      flex-shrink: 0;
+      transition: background 0.15s, color 0.15s;
+    }
+    .modal-maximize-btn:hover { background: var(--fg); color: var(--bg); }
     .modal.modal-minimized { display: none !important; }
     /* Window tile snap ghost (desktop only) */
     #tile-ghost {


### PR DESCRIPTION
## Summary

Adds a maximize/restore control to every tool modal. `modalManager` now injects a maximize/restore button into each modal header, placed between minimize and close, so windows consistently read minimize, maximize, close. A shared, exported `injectMaximizeButton` helper does a generic resize of the modal's `.modal-content` and restores it on a second click. Notes, whose bespoke header the generic system never saw, also gains a full close (the `_` still docks/minimizes) and a maximize via the same helper, so it matches every other tool window.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Closes #4458

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [x] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Open any tool modal (Settings, Deep Research, Calendar). The header now shows minimize, maximize, close.
2. Click the maximize button: the window expands to fill, click it again to restore to the previous size.
3. Open Notes: it now has a full close (the `_` still docks/minimizes) plus a maximize, matching the other windows.

## Visual / UI changes — REQUIRED if you touched anything that renders

- [x] Screenshot or short clip of the change in the running app, attached below.
- [x] Style match: reuses `--bg` / `--fg`, mirrors the existing `.modal-minimize-btn` rule, adds no new color/spacing units, no emoji (the icon is plain), Fira Code preserved, dark theme default.
- [x] No new component patterns: extends the existing modalManager minimize/close system rather than a parallel widget.
- [ ] I am not an LLM agent submitting a bulk PR.

### Screenshots / clips

Tool modal headers now read minimize, maximize, close:

**Settings**

![Settings modal showing minimize, maximize, close controls](https://raw.githubusercontent.com/azfahimaf/OdysseusBD/pr-assets/modal-maximize/settings.png)

**Deep Research**

![Deep Research modal showing minimize, maximize, close controls](https://raw.githubusercontent.com/azfahimaf/OdysseusBD/pr-assets/modal-maximize/deep-research.png)

