### PR TITLE
fix(llm): add default context window lengths for Xiaomi Mimo 2.5 models

### DIFF
--- a/src/model_context.py
+++ b/src/model_context.py
@@ -220,6 +220,10 @@ KNOWN_CONTEXT_WINDOWS = {
     'hermes': 131072,
     'nous-hermes': 131072,
 
+    # --- Xiaomi ---
+    'mimo-v2.5-pro': 1048576,
+    'mimo-v2.5': 1048576,
+
     # --- Open community ---
     'dolphin': 32768,
     'mythomax': 4096,


### PR DESCRIPTION
## Summary

The default context window lengths for Xiaomi Mimo 2.5 and Mimo 2.5 Pro models has been added so the UI reflects them correctly. I have tested the change on my local instance of odysseus.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

<!-- Every PR should be linked to an issue.
     Use one of:  Fixes #NNN  |  Part of #NNN  |  Closes #NNN  -->

Closes #4578

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

<!-- Step-by-step instructions a reviewer can follow to verify this works.
     Do not leave this empty — a PR without test steps will be sent back. -->

1. Get some [Xiaomi Tokens](https://platform.xiaomimimo.com/console)
2. Generate an API Token
3. Configure the Mimo API endpoint in odysseus: Custom URL -> https://api.xiaomimimo.com/v1
4. Write something

### Screenshots / clips

<img width="404" height="193" alt="image" src="https://github.com/user-attachments/assets/45046e84-0542-430e-b00e-e0d8bb099443" />
