### PR TITLE
fix(email): validate IMAP/SMTP ports instead of crashing with 500

### DIFF
--- a/routes/email_routes.py
+++ b/routes/email_routes.py
@@ -63,6 +63,21 @@ logger = logging.getLogger(__name__)
 ODYSSEUS_MAIL_ORIGIN = "odysseus-ui"
 
 
+def _coerce_port(value, default):
+    """Coerce a user-supplied port to int.
+
+    Returns ``(port, error)``. A missing or blank value yields ``default``; a
+    non-numeric value yields ``(None, message)`` so callers can return a clean
+    error instead of letting ``int()`` raise and surface as an HTTP 500.
+    """
+    if value in (None, ""):
+        return default, None
+    try:
+        return int(value), None
+    except (TypeError, ValueError):
+        return None, f"Invalid port {value!r}; must be a whole number"
+
+
 def _email_tag_owner_aliases(account_id: str | None, owner: str = "") -> list[str]:
     aliases = [owner or ""]
     try:
@@ -3152,6 +3167,12 @@ def setup_email_routes():
         name = (data.get("name") or "").strip()
         if not name:
             return {"ok": False, "error": "name required"}
+        imap_port, port_err = _coerce_port(data.get("imap_port"), 993)
+        if port_err:
+            return {"ok": False, "error": port_err}
+        smtp_port, port_err = _coerce_port(data.get("smtp_port"), 465)
+        if port_err:
+            return {"ok": False, "error": port_err}
         db = SessionLocal()
         try:
             row = EmailAccount(
@@ -3160,13 +3181,13 @@ def setup_email_routes():
                 is_default=bool(data.get("is_default", False)),
                 enabled=bool(data.get("enabled", True)),
                 imap_host=(data.get("imap_host") or "").strip(),
-                imap_port=int(data.get("imap_port") or 993),
+                imap_port=imap_port,
                 imap_user=(data.get("imap_user") or "").strip(),
                 imap_password=_enc(data.get("imap_password") or ""),
                 imap_starttls=bool(data.get("imap_starttls", True)),
                 smtp_host=(data.get("smtp_host") or "").strip(),
-                smtp_port=int(data.get("smtp_port") or 465),
-                smtp_security=_smtp_security_mode({"smtp_security": data.get("smtp_security"), "smtp_port": data.get("smtp_port") or 465}),
+                smtp_port=smtp_port,
+                smtp_security=_smtp_security_mode({"smtp_security": data.get("smtp_security"), "smtp_port": smtp_port}),
                 smtp_user=(data.get("smtp_user") or "").strip(),
                 smtp_password=_enc(data.get("smtp_password") or ""),
                 from_address=(data.get("from_address") or "").strip(),
@@ -3210,7 +3231,10 @@ def setup_email_routes():
                     setattr(row, key, (data[key] or "").strip())
             for key in ("imap_port", "smtp_port"):
                 if data.get(key) not in (None, ""):
-                    setattr(row, key, int(data[key]))
+                    port, port_err = _coerce_port(data.get(key), None)
+                    if port_err:
+                        return {"ok": False, "error": port_err}
+                    setattr(row, key, port)
             if "smtp_security" in data:
                 row.smtp_security = _smtp_security_mode({"smtp_security": data.get("smtp_security"), "smtp_port": data.get("smtp_port") or row.smtp_port})
             for key in ("imap_starttls", "enabled"):
@@ -3314,12 +3338,14 @@ def setup_email_routes():
         smtp_result = None
 
         imap_host = (body.get("imap_host") or "").strip()
-        imap_port = int(body.get("imap_port") or 993)
+        imap_port, imap_port_err = _coerce_port(body.get("imap_port"), 993)
         imap_user = (body.get("imap_user") or "").strip()
         imap_pass = body.get("imap_password") or ""
         imap_starttls = bool(body.get("imap_starttls"))
 
-        if not (imap_host and imap_user and imap_pass):
+        if imap_port_err:
+            imap_result = {"ok": False, "error": imap_port_err}
+        elif not (imap_host and imap_user and imap_pass):
             imap_result = {"ok": False, "error": "Need IMAP host, username, and password"}
         else:
             # Connection mode resolution:
@@ -3346,8 +3372,10 @@ def setup_email_routes():
                 imap_result = {"ok": False, "error": _friendly_email_auth_error("IMAP", imap_host, e)}
 
         smtp_host = (body.get("smtp_host") or "").strip()
-        if smtp_host:
-            smtp_port = int(body.get("smtp_port") or 465)
+        smtp_port, smtp_port_err = _coerce_port(body.get("smtp_port"), 465)
+        if smtp_host and smtp_port_err:
+            smtp_result = {"ok": False, "error": smtp_port_err}
+        elif smtp_host:
             smtp_security = _smtp_security_mode({"smtp_security": body.get("smtp_security"), "smtp_port": smtp_port})
             smtp_user = (body.get("smtp_user") or imap_user).strip()
             smtp_pass = body.get("smtp_password") or imap_pass

--- a/tests/test_email_account_port_validation.py
+++ b/tests/test_email_account_port_validation.py
@@ -1,0 +1,56 @@
+"""User-supplied IMAP/SMTP ports must not crash the email-account endpoints.
+
+A non-numeric port (for example ``"imap"`` or ``"993x"``) previously reached an
+unguarded ``int(...)`` in create / update / test-config and raised ``ValueError``,
+which surfaces as an HTTP 500. The endpoints should reject it with their standard
+``{"ok": False, "error": ...}`` response instead.
+"""
+
+import pytest
+
+
+def _route_endpoint(router, path: str, method: str):
+    method = method.upper()
+    for route in router.routes:
+        if route.path == path and method in getattr(route, "methods", set()):
+            return route.endpoint
+    raise AssertionError(f"route not found: {method} {path}")
+
+
+def test_coerce_port_accepts_int_and_numeric_string():
+    import routes.email_routes as email_routes
+    assert email_routes._coerce_port(2525, 993) == (2525, None)
+    assert email_routes._coerce_port("465", 993) == (465, None)
+
+
+def test_coerce_port_blank_uses_default():
+    import routes.email_routes as email_routes
+    assert email_routes._coerce_port(None, 993) == (993, None)
+    assert email_routes._coerce_port("", 465) == (465, None)
+
+
+def test_coerce_port_rejects_non_numeric():
+    import routes.email_routes as email_routes
+    port, err = email_routes._coerce_port("imap", 993)
+    assert port is None
+    assert err and "port" in err.lower()
+
+
+@pytest.mark.asyncio
+async def test_create_account_rejects_non_numeric_port():
+    """A bad port is rejected before any DB work, with the endpoint's error shape."""
+    import routes.email_routes as email_routes
+    router = email_routes.setup_email_routes()
+    create = _route_endpoint(router, "/api/email/accounts", "POST")
+    result = await create(
+        {
+            "name": "Test",
+            "imap_host": "mail.example.com",
+            "imap_user": "u",
+            "imap_password": "p",
+            "imap_port": "not-a-number",
+        },
+        owner="alice",
+    )
+    assert result["ok"] is False
+    assert "port" in result["error"].lower()


### PR DESCRIPTION
## Summary

Non-numeric IMAP/SMTP ports crashed the email-account endpoints with an HTTP 500. The port was coerced with a bare `int(data.get("imap_port") or 993)`, so input like `"imap"` raises `ValueError` and, with no handler, surfaces as a 500 in the create, update, and test-config endpoints. This adds a small `_coerce_port(value, default)` helper and uses it in all three, so bad input now returns the endpoints' standard `{"ok": False, "error": ...}` response (consistent with the existing `"name required"` validation) instead of crashing. A blank or missing port still falls back to the default (993/465); valid input is unchanged.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4463

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. On `dev`, as an authenticated user, `POST /api/email/accounts` with a non-numeric port, e.g. body `{"name":"T","imap_host":"h","imap_user":"u","imap_password":"p","imap_port":"imap"}`. Current behaviour: HTTP 500.
2. With this branch, the same request returns `{"ok": false, "error": "Invalid port 'imap'; must be a whole number"}`, and a valid numeric port still creates the account normally. The same applies to `PUT /api/email/accounts/{id}` and `POST /api/email/accounts/test`.
3. Automated: `python -m pytest tests/test_email_account_port_validation.py -q` → 4 passed; `python -m pytest tests/ -k email -q` → 125 passed; `python -m py_compile routes/email_routes.py` → OK. Reverting only the `routes/email_routes.py` change (keeping the test) reproduces the crash (`ValueError: invalid literal for int()`).

I verified by driving the endpoints through the same route harness the email test suite uses (`setup_email_routes()` + direct endpoint call); I left the "ran the full app end-to-end" box unchecked because I did not stand up uvicorn over HTTP in this environment.

## Visual / UI changes

None — this is a backend-only change to `routes/email_routes.py` and a test file. Nothing that renders to the DOM is touched.
