### PR TITLE
fix(llm): skip cache affinity fields for Cerebras

### DIFF
--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -638,7 +638,11 @@ def _is_self_hosted_openai_compatible(url: str) -> bool:
     loses the affinity hint unless its endpoint kind is set to "local" -
     a lost perf hint, versus a hard 4xx on every request the other way.
     """
-    if _detect_provider(url) != "openai" or _host_match(url, "openai.com"):
+    if (
+        _detect_provider(url) != "openai"
+        or _host_match(url, "openai.com")
+        or _host_match(url, "cerebras.ai")
+    ):
         return False
     from src.model_context import is_local_endpoint
     return is_local_endpoint(url)

--- a/tests/test_provider_classification.py
+++ b/tests/test_provider_classification.py
@@ -20,7 +20,9 @@ real module is side-effect free.
 import pytest
 
 from src.llm_core import (
+    _apply_local_cache_affinity,
     _detect_provider,
+    _is_self_hosted_openai_compatible,
     _provider_label,
 )
 
@@ -68,6 +70,35 @@ class TestDetectProvider:
     @pytest.mark.parametrize("url", ["", None, "not a url", "://broken"])
     def test_unidentifiable_falls_back_to_openai(self, url):
         assert _detect_provider(url) == "openai"
+
+
+# ── local cache affinity ──
+
+class TestLocalCacheAffinity:
+    def test_cerebras_cloud_never_receives_llamacpp_cache_fields(self, monkeypatch):
+        monkeypatch.setattr(
+            "src.model_context.is_local_endpoint",
+            lambda _url: True,
+        )
+
+        payload = {}
+        _apply_local_cache_affinity(
+            payload,
+            "https://api.cerebras.ai/v1",
+            "session-1",
+        )
+
+        assert payload == {}
+
+    def test_cerebras_lookalike_host_is_not_excluded(self, monkeypatch):
+        monkeypatch.setattr(
+            "src.model_context.is_local_endpoint",
+            lambda _url: True,
+        )
+
+        assert _is_self_hosted_openai_compatible(
+            "https://cerebras.ai.evil.example/v1"
+        ) is True
 
 
 # ── _provider_label ──


### PR DESCRIPTION
## Summary

Prevents Cerebras cloud endpoints from receiving the llama.cpp-specific `session_id` and `cache_prompt` fields when an endpoint is incorrectly configured as local.

## Linked Issue

Fixes #4640

## Type of Change

- [x] Bug fix

## Checklist

- [x] I searched open issues and open PRs and confirmed this is not a duplicate.
- [x] This PR targets dev.
- [x] The change is limited to the reported bug.

## How to Test

Run `python -m pytest tests/test_provider_classification.py -q` and confirm that all 40 tests pass. The regression test verifies that Cerebras receives neither `session_id` nor `cache_prompt`, while look-alike domains are not excluded.