### PR TITLE
feat(hwfit): dynamic catalog, model capabilities, and fit UX

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,11 @@ LLM_HOST=localhost
 # when LM Studio is set to serve on all interfaces (0.0.0.0).
 # LM_STUDIO_URL=http://host.docker.internal:1234
 
+# Extra local GGUF model directories scanned by Cookbook -> What Fits?
+# Use ';' on Windows and ':' on Linux/macOS/Docker. Built-in scan paths already
+# include ./data/huggingface and the default LM Studio model directory.
+# ODYSSEUS_MODEL_SCAN_DIRS=D:\Models;E:\LM Studio Models
+
 # OpenAI API key (only needed if using OpenAI models).
 # Do not commit real keys. Keep this commented until needed.
 # OPENAI_API_KEY=your_openai_api_key_here
@@ -190,6 +195,12 @@ SEARXNG_INSTANCE=http://localhost:8080
 # These overlays only expose the GPU devices. The slim Odysseus image
 # still needs CUDA/ROCm userspace via Cookbook -> Dependencies (vLLM,
 # llama-cpp-python, etc.) before models can actually serve on GPU.
+#
+# Hardware detection inside Docker/WSL reports the RAM Odysseus can actually
+# allocate, which may be lower than installed host RAM. Optional display-only
+# host RAM metadata; ranking still uses the container/WSL budget above.
+# ODYSSEUS_HOST_TOTAL_RAM_GB=64
+# ODYSSEUS_HOST_AVAILABLE_RAM_GB=48
 
 # ============================================================
 # Storage Paths (Docker Compose)

--- a/core/database.py
+++ b/core/database.py
@@ -3,7 +3,7 @@ import logging
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
-from sqlalchemy import event, create_engine, Column, String, Text, Boolean, DateTime, Integer, ForeignKey, JSON, Index, func, text
+from sqlalchemy import event, create_engine, Column, String, Text, Boolean, DateTime, Integer, Float, ForeignKey, JSON, Index, func, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.types import TypeDecorator
 from sqlalchemy.ext.declarative import declarative_base, declared_attr
@@ -406,6 +406,35 @@ class ProviderAuthSession(TimestampMixin, Base):
     refresh_token = Column(EncryptedText, nullable=True)
     last_refresh = Column(DateTime, nullable=True)
     auth_mode = Column(String, nullable=True)
+
+
+class DiscoveredModel(TimestampMixin, Base):
+    """Persisted model catalog row used by the hardware-fit recommender."""
+    __tablename__ = "discovered_models"
+
+    id = Column(String, primary_key=True, index=True)
+    name = Column(String, nullable=False, unique=True, index=True)
+    provider = Column(String, nullable=True)
+    parameter_count = Column(String, nullable=True)
+    params_b = Column(Float, nullable=True)
+    quantization = Column(String, nullable=True)
+    pipeline_tag = Column(String, nullable=True, index=True)
+    source = Column(String, nullable=False, default="hf_trending", index=True)
+    gguf_sources = Column(JSON, default=list)
+    capabilities = Column(JSON, default=list)
+    context_length = Column(Integer, nullable=True)
+    release_date = Column(String, nullable=True)
+    backend = Column(String, nullable=True)
+    local_path = Column(String, nullable=True)
+    mmproj_path = Column(String, nullable=True)
+    architecture = Column(String, nullable=True)
+    format = Column(String, nullable=True)
+    last_seen = Column(DateTime, default=utcnow_naive, nullable=False, index=True)
+
+    __table_args__ = (
+        Index("ix_discovered_models_source_seen", "source", "last_seen"),
+    )
+
 
 class McpServer(TimestampMixin, Base):
     """Admin-configured MCP (Model Context Protocol) tool servers."""

--- a/routes/cookbook_helpers.py
+++ b/routes/cookbook_helpers.py
@@ -779,6 +779,25 @@ def _append_serve_exit_code_lines(
         runner_lines.append('exit "$ODYSSEUS_CMD_EXIT"')
 
 
+def _compute_gpu_layers(run_mode: str, vram_gb, required_gb) -> int:
+    """Compute the initial -ngl value for llama.cpp based on hwfit analysis.
+
+    Returns 99 when the model fits fully on GPU, 0 when there is no GPU or the
+    model must run entirely in RAM, and a proportional layer count for partial
+    offload (cpu_offload) so the first serve attempt doesn't immediately OOM.
+    The runtime retry loop in the bash runner further halves the value on OOM.
+    """
+    if run_mode == "cpu_only":
+        return 0
+    if run_mode != "cpu_offload" or not vram_gb or not required_gb:
+        return 99
+    try:
+        frac = min(1.0, float(vram_gb) / float(required_gb))
+    except (TypeError, ZeroDivisionError, ValueError):
+        return 99
+    return max(1, int(frac * 99))
+
+
 def _append_llama_cpp_linux_accel_build_lines(runner_lines: list[str]) -> None:
     """Append Linux llama.cpp build lines that prefer ROCm/HIP when available.
 

--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -46,9 +46,7 @@ from routes.cookbook_helpers import (
     load_stored_hf_token,
     _append_vllm_linux_preflight_lines, _ollama_bind_from_cmd, _pip_install_fallback_chain,
     _pip_install_no_cache, _user_shell_path_bootstrap, _venv_safe_local_pip_install_cmd,
-    _diagnose_serve_output, run_ssh_command_async,
-    _ollama_bind_from_cmd, _pip_install_fallback_chain, _pip_install_no_cache,
-    _user_shell_path_bootstrap, _venv_safe_local_pip_install_cmd,
+    _diagnose_serve_output, _compute_gpu_layers, run_ssh_command_async,
     _normalize_llama_cpp_python_cache_types,
     ModelDownloadRequest, ServeRequest,
 )
@@ -1535,22 +1533,64 @@ def setup_cookbook_routes() -> APIRouter:
                     runner_lines,
                     keep_shell_open=not local_windows,
                 )
-                runner_lines.append(req.cmd)
-                if local_windows:
-                    # Detached background process — no interactive shell to keep open.
-                    # Print the exit marker the status poller looks for, then stop.
-                    _append_serve_exit_code_lines(
-                        runner_lines,
-                        keep_shell_open=False,
-                        is_pip_install=is_pip_install,
-                    )
+                # OOM retry for native llama-server on POSIX (tmux) runs.
+                # Windows detached process and remote PowerShell use different
+                # runners that don't support this bash loop.
+                _is_llamacpp_bash_retry = "llama-server" in req.cmd and not local_windows
+                if _is_llamacpp_bash_retry:
+                    # Extract the literal -ngl value so we can initialize the
+                    # bash variable with whatever the frontend computed (99 by
+                    # default, or a hardware-computed partial-offload value).
+                    _ngl_m = re.search(r'-ngl\s+(\d+)', req.cmd)
+                    _initial_ngl = int(_ngl_m.group(1)) if _ngl_m else 99
+                    # Replace all literal ngl numbers with a bash variable so
+                    # the retry loop can halve it without rebuilding the command.
+                    _cmd_tmpl = re.sub(r'(-ngl\s+)\d+', r'\1$_OOM_NGL', req.cmd)
+                    _cmd_tmpl = re.sub(r'(--n_gpu_layers\s+)\d+', r'\1$_OOM_NGL', _cmd_tmpl)
+                    _log_path = f'/tmp/odysseus-tmux/{session_id}.log'
+                    runner_lines.append(f'_OOM_NGL={_initial_ngl}')
+                    runner_lines.append('_OOM_RETRIES=0')
+                    runner_lines.append('while true; do')
+                    runner_lines.append(f'  {_cmd_tmpl}')
+                    runner_lines.append('  _OOM_EC=$?')
+                    runner_lines.append('  [ $_OOM_EC -eq 0 ] && break')
+                    # 127 = command not found (llama-server missing); Python
+                    # bindings fallback already ran via ||; don't retry.
+                    runner_lines.append('  [ $_OOM_EC -eq 127 ] && break')
+                    runner_lines.append('  [ $_OOM_RETRIES -ge 3 ] && break')
+                    runner_lines.append(f'  if [ $_OOM_EC -eq 137 ] || grep -qi "out of memory\\|failed to allocate" {_log_path} 2>/dev/null; then')
+                    runner_lines.append('    _OOM_NGL=$((_OOM_NGL / 2))')
+                    runner_lines.append('    _OOM_RETRIES=$((_OOM_RETRIES + 1))')
+                    runner_lines.append('    echo "[odysseus] OOM fallback: retrying with -ngl $_OOM_NGL (attempt $_OOM_RETRIES/3)"')
+                    runner_lines.append('    sleep 2')
+                    runner_lines.append('    continue')
+                    runner_lines.append('  fi')
+                    runner_lines.append('  break')
+                    runner_lines.append('done')
+                    # $? after the while loop is always 0 (from break); preserve
+                    # the actual serve exit code via _OOM_EC for the exit handler.
+                    runner_lines.append('ODYSSEUS_CMD_EXIT=$_OOM_EC')
+                    runner_lines.append('echo ""; echo "=== Process exited with code $ODYSSEUS_CMD_EXIT ==="')
+                    runner_lines.append('exec 1>&3 2>&4 3>&- 4>&- 2>/dev/null || true')
+                    runner_lines.append('sleep 0.2  # let tee child flush + exit')
+                    runner_lines.append('exec "${SHELL:-/bin/bash}"')
                 else:
-                    # Keep shell open after exit so user can see errors
-                    _append_serve_exit_code_lines(
-                        runner_lines,
-                        keep_shell_open=True,
-                        is_pip_install=is_pip_install,
-                    )
+                    runner_lines.append(req.cmd)
+                    if local_windows:
+                        # Detached background process — no interactive shell to keep open.
+                        # Print the exit marker the status poller looks for, then stop.
+                        _append_serve_exit_code_lines(
+                            runner_lines,
+                            keep_shell_open=False,
+                            is_pip_install=is_pip_install,
+                        )
+                    else:
+                        # Keep shell open after exit so user can see errors
+                        _append_serve_exit_code_lines(
+                            runner_lines,
+                            keep_shell_open=True,
+                            is_pip_install=is_pip_install,
+                        )
 
             runner_path = TMUX_LOG_DIR / f"{session_id}_run.sh"
             runner_path.write_text("\n".join(runner_lines) + "\n", encoding="utf-8")
@@ -2227,20 +2267,44 @@ def setup_cookbook_routes() -> APIRouter:
         import re
         import httpx
 
+        # Pipelines that represent runnable chat/LLM models. Multimodal flagships
+        # (Gemma 4, Qwen-VL, etc.) are tagged image-text-to-text or any-to-any on
+        # HF, not text-generation — so a text-generation-only query silently drops
+        # them. For the default LLM browse we pull all three and merge; an explicit
+        # non-LLM pipeline (e.g. text-to-image for the image tab) is honored as-is.
+        llm_pipelines = ("text-generation", "image-text-to-text", "any-to-any")
+        pipelines = list(llm_pipelines) if pipeline in ("", "text-generation", "llm") else [pipeline]
+
         # Fetch a larger pool so we have enough to filter from (we drop ~80%)
         pool_size = max(limit * 15, 100)
-        url = (
-            "https://huggingface.co/api/models"
-            f"?sort=trendingScore&direction=-1&limit={pool_size}&filter={pipeline}"
-        )
+        raw = []
+        seen_repos = set()
+        last_error = None
         try:
             async with httpx.AsyncClient(timeout=15) as client:
-                resp = await client.get(url)
-                if resp.status_code != 200:
-                    return {"models": [], "error": f"HF API HTTP {resp.status_code}"}
-                raw = resp.json()
+                for _pl in pipelines:
+                    url = (
+                        "https://huggingface.co/api/models"
+                        f"?sort=trendingScore&direction=-1&limit={pool_size}&filter={_pl}"
+                    )
+                    resp = await client.get(url)
+                    if resp.status_code != 200:
+                        last_error = f"HF API HTTP {resp.status_code}"
+                        continue
+                    for _entry in resp.json():
+                        _rid = _entry.get("modelId") or _entry.get("id") or ""
+                        if _rid and _rid in seen_repos:
+                            continue
+                        if _rid:
+                            seen_repos.add(_rid)
+                        raw.append(_entry)
         except Exception as e:
             return {"models": [], "error": str(e)}
+        if not raw:
+            return {"models": [], "error": last_error or "no models returned"}
+        # Merged across pipelines — re-establish a single trending order.
+        raw.sort(key=lambda e: e.get("trendingScore", 0) or 0, reverse=True)
+        allowed_pipelines = set(pipelines)
 
         # Estimate VRAM from the model id. Looks for patterns like "7B", "70B", "1.5B" etc.
         # Returns approx VRAM in GB at fp16 (params*2). Caller adjusts for quant.
@@ -2262,7 +2326,8 @@ def setup_cookbook_routes() -> APIRouter:
                 return 1.0
             return 1.0  # default fp16
 
-        # Exclude adapters, LoRAs, datasets, GGUF-only repos, and other non-runnable artifacts
+        # Exclude adapters, LoRAs, datasets, and other non-runnable artifacts.
+        # GGUF repos are NOT excluded — they are the preferred local-serving format.
         EXCLUDE_TAG_SUBSTRINGS = (
             "lora", "adapter", "peft", "qlora",
             "dataset", "embeddings",
@@ -2296,18 +2361,33 @@ def setup_cookbook_routes() -> APIRouter:
             tags = entry.get("tags") or []
             pipeline_tag = entry.get("pipeline_tag") or ""
 
-            # Hard filter: only the requested pipeline (HF's filter param is loose)
-            if pipeline and pipeline_tag and pipeline_tag != pipeline:
+            # Keep only the requested/runnable pipelines (HF's filter param is
+            # loose). allowed_pipelines covers multimodal-tagged chat models too,
+            # so flagships like Gemma 4 (any-to-any) are no longer dropped. An
+            # empty pipeline_tag is kept, as before.
+            if pipeline_tag and pipeline_tag not in allowed_pipelines:
                 continue
             # Skip adapters, LoRAs, datasets, etc.
             if _is_excluded(repo_id, tags):
                 continue
 
-            est_fp16 = _est_vram_fp16(repo_id)
-            quant_mult = _quant_factor(repo_id, tags)
-            est_vram = (est_fp16 * quant_mult) if est_fp16 else None
-            # Add 30% headroom for KV cache, activations, etc.
-            needed_vram = (est_vram * 1.3) if est_vram else None
+            # GGUF repos are served by llama-server which offloads layers to CPU
+            # RAM — VRAM is not the gating constraint. Bypassing the VRAM filter
+            # for GGUF is correct: the user picks a quantization at download time,
+            # and llama.cpp will mix VRAM + CPU RAM to fit whatever they choose.
+            is_gguf = (
+                "gguf" in repo_id.lower()
+                or "gguf" in " ".join(tags or []).lower()
+            )
+            if is_gguf:
+                est_vram = None
+                needed_vram = None
+            else:
+                est_fp16 = _est_vram_fp16(repo_id)
+                quant_mult = _quant_factor(repo_id, tags)
+                est_vram = (est_fp16 * quant_mult) if est_fp16 else None
+                # Add 30% headroom for KV cache, activations, etc.
+                needed_vram = (est_vram * 1.3) if est_vram else None
 
             if vram_gb > 0 and needed_vram is not None and needed_vram > vram_gb:
                 continue

--- a/routes/hwfit_routes.py
+++ b/routes/hwfit_routes.py
@@ -107,6 +107,31 @@ def _apply_manual_hardware(system, manual_mode="", manual_gpu_count="", manual_v
     return system
 
 
+def _apply_ram_override(system, override_ram_gb=""):
+    """Override only the available-RAM budget the ranker uses, leaving the
+    DETECTED GPU intact.
+
+    Distinct from the manual-hardware simulator: probed ``available_ram_gb`` is
+    just the live free memory at scan time, not a real ceiling. This lets the
+    user say "rank as if I'll free N GB before serving" (the inline RAM-budget
+    chip) without faking a different GPU, so speed estimates keep using the real
+    card's bandwidth. ``total_ram_gb`` is bumped to at least the override so the
+    chip's "used / total" reads sensibly.
+    """
+    try:
+        ov = float(override_ram_gb) if override_ram_gb else 0.0
+    except (TypeError, ValueError):
+        return system
+    if ov <= 0:
+        return system
+    ov = round(min(ov, 100000.0), 1)
+    system["available_ram_gb"] = ov
+    if (system.get("total_ram_gb") or 0) < ov:
+        system["total_ram_gb"] = ov
+    system["ram_override_gb"] = ov
+    return system
+
+
 def setup_hwfit_routes():
     router = APIRouter(prefix="/api/hwfit", tags=["hwfit"])
 
@@ -119,7 +144,7 @@ def setup_hwfit_routes():
         return detect_system(host=host, ssh_port=ssh_port, platform=platform, fresh=fresh)
 
     @router.get("/models")
-    def get_models(use_case: str = "", sort: str = "newest", limit: int = 50, search: str = "", host: str = "", quant: str = "", ctx: str = "", gpu_count: str = "", gpu_group: str = "", ssh_port: str = "", platform: str = "", fresh: bool = False, manual_mode: str = "", manual_gpu_count: str = "", manual_vram_gb: str = "", manual_ram_gb: str = "", manual_backend: str = "", ignore_detected_gpu: bool = False, ignore_detected_ram: bool = False, fit_only: bool = False):
+    def get_models(use_case: str = "", sort: str = "newest", limit: int = 50, search: str = "", host: str = "", quant: str = "", ctx: str = "", gpu_count: str = "", gpu_group: str = "", ssh_port: str = "", platform: str = "", fresh: bool = False, manual_mode: str = "", manual_gpu_count: str = "", manual_vram_gb: str = "", manual_ram_gb: str = "", manual_backend: str = "", ignore_detected_gpu: bool = False, ignore_detected_ram: bool = False, override_ram_gb: str = "", fit_only: bool = False):
         """Rank LLM models against detected hardware and return scored results.
         gpu_count: override GPU count (0 = CPU only, 1-N = simulate N GPUs of the
             active group). gpu_group: index into system.gpu_groups (the homogeneous
@@ -128,6 +153,7 @@ def setup_hwfit_routes():
         fresh=true bypasses the hardware-detection cache."""
         from services.hwfit.hardware import detect_system
         from services.hwfit.fit import rank_models
+        from services.hwfit.catalog_sync import get_catalog_or_static, upsert_discovered_models
         from services.hwfit.models import get_models, model_catalog_path
         host, ssh_port = _validate_detection_target(host, ssh_port)
         system = deepcopy(detect_system(host=host, ssh_port=ssh_port, platform=platform, fresh=fresh))
@@ -151,7 +177,12 @@ def setup_hwfit_routes():
             system["available_ram_gb"] = 0
             system["total_ram_gb"] = 0
 
+        # True installed RAM, captured before any simulator/override mutates it,
+        # so the inline RAM-budget control can cap its slider at the real ceiling.
+        system["detected_ram_total_gb"] = system.get("total_ram_gb")
+
         system = _apply_manual_hardware(system, manual_mode, manual_gpu_count, manual_vram_gb, manual_ram_gb, manual_backend)
+        system = _apply_ram_override(system, override_ram_gb)
 
         # Keep the raw detection around so the UI can still show the box's full
         # GPU complement even while we rank against one homogeneous pool.
@@ -214,24 +245,23 @@ def setup_hwfit_routes():
         if target_context is not None:
             target_context = max(1024, min(target_context, 1000000))
 
-        rank_kwargs = {
-            "use_case": use_case or None,
-            "limit": limit,
-            "search": search or None,
-            "sort": sort,
-            "quant": quant or None,
-            "fit_only": fit_only,
-        }
-        if target_context is not None:
-            rank_kwargs["target_context"] = target_context
-        try:
-            import inspect
-            supported = set(inspect.signature(rank_models).parameters)
-            rank_kwargs = {k: v for k, v in rank_kwargs.items() if k in supported}
-        except Exception:
-            rank_kwargs.pop("target_context", None)
-            rank_kwargs.pop("fit_only", None)
-        results = rank_models(system, **rank_kwargs)
+        from services.hwfit.local_scanner import scan_local_gguf
+        from services.hwfit.lmstudio_catalog import fetch_lmstudio_models
+        from services.hwfit.ollama_catalog import fetch_ollama_models
+        catalog_models = get_catalog_or_static(seed_if_empty=True)
+        local_models = scan_local_gguf() if not host else []
+        lmstudio_models = fetch_lmstudio_models(host=host)
+        ollama_models = fetch_ollama_models(host=host)
+        live_models = local_models + lmstudio_models + ollama_models
+        if live_models:
+            try:
+                from core.database import get_db_session
+                with get_db_session() as db:
+                    upsert_discovered_models(db, live_models)
+                    db.commit()
+            except Exception:
+                pass
+        results = rank_models(system, use_case=use_case or None, limit=limit, search=search or None, sort=sort, quant=quant or None, target_context=target_context, fit_only=fit_only, extra_models=live_models, catalog_models=catalog_models)
         return {"system": system, "models": results}
 
     @router.get("/profiles")
@@ -283,6 +313,27 @@ def setup_hwfit_routes():
             if isinstance(v, (int, float)) and v > 0:
                 model_ctx_max = int(v)
                 break
+        # Compute the smart initial -ngl default. Uses analyze_model() to determine
+        # whether the model fits fully on GPU, partially offloads, or is CPU-only,
+        # then translates that to an integer layer count (99/proportional/0).
+        from services.hwfit.fit import analyze_model, _default_ram_budget
+        from routes.cookbook_helpers import _compute_gpu_layers
+        # Rank the serve recommendation against the model's default RAM budget
+        # (e.g. 20 GB for the 26B) so the panel's -ngl matches the What Fits
+        # verdict instead of whatever RAM happens to be free this second. The
+        # explicit RAM override still wins; copy the dict so the cached detection
+        # result isn't mutated.
+        _mb = _default_ram_budget(m)
+        if _mb > 0 and not system.get("ram_override_gb"):
+            _cap = system.get("total_ram_gb") or _mb
+            _budget = round(min(_mb, float(_cap)), 1)
+            system = {**system, "available_ram_gb": _budget, "ram_budget_gb": _budget}
+        _fit = analyze_model(m, system)
+        recommended_ngl = _compute_gpu_layers(
+            (_fit or {}).get("run_mode", "gpu"),
+            (_fit or {}).get("vram_gb"),
+            (_fit or {}).get("required_gb"),
+        )
         return {
             "system": system,
             "profiles": compute_serve_profiles(
@@ -291,6 +342,7 @@ def setup_hwfit_routes():
                 serve_quant=(serve_quant or None),
             ),
             "model_ctx_max": model_ctx_max,
+            "recommended_ngl": recommended_ngl,
         }
 
     @router.get("/image-models")
@@ -320,5 +372,32 @@ def setup_hwfit_routes():
         system["gpu_count"] = 1 if single_vram > 0 else 0
         results = rank_image_models(system, search=search or None, sort=sort)
         return {"system": system, "models": results}
+
+    @router.get("/model-caps")
+    def get_model_caps(model: str = ""):
+        """Return the capability list for a model ID looked up in the catalog DB.
+
+        Performs an exact name match first, then a suffix match on the portion
+        after the last ``/``. Returns an empty capability list (not an error)
+        when the model is unknown so the frontend can degrade gracefully.
+        """
+        if not model:
+            return {"model_id": model, "capabilities": [], "found": False}
+        from core.database import get_db_session, DiscoveredModel
+        with get_db_session() as db:
+            row = db.query(DiscoveredModel).filter(
+                DiscoveredModel.name == model
+            ).first()
+            if row is None:
+                suffix = model.split("/")[-1]
+                row = (
+                    db.query(DiscoveredModel)
+                    .filter(DiscoveredModel.name.like(f"%/{suffix}"))
+                    .first()
+                )
+            if row is not None:
+                caps = row.capabilities if isinstance(row.capabilities, list) else []
+                return {"model_id": model, "capabilities": caps, "found": True}
+        return {"model_id": model, "capabilities": [], "found": False}
 
     return router

--- a/services/hwfit/catalog_sync.py
+++ b/services/hwfit/catalog_sync.py
@@ -1,0 +1,327 @@
+"""Persist and retrieve the dynamic hardware-fit model catalog."""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from core.database import DiscoveredModel, get_db_session, utcnow_naive
+from services.hwfit.models import get_models as get_static_models
+from services.hwfit.models import infer_quantization_from_name
+from services.hwfit.models import params_b
+
+
+SOURCE_PRIORITY = {
+    "hf_trending": 1,
+    "ollama": 2,
+    "lmstudio": 3,
+    "local_gguf": 4,
+}
+
+HF_TRENDING_PIPELINES = ("text-generation", "image-text-to-text", "any-to-any")
+HF_TRENDING_REFRESH_INTERVAL_S = 6 * 60 * 60
+_EXCLUDE_TAG_SUBSTRINGS = (
+    "lora",
+    "adapter",
+    "peft",
+    "qlora",
+    "dataset",
+    "embeddings",
+    "merge",
+    "control-lora",
+    "diffusion-lora",
+    "stable-diffusion-lora",
+    "text-classification",
+    "token-classification",
+    "feature-extraction",
+    "sentence-similarity",
+)
+_EXCLUDE_NAME_SUBSTRINGS = (
+    "lora",
+    "adapter",
+    "peft",
+    "qlora",
+    "embedding",
+    "embed-",
+    "dataset",
+)
+
+
+def normalize_catalog_entry(entry: dict, source: str | None = None) -> dict:
+    """Return a ranker-compatible catalog entry with normalized source fields."""
+    model = dict(entry or {})
+    resolved_source = source or model.get("_source") or model.get("source") or "hf_trending"
+    model["_source"] = resolved_source
+    model["source"] = resolved_source
+    if not model.get("quantization") and model.get("quant"):
+        model["quantization"] = model["quant"]
+    if not model.get("quant") and model.get("quantization"):
+        model["quant"] = model["quantization"]
+    if "params_b" not in model:
+        model["params_b"] = params_b(model) or None
+    return model
+
+
+def upsert_discovered_model(db: Session, entry: dict, source: str | None = None) -> DiscoveredModel:
+    """Insert or update one discovered model using source-priority semantics."""
+    model = normalize_catalog_entry(entry, source=source)
+    name = str(model.get("name") or "").strip()
+    if not name:
+        raise ValueError("discovered model entry requires a name")
+
+    now = utcnow_naive()
+    incoming_source = model.get("_source") or "hf_trending"
+    row = db.query(DiscoveredModel).filter(DiscoveredModel.name == name).first()
+    if row is None:
+        row = DiscoveredModel(id=str(uuid4()), name=name)
+        db.add(row)
+        should_replace = True
+    else:
+        should_replace = _source_priority(incoming_source) >= _source_priority(row.source)
+
+    if should_replace:
+        _apply_entry(row, model)
+    else:
+        _fill_missing_entry(row, model)
+    row.last_seen = now
+    db.flush()
+    return row
+
+
+def upsert_discovered_models(db: Session, entries: Iterable[dict], source: str | None = None) -> list[DiscoveredModel]:
+    """Upsert multiple discovered models and return the affected rows."""
+    rows = []
+    for entry in entries:
+        rows.append(upsert_discovered_model(db, entry, source=source))
+    return rows
+
+
+def seed_static_catalog(db: Session) -> int:
+    """Seed the discovered-model table from hf_models.json when it is empty."""
+    if db.query(DiscoveredModel.id).first() is not None:
+        return 0
+    rows = upsert_discovered_models(db, get_static_models(), source="hf_trending")
+    return len(rows)
+
+
+def get_discovered_catalog(db: Session, seed_if_empty: bool = True) -> list[dict]:
+    """Return persisted catalog rows as dictionaries accepted by rank_models()."""
+    if seed_if_empty:
+        seed_static_catalog(db)
+    rows = db.query(DiscoveredModel).order_by(DiscoveredModel.name.asc()).all()
+    return [discovered_model_to_dict(row) for row in rows]
+
+
+def get_catalog_or_static(seed_if_empty: bool = True) -> list[dict]:
+    """Return the DB-backed catalog, falling back to static JSON on DB errors."""
+    try:
+        with get_db_session() as db:
+            catalog = get_discovered_catalog(db, seed_if_empty=seed_if_empty)
+            return catalog or [normalize_catalog_entry(m, source="hf_trending") for m in get_static_models()]
+    except Exception:
+        return [normalize_catalog_entry(m, source="hf_trending") for m in get_static_models()]
+
+
+async def fetch_hf_trending_catalog(limit: int = 300, pipelines: Iterable[str] | None = None) -> list[dict]:
+    """Fetch Hugging Face trending LLM entries in ranker-compatible form."""
+    import httpx
+
+    selected_pipelines = tuple(pipelines or HF_TRENDING_PIPELINES)
+    pool_size = max(limit, 100)
+    raw: list[dict] = []
+    seen_repos: set[str] = set()
+    async with httpx.AsyncClient(timeout=15) as client:
+        for pipeline in selected_pipelines:
+            url = (
+                "https://huggingface.co/api/models"
+                f"?sort=trendingScore&direction=-1&limit={pool_size}&filter={pipeline}"
+            )
+            response = await client.get(url)
+            if response.status_code != 200:
+                continue
+            for item in response.json():
+                repo_id = item.get("modelId") or item.get("id") or ""
+                if not repo_id or repo_id in seen_repos:
+                    continue
+                seen_repos.add(repo_id)
+                raw.append(item)
+
+    raw.sort(key=lambda item: item.get("trendingScore", 0) or 0, reverse=True)
+    allowed_pipelines = set(selected_pipelines)
+    entries = []
+    for item in raw:
+        entry = _hf_api_item_to_catalog_entry(item, allowed_pipelines)
+        if not entry:
+            continue
+        entries.append(entry)
+        if len(entries) >= limit:
+            break
+    return entries
+
+
+async def refresh_hf_trending_catalog(limit: int = 300) -> int:
+    """Fetch HF trending models and upsert them into the discovered catalog."""
+    entries = await fetch_hf_trending_catalog(limit=limit)
+    if not entries:
+        return 0
+    with get_db_session() as db:
+        rows = upsert_discovered_models(db, entries, source="hf_trending")
+        db.commit()
+        return len(rows)
+
+
+def refresh_live_catalog_sources(host: str = "") -> int:
+    """Scan live local sources and persist them into the discovered catalog."""
+    from services.hwfit.lmstudio_catalog import fetch_lmstudio_models
+    from services.hwfit.local_scanner import scan_local_gguf
+    from services.hwfit.ollama_catalog import fetch_ollama_models
+
+    entries = []
+    if not host:
+        entries.extend(scan_local_gguf())
+    entries.extend(fetch_lmstudio_models(host=host))
+    entries.extend(fetch_ollama_models(host=host))
+    if not entries:
+        return 0
+    with get_db_session() as db:
+        rows = upsert_discovered_models(db, entries)
+        db.commit()
+        return len(rows)
+
+
+def discovered_model_to_dict(row: DiscoveredModel) -> dict:
+    """Convert one persisted catalog row into a ranker-compatible dictionary."""
+    model = {
+        "name": row.name,
+        "provider": row.provider,
+        "parameter_count": row.parameter_count,
+        "params_b": row.params_b,
+        "quantization": row.quantization or "",
+        "quant": row.quantization or "",
+        "pipeline_tag": row.pipeline_tag,
+        "source": row.source,
+        "_source": row.source,
+        "gguf_sources": row.gguf_sources or [],
+        "capabilities": row.capabilities or [],
+        "context_length": row.context_length,
+        "context": row.context_length,
+        "release_date": row.release_date or "",
+        "backend": row.backend or "",
+        "local_path": row.local_path or "",
+        "mmproj_path": row.mmproj_path or "",
+        "architecture": row.architecture or "",
+        "format": row.format or "",
+    }
+    if model["gguf_sources"]:
+        model["is_gguf"] = True
+    return model
+
+
+def _apply_entry(row: DiscoveredModel, model: dict) -> None:
+    """Overwrite a row with incoming normalized model metadata."""
+    row.provider = model.get("provider")
+    row.parameter_count = model.get("parameter_count")
+    row.params_b = model.get("params_b")
+    row.quantization = model.get("quantization") or model.get("quant")
+    row.pipeline_tag = model.get("pipeline_tag")
+    row.source = model.get("_source") or model.get("source") or "hf_trending"
+    row.gguf_sources = list(model.get("gguf_sources") or [])
+    row.capabilities = list(model.get("capabilities") or [])
+    row.context_length = _int_or_none(model.get("context_length") or model.get("context"))
+    row.release_date = model.get("release_date") or ""
+    row.backend = model.get("backend") or ""
+    row.local_path = model.get("local_path") or ""
+    row.mmproj_path = model.get("mmproj_path") or ""
+    row.architecture = model.get("architecture") or ""
+    row.format = model.get("format") or ""
+
+
+def _fill_missing_entry(row: DiscoveredModel, model: dict) -> None:
+    """Fill sparse fields without demoting a higher-priority source row."""
+    row.provider = row.provider or model.get("provider")
+    row.parameter_count = row.parameter_count or model.get("parameter_count")
+    row.params_b = row.params_b or model.get("params_b")
+    row.quantization = row.quantization or model.get("quantization") or model.get("quant")
+    row.pipeline_tag = row.pipeline_tag or model.get("pipeline_tag")
+    row.gguf_sources = row.gguf_sources or list(model.get("gguf_sources") or [])
+    row.capabilities = row.capabilities or list(model.get("capabilities") or [])
+    row.context_length = row.context_length or _int_or_none(model.get("context_length") or model.get("context"))
+    row.release_date = row.release_date or model.get("release_date") or ""
+    row.backend = row.backend or model.get("backend") or ""
+    row.local_path = row.local_path or model.get("local_path") or ""
+    row.mmproj_path = row.mmproj_path or model.get("mmproj_path") or ""
+    row.architecture = row.architecture or model.get("architecture") or ""
+    row.format = row.format or model.get("format") or ""
+
+
+def _source_priority(source: str | None) -> int:
+    """Return catalog source precedence."""
+    return SOURCE_PRIORITY.get(source or "", 0)
+
+
+def _int_or_none(value: object) -> int | None:
+    """Convert a numeric-looking value to int, otherwise None."""
+    if value in (None, ""):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _hf_api_item_to_catalog_entry(item: dict, allowed_pipelines: set[str]) -> dict | None:
+    """Convert one Hugging Face API item into a persisted catalog entry."""
+    repo_id = str(item.get("modelId") or item.get("id") or "").strip()
+    if not repo_id:
+        return None
+    tags = item.get("tags") or []
+    pipeline_tag = item.get("pipeline_tag") or ""
+    if pipeline_tag and pipeline_tag not in allowed_pipelines:
+        return None
+    if _is_excluded_hf_repo(repo_id, tags):
+        return None
+
+    parameter_count = _infer_parameter_count(repo_id)
+    quantization = infer_quantization_from_name(repo_id)
+    tag_text = " ".join(str(tag) for tag in tags)
+    is_gguf = "gguf" in repo_id.lower() or "gguf" in tag_text.lower()
+    capabilities = []
+    if pipeline_tag in {"image-text-to-text", "any-to-any"}:
+        capabilities.append("vision")
+
+    entry = {
+        "name": repo_id,
+        "provider": repo_id.split("/", 1)[0] if "/" in repo_id else "Hugging Face",
+        "parameter_count": parameter_count,
+        "quantization": quantization or "",
+        "pipeline_tag": pipeline_tag,
+        "source": "hf_trending",
+        "_source": "hf_trending",
+        "gguf_sources": [{"repo": repo_id, "kind": "GGUF"}] if is_gguf else [],
+        "capabilities": capabilities,
+        "release_date": item.get("createdAt") or "",
+        "backend": "llamacpp" if is_gguf else "",
+    }
+    if is_gguf:
+        entry["is_gguf"] = True
+    return entry
+
+
+def _infer_parameter_count(repo_id: str) -> str:
+    """Infer a catalog parameter count like 7B from a Hugging Face repo id."""
+    match = re.search(r"(?i)(?:^|[-_/])(\d+(?:\.\d+)?)\s*([BM])(?:$|[-_/])", repo_id)
+    if not match:
+        return ""
+    return f"{float(match.group(1)):g}{match.group(2).upper()}"
+
+
+def _is_excluded_hf_repo(repo_id: str, tags: list[str]) -> bool:
+    """Return True for HF artifacts that are not standalone runnable models."""
+    text = repo_id.lower()
+    if any(fragment in text for fragment in _EXCLUDE_NAME_SUBSTRINGS):
+        return True
+    tag_text = " ".join(str(tag).lower() for tag in tags)
+    return any(fragment in tag_text for fragment in _EXCLUDE_TAG_SUBSTRINGS)

--- a/services/hwfit/fit.py
+++ b/services/hwfit/fit.py
@@ -9,7 +9,7 @@ from services.hwfit.models import (
 GPU_BANDWIDTH = {
     "5090": 1792, "5080": 960, "5070 ti": 896, "5070": 672, "5060 ti": 448, "5060": 256,
     "4090": 1008, "4080 super": 736, "4080": 717, "4070 ti super": 672, "4070 ti": 504, "4070 super": 504, "4070": 504, "4060 ti": 288, "4060": 272,
-    "3090 ti": 1008, "3090": 936, "3080 ti": 912, "3080": 760, "3070 ti": 608, "3070": 448, "3060 ti": 448, "3060": 360,
+    "3090 ti": 1008, "3090": 936, "3080 ti": 912, "3080": 760, "3070 ti": 608, "3070": 448, "3060 ti": 448, "3060": 360, "3050 ti": 192, "3050": 224,
     "2080 ti": 616, "2080 super": 496, "2080": 448, "2070 super": 448, "2070": 448, "2060 super": 448, "2060": 336,
     "1660 ti": 288, "1660 super": 336, "1660": 192, "1650 super": 192, "1650": 128,
     "h100 sxm": 3350, "h100": 2039, "h200": 4800, "a100 sxm": 2039, "a100": 1555,
@@ -50,6 +50,41 @@ _APPLE_VARIANT_KEYS_SORTED = sorted(APPLE_BANDWIDTH_BY_CORES.keys(), key=len, re
 # metal: backstop for Apple Silicon chips not in the explicit tables above
 # (e.g. a future M6) — use a conservative generic estimate when unknown.
 FALLBACK_K = {"cuda": 220, "rocm": 180, "metal": 150, "cpu_x86": 70, "cpu_arm": 90}
+
+# Hardcoded default RAM budgets (GB) for specific models, applied only when the
+# user has NOT set an explicit RAM override (the RAM chip). The probed
+# available-RAM is just whatever's momentarily free, so a heavy model you always
+# intend to give N GB would otherwise read as marginal/too_tight until you free
+# memory. Listing it here lets that model rank against its intended budget by
+# default. Models NOT listed track live free RAM, i.e. update dynamically with
+# whatever you have left. A catalog entry may also carry its own
+# "default_ram_budget_gb"; that takes precedence over this map.
+DEFAULT_RAM_BUDGET_GB = {
+    "google/gemma-4-26B-A4B-it-qat-q4_0-gguf": 20.0,
+    "google/gemma-4-26B-A4B-it": 20.0,
+}
+
+
+def _default_ram_budget(model):
+    """Return the model's declared/hardcoded default RAM budget in GB, or 0.0.
+
+    Prefers an explicit ``default_ram_budget_gb`` field on the catalog entry,
+    then the DEFAULT_RAM_BUDGET_GB map (exact name, then the bare repo name after
+    the last ``/`` so local/alias copies still match)."""
+    try:
+        field = float(model.get("default_ram_budget_gb") or 0)
+    except (TypeError, ValueError):
+        field = 0.0
+    if field > 0:
+        return field
+    name = model.get("name") or ""
+    if name in DEFAULT_RAM_BUDGET_GB:
+        return DEFAULT_RAM_BUDGET_GB[name]
+    suffix = name.split("/")[-1]
+    for k, v in DEFAULT_RAM_BUDGET_GB.items():
+        if k.split("/")[-1] == suffix:
+            return v
+    return 0.0
 
 USE_CASE_WEIGHTS = {
     "general":    (0.45, 0.30, 0.15, 0.10),
@@ -411,6 +446,18 @@ def analyze_model(model, system, target_quant=None, scoring_use_case=None, targe
     gpu_count = system.get("gpu_count", 1) or 1
     single_gpu_vram = gpu_vram / gpu_count if gpu_count > 1 else gpu_vram
     available_ram = system.get("available_ram_gb", 0)
+    # Per-model default RAM budget. The explicit global RAM override (the chip,
+    # surfaced as ram_override_gb) always wins. Otherwise, a model with a declared
+    # default budget is ranked against it (capped at installed RAM), while models
+    # without one keep tracking live free RAM. See DEFAULT_RAM_BUDGET_GB.
+    if not system.get("ram_override_gb"):
+        _model_budget = _default_ram_budget(model)
+        if _model_budget > 0:
+            _ram_cap = system.get("detected_ram_total_gb") or system.get("total_ram_gb") or _model_budget
+            try:
+                available_ram = min(_model_budget, float(_ram_cap))
+            except (TypeError, ValueError):
+                available_ram = _model_budget
     # When the user has explicitly picked a GPU config (not RAM mode), they want
     # to see what runs ON the GPU(s) — not big models that only "fit" by spilling
     # most layers to system RAM. Zeroing the offload budget makes _try_quant_at
@@ -429,6 +476,17 @@ def analyze_model(model, system, target_quant=None, scoring_use_case=None, targe
     native_quant = _native_quant(model)
     preq = is_prequantized(model)
 
+    # Quantization-aware-training builds that ship a real GGUF are served by
+    # llama.cpp, not vLLM: Gemma QAT is distributed as int4 GGUF for exactly
+    # this consumer path. So a QAT row WITH gguf_sources must be treated like
+    # any other GGUF — eligible for CPU offload — instead of the vLLM/GPU-only
+    # path the bare "QAT-" prequant label would otherwise force. QAT safetensors
+    # (no GGUF) stay vLLM-only via the unchanged native_gpu_only below.
+    qat_gguf = (
+        native_quant.upper().startswith("QAT")
+        and bool(model.get("is_gguf") or model.get("gguf_sources"))
+    )
+
     # GGUF models can't be sharded across GPUs — use single GPU VRAM
     is_gguf = bool(model.get("gguf_sources"))
     quant_upper = (native_quant or "").upper()
@@ -437,12 +495,12 @@ def analyze_model(model, system, target_quant=None, scoring_use_case=None, targe
     # across GPUs). Prequantized formats (AWQ/GPTQ/FP8) are served sharded by
     # vLLM across all GPUs, so they get the FULL multi-GPU VRAM — even when the
     # model also lists a GGUF alternate download (gguf_sources).
-    if (is_gguf or is_gguf_quant) and not preq:
+    if ((is_gguf or is_gguf_quant) and not preq) or qat_gguf:
         effective_vram = single_gpu_vram
     else:
         effective_vram = gpu_vram
 
-    native_gpu_only = preq and not native_quant.startswith("mlx-")
+    native_gpu_only = preq and not native_quant.startswith("mlx-") and not qat_gguf
 
     # Determine which quant to evaluate at
     native_quant_prefixes = (
@@ -511,6 +569,10 @@ def analyze_model(model, system, target_quant=None, scoring_use_case=None, targe
             "gguf_sources": model.get("gguf_sources", []),
             "context_length": model_ctx,
             "target_context": target_context or None,
+            "_source": model.get("_source", ""),
+            "source": model.get("_source", ""),
+            "local_path": model.get("local_path", ""),
+            "mmproj_path": model.get("mmproj_path", ""),
         }
 
     run_mode, quant, fit_ctx, required_gb = result
@@ -528,6 +590,11 @@ def analyze_model(model, system, target_quant=None, scoring_use_case=None, targe
         else:
             fit_level = "marginal"
     elif run_mode == "cpu_offload":
+        fit_level = "good" if available_ram >= required_gb * 1.2 else "marginal"
+    elif run_mode == "cpu_only":
+        # Previously always "marginal" regardless of RAM headroom. A model that
+        # fits comfortably in RAM with 20% headroom is a legitimate "good" fit;
+        # "marginal" should be reserved for tight cases where OOM is a real risk.
         fit_level = "good" if available_ram >= required_gb * 1.2 else "marginal"
     else:
         fit_level = "marginal"
@@ -547,6 +614,14 @@ def analyze_model(model, system, target_quant=None, scoring_use_case=None, targe
     wq, ws, wf, wc = USE_CASE_WEIGHTS.get(score_use_case, (0.45, 0.30, 0.15, 0.10))
     composite = q_score * wq + s_score * ws + f_score * wf + c_score * wc
 
+    # For cpu_offload rows, expose how much of required_gb lands on GPU vs RAM
+    # so the UI can render a "4.5G+3.0G" partial-offload split in the Mem column.
+    vram_gb = None
+    ram_gb = None
+    if run_mode == "cpu_offload" and effective_vram > 0:
+        vram_gb = round(min(effective_vram, required_gb), 1)
+        ram_gb = round(max(0.0, required_gb - effective_vram), 1)
+
     return {
         "name": model.get("name"),
         "provider": model.get("provider"),
@@ -559,6 +634,9 @@ def analyze_model(model, system, target_quant=None, scoring_use_case=None, targe
         "quant": quant,
         "context": fit_ctx,
         "required_gb": round(required_gb, 1),
+        "ram_budget_gb": round(available_ram, 1),
+        "vram_gb": vram_gb,
+        "ram_gb": ram_gb,
         "speed_tps": round(tps, 1),
         "score": round(composite, 1),
         "scores": {
@@ -571,6 +649,10 @@ def analyze_model(model, system, target_quant=None, scoring_use_case=None, targe
         "context_length": model_ctx,
         "release_date": model.get("release_date", ""),
         "target_context": target_context or None,
+        "_source": model.get("_source", ""),
+        "source": model.get("_source", ""),
+        "local_path": model.get("local_path", ""),
+        "mmproj_path": model.get("mmproj_path", ""),
     }
 
 
@@ -620,16 +702,34 @@ SORT_KEYS = {
     "newest": lambda r: r.get("release_date") or "",
 }
 
+_SOURCE_PRIORITY = {
+    "local_gguf": 4,
+    "lmstudio": 3,
+    "ollama": 2,
+    "hf_trending": 1,
+    "": 0,
+}
 
-def rank_models(system, use_case=None, limit=50, search=None, sort="score", quant=None, target_context=None, fit_only=False):
+
+def _source_priority(result):
+    """Return source precedence for same-metric catalog rows."""
+    return _SOURCE_PRIORITY.get(result.get("_source") or result.get("source") or "", 0)
+
+
+def rank_models(system, use_case=None, limit=50, search=None, sort="score", quant=None, target_context=None, fit_only=False, extra_models=None, catalog_models=None):
     """Rank all models against detected hardware. Returns sorted list of fit results.
 
     fit_only: when True, drop rows whose fit_level is "too_tight" (model doesn't
     actually fit on the chosen budget). When False (default), every model is
     shown — sorting by Param means highest-param PERIOD, even ones that won't
     run, so the user can see the truth.
+    extra_models: additional catalog entries (e.g. from Ollama) to include in
+    the ranking pass alongside the static catalog.
+    catalog_models: optional primary catalog override, used by the dynamic DB
+    catalog while preserving the static JSON fallback for existing callers.
     """
-    models = get_models()
+    models = list(catalog_models) if catalog_models is not None else get_models()
+    models = models + list(extra_models or [])
     results = []
 
     # Include image gen models only when explicitly filtered
@@ -667,7 +767,7 @@ def rank_models(system, use_case=None, limit=50, search=None, sort="score", quan
             })
         if use_case == "image_gen":
             sort_fn = SORT_KEYS.get(sort, SORT_KEYS["score"])
-            results.sort(key=sort_fn, reverse=True)  # see main path below
+            results.sort(key=lambda r: (sort_fn(r), _source_priority(r)), reverse=True)  # see main path below
             return results[:limit]
 
     # If user picked a native prequantized format, filter to only those models.
@@ -773,6 +873,6 @@ def rank_models(system, use_case=None, limit=50, search=None, sort="score", quan
     # global highest by that metric. Before, vram was special-cased
     # ascending → truncate kept the 50 SMALLEST models and "highest VRAM"
     # could never appear, breaking the column-click toggle.
-    results.sort(key=sort_fn, reverse=True)
+    results.sort(key=lambda r: (sort_fn(r), _source_priority(r)), reverse=True)
     results = results[:limit]
     return results

--- a/services/hwfit/hardware.py
+++ b/services/hwfit/hardware.py
@@ -417,6 +417,37 @@ def _read_file(path):
         return None
 
 
+def _running_in_container():
+    """Return True when Odysseus appears to be running inside a container."""
+    if _remote_host:
+        return False
+    if os.path.exists("/.dockerenv"):
+        return True
+    cgroup = _read_file("/proc/1/cgroup") or ""
+    return any(marker in cgroup.lower() for marker in ("docker", "containerd", "kubepods"))
+
+
+def _container_gpu_error():
+    """Return a helpful GPU visibility warning for containerized deployments."""
+    if not _running_in_container():
+        return None
+    if os.path.exists("/dev/kfd") or os.path.exists("/dev/dri"):
+        return None
+    if os.path.exists("/dev/nvidiactl") or os.path.exists("/dev/nvidia0"):
+        return None
+    if os.environ.get("NVIDIA_VISIBLE_DEVICES"):
+        return (
+            "The NVIDIA GPU compose overlay is configured, but no NVIDIA device "
+            "is visible inside the Odysseus Docker container. Check Docker Desktop "
+            "GPU support or the NVIDIA Container Toolkit setup in docs/HARDWARE_SETUP.md."
+        )
+    return (
+        "No GPU is visible inside the Odysseus Docker container. "
+        "If this host has a GPU, restart with the NVIDIA or AMD GPU compose overlay "
+        "from docs/HARDWARE_SETUP.md."
+    )
+
+
 def _parse_meminfo():
     """Parse /proc/meminfo into a dict of key -> KB values."""
     text = _read_file("/proc/meminfo")
@@ -503,6 +534,87 @@ def _get_cpu_count():
     return os.cpu_count() or 1
 
 
+def _get_physical_cpu_count():
+    """Return physical CPU core count when the OS exposes it."""
+    text = _read_file("/proc/cpuinfo") or ""
+    if text:
+        physical_cores: set[tuple[str, str]] = set()
+        package_cores: dict[str, int] = {}
+        current: dict[str, str] = {}
+        for line in text.splitlines() + [""]:
+            if not line.strip():
+                if "physical id" in current and "core id" in current:
+                    physical_cores.add((current["physical id"], current["core id"]))
+                elif "physical id" in current and "cpu cores" in current:
+                    try:
+                        package_cores[current["physical id"]] = int(current["cpu cores"])
+                    except ValueError:
+                        pass
+                current = {}
+                continue
+            if ":" not in line:
+                continue
+            key, value = line.split(":", 1)
+            current[key.strip()] = value.strip()
+        if physical_cores:
+            return len(physical_cores)
+        if package_cores:
+            return sum(package_cores.values())
+
+    if _remote_host:
+        out = _run(["sysctl", "-n", "hw.physicalcpu"])
+        if out:
+            try:
+                return int(out.strip())
+            except ValueError:
+                pass
+    return None
+
+
+def _runtime_context():
+    """Return runtime metadata that explains container/WSL resource scopes."""
+    version = (_read_file("/proc/version") or "").lower()
+    in_container = _running_in_container()
+    in_wsl = "microsoft" in version or "wsl" in version
+    runtime = "host"
+    ram_scope = "host"
+    if in_container and in_wsl:
+        runtime = "docker_wsl2"
+        ram_scope = "docker_wsl2"
+    elif in_container:
+        runtime = "docker"
+        ram_scope = "docker"
+    elif in_wsl:
+        runtime = "wsl2"
+        ram_scope = "wsl2"
+
+    return {
+        "runtime": runtime,
+        "ram_scope": ram_scope,
+        "in_container": in_container,
+        "in_wsl": in_wsl,
+    }
+
+
+def _configured_host_ram():
+    """Return optional host RAM metadata supplied by deployment environment."""
+    def _float_env(name):
+        try:
+            value = os.environ.get(name)
+            return round(float(value), 1) if value not in (None, "") else None
+        except ValueError:
+            return None
+
+    total = _float_env("ODYSSEUS_HOST_TOTAL_RAM_GB")
+    available = _float_env("ODYSSEUS_HOST_AVAILABLE_RAM_GB")
+    if total is None and available is None:
+        return {}
+    return {
+        "host_total_ram_gb": total,
+        "host_available_ram_gb": available,
+    }
+
+
 def _canonical_cpu_arch(value):
     arch = str(value or "").lower().strip().replace("-", "_")
     if arch in ("x86_64", "amd64", "x64"):
@@ -546,6 +658,7 @@ def _detect_windows():
         $cpu = Get-CimInstance Win32_Processor | Select-Object -First 1
         $r.cpu_name = $cpu.Name
         $r.cpu_cores = (Get-CimInstance Win32_Processor | Measure-Object -Property NumberOfLogicalProcessors -Sum).Sum
+        $r.cpu_physical_cores = (Get-CimInstance Win32_Processor | Measure-Object -Property NumberOfCores -Sum).Sum
         $r.arch = $cpu.AddressWidth
         $r.cpu_arch = if ($env:PROCESSOR_ARCHITEW6432) { $env:PROCESSOR_ARCHITEW6432 } else { $env:PROCESSOR_ARCHITECTURE }
         # GPU detection via nvidia-smi (fastest) or WMI fallback
@@ -618,6 +731,8 @@ def _detect_windows():
             "total_ram_gb": d.get("ram_gb", 0),
             "available_ram_gb": d.get("avail_gb", 0),
             "cpu_cores": _as_int(d.get("cpu_cores"), 1),
+            "cpu_logical_cores": _as_int(d.get("cpu_cores"), 1),
+            "cpu_physical_cores": _as_int(d.get("cpu_physical_cores"), 0) or None,
             "cpu_name": _cpu_name,
             "cpu_arch": _canonical_cpu_arch(d.get("cpu_arch")),
             "has_gpu": bool(d.get("gpu_name")),
@@ -628,6 +743,10 @@ def _detect_windows():
             "homogeneous": True,
             "gpu_error": None,
             "platform": "windows",
+            "runtime": "host",
+            "ram_scope": "host",
+            "in_container": False,
+            "in_wsl": False,
         }
         # PowerShell only reports aggregate GPU info, not per-card detail, so we
         # can't tell a mixed box from a uniform one here — assume one homogeneous
@@ -814,7 +933,10 @@ def detect_system(host="", ssh_port="", platform="", fresh=False):
         return result
     available_ram = round(_get_available_ram_gb(), 1)
     cpu_cores = _get_cpu_count()
+    physical_cores = _get_physical_cpu_count()
     cpu_name = _get_cpu_name()
+    runtime_context = _runtime_context()
+    host_ram = _configured_host_ram()
     cpu_arch = _get_cpu_arch()
 
     gpu_info = _detect_apple_silicon() or _detect_nvidia() or _detect_amd()
@@ -824,6 +946,8 @@ def detect_system(host="", ssh_port="", platform="", fresh=False):
             "total_ram_gb": total_ram,
             "available_ram_gb": available_ram,
             "cpu_cores": cpu_cores,
+            "cpu_logical_cores": cpu_cores,
+            "cpu_physical_cores": physical_cores,
             "cpu_name": cpu_name,
             "cpu_arch": cpu_arch,
             "has_gpu": True,
@@ -838,6 +962,8 @@ def detect_system(host="", ssh_port="", platform="", fresh=False):
             # Apple Silicon / AMD APUs share system RAM with the GPU — carry the
             # flag through so callers can tell unified from discrete VRAM.
             "unified_memory": gpu_info.get("unified_memory", False),
+            **runtime_context,
+            **host_ram,
         }
     else:
         backend = "cpu_arm" if cpu_arch == "arm64" else "cpu_x86"
@@ -845,6 +971,8 @@ def detect_system(host="", ssh_port="", platform="", fresh=False):
             "total_ram_gb": total_ram,
             "available_ram_gb": available_ram,
             "cpu_cores": cpu_cores,
+            "cpu_logical_cores": cpu_cores,
+            "cpu_physical_cores": physical_cores,
             "cpu_name": cpu_name,
             "cpu_arch": cpu_arch,
             "has_gpu": False,
@@ -855,7 +983,9 @@ def detect_system(host="", ssh_port="", platform="", fresh=False):
             # Set when nvidia-smi exists but failed (e.g. driver/library
             # version mismatch) — lets the UI say "GPU driver error" instead
             # of the misleading "No GPU".
-            "gpu_error": _last_gpu_error,
+            "gpu_error": _last_gpu_error or _container_gpu_error(),
+            **runtime_context,
+            **host_ram,
         }
 
     result = _attach_probe_context(result, host=host)

--- a/services/hwfit/lmstudio_catalog.py
+++ b/services/hwfit/lmstudio_catalog.py
@@ -1,0 +1,185 @@
+"""Discover models exposed by a local LM Studio server for hwfit ranking."""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+from urllib.parse import urlparse
+
+import httpx
+
+from services.hwfit.models import infer_quantization_from_name
+
+
+_CACHE_TTL = 30.0
+_lmstudio_cache: dict[str, tuple[list[dict], float]] = {}
+_PARAM_RE = re.compile(r"(?i)(?:^|[-_.])(\d+(?:\.\d+)?)\s*([BM])(?:[-_.]|$)")
+_CONTEXT_BY_ARCH = {
+    "gemma": 8192,
+    "llama": 4096,
+    "qwen": 32768,
+    "mistral": 32768,
+    "mixtral": 32768,
+    "deepseek": 65536,
+    "phi": 4096,
+}
+
+
+def fetch_lmstudio_models(host: str = "") -> list[dict]:
+    """Query LM Studio's native API and return hwfit-compatible model dicts."""
+    cache_key = host or "local"
+    now = time.monotonic()
+    cached = _lmstudio_cache.get(cache_key)
+    if cached and cached[1] > now:
+        return list(cached[0])
+
+    models: list[dict] = []
+    seen: set[str] = set()
+    for url in _candidate_urls(host):
+        try:
+            response = httpx.get(url, timeout=1.5)
+            data = response.json() if response.is_success else {}
+        except Exception:
+            continue
+        raw_models = data.get("models")
+        if not _looks_like_lmstudio(raw_models):
+            continue
+        for item in raw_models:
+            entry = _entry_from_lmstudio_item(item)
+            if not entry or entry["name"] in seen:
+                continue
+            seen.add(entry["name"])
+            models.append(entry)
+        break
+
+    _lmstudio_cache[cache_key] = (models, now + _CACHE_TTL)
+    return list(models)
+
+
+def invalidate_cache() -> None:
+    """Clear the LM Studio catalog cache."""
+    _lmstudio_cache.clear()
+
+
+def _candidate_urls(host: str) -> list[str]:
+    """Return native LM Studio model-list URLs to try."""
+    if host:
+        return [f"http://{host}:1234/api/v1/models"]
+
+    urls: list[str] = []
+    env_url = (os.environ.get("LM_STUDIO_URL") or "").strip()
+    if env_url:
+        parsed = urlparse(env_url if "://" in env_url else "http://" + env_url)
+        if parsed.hostname:
+            scheme = parsed.scheme or "http"
+            port = parsed.port or 1234
+            urls.append(f"{scheme}://{parsed.hostname}:{port}/api/v1/models")
+    urls.extend([
+        "http://127.0.0.1:1234/api/v1/models",
+        "http://host.docker.internal:1234/api/v1/models",
+    ])
+    return list(dict.fromkeys(urls))
+
+
+def _looks_like_lmstudio(models: object) -> bool:
+    """Return True when a model list has LM Studio's native item shape."""
+    return (
+        isinstance(models, list)
+        and bool(models)
+        and isinstance(models[0], dict)
+        and "key" in models[0]
+        and "architecture" in models[0]
+    )
+
+
+def _entry_from_lmstudio_item(item: dict) -> dict | None:
+    """Convert one LM Studio native model item to a hwfit catalog entry."""
+    key = str(item.get("key") or item.get("id") or "").strip()
+    if not key:
+        return None
+    display_name = str(item.get("display_name") or key).strip()
+    architecture = str(item.get("architecture") or "").strip()
+    fmt = str(item.get("format") or "").lower()
+    quant = _quantization_name(item) or infer_quantization_from_name(key) or "Q4_K_M"
+    parameter_count = _parameter_count(item, key)
+    context = _context_length(item, architecture, key)
+    is_gguf = fmt == "gguf" or quant.upper().startswith(("Q", "IQ"))
+    capabilities = _capabilities(item)
+
+    entry = {
+        "name": display_name,
+        "provider": "LM Studio",
+        "parameter_count": parameter_count,
+        "quantization": quant,
+        "quant": quant,
+        "architecture": architecture,
+        "format": fmt,
+        "context_length": context,
+        "context": context,
+        "backend": "lmstudio",
+        "_source": "lmstudio",
+        "source": "lmstudio",
+        "capabilities": capabilities,
+        "lmstudio_key": key,
+    }
+    if is_gguf:
+        entry["is_gguf"] = True
+        entry["gguf_sources"] = [{"repo": key, "kind": "GGUF"}]
+    else:
+        entry["gguf_sources"] = []
+    return entry
+
+
+def _quantization_name(item: dict) -> str:
+    """Return LM Studio's quantization label when present."""
+    quant = item.get("quantization")
+    if isinstance(quant, dict):
+        return str(quant.get("name") or "").upper()
+    if isinstance(quant, str):
+        return quant.upper()
+    return ""
+
+
+def _parameter_count(item: dict, key: str) -> str:
+    """Infer parameter count from LM Studio metadata or model key."""
+    for field in ("parameter_count", "params"):
+        value = item.get(field)
+        if isinstance(value, str) and value.strip():
+            return value.strip().upper()
+        if isinstance(value, (int, float)) and value > 0:
+            if value > 1_000_000:
+                return f"{value / 1_000_000_000:g}B"
+    value = item.get("size")
+    if isinstance(value, str) and value.strip():
+        return value.strip().upper()
+    match = _PARAM_RE.search(key)
+    if match:
+        return f"{float(match.group(1)):g}{match.group(2).upper()}"
+    return ""
+
+
+def _context_length(item: dict, architecture: str, key: str) -> int:
+    """Return context length from LM Studio metadata or a family default."""
+    for field in ("context_length", "max_context_length", "trained_context_length", "n_ctx_train"):
+        value = item.get(field)
+        if isinstance(value, (int, float)) and value > 0:
+            return int(value)
+    haystack = f"{architecture} {key}".lower()
+    for family, ctx in _CONTEXT_BY_ARCH.items():
+        if family in haystack:
+            return ctx
+    return 4096
+
+
+def _capabilities(item: dict) -> list[str]:
+    """Normalize LM Studio capability flags to Odysseus catalog labels."""
+    caps = item.get("capabilities")
+    if not isinstance(caps, dict):
+        return []
+    out = []
+    if caps.get("vision"):
+        out.append("vision")
+    if caps.get("tools") or caps.get("tool_use"):
+        out.append("tools")
+    return out

--- a/services/hwfit/local_scanner.py
+++ b/services/hwfit/local_scanner.py
@@ -1,0 +1,172 @@
+"""Discover locally available GGUF model files for the hwfit catalog."""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+from services.hwfit.models import QUANT_BYTES_PER_PARAM
+
+
+_QUANT_RE = re.compile(
+    r"(?i)(?:^|[-_.])((?:IQ)?Q[2-8](?:_[A-Z0-9]+){0,2}|F16|F32|BF16)(?:[-_.]|$)"
+)
+_PARAM_RE = re.compile(r"(?i)(?:^|[-_.])(\d+(?:\.\d+)?)\s*([BM])(?:[-_.]|$)")
+_FAMILY_ALIASES = (
+    "deepseek",
+    "gemma",
+    "llama",
+    "mistral",
+    "mixtral",
+    "phi",
+    "qwen",
+    "starcoder",
+    "yi",
+)
+_CONTEXT_BY_FAMILY = {
+    "gemma": 8192,
+    "llama": 4096,
+    "qwen": 32768,
+    "mistral": 32768,
+    "mixtral": 32768,
+    "deepseek": 65536,
+    "phi": 4096,
+}
+
+
+def default_scan_dirs() -> list[Path]:
+    """Return the local directories Odysseus should scan for GGUF files."""
+    repo_root = Path(__file__).resolve().parents[2]
+    paths = [repo_root / "data" / "huggingface"]
+
+    userprofile = os.environ.get("USERPROFILE")
+    if userprofile:
+        paths.append(Path(userprofile) / ".lmstudio" / "models")
+    paths.append(Path.home() / ".lmstudio" / "models")
+    paths.extend(_extra_scan_dirs(os.environ.get("ODYSSEUS_MODEL_SCAN_DIRS", "")))
+
+    out: list[Path] = []
+    seen: set[str] = set()
+    for path in paths:
+        key = str(path.expanduser())
+        if key not in seen:
+            out.append(path.expanduser())
+            seen.add(key)
+    return out
+
+
+def scan_local_gguf(scan_dirs: list[str | Path] | None = None) -> list[dict]:
+    """Scan local directories and return hwfit-compatible GGUF model entries."""
+    roots = [Path(p).expanduser() for p in (scan_dirs or default_scan_dirs())]
+    entries: list[dict] = []
+    seen: set[str] = set()
+    for root in roots:
+        if not root.exists() or not root.is_dir():
+            continue
+        for path in root.rglob("*.gguf"):
+            if not path.is_file() or _is_mmproj(path):
+                continue
+            resolved = str(path.resolve())
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            entries.append(_entry_from_file(path))
+    entries.sort(key=lambda m: (m.get("family") or "", m.get("name") or ""))
+    return entries
+
+
+def _extra_scan_dirs(raw: str) -> list[Path]:
+    """Split configured scan paths while tolerating Windows drive letters."""
+    if not raw.strip():
+        return []
+    if ";" in raw:
+        parts = raw.split(";")
+    elif ":" in raw:
+        # Docker/Linux paths use ':'. Windows drive-letter paths are safer as ';',
+        # but this still accepts "D:\Models:E:\More" without splitting drives.
+        parts = re.split(r":(?![\\/])", raw)
+    else:
+        parts = [raw]
+    return [Path(p.strip()) for p in parts if p.strip()]
+
+
+def _entry_from_file(path: Path) -> dict:
+    """Build one catalog entry from a GGUF file path."""
+    stem = path.stem
+    family = _infer_family(stem)
+    quant = _infer_quant(stem)
+    parameter_count = _infer_parameter_count(stem, quant, path.stat().st_size)
+    mmproj = _find_mmproj(path)
+    source = {
+        "repo": str(path.resolve()),
+        "kind": "GGUF",
+        "path": str(path.resolve()),
+        "filename": path.name,
+    }
+    if mmproj:
+        source["mmproj_path"] = str(mmproj.resolve())
+
+    return {
+        "name": f"local/{stem}",
+        "provider": "Local GGUF",
+        "parameter_count": parameter_count,
+        "quantization": quant,
+        "quant": quant,
+        "family": family,
+        "is_gguf": True,
+        "gguf_sources": [source],
+        "backend": "llamacpp",
+        "context_length": _CONTEXT_BY_FAMILY.get(family, 4096),
+        "context": _CONTEXT_BY_FAMILY.get(family, 4096),
+        "local_path": str(path.resolve()),
+        "mmproj_path": str(mmproj.resolve()) if mmproj else "",
+        "_source": "local_gguf",
+    }
+
+
+def _infer_family(stem: str) -> str:
+    """Infer a known model family from a GGUF filename stem."""
+    lower = stem.lower()
+    for family in _FAMILY_ALIASES:
+        if family in lower:
+            return family
+    token = re.split(r"[-_.\s]+", lower, maxsplit=1)[0]
+    return token or "local"
+
+
+def _infer_quant(stem: str) -> str:
+    """Infer a GGUF quantization tier from a filename stem."""
+    match = _QUANT_RE.search(stem)
+    if not match:
+        return "Q4_K_M"
+    return match.group(1).upper()
+
+
+def _infer_parameter_count(stem: str, quant: str, size_bytes: int) -> str:
+    """Infer parameter count from filename, falling back to file size."""
+    match = _PARAM_RE.search(stem)
+    if match:
+        value = float(match.group(1))
+        suffix = match.group(2).upper()
+        return f"{value:g}{suffix}"
+
+    gib = size_bytes / (1024 ** 3)
+    bpp = QUANT_BYTES_PER_PARAM.get(quant, 0.5)
+    if bpp <= 0:
+        return ""
+    return f"{max(gib / bpp, 0.1):.1f}B"
+
+
+def _is_mmproj(path: Path) -> bool:
+    """Return True when a GGUF file is a multimodal projection sidecar."""
+    return "mmproj" in path.name.lower()
+
+
+def _find_mmproj(path: Path) -> Path | None:
+    """Find a likely mmproj sidecar in the same directory as a GGUF model."""
+    candidates = sorted(path.parent.glob("*mmproj*.gguf"))
+    if candidates:
+        return candidates[0]
+    candidates = sorted(path.parent.glob("*-mmproj.gguf"))
+    return candidates[0] if candidates else None

--- a/services/hwfit/models.py
+++ b/services/hwfit/models.py
@@ -12,6 +12,7 @@ QUANT_BPP = {
     "Q4_K_M": 0.58, "Q4_0": 0.58, "Q3_K_M": 0.48, "Q2_K": 0.37,
     "AWQ-4bit": 0.50, "AWQ-8bit": 1.0,
     "GPTQ-Int4": 0.50, "GPTQ-Int8": 1.0,
+    "QAT-INT4": 0.50, "QAT-INT8": 1.0,
     "mlx-4bit": 0.55, "mlx-8bit": 1.0, "mlx-6bit": 0.75,
     # DeepSeek-V4-style mixed: MoE experts in FP4 (bulk), attention + non-
     # expert dense in FP8, embeddings/LM head in BF16. By weight count the
@@ -30,6 +31,7 @@ QUANT_SPEED_MULT = {
     "Q4_K_M": 1.15, "Q4_0": 1.15, "Q3_K_M": 1.25, "Q2_K": 1.35,
     "AWQ-4bit": 1.2, "AWQ-8bit": 0.85,
     "GPTQ-Int4": 1.2, "GPTQ-Int8": 0.85,
+    "QAT-INT4": 1.15, "QAT-INT8": 0.85,
     "mlx-4bit": 1.15, "mlx-8bit": 0.85, "mlx-6bit": 1.0,
     "FP4-MoE-Mixed": 1.10,  # slightly slower than pure FP4 because of mixed-dtype dispatch
     "FP8-Mixed": 0.85,
@@ -47,6 +49,10 @@ QUANT_QUALITY_PENALTY = {
     # penalty so FP8 wins when both fit. AWQ-4bit stays heavier.
     "AWQ": -1.0, "AWQ-4bit": -4.0, "AWQ-8bit": -1.0,
     "GPTQ": -1.0, "GPTQ-Int4": -4.0, "GPTQ-Int8": -1.0,
+    # Quantization-aware training recovers most of the int4 quality loss, so a
+    # QAT-INT4 build lands far closer to bf16 than a post-training Q4/INT4
+    # (Google reports near-bf16 quality). Penalize it lightly, not like Q4_K_M.
+    "QAT-INT4": -1.0, "QAT-INT8": 0.0,
     "mlx-4bit": -4.0, "mlx-8bit": -0.5, "mlx-6bit": -1.5,
     # DeepSeek-V4 mixed: only MoE experts at FP4 (the rest is FP8/BF16),
     # so the realized quality is much closer to FP8 than to pure FP4 —
@@ -63,6 +69,7 @@ QUANT_BYTES_PER_PARAM = {
     "Q4_K_M": 0.5, "Q4_0": 0.5, "Q3_K_M": 0.375, "Q2_K": 0.25,
     "AWQ-4bit": 0.5, "AWQ-8bit": 1.0,
     "GPTQ-Int4": 0.5, "GPTQ-Int8": 1.0,
+    "QAT-INT4": 0.5, "QAT-INT8": 1.0,
     "mlx-4bit": 0.5, "mlx-8bit": 1.0, "mlx-6bit": 0.75,
     "FP4-MoE-Mixed": 0.55,
     "FP8-Mixed": 1.0,
@@ -74,6 +81,7 @@ PREQUANTIZED_PREFIXES = (
     "AWQ-", "GPTQ-", "mlx-", "FP8", "FP4", "NVFP4", "MXFP4", "NF4",
     "INT4", "INT8", "W4A16", "W8A8", "W8A16",
     "FP4-MoE-Mixed", "FP8-Mixed",
+    "QAT-",
 )
 
 
@@ -111,12 +119,26 @@ def infer_quantization_from_name(name):
     return ""
 
 
+_VISION_PIPELINE_TAGS = frozenset({"image-text-to-text", "any-to-any"})
+_AUDIO_PIPELINE_TAGS = frozenset({"any-to-any", "automatic-speech-recognition"})
+
+
 def _normalize_model_entry(model):
     if not isinstance(model, dict):
         return model
     inferred = infer_quantization_from_name(model.get("name", ""))
     if inferred and (model.get("quantization") in (None, "", "Q4_K_M") or model.get("_discovered")):
         model["quantization"] = inferred
+    # Backfill capability tags from pipeline_tag when the entry has none.
+    # Avoids manual edits to every multimodal row in hf_models.json.
+    pipeline = model.get("pipeline_tag") or ""
+    caps = list(model.get("capabilities") or [])
+    if pipeline in _VISION_PIPELINE_TAGS and "vision" not in caps:
+        caps.append("vision")
+    if pipeline in _AUDIO_PIPELINE_TAGS and "audio" not in caps:
+        caps.append("audio")
+    if caps != list(model.get("capabilities") or []):
+        model["capabilities"] = caps
     return model
 
 

--- a/services/hwfit/ollama_catalog.py
+++ b/services/hwfit/ollama_catalog.py
@@ -1,0 +1,135 @@
+"""Discover models installed in a local Ollama instance and return
+hwfit-compatible catalog entries for ranking in the What Fits? tab."""
+
+import json
+import re
+import time
+import urllib.request
+
+_CACHE_TTL = 30  # seconds — avoids hammering Ollama on every scan request
+_ollama_cache: list | None = None
+_ollama_cache_ts: float = 0.0
+
+# Context defaults derived from well-known model families.
+# Ollama's /api/tags does not expose context length, so we use
+# conservative known-good defaults rather than guessing a huge value.
+_CONTEXT_BY_FAMILY = {
+    "gemma3": 131072,
+    "llama3": 131072,
+    "qwen3": 32768,
+    "qwen2": 32768,
+    "gemma2": 8192,
+    "gemma": 8192,
+    "mistral": 32768,
+    "phi": 4096,
+    "deepseek": 65536,
+    "llama": 4096,
+}
+
+_PARAM_RE = re.compile(r"([\d.]+)\s*([BKMGT]?)", re.IGNORECASE)
+
+
+def _parse_param_count(raw: str) -> str:
+    """Normalise Ollama's '3.2B', '7b', '70B' etc. to the catalog 'XB' format."""
+    if not raw:
+        return ""
+    m = _PARAM_RE.match(raw.strip())
+    if not m:
+        return ""
+    val, suffix = m.group(1), m.group(2).upper()
+    return f"{val}{suffix or 'B'}"
+
+
+def _infer_context(details: dict) -> int:
+    """Return a plausible default context from the Ollama family metadata."""
+    families = list(details.get("families") or [])
+    if details.get("family"):
+        families.append(details["family"])
+    for fam in families:
+        fam = fam.lower()
+        for key, ctx in _CONTEXT_BY_FAMILY.items():
+            if key in fam:
+                return ctx
+    return 4096
+
+
+def fetch_ollama_models(host: str = "") -> list:
+    """Query a local Ollama instance and return hwfit-compatible model dicts.
+
+    Returns an empty list silently when Ollama is not running or when a remote
+    host is requested (SSH tunnelling is not yet implemented here).
+
+    Results are cached for _CACHE_TTL seconds to avoid adding latency on
+    every What Fits? scan request when Ollama is absent.
+    """
+    global _ollama_cache, _ollama_cache_ts
+
+    if host:
+        # Remote Ollama is accessible via the serve command but the hwfit
+        # catalog fetch cannot SSH-tunnel a urllib call yet — return nothing.
+        return []
+
+    now = time.monotonic()
+    if _ollama_cache is not None and (now - _ollama_cache_ts) < _CACHE_TTL:
+        return list(_ollama_cache)
+
+    urls = [
+        "http://127.0.0.1:11434/api/tags",
+        "http://host.docker.internal:11434/api/tags",
+    ]
+    raw = None
+    for url in urls:
+        try:
+            with urllib.request.urlopen(url, timeout=1) as r:
+                raw = json.loads(r.read().decode("utf-8", "replace"))
+            break
+        except Exception:
+            continue
+
+    if not raw:
+        # Cache the empty result so rapid successive calls don't all wait 1s×2.
+        _ollama_cache = []
+        _ollama_cache_ts = now
+        return []
+
+    models = []
+    seen: set[str] = set()
+    for item in raw.get("models", []):
+        name = (item.get("name") or item.get("model") or "").strip()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+
+        details = item.get("details") or {}
+        param_str = details.get("parameter_size") or ""
+        quant = (details.get("quantization_level") or "Q4_K_M").upper()
+        ctx = _infer_context(details)
+
+        models.append({
+            "name": name,
+            "provider": "Ollama",
+            "parameter_count": _parse_param_count(param_str),
+            "quantization": quant,
+            "quant": quant,
+            # Ollama stores all models as GGUF internally. Setting both fields
+            # ensures the fit ranker uses single-GPU VRAM (not multi-GPU sharding)
+            # and that Windows/Metal/RDNA filters don't exclude the entry.
+            "is_gguf": True,
+            "gguf_sources": [{"repo": name, "kind": "GGUF"}],
+            "is_ollama": True,
+            "backend": "ollama",
+            "context_length": ctx,
+            "context": ctx,
+            "_source": "ollama",
+        })
+
+    _ollama_cache = models
+    _ollama_cache_ts = now
+    return list(models)
+
+
+def invalidate_cache() -> None:
+    """Force the next fetch_ollama_models() call to re-query Ollama.
+    Useful after a model is downloaded or removed via Odysseus."""
+    global _ollama_cache_ts
+    _ollama_cache_ts = 0.0

--- a/src/model_discovery.py
+++ b/src/model_discovery.py
@@ -163,6 +163,21 @@ class ModelDiscovery:
                     return "lmstudio"
         except Exception:
             pass
+        # llama.cpp's llama-server exposes a native /props endpoint (no /v1 prefix)
+        # describing the loaded model, slots, and chat template — distinct from
+        # LM Studio (/api/v1/models) and vLLM (/version, /metrics).
+        try:
+            r = httpx.get(f"http://{host}:{port}/props", timeout=1.5)
+            if r.is_success:
+                props = r.json() or {}
+                if isinstance(props, dict) and (
+                    "default_generation_settings" in props
+                    or "total_slots" in props
+                    or "chat_template" in props
+                ):
+                    return "llamacpp"
+        except Exception:
+            pass
         return None
 
     def _check_port(self, host: str, port: int) -> Optional[Dict[str, Any]]:
@@ -194,10 +209,11 @@ class ModelDiscovery:
 
         logger.info(f"Scanning {len(hosts)} hosts for models: {hosts}")
 
-        # Well-known ports: 8000-8020 (vLLM, llama.cpp, SGLang, Cookbook),
-        # 1234 (LM Studio), 11434 (Ollama), 11435 for APFEL as its default port is
-        # occupied by Ollama. The env vars can add more ports which will be merged in.
-        ports = list(range(8000, 8021)) + [1234, 11434, 11435]
+        # Well-known ports: 8000-8020 (vLLM, SGLang, Cookbook), 8080 (llama.cpp /
+        # llama-server default), 1234 (LM Studio), 11434 (Ollama), 11435 for APFEL
+        # as its default port is occupied by Ollama. The env vars can add more
+        # ports which will be merged in.
+        ports = list(range(8000, 8021)) + [8080, 1234, 11434, 11435]
         ports += [p for p in sorted(self._extra_ports) if p not in ports]
         targets = [(h, p) for h in hosts for p in ports]
 
@@ -218,10 +234,50 @@ class ModelDiscovery:
         # Sort by host then port for consistent ordering
         items.sort(key=lambda x: (x["host"], x["port"]))
 
-        logger.info(
-            f"Discovered {len(items)} model endpoints across {len(hosts)} hosts"
-        )
+        logger.info(f"Discovered {len(items)} model endpoints across {len(hosts)} hosts")
+
+        # Persist catalog entries for any LM Studio / Ollama endpoints found.
+        # Runs in a daemon thread so it never blocks the scan response.
+        lm_hosts = {item["host"] for item in items if item.get("provider") == "lmstudio"}
+        ollama_hosts = {item["host"] for item in items if item.get("port") == 11434}
+        if lm_hosts or ollama_hosts:
+            import threading
+            threading.Thread(
+                target=self._persist_discovered_endpoints,
+                args=(lm_hosts, ollama_hosts),
+                daemon=True,
+            ).start()
+
         return {"hosts": hosts, "items": items}
+
+    def _persist_discovered_endpoints(self, lm_hosts: set, ollama_hosts: set) -> None:
+        """Persist catalog entries for discovered LM Studio and Ollama endpoints."""
+        entries: List[Dict[str, Any]] = []
+        for host in lm_hosts:
+            try:
+                from services.hwfit.lmstudio_catalog import fetch_lmstudio_models
+                entries.extend(fetch_lmstudio_models(host=host))
+            except Exception:
+                logger.debug("LM Studio catalog fetch failed for %s", host, exc_info=True)
+        for host in ollama_hosts:
+            try:
+                from services.hwfit.ollama_catalog import fetch_ollama_models
+                entries.extend(fetch_ollama_models(host=host))
+            except Exception:
+                logger.debug("Ollama catalog fetch failed for %s", host, exc_info=True)
+        if not entries:
+            return
+        try:
+            from services.hwfit.catalog_sync import upsert_discovered_models
+            from core.database import get_db_session
+            with get_db_session() as db:
+                upsert_discovered_models(db, entries)
+                db.commit()
+            logger.debug(
+                "Persisted %d catalog entries from endpoint discovery", len(entries)
+            )
+        except Exception:
+            logger.debug("Catalog persistence after endpoint discovery failed", exc_info=True)
 
     def warmup_ping_urls(self, limit: int = 5) -> List[str]:
         """The ``/models`` URLs of up to ``limit`` discovered endpoints.

--- a/src/task_scheduler.py
+++ b/src/task_scheduler.py
@@ -504,6 +504,7 @@ class TaskScheduler:
         # old event scanner too caused duplicate emails/notifications for the
         # same calendar event.
         self._note_pings_task = asyncio.create_task(self._note_pings_loop())
+        self._catalog_refresh_task = asyncio.create_task(self._catalog_refresh_loop())
         logger.info(f"Task scheduler started (concurrency cap: {self._concurrency_cap})")
         # Audit clusters: show any minute-of-day where >1 active scheduled
         # tasks land. Helps spot "all my tasks fire at 9am" patterns the user
@@ -540,13 +541,35 @@ class TaskScheduler:
                 await self._task
             except asyncio.CancelledError:
                 pass
-        for attr in ("_note_pings_task", "_event_pings_task"):
+        for attr in ("_note_pings_task", "_event_pings_task", "_catalog_refresh_task"):
             t = getattr(self, attr, None)
             if t:
                 t.cancel()
                 try: await t
                 except asyncio.CancelledError: pass
         logger.info("Task scheduler stopped")
+
+    async def _catalog_refresh_loop(self):
+        """Refresh the dynamic model catalog on a six-hour cadence."""
+        from services.hwfit.catalog_sync import (
+            HF_TRENDING_REFRESH_INTERVAL_S,
+            refresh_hf_trending_catalog,
+            refresh_live_catalog_sources,
+        )
+
+        await asyncio.sleep(20)
+        while self._running:
+            try:
+                live_count = await asyncio.to_thread(refresh_live_catalog_sources)
+                hf_count = await refresh_hf_trending_catalog()
+                logger.info(
+                    "Catalog refresh complete: live=%d hf_trending=%d",
+                    live_count,
+                    hf_count,
+                )
+            except Exception as e:
+                logger.warning(f"Catalog refresh errored: {e}")
+            await asyncio.sleep(HF_TRENDING_REFRESH_INTERVAL_S)
 
     async def _note_pings_loop(self):
         """Built-in note-due scanner — ticks every 60s inside the scheduler.

--- a/static/app.js
+++ b/static/app.js
@@ -3748,6 +3748,52 @@ function startOdysseusApp() {
   // Expose globally so voiceRecorder can trigger update after async fetch
   window._updateSendBtnIcon = _updateSendBtnIcon;
 
+  // ── Model capability affordances ──
+  // When modelPicker broadcasts 'odysseus:model-capabilities', update which
+  // input affordances are enabled based on the active model's capability list.
+  let _activeModelCaps = [];
+
+  function _applyAffordances(caps) {
+    const hasVision = caps.includes('vision');
+    const hasAudio  = caps.includes('audio');
+    const hasTools  = caps.includes('tools');
+
+    // Vision: show dedicated image-attach button only for vision models.
+    const visionBtn = el('vision-attach-btn');
+    if (visionBtn) visionBtn.style.display = hasVision ? '' : 'none';
+
+    // Stamp data attributes on the input bar so CSS can react.
+    const inputBar = document.querySelector('.chat-input-bar');
+    if (inputBar) {
+      inputBar.dataset.modelVision = hasVision ? 'true' : 'false';
+      inputBar.dataset.modelAudio  = hasAudio  ? 'true' : 'false';
+      inputBar.dataset.modelTools  = hasTools  ? 'true' : 'false';
+    }
+
+    // Expose for _updateSendBtnIcon and any other module that needs it.
+    window._activeModelHasAudio = hasAudio;
+    window._activeModelHasVision = hasVision;
+  }
+
+  document.addEventListener('odysseus:model-capabilities', (e) => {
+    _activeModelCaps = (e.detail && e.detail.capabilities) || [];
+    _applyAffordances(_activeModelCaps);
+    try { _updateSendBtnIcon(); } catch (_) {}
+  });
+
+  // Wire the vision-attach button to an image-only file picker.
+  const _visionAttachBtn = el('vision-attach-btn');
+  if (_visionAttachBtn) {
+    _visionAttachBtn.addEventListener('click', () => {
+      const fi = document.getElementById('file-input');
+      if (!fi) return;
+      const prev = fi.accept;
+      fi.accept = 'image/*';
+      fi.click();
+      fi.addEventListener('change', () => { fi.accept = prev; }, { once: true });
+    });
+  }
+
   // Initial icon state
   _updateSendBtnIcon();
 

--- a/static/index.html
+++ b/static/index.html
@@ -1069,6 +1069,15 @@
               </button>
             </div>
           </div>
+          <!-- Vision image-attach — shown only when the active model has vision capability -->
+          <button type="button" class="input-icon-btn" id="vision-attach-btn"
+                  title="Attach image (model supports vision)" aria-label="Attach image"
+                  style="display:none">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/>
+              <circle cx="12" cy="13" r="4"/>
+            </svg>
+          </button>
           <!-- Web search (magnifying glass) -->
           <button type="button" class="input-icon-btn" title="Web search" id="web-toggle-btn" data-mode-tool="true" aria-label="Web search" aria-pressed="false">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/static/js/cookbook-hwfit.js
+++ b/static/js/cookbook-hwfit.js
@@ -1366,15 +1366,23 @@ export function _hwfitRenderList(el, models) {
       : '';
     const moeBadge = m.is_moe ? '<span class="hwfit-badge hwfit-moe">MoE</span>' : '';
     const imgBadge = m.is_image_gen ? '<span class="hwfit-badge" style="background:color-mix(in srgb, var(--red) 20%, transparent);color:var(--red);font-size:8px;padding:1px 4px;border-radius:3px;margin-left:4px;">IMG</span>' : '';
+    // One unified "you already have this locally" cue. A GGUF on disk, a model
+    // in your HF download cache, or one served by a local LM Studio / Ollama all
+    // mean "present on this machine" \u2014 so they share the same badge styling and
+    // the tooltip names the specific source. (Previously a separate green dot
+    // for the HF cache and a "local" badge for GGUF files looked redundant and
+    // were mutually exclusive, which was confusing.)
     let sourceBadge = '';
+    const _cachedHere = _cachedModelIds && (_cachedModelIds.has(m.name) || [..._cachedModelIds].some(id => id === m.name?.split('/').pop()));
     if (m._source === 'local_gguf') {
-      sourceBadge = '<span class="hwfit-badge hwfit-source-local" title="Installed GGUF file">local</span>';
+      sourceBadge = '<span class="hwfit-badge hwfit-source-local" title="GGUF file on this machine">local</span>';
     } else if (m._source === 'lmstudio') {
-      sourceBadge = '<span class="hwfit-badge hwfit-source-lmstudio" title="Available in LM Studio">LM</span>';
+      sourceBadge = '<span class="hwfit-badge hwfit-source-lmstudio" title="Served by LM Studio on this machine">LM</span>';
     } else if (m._source === 'ollama') {
-      sourceBadge = '<span class="hwfit-badge hwfit-source-ollama" title="Installed in local Ollama">Ollama</span>';
+      sourceBadge = '<span class="hwfit-badge hwfit-source-ollama" title="Served by Ollama on this machine">Ollama</span>';
+    } else if (_cachedHere) {
+      sourceBadge = '<span class="hwfit-badge hwfit-source-local" title="Downloaded to your model cache">local</span>';
     }
-    const dlDot = (_cachedModelIds && (_cachedModelIds.has(m.name) || [..._cachedModelIds].some(id => id === m.name?.split('/').pop()))) ? '<span class="hwfit-dl-dot" title="Downloaded">\u25CF</span>' : '';
     html += `<div class="hwfit-row" data-model="${esc(m.name)}">`;
     html += `<span class="hwfit-col hwfit-fit" style="color:${fitColor}">${esc(fitLabel)}${ramBadge}</span>`;
     // Append quant to the title when it's not already in the repo name. The
@@ -1395,7 +1403,7 @@ export function _hwfitRenderList(el, models) {
         _quantSuffix = ` <span class="hwfit-name-quant" title="${esc(_quantTag)} — full storage format">(${esc(_display)})</span>`;
       }
     }
-    html += `<span class="hwfit-col hwfit-name">${modelLogo(m.name)}${esc(_short)}${_quantSuffix}${moeBadge}${imgBadge}${sourceBadge}${dlDot}</span>`;
+    html += `<span class="hwfit-col hwfit-name">${modelLogo(m.name)}${esc(_short)}${_quantSuffix}${moeBadge}${imgBadge}${sourceBadge}</span>`;
     html += `<span class="hwfit-col hwfit-c-params">${esc(pcount)}</span>`;
     // Truncate the Quant cell to 9 chars + ellipsis so long tags like
     // "FP4-MoE-Mixed" don't push neighboring columns. Full tag stays in title.

--- a/static/js/cookbook-hwfit.js
+++ b/static/js/cookbook-hwfit.js
@@ -287,6 +287,7 @@ export function _renderGpuToggles(system) {
 // reload paints instantly, then we refresh in the background and swap.
 const _SCAN_CACHE_KEY = 'hwfit_scan_cache_v1';
 const _MANUAL_HW_KEY = 'hwfit_manual_hardware_v1';
+const _RAM_OVERRIDE_KEY = 'hwfit_ram_override_v1';
 const _CTX_KEY = 'hwfit_target_context_v1';
 const _CTX_PRESETS = [8192, 16384, 32768, 50000, 131072, 0]; // 0 = model max
 const _SCAN_CACHE_MAX = 12;            // keep the newest N signatures
@@ -329,6 +330,23 @@ function _saveManualHwState(s) {
   try {
     if (!s || !s.mode) localStorage.removeItem(_MANUAL_HW_KEY);
     else localStorage.setItem(_MANUAL_HW_KEY, JSON.stringify(s));
+  } catch {}
+}
+
+// Inline RAM-budget override (the editable RAM chip). Distinct from the manual
+// simulator: it only raises/lowers the available-RAM budget the ranker uses,
+// keeping the detected GPU so speed estimates stay accurate. null = use detected.
+function _ramOverride() {
+  try {
+    const v = Number(JSON.parse(localStorage.getItem(_RAM_OVERRIDE_KEY) || 'null'));
+    return Number.isFinite(v) && v > 0 ? v : null;
+  } catch { return null; }
+}
+
+function _saveRamOverride(v) {
+  try {
+    if (!v || v <= 0) localStorage.removeItem(_RAM_OVERRIDE_KEY);
+    else localStorage.setItem(_RAM_OVERRIDE_KEY, JSON.stringify(Math.round(v)));
   } catch {}
 }
 
@@ -422,6 +440,7 @@ function _scanSig() {
     g: (tc && typeof tc._activeCount === 'number') ? String(tc._activeCount) : '',
     gg: (tc && tc._activeGroup) ? String(tc._activeGroup) : '',
     m: _manualHwParams(),
+    ro: _ramOverride() || 0,
     d: Array.from(_dismissedHwChips).sort(),
   });
 }
@@ -666,6 +685,13 @@ export async function _hwfitFetch(fresh = false) {
     Object.entries(manualParams).forEach(([k, v]) => {
       if (v !== '') params.set(k, v);
     });
+    // Inline RAM-budget override — only when not in the full manual simulator
+    // (manual mode already replaces RAM via manual_ram_gb) and not when RAM is
+    // dismissed entirely. Keeps the detected GPU; just changes the RAM budget.
+    const ramOv = _ramOverride();
+    if (ramOv && !_manualHwState() && !_dismissedHwChips.has('ram')) {
+      params.set('override_ram_gb', String(ramOv));
+    }
     if (hasManualOrDismissed) params.set('_hw_override_ts', String(Date.now()));
     // Image models use a separate registry/endpoint
     const isImageMode = useCase === 'image_gen';
@@ -950,9 +976,12 @@ export function _hwfitRenderHw(el, sys) {
       ? ''
       : (() => {
           const dim = _dismissedHwChips.has('gpu') ? ' hwfit-hw-chip-off' : '';
+          const label = /docker|container|compose overlay/i.test(sys.gpu_error || '')
+            ? 'GPU unavailable'
+            : 'GPU driver error';
           return (
             `<span class="hwfit-hw-chip hwfit-hw-chip-row hwfit-hw-chip-error${dim}" data-hw-chip="gpu">`
-            + `<button type="button" class="hwfit-hw-chip-toggle" data-hw-chip="gpu" title="${esc(sys.gpu_error)}">GPU driver error</button>`
+            + `<button type="button" class="hwfit-hw-chip-toggle" data-hw-chip="gpu" title="${esc(sys.gpu_error)}">${label}</button>`
             + `<button type="button" class="hwfit-hw-chip-x" data-hw-chip="gpu" title="Remove this chip" aria-label="Remove">×</button>`
             + `</span>`
           );
@@ -961,8 +990,21 @@ export function _hwfitRenderHw(el, sys) {
     gpuChip = chip('gpu', 'No GPU');
   }
   const vram = sys.gpu_vram_gb ? `${sys.gpu_vram_gb.toFixed(1)} GB VRAM` : '';
-  const ram = `${sys.available_ram_gb?.toFixed(1) || '?'} / ${sys.total_ram_gb?.toFixed(1) || '?'} GB RAM`;
-  const cores = `${sys.cpu_cores || '?'} cores`;
+  const ramScope = String(sys.ram_scope || '');
+  const scopedRam = /docker|wsl/i.test(ramScope);
+  const ramName = scopedRam ? 'Odysseus RAM' : 'RAM';
+  const ram = `${sys.available_ram_gb?.toFixed(1) || '?'} / ${sys.total_ram_gb?.toFixed(1) || '?'} GB ${ramName}`;
+  const hostRam = sys.host_total_ram_gb
+    ? ` Host installed RAM: ${Number(sys.host_total_ram_gb).toFixed(1)} GB.`
+    : '';
+  const ramTitle = scopedRam
+    ? `RAM available to Odysseus inside ${sys.runtime || 'container/WSL'}.${hostRam} Increase Docker Desktop or WSL memory to make more host RAM usable for local serving.`
+    : 'Click to toggle off (X to hide)';
+  const logicalCores = sys.cpu_logical_cores || sys.cpu_cores || 0;
+  const physicalCores = sys.cpu_physical_cores || 0;
+  const cores = physicalCores && logicalCores && physicalCores !== logicalCores
+    ? `${physicalCores}C/${logicalCores}T`
+    : `${logicalCores || '?'} cores`;
   const manual = _manualHwState();
   const manualChip = (sys.manual_hardware || manual)
     ? `<span class="hwfit-hw-chip hwfit-hw-chip-row hwfit-hw-chip-manual" data-hw-chip="manual">`
@@ -970,10 +1012,28 @@ export function _hwfitRenderHw(el, sys) {
       + `<button type="button" class="hwfit-hw-chip-x" data-hw-chip="manual" title="Clear manual hardware" aria-label="Clear">×</button>`
       + `</span>`
     : '';
+  // RAM chip is editable: clicking the body opens a budget editor (slider +
+  // number) that overrides available_ram_gb while keeping the detected GPU, so
+  // the user can rank "as if I free N GB" without faking hardware. The probed
+  // value is just live free memory, not a real ceiling. ↺ clears the override.
+  const ramOv = _ramOverride();
+  const ramOff = _dismissedHwChips.has('ram') ? ' hwfit-hw-chip-off' : '';
+  const ramBtnInner = esc(ramOv ? `RAM: ${Math.round(ramOv)} GB` : ram)
+    + (ramOv ? ' <span class="hwfit-ram-ovr-tag">override</span>' : '');
+  const ramResetBtn = ramOv
+    ? `<button type="button" class="hwfit-ram-reset" title="Reset to detected RAM" aria-label="Reset RAM to detected">↺</button>`
+    : '';
+  const ramChip = _removedHwChips.has('ram') ? '' : (
+    `<span class="hwfit-hw-chip hwfit-hw-chip-row hwfit-ram-chip${ramOv ? ' hwfit-ram-chip-ovr' : ''}${ramOff}" data-hw-chip="ram">`
+    + `<button type="button" class="hwfit-hw-chip-toggle hwfit-ram-edit" data-hw-chip="ram" title="${esc('Set the RAM budget to rank against. ' + ramTitle)}">${ramBtnInner}</button>`
+    + ramResetBtn
+    + `<button type="button" class="hwfit-hw-chip-x" data-hw-chip="ram" title="Remove this chip" aria-label="Remove">×</button>`
+    + `</span>`
+  );
   el.innerHTML = gpuChip
     + (vram ? chip('vram', vram) : '')
-    + chip('ram', ram)
-    + chip('cores', cores)
+    + ramChip
+    + chip('cores', cores, sys.cpu_name || 'Click to toggle off (X to hide)')
     + chip('backend', esc(sys.backend || ''))
     + manualChip;
   _renderHwVisibilityWarning(sys);
@@ -986,7 +1046,9 @@ export function _hwfitRenderHw(el, sys) {
     btn.addEventListener('click', (e) => {
       e.stopPropagation();
       const key = btn.dataset.hwChip;
-      if (!key || key === 'manual') return;
+      // 'manual' and 'ram' have bespoke click behavior (manual = open panel,
+      // ram = open the budget editor), so they opt out of the dim-toggle here.
+      if (!key || key === 'manual' || key === 'ram') return;
       const row = btn.closest('.hwfit-hw-chip-row');
       if (_dismissedHwChips.has(key)) {
         _dismissedHwChips.delete(key);
@@ -1029,6 +1091,87 @@ export function _hwfitRenderHw(el, sys) {
     });
   });
   _wireManualHardwareControls(el);
+  _wireRamBudgetControl(el, sys);
+}
+
+// Inline RAM-budget editor: a slider + number popover anchored under the RAM
+// chip. Lets the user rank against a chosen available-RAM budget (e.g. what
+// they'll free before serving) without faking the GPU, then re-ranks live.
+function _openRamEditor(anchorEl, sys) {
+  document.getElementById('hwfit-ram-editor')?.remove();
+  const installed = Math.max(8, Math.round(sys.detected_ram_total_gb || sys.total_ram_gb || 8));
+  const cur = Math.round(_ramOverride() || sys.available_ram_gb || Math.min(8, installed));
+  const min = 1, max = installed;
+  const pop = document.createElement('div');
+  pop.id = 'hwfit-ram-editor';
+  pop.className = 'hwfit-ram-editor';
+  pop.innerHTML =
+    `<div class="hwfit-ram-editor-title">RAM budget to rank against</div>`
+    + `<div class="hwfit-ram-editor-row">`
+    + `<input type="range" class="hwfit-ram-range" min="${min}" max="${max}" step="1" value="${Math.min(cur, max)}">`
+    + `<input type="number" class="hwfit-ram-num" min="${min}" max="${max}" step="1" value="${Math.min(cur, max)}">`
+    + `<span class="hwfit-ram-unit">GB</span>`
+    + `</div>`
+    + `<div class="hwfit-ram-editor-hint">Assumes you free this much before serving. Doesn't resize a running server. Installed: ${installed} GB.</div>`
+    + `<div class="hwfit-ram-editor-actions"><button type="button" class="hwfit-ram-editor-reset">Reset to detected</button></div>`;
+  document.body.appendChild(pop);
+  const r = anchorEl.getBoundingClientRect();
+  pop.style.top = `${Math.round(r.bottom + 6)}px`;
+  pop.style.left = `${Math.round(Math.max(8, Math.min(r.left, window.innerWidth - 268)))}px`;
+
+  const range = pop.querySelector('.hwfit-ram-range');
+  const num = pop.querySelector('.hwfit-ram-num');
+  let debounce;
+  const apply = (raw) => {
+    let v = Math.round(Number(raw) || 0);
+    v = Math.max(min, Math.min(max, v));
+    range.value = String(v);
+    num.value = String(v);
+    clearTimeout(debounce);
+    debounce = setTimeout(() => {
+      _saveRamOverride(v);
+      _resetGpuToggleState(false);
+      _hwfitCache = null;
+      _hwfitFetch(true);
+    }, 300);
+  };
+  range.addEventListener('input', () => apply(range.value));
+  num.addEventListener('input', () => apply(num.value));
+
+  const close = () => {
+    pop.remove();
+    document.removeEventListener('mousedown', onDoc);
+    document.removeEventListener('keydown', onKey);
+  };
+  const onDoc = (e) => { if (!pop.contains(e.target) && !anchorEl.contains(e.target)) close(); };
+  const onKey = (e) => { if (e.key === 'Escape') close(); };
+  pop.querySelector('.hwfit-ram-editor-reset').addEventListener('click', () => {
+    _saveRamOverride(null);
+    close();
+    _resetGpuToggleState(false);
+    _hwfitCache = null;
+    _hwfitFetch(true);
+  });
+  setTimeout(() => {
+    document.addEventListener('mousedown', onDoc);
+    document.addEventListener('keydown', onKey);
+  }, 0);
+  num.focus();
+  num.select();
+}
+
+function _wireRamBudgetControl(el, sys) {
+  el.querySelector('.hwfit-ram-edit')?.addEventListener('click', (e) => {
+    e.stopPropagation();
+    _openRamEditor(e.currentTarget, sys);
+  });
+  el.querySelector('.hwfit-ram-reset')?.addEventListener('click', (e) => {
+    e.stopPropagation();
+    _saveRamOverride(null);
+    _resetGpuToggleState(false);
+    _hwfitCache = null;
+    _hwfitFetch(true);
+  });
 }
 
 function _wireManualHardwareControls(el) {
@@ -1105,12 +1248,31 @@ function _modeLabel(model) {
   return String(model?.run_mode || '').replace('_', '+');
 }
 
+// Returns a tooltip explaining why the detected backend is preferred for a model.
+function _backendBadgeTip(backend, model) {
+  const isGguf = model?.is_gguf
+    || /^Q[2-8]|^IQ/.test((model?.quant || '').toUpperCase())
+    || (model?.quant || '').toUpperCase() === 'GGUF'
+    || `${model?.name || ''} ${model?.repo_id || ''}`.toLowerCase().includes('gguf');
+  switch (backend) {
+    case 'llamacpp': return isGguf
+      ? 'llama.cpp preferred — GGUF format runs on CPU or GPU without CUDA drivers'
+      : 'llama.cpp preferred — platform does not support vLLM/SGLang';
+    case 'vllm':     return 'vLLM preferred — safetensors format; fast GPU serving with CUDA';
+    case 'sglang':   return 'SGLang preferred — safetensors on ROCm (AMD GPU)';
+    case 'lmstudio': return 'Available from a running LM Studio server';
+    case 'ollama':   return 'Served via Ollama registry';
+    case 'diffusers':return 'Image generation via Diffusers pipeline';
+    default:         return '';
+  }
+}
+
 export const _hwfitColumns = [
   { key: 'fit', label: 'Fit',    cls: 'hwfit-fit' },
   { key: 'newest', label: 'Model (latest)',  cls: 'hwfit-name' },
   { key: 'params',label: 'Param', cls: 'hwfit-c-params' },
   { key: null,    label: 'Quant',  cls: 'hwfit-c-quant' },
-  { key: 'vram',  label: 'VRAM',   cls: 'hwfit-c-vram' },
+  { key: 'vram',  label: 'Mem',    cls: 'hwfit-c-vram' },
   { key: 'context',label: 'Ctx',   cls: 'hwfit-c-ctx' },
   { key: 'speed', label: 'Speed',  cls: 'hwfit-c-speed' },
   { key: 'score', label: 'Score',  cls: 'hwfit-c-score' },
@@ -1186,12 +1348,35 @@ export function _hwfitRenderList(el, models) {
     const ctx = m.context ? (m.context >= 1024 ? (m.context / 1024).toFixed(0) + 'k' : m.context) : '?';
     const fitLabel = (m.fit_level || '').replace('_', ' ');
     const modeLabel = _modeLabel(m);
-    const vramLabel = m.required_gb ? m.required_gb.toFixed(1) + 'G' : '?';
+    const _bkDetected = _detectBackend(m);
+    const _bkTip = _backendBadgeTip(_bkDetected.backend, m);
+    // Partial-offload split: cpu_offload rows show "X.XG+Y.YG" to indicate
+    // GPU VRAM portion + RAM portion. All other rows show total required_gb.
+    let vramLabel, vramTitle;
+    if (m.run_mode === 'cpu_offload' && m.vram_gb != null && m.ram_gb != null) {
+      vramLabel = `${m.vram_gb.toFixed(1)}G+${m.ram_gb.toFixed(1)}G`;
+      vramTitle = `${m.vram_gb.toFixed(1)} GB on GPU + ${m.ram_gb.toFixed(1)} GB in RAM (partial offload)`;
+    } else {
+      vramLabel = m.required_gb ? m.required_gb.toFixed(1) + 'G' : '?';
+      vramTitle = '';
+    }
+    // (RAM) sub-label for rows that rely on system RAM for inference.
+    const ramBadge = (m.run_mode === 'cpu_offload' || m.run_mode === 'cpu_only')
+      ? ' <span style="opacity:0.55;font-size:9px;">(RAM)</span>'
+      : '';
     const moeBadge = m.is_moe ? '<span class="hwfit-badge hwfit-moe">MoE</span>' : '';
     const imgBadge = m.is_image_gen ? '<span class="hwfit-badge" style="background:color-mix(in srgb, var(--red) 20%, transparent);color:var(--red);font-size:8px;padding:1px 4px;border-radius:3px;margin-left:4px;">IMG</span>' : '';
+    let sourceBadge = '';
+    if (m._source === 'local_gguf') {
+      sourceBadge = '<span class="hwfit-badge hwfit-source-local" title="Installed GGUF file">local</span>';
+    } else if (m._source === 'lmstudio') {
+      sourceBadge = '<span class="hwfit-badge hwfit-source-lmstudio" title="Available in LM Studio">LM</span>';
+    } else if (m._source === 'ollama') {
+      sourceBadge = '<span class="hwfit-badge hwfit-source-ollama" title="Installed in local Ollama">Ollama</span>';
+    }
     const dlDot = (_cachedModelIds && (_cachedModelIds.has(m.name) || [..._cachedModelIds].some(id => id === m.name?.split('/').pop()))) ? '<span class="hwfit-dl-dot" title="Downloaded">\u25CF</span>' : '';
     html += `<div class="hwfit-row" data-model="${esc(m.name)}">`;
-    html += `<span class="hwfit-col hwfit-fit" style="color:${fitColor}">${esc(fitLabel)}</span>`;
+    html += `<span class="hwfit-col hwfit-fit" style="color:${fitColor}">${esc(fitLabel)}${ramBadge}</span>`;
     // Append quant to the title when it's not already in the repo name. The
     // suffix strips quant-parts the name already contains — e.g. for
     // QuantTrio/MiniMax-M2-AWQ + quant=AWQ-4bit we just show "(4bit)", not
@@ -1210,18 +1395,18 @@ export function _hwfitRenderList(el, models) {
         _quantSuffix = ` <span class="hwfit-name-quant" title="${esc(_quantTag)} — full storage format">(${esc(_display)})</span>`;
       }
     }
-    html += `<span class="hwfit-col hwfit-name">${modelLogo(m.name)}${esc(_short)}${_quantSuffix}${moeBadge}${imgBadge}${dlDot}</span>`;
+    html += `<span class="hwfit-col hwfit-name">${modelLogo(m.name)}${esc(_short)}${_quantSuffix}${moeBadge}${imgBadge}${sourceBadge}${dlDot}</span>`;
     html += `<span class="hwfit-col hwfit-c-params">${esc(pcount)}</span>`;
     // Truncate the Quant cell to 9 chars + ellipsis so long tags like
     // "FP4-MoE-Mixed" don't push neighboring columns. Full tag stays in title.
     const _qRaw = m.quant || '?';
     const _qShort = _qRaw.length > 9 ? _qRaw.slice(0, 9) + '…' : _qRaw;
     html += `<span class="hwfit-col hwfit-c-quant" title="${esc(_qRaw)}">${esc(_qShort)}</span>`;
-    html += `<span class="hwfit-col hwfit-c-vram">${vramLabel}</span>`;
+    html += `<span class="hwfit-col hwfit-c-vram"${vramTitle ? ` title="${esc(vramTitle)}"` : ''}>${vramLabel}</span>`;
     html += `<span class="hwfit-col hwfit-c-ctx">${m.is_image_gen ? '\u2014' : ctx}</span>`;
     html += `<span class="hwfit-col hwfit-c-speed">${m.is_image_gen ? '\u2014' : tps + ' t/s'}</span>`;
     html += `<span class="hwfit-col hwfit-c-score">${score}</span>`;
-    html += `<span class="hwfit-col hwfit-c-mode" title="${_requiresAcceleratorBackend(m) ? 'Requires vLLM or SGLang with a visible CUDA/ROCm accelerator. llama.cpp and Ollama need GGUF files.' : ''}">${esc(modeLabel)}</span>`;
+    html += `<span class="hwfit-col hwfit-c-mode"><span class="hwfit-backend-badge" data-backend="${esc(_bkDetected.backend)}" title="${esc(_bkTip)}">${esc(modeLabel)}</span></span>`;
     html += `</div>`;
   }
   el.innerHTML = html;
@@ -1415,6 +1600,15 @@ export function _expandModelRow(row, modelData) {
 
   const dlSource = _downloadSourceRepo(modelData, backend);
   const hfUrl = `https://huggingface.co/${dlSource.repo}`;
+
+  const isLocalGguf = modelData._source === 'local_gguf';
+  const _modelShort = modelData.name.split('/').pop();
+  const _isCached = !isLocalGguf && _cachedModelIds && (
+    _cachedModelIds.has(modelData.name)
+    || [..._cachedModelIds].some(id => id === modelData.name || id.endsWith('/' + _modelShort))
+  );
+  const dlBtnLabel = isLocalGguf ? 'Serve' : (_isCached ? 'Update' : 'Download');
+
   // Official vendor recipe deep-links. These point to vLLM / SGLang's curated
   // hardware-specific launch-command pages. They 404 for uncatalogued models \u2014
   // a known tradeoff; user just gets the vendor's "model not found" page.
@@ -1434,7 +1628,7 @@ export function _expandModelRow(row, modelData) {
   }
   html += `</div>`;
   html += `<div class="hwfit-panel-actions">`;
-  html += `<button class="cookbook-btn hwfit-dl-btn">Download</button>`;
+  html += `<button class="cookbook-btn hwfit-dl-btn">${esc(dlBtnLabel)}</button>`;
   if (!modelData.is_image_gen) {
     html += `<button class="cookbook-btn cookbook-run-btn hwfit-quickrun-btn" title="Download + launch with smart defaults">Run</button>`;
     html += `<button class="cookbook-btn hwfit-serve-expand-btn" title="Configure & serve">Configure</button>`;
@@ -1459,10 +1653,15 @@ export function _expandModelRow(row, modelData) {
   row.insertAdjacentHTML('afterend', html);
   const panel = row.nextElementSibling;
 
-  // Wire download button
+  // Wire download/serve button
   const dlBtn = panel.querySelector('.hwfit-dl-btn');
   if (dlBtn) {
     dlBtn.addEventListener('click', () => {
+      // Local GGUF is already on disk — skip download, open the serve panel.
+      if (isLocalGguf) {
+        panel.querySelector('.hwfit-serve-expand-btn')?.click();
+        return;
+      }
       const host = _syncHostFromScanDropdown();   // host the user picked, passed explicitly
       if (backend === 'ollama') {
         _runPanelCmd(panel, _buildDownloadCmd(modelData, backend), { timeout: 0 });

--- a/static/js/cookbook.js
+++ b/static/js/cookbook.js
@@ -352,6 +352,9 @@ export function _detectToolParser(modelName) {
 // ── Backend detection ──
 
 export function _detectBackend(model) {
+  if (model?.backend === 'lmstudio' || model?._source === 'lmstudio') {
+    return { backend: 'lmstudio', label: 'LM Studio' };
+  }
   const _ollamaName = String(model?.repo_id || model?.name || model?.id || '').trim();
   const _ollamaMeta = `${model?.backend || ''} ${model?.endpoint_kind || ''} ${model?.provider || ''} ${model?.source || ''}`.toLowerCase();
   const _looksLikeOllamaTag = /^[A-Za-z0-9][A-Za-z0-9._-]*(?::[A-Za-z0-9][A-Za-z0-9._-]*)$/.test(_ollamaName);

--- a/static/js/modelPicker.js
+++ b/static/js/modelPicker.js
@@ -78,6 +78,54 @@ function _handlePickerKeydown(e, listEl, itemSelector, closeFn) {
 let _deps = null;
 let _autoSelectingDefault = false;
 
+// Capability cache for the active model
+let _activeModelCaps = [];
+let _capsFetchModelId = '';
+
+/**
+ * Returns the cached capability list for the currently-active model.
+ * @returns {string[]}
+ */
+export function getActiveModelCaps() {
+  return _activeModelCaps;
+}
+
+/**
+ * Fetches capabilities for the given model ID from the catalog API and
+ * broadcasts an ``odysseus:model-capabilities`` event on the document.
+ * @param {string} modelId
+ */
+async function _fetchAndBroadcastCaps(modelId) {
+  if (!modelId) {
+    _activeModelCaps = [];
+    _capsFetchModelId = '';
+    document.dispatchEvent(new CustomEvent('odysseus:model-capabilities', {
+      detail: { modelId: '', capabilities: [] },
+    }));
+    return;
+  }
+  if (modelId === _capsFetchModelId) {
+    // Same model — re-broadcast without re-fetching
+    document.dispatchEvent(new CustomEvent('odysseus:model-capabilities', {
+      detail: { modelId, capabilities: _activeModelCaps },
+    }));
+    return;
+  }
+  _capsFetchModelId = modelId;
+  try {
+    const r = await fetch(
+      `${API_BASE}/api/hwfit/model-caps?model=${encodeURIComponent(modelId)}`,
+      { credentials: 'same-origin' }
+    );
+    _activeModelCaps = r.ok ? ((await r.json()).capabilities || []) : [];
+  } catch {
+    _activeModelCaps = [];
+  }
+  document.dispatchEvent(new CustomEvent('odysseus:model-capabilities', {
+    detail: { modelId, capabilities: _activeModelCaps },
+  }));
+}
+
 function _modelExists(modelId, url) {
   if (!modelId || !window.modelsModule || !window.modelsModule.getCachedItems) return false;
   const items = window.modelsModule.getCachedItems() || [];
@@ -103,6 +151,13 @@ function _modelExists(modelId, url) {
 export function initModelPicker(deps) {
   _deps = deps;
   _initModelPickerDropdown();
+  // Refresh badge when cookbookServe signals a profile was selected.
+  document.addEventListener('odysseus:profile-selected', () => {
+    const sid = _deps?.getCurrentSessionId?.();
+    const s = (_deps?.getSessions?.() || []).find(x => x.id === sid);
+    const mid = s?.model || _deps?.getPendingChat?.()?.modelId || '';
+    _refreshProfileBadge(mid ? mid.split('/').pop() : '');
+  });
 }
 
 function _initModelPickerDropdown() {
@@ -623,6 +678,175 @@ function _initModelPickerDropdown() {
       _close();
     }
   });
+  // Active profile badge — shows inline profile selector popover.
+  const badge = document.getElementById('active-profile-badge');
+  if (badge && !badge._profileClickBound) {
+    badge._profileClickBound = true;
+    badge.addEventListener('click', async (e) => {
+      e.stopPropagation();
+      // Toggle: close if popover already open.
+      const existing = document.getElementById('profile-selector-popover');
+      if (existing) { existing.remove(); return; }
+      await _showProfilePopover(badge);
+    });
+  }
+}
+
+/**
+ * Renders a small popover below the profile badge so the user can switch
+ * profiles without leaving the chat. Selecting a profile updates
+ * ``localStorage['odysseus_active_profile']`` and broadcasts
+ * ``odysseus:profile-selected``. A footer link re-opens the full Cookbook
+ * serve panel for users who want to adjust advanced serve flags.
+ * @param {HTMLElement} badgeEl
+ */
+async function _showProfilePopover(badgeEl) {
+  // Fetch available profiles from the API.
+  let profiles = [];
+  try {
+    const r = await fetch(`${API_BASE}/api/profiles`, { credentials: 'same-origin' });
+    if (r.ok) profiles = await r.json();
+  } catch { /* fall through with empty list */ }
+
+  const stored = (() => {
+    try { return JSON.parse(localStorage.getItem('odysseus_active_profile') || 'null'); } catch { return null; }
+  })();
+
+  const pop = document.createElement('div');
+  pop.id = 'profile-selector-popover';
+  pop.className = 'profile-selector-popover';
+  pop.setAttribute('role', 'menu');
+
+  const header = document.createElement('div');
+  header.className = 'profile-sel-header';
+  header.textContent = 'Serving profile';
+  pop.appendChild(header);
+
+  // Render a chip per profile
+  for (const p of profiles) {
+    const row = document.createElement('button');
+    row.type = 'button';
+    row.className = 'profile-sel-row' + (stored?.key === p.key ? ' active' : '');
+    row.setAttribute('role', 'menuitem');
+    row.dataset.profileKey = p.key;
+
+    const name = document.createElement('span');
+    name.className = 'profile-sel-name';
+    name.textContent = p.label;
+
+    const ttft = document.createElement('span');
+    ttft.className = 'profile-sel-ttft';
+    ttft.textContent = p.ttft_estimate || '';
+
+    row.appendChild(name);
+    row.appendChild(ttft);
+    row.title = p.description || '';
+
+    row.addEventListener('click', () => {
+      // Build a minimal stored profile entry and save it.
+      const ctxK = Math.round((p.ctx_size || 4096) / 1024);
+      const ctxLabel = ctxK >= 1 ? `${ctxK}k` : String(p.ctx_size);
+      const next = {
+        key: p.key,
+        label: p.label,
+        ctx: p.ctx_size || 4096,
+        ctxLabel,
+        repo: stored?.repo || '',
+      };
+      try { localStorage.setItem('odysseus_active_profile', JSON.stringify(next)); } catch { /* quota */ }
+      document.dispatchEvent(new CustomEvent('odysseus:profile-selected', { detail: next }));
+      pop.remove();
+      if (uiModule && uiModule.showToast) uiModule.showToast(`Profile: ${p.label} — re-serve to apply`);
+    });
+
+    pop.appendChild(row);
+  }
+
+  // Footer: open Cookbook serve panel (original badge behaviour)
+  const footer = document.createElement('div');
+  footer.className = 'profile-sel-footer';
+  const cookbookLink = document.createElement('button');
+  cookbookLink.type = 'button';
+  cookbookLink.className = 'profile-sel-cookbook-link';
+  cookbookLink.textContent = 'Re-serve in Cookbook →';
+  cookbookLink.addEventListener('click', async () => {
+    pop.remove();
+    try {
+      const s2 = (() => {
+        try { return JSON.parse(localStorage.getItem('odysseus_active_profile') || 'null'); } catch { return null; }
+      })();
+      if (!s2?.repo) return;
+      const { openServePanelForRepo } = await import('./cookbookServe.js');
+      await openServePanelForRepo(s2.repo);
+      if (s2.key) {
+        for (let i = 0; i < 20; i++) {
+          const chip = document.querySelector(`.hwfit-profile-chip[data-intent-key="${s2.key}"]`);
+          if (chip) { chip.click(); break; }
+          await new Promise(r => setTimeout(r, 100));
+        }
+      }
+    } catch {}
+  });
+  footer.appendChild(cookbookLink);
+  pop.appendChild(footer);
+
+  // Position below the badge
+  document.body.appendChild(pop);
+  const rect = badgeEl.getBoundingClientRect();
+  pop.style.position = 'fixed';
+  pop.style.top  = (rect.bottom + 6) + 'px';
+  pop.style.left = rect.left + 'px';
+  pop.style.zIndex = '9999';
+
+  // Clamp to viewport right edge
+  requestAnimationFrame(() => {
+    const pw = pop.offsetWidth;
+    const vw = window.innerWidth;
+    if (rect.left + pw > vw - 8) {
+      pop.style.left = Math.max(8, vw - pw - 8) + 'px';
+    }
+  });
+
+  // Close on outside click or Escape
+  function _dismiss(ev) {
+    if (!pop.contains(ev.target) && ev.target !== badgeEl) {
+      pop.remove();
+      document.removeEventListener('click', _dismiss);
+      document.removeEventListener('keydown', _dismissKey);
+    }
+  }
+  function _dismissKey(ev) {
+    if (ev.key === 'Escape') {
+      pop.remove();
+      document.removeEventListener('click', _dismiss);
+      document.removeEventListener('keydown', _dismissKey);
+    }
+  }
+  setTimeout(() => {
+    document.addEventListener('click', _dismiss);
+    document.addEventListener('keydown', _dismissKey);
+  }, 0);
+}
+
+/**
+ * Shows or hides the active-profile-badge in the chat header.
+ * The badge is shown only when the currently-selected chat model matches the
+ * model for which a profile was last configured in the Cookbook serve panel.
+ */
+function _refreshProfileBadge(currentShort) {
+  const badge = document.getElementById('active-profile-badge');
+  if (!badge) return;
+  try {
+    const stored = JSON.parse(localStorage.getItem('odysseus_active_profile') || 'null');
+    if (!stored || !stored.repo || !currentShort) { badge.style.display = 'none'; return; }
+    const storedShort = stored.repo.split('/').pop();
+    if (storedShort !== currentShort) { badge.style.display = 'none'; return; }
+    badge.textContent = `${stored.key.toLowerCase()} · ${stored.ctxLabel} ctx`;
+    badge.title = `Serving profile: ${stored.label} (ctx ${stored.ctxLabel}) — click to open Cookbook serve`;
+    badge.style.display = '';
+  } catch {
+    badge.style.display = 'none';
+  }
 }
 
 /**
@@ -720,4 +944,6 @@ export function updateModelPicker() {
   } else {
     label.textContent = displayName;
   }
+  _refreshProfileBadge(modelId ? modelId.split('/').pop() : '');
+  _fetchAndBroadcastCaps(modelId || '');
 }

--- a/static/style.css
+++ b/static/style.css
@@ -21892,11 +21892,11 @@ body.gallery-selecting .gallery-dl-btn,
   transition: background 0.1s;
 }
 .hwfit-row:hover { background: color-mix(in srgb, var(--fg) 6%, transparent); }
-/* Already-downloaded rows: dim slightly so attention falls on undownloaded
-   options. The green dot stays bright as the "this is local" cue. */
-.hwfit-row:has(.hwfit-dl-dot) { opacity: 0.55; }
-.hwfit-row:has(.hwfit-dl-dot):hover { opacity: 0.9; }
-.hwfit-row:has(.hwfit-dl-dot) .hwfit-dl-dot { opacity: 1; }
+/* Rows you already have locally: dim slightly so attention falls on options
+   you'd still need to download. The green "local" badge stays bright as the cue. */
+.hwfit-row:has(.hwfit-source-local) { opacity: 0.55; }
+.hwfit-row:has(.hwfit-source-local):hover { opacity: 0.9; }
+.hwfit-row:has(.hwfit-source-local) .hwfit-source-local { opacity: 1; }
 .hwfit-header {
   cursor: default; position: sticky; top: 0; z-index: 1;
   background: var(--panel); border-bottom: 1px solid var(--border);
@@ -21912,7 +21912,7 @@ body.gallery-selecting .gallery-dl-btn,
   flex-shrink: 0; white-space: nowrap; text-align: left;
   font-size: 9px; color: var(--fg-muted);
 }
-.hwfit-fit { width: 52px; font-weight: 700; text-transform: uppercase; }
+.hwfit-fit { width: 92px; font-weight: 700; text-transform: uppercase; overflow: hidden; text-overflow: ellipsis; }
 .hwfit-name {
   flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis;
   font-weight: 500; font-size: 11px; color: var(--fg);

--- a/static/style.css
+++ b/static/style.css
@@ -21739,6 +21739,78 @@ body.gallery-selecting .gallery-dl-btn,
 .hwfit-hw-chip-manual:hover {
   background: color-mix(in srgb, var(--accent, var(--red)) 22%, transparent);
 }
+/* Editable RAM-budget chip. The body is a click target (opens the editor),
+   so give it the affordance and a hover lift. When an override is active the
+   chip picks up the accent treatment so it reads as "modified". */
+.hwfit-ram-edit { cursor: pointer; }
+.hwfit-ram-chip:hover { opacity: 1; }
+.hwfit-ram-chip-ovr {
+  border: 1px solid color-mix(in srgb, var(--accent, var(--red)) 45%, transparent);
+  background: color-mix(in srgb, var(--accent, var(--red)) 14%, transparent);
+  color: var(--accent, var(--red));
+  opacity: 1;
+}
+.hwfit-ram-ovr-tag {
+  font-size: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 0.8;
+  margin-left: 3px;
+}
+.hwfit-ram-reset {
+  cursor: pointer;
+  font-size: 11px !important;
+  line-height: 1 !important;
+  transform: translateY(-2px);
+  opacity: 0.75;
+}
+.hwfit-ram-reset:hover { opacity: 1; }
+/* RAM-budget editor popover (anchored under the chip, appended to <body>). */
+.hwfit-ram-editor {
+  position: fixed;
+  z-index: 9999;
+  width: 256px;
+  box-sizing: border-box;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  color: var(--fg);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.28);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.hwfit-ram-editor-title { font-size: 11px; font-weight: 600; }
+.hwfit-ram-editor-row { display: flex; align-items: center; gap: 8px; }
+.hwfit-ram-editor-row .hwfit-ram-range { flex: 1; accent-color: var(--accent, var(--red)); }
+.hwfit-ram-editor-row .hwfit-ram-num {
+  width: 56px;
+  height: 24px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--fg);
+  border-radius: 4px;
+  font: inherit;
+  font-size: 11px;
+  padding: 0 6px;
+  box-sizing: border-box;
+}
+.hwfit-ram-editor-row .hwfit-ram-unit { font-size: 10px; opacity: 0.6; }
+.hwfit-ram-editor-hint { font-size: 9px; line-height: 1.4; color: var(--fg-muted); opacity: 0.85; }
+.hwfit-ram-editor-actions { display: flex; justify-content: flex-end; }
+.hwfit-ram-editor-reset {
+  cursor: pointer;
+  font: inherit;
+  font-size: 10px;
+  height: 22px;
+  padding: 0 8px;
+  border: 1px solid var(--border);
+  background: none;
+  color: var(--fg);
+  border-radius: 4px;
+}
+.hwfit-ram-editor-reset:hover { background: color-mix(in srgb, var(--fg) 8%, transparent); }
 .hwfit-hw-manual-btn {
   min-width: 42px;
 }
@@ -21856,6 +21928,51 @@ body.gallery-selecting .gallery-dl-btn,
   display: inline-block; padding: 0 4px; border-radius: 4px; margin-left: 4px;
   background: color-mix(in srgb, var(--red) 15%, transparent);
   color: var(--red); font-weight: 600; font-size: 8px;
+}
+.hwfit-source-ollama {
+  display: inline-block; padding: 0 4px; border-radius: 4px; margin-left: 4px;
+  background: color-mix(in srgb, var(--warn) 15%, transparent);
+  color: var(--warn); font-weight: 600; font-size: 8px;
+}
+.hwfit-source-local {
+  display: inline-block; padding: 0 4px; border-radius: 4px; margin-left: 4px;
+  background: color-mix(in srgb, var(--green) 16%, transparent);
+  color: var(--green); font-weight: 600; font-size: 8px;
+}
+.hwfit-source-lmstudio {
+  display: inline-block; padding: 0 4px; border-radius: 4px; margin-left: 4px;
+  background: color-mix(in srgb, var(--hl-keyword) 15%, transparent);
+  color: var(--hl-keyword); font-weight: 600; font-size: 8px;
+}
+.hwfit-backend-badge {
+  display: inline-block; padding: 1px 5px; border-radius: 4px;
+  font-size: 9px; font-weight: 600; white-space: nowrap;
+  background: color-mix(in srgb, var(--fg) 8%, transparent);
+  color: var(--color-muted);
+}
+.hwfit-backend-badge[data-backend="llamacpp"] {
+  background: color-mix(in srgb, var(--green) 15%, transparent);
+  color: var(--green);
+}
+.hwfit-backend-badge[data-backend="vllm"] {
+  background: color-mix(in srgb, var(--hl-function) 15%, transparent);
+  color: var(--hl-function);
+}
+.hwfit-backend-badge[data-backend="sglang"] {
+  background: color-mix(in srgb, var(--hl-keyword) 15%, transparent);
+  color: var(--hl-keyword);
+}
+.hwfit-backend-badge[data-backend="lmstudio"] {
+  background: color-mix(in srgb, var(--hl-keyword) 15%, transparent);
+  color: var(--hl-keyword);
+}
+.hwfit-backend-badge[data-backend="ollama"] {
+  background: color-mix(in srgb, var(--warn) 15%, transparent);
+  color: var(--warn);
+}
+.hwfit-backend-badge[data-backend="diffusers"] {
+  background: color-mix(in srgb, var(--red) 15%, transparent);
+  color: var(--red);
 }
 .hwfit-sort, .hwfit-quant { width: auto; min-width: 70px; flex-shrink: 0; }
 .hwfit-row-active { background: color-mix(in srgb, var(--red) 8%, transparent); }

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -1,0 +1,268 @@
+"""Tests for the dynamic hwfit catalog persistence layer."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from core.database import DiscoveredModel, SessionLocal
+from services.hwfit.catalog_sync import (
+    discovered_model_to_dict,
+    fetch_hf_trending_catalog,
+    get_discovered_catalog,
+    refresh_hf_trending_catalog,
+    seed_static_catalog,
+    upsert_discovered_model,
+)
+from services.hwfit.fit import rank_models
+
+
+def _cpu_system():
+    return {
+        "has_gpu": False,
+        "backend": "cpu_x86",
+        "gpu_name": None,
+        "gpu_vram_gb": 0,
+        "gpu_count": 0,
+        "available_ram_gb": 32.0,
+        "total_ram_gb": 32.0,
+    }
+
+
+@pytest.fixture
+def db():
+    session = SessionLocal()
+    session.query(DiscoveredModel).delete()
+    session.commit()
+    try:
+        yield session
+    finally:
+        session.query(DiscoveredModel).delete()
+        session.commit()
+        session.close()
+
+
+def test_upsert_discovered_model_creates_row(db):
+    row = upsert_discovered_model(
+        db,
+        {
+            "name": "google/gemma-test",
+            "provider": "Google",
+            "parameter_count": "4B",
+            "quantization": "Q4_K_M",
+            "pipeline_tag": "text-generation",
+            "context_length": 8192,
+            "gguf_sources": [{"repo": "example/gemma-test-GGUF"}],
+        },
+        source="hf_trending",
+    )
+    db.commit()
+
+    assert row.id
+    assert row.name == "google/gemma-test"
+    assert row.source == "hf_trending"
+    assert row.params_b == 4.0
+    assert row.gguf_sources == [{"repo": "example/gemma-test-GGUF"}]
+
+
+def test_upsert_discovered_model_updates_existing_equal_priority(db):
+    upsert_discovered_model(
+        db,
+        {"name": "google/gemma-test", "provider": "Google", "parameter_count": "4B"},
+        source="hf_trending",
+    )
+    row = upsert_discovered_model(
+        db,
+        {"name": "google/gemma-test", "provider": "Google", "parameter_count": "12B"},
+        source="hf_trending",
+    )
+    db.commit()
+
+    assert row.parameter_count == "12B"
+    assert row.params_b == 12.0
+
+
+def test_source_priority_local_overwrites_hf_for_same_name(db):
+    upsert_discovered_model(
+        db,
+        {
+            "name": "local/Phi-3-mini-4B-Q4_K_M",
+            "provider": "Hugging Face",
+            "parameter_count": "4B",
+            "gguf_sources": [{"repo": "hf/phi"}],
+        },
+        source="hf_trending",
+    )
+    row = upsert_discovered_model(
+        db,
+        {
+            "name": "local/Phi-3-mini-4B-Q4_K_M",
+            "provider": "Local GGUF",
+            "parameter_count": "4B",
+            "local_path": "D:/Models/Phi-3-mini-4B-Q4_K_M.gguf",
+            "gguf_sources": [{"path": "D:/Models/Phi-3-mini-4B-Q4_K_M.gguf"}],
+        },
+        source="local_gguf",
+    )
+    db.commit()
+
+    model = discovered_model_to_dict(row)
+    assert model["_source"] == "local_gguf"
+    assert model["provider"] == "Local GGUF"
+    assert model["local_path"] == "D:/Models/Phi-3-mini-4B-Q4_K_M.gguf"
+    assert model["gguf_sources"] == [{"path": "D:/Models/Phi-3-mini-4B-Q4_K_M.gguf"}]
+
+
+def test_source_priority_does_not_demote_local_with_hf_refresh(db):
+    upsert_discovered_model(
+        db,
+        {
+            "name": "local/Phi-3-mini-4B-Q4_K_M",
+            "provider": "Local GGUF",
+            "parameter_count": "4B",
+            "local_path": "D:/Models/Phi-3-mini-4B-Q4_K_M.gguf",
+        },
+        source="local_gguf",
+    )
+    row = upsert_discovered_model(
+        db,
+        {
+            "name": "local/Phi-3-mini-4B-Q4_K_M",
+            "provider": "Hugging Face",
+            "parameter_count": "4B",
+            "release_date": "2026-06-01",
+        },
+        source="hf_trending",
+    )
+    db.commit()
+
+    assert row.source == "local_gguf"
+    assert row.provider == "Local GGUF"
+    assert row.release_date == "2026-06-01"
+
+
+def test_source_priority_orders_all_catalog_sources(db):
+    name = "qwen/test-7b-q4"
+    for source in ("hf_trending", "ollama", "lmstudio", "local_gguf"):
+        row = upsert_discovered_model(
+            db,
+            {
+                "name": name,
+                "provider": source,
+                "parameter_count": "7B",
+                "backend": source,
+            },
+            source=source,
+        )
+
+    assert row.source == "local_gguf"
+    assert row.provider == "local_gguf"
+
+
+def test_seed_static_catalog_only_when_empty(db):
+    first_count = seed_static_catalog(db)
+    second_count = seed_static_catalog(db)
+
+    assert first_count > 0
+    assert second_count == 0
+    assert db.query(DiscoveredModel).count() == first_count
+
+
+def test_rank_models_accepts_db_catalog_override(db):
+    upsert_discovered_model(
+        db,
+        {
+            "name": "local/Phi-3-mini-4B-Q4_K_M",
+            "provider": "Local GGUF",
+            "parameter_count": "4B",
+            "quantization": "Q4_K_M",
+            "context_length": 4096,
+            "gguf_sources": [{"path": "D:/Models/Phi-3-mini-4B-Q4_K_M.gguf"}],
+        },
+        source="local_gguf",
+    )
+    catalog = get_discovered_catalog(db, seed_if_empty=False)
+
+    results = rank_models(
+        _cpu_system(),
+        search="Phi-3-mini",
+        catalog_models=catalog,
+        limit=5,
+    )
+
+    match = next(r for r in results if r["name"] == "local/Phi-3-mini-4B-Q4_K_M")
+    assert match["_source"] == "local_gguf"
+    assert match["source"] == "local_gguf"
+
+
+def _hf_entry(repo_id, pipeline_tag, trending=100, tags=None):
+    return {
+        "modelId": repo_id,
+        "pipeline_tag": pipeline_tag,
+        "tags": tags if tags is not None else [pipeline_tag],
+        "downloads": 1000,
+        "likes": 50,
+        "createdAt": "2026-04-01",
+        "trendingScore": trending,
+    }
+
+
+def _mock_hf_client(text_gen=None, image_text=None, any_to_any=None):
+    """Build a patched httpx.AsyncClient that routes by pipeline keyword in URL."""
+
+    async def _get(url, **kw):
+        response = MagicMock()
+        response.status_code = 200
+        if "any-to-any" in url:
+            response.json.return_value = any_to_any or []
+        elif "image-text-to-text" in url:
+            response.json.return_value = image_text or []
+        else:
+            response.json.return_value = text_gen or []
+        return response
+
+    client = AsyncMock()
+    client.get.side_effect = _get
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    return MagicMock(return_value=client)
+
+
+@pytest.mark.asyncio
+async def test_fetch_hf_trending_catalog_merges_and_filters_pipelines():
+    mock_client = _mock_hf_client(
+        text_gen=[
+            _hf_entry("good/model-7b", "text-generation", trending=80),
+            _hf_entry("bad/lora-adapter-7b", "text-generation", trending=90),
+        ],
+        image_text=[_hf_entry("qwen/qwen2-vl-7b", "image-text-to-text", trending=70)],
+        any_to_any=[_hf_entry("google/gemma-4-12b-it", "any-to-any", trending=100)],
+    )
+
+    with patch("httpx.AsyncClient", mock_client):
+        entries = await fetch_hf_trending_catalog(limit=10)
+
+    names = [entry["name"] for entry in entries]
+    assert names[:3] == ["google/gemma-4-12b-it", "good/model-7b", "qwen/qwen2-vl-7b"]
+    assert "bad/lora-adapter-7b" not in names
+    gemma = entries[0]
+    assert gemma["source"] == "hf_trending"
+    assert gemma["parameter_count"] == "12B"
+    assert gemma["capabilities"] == ["vision"]
+
+
+@pytest.mark.asyncio
+async def test_refresh_hf_trending_catalog_upserts_rows(db):
+    mock_client = _mock_hf_client(
+        text_gen=[_hf_entry("unsloth/gemma-4-12B-it-GGUF", "text-generation", tags=["gguf"])]
+    )
+
+    with patch("httpx.AsyncClient", mock_client):
+        count = await refresh_hf_trending_catalog(limit=10)
+
+    assert count == 1
+    row = db.query(DiscoveredModel).filter(DiscoveredModel.name == "unsloth/gemma-4-12B-it-GGUF").first()
+    assert row is not None
+    model = discovered_model_to_dict(row)
+    assert model["source"] == "hf_trending"
+    assert model["is_gguf"] is True
+    assert model["gguf_sources"] == [{"repo": "unsloth/gemma-4-12B-it-GGUF", "kind": "GGUF"}]

--- a/tests/test_gpu_layers_helper.py
+++ b/tests/test_gpu_layers_helper.py
@@ -1,0 +1,57 @@
+"""Tests for _compute_gpu_layers helper in cookbook_helpers.
+
+Covers the three fit modes:
+- gpu       → 99 (all layers on GPU)
+- cpu_only  → 0
+- cpu_offload → proportional layer count (floor(frac * 99))
+"""
+
+import pytest
+from routes.cookbook_helpers import _compute_gpu_layers
+
+
+def test_gpu_mode_returns_99():
+    assert _compute_gpu_layers("gpu", vram_gb=8.0, required_gb=7.5) == 99
+
+
+def test_cpu_only_returns_0():
+    assert _compute_gpu_layers("cpu_only", vram_gb=None, required_gb=32.0) == 0
+
+
+def test_cpu_only_with_vram_still_returns_0():
+    # run_mode overrides the VRAM hint — if the ranker decided cpu_only, ngl=0.
+    assert _compute_gpu_layers("cpu_only", vram_gb=4.0, required_gb=32.0) == 0
+
+
+def test_cpu_offload_proportional():
+    # 8 GB on GPU out of 16 GB required → 50 % → floor(0.5 * 99) = 49
+    ngl = _compute_gpu_layers("cpu_offload", vram_gb=8.0, required_gb=16.0)
+    assert ngl == 49
+
+
+def test_cpu_offload_large_fraction():
+    # 14 GB on GPU out of 16 GB required → floor(0.875 * 99) = 86
+    ngl = _compute_gpu_layers("cpu_offload", vram_gb=14.0, required_gb=16.0)
+    assert ngl == 86
+
+
+def test_cpu_offload_tiny_vram_clamps_to_1():
+    # Negligible VRAM — should still return at least 1 (not 0, not negative)
+    ngl = _compute_gpu_layers("cpu_offload", vram_gb=0.1, required_gb=32.0)
+    assert ngl == 1
+
+
+def test_missing_vram_falls_back_to_99():
+    assert _compute_gpu_layers("cpu_offload", vram_gb=None, required_gb=16.0) == 99
+
+
+def test_missing_required_falls_back_to_99():
+    assert _compute_gpu_layers("cpu_offload", vram_gb=8.0, required_gb=None) == 99
+
+
+def test_zero_required_falls_back_to_99():
+    assert _compute_gpu_layers("cpu_offload", vram_gb=8.0, required_gb=0) == 99
+
+
+def test_unknown_run_mode_falls_back_to_99():
+    assert _compute_gpu_layers("no_fit", vram_gb=None, required_gb=None) == 99

--- a/tests/test_hf_latest_integration.py
+++ b/tests/test_hf_latest_integration.py
@@ -1,0 +1,172 @@
+"""Integration tests for the GET /api/cookbook/hf-latest route.
+
+Verifies the multi-pipeline merge logic (any-to-any / image-text-to-text models
+are included alongside text-generation), GGUF VRAM bypass, deduplication across
+pipelines, and exclusion of adapters/LoRAs.
+
+Uses a minimal FastAPI app with the cookbook router and overrides the auth
+dependency so no session / DB state is needed.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+# ─── minimal test app ────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="module")
+def client():
+    """A TestClient that wraps the cookbook router with auth bypassed."""
+    from routes.cookbook_routes import setup_cookbook_routes
+    from src.auth_helpers import require_user
+
+    app = FastAPI()
+    app.include_router(setup_cookbook_routes())
+    app.dependency_overrides[require_user] = lambda: "test_user"
+    return TestClient(app)
+
+
+# ─── HF API stub helpers ─────────────────────────────────────────────────────
+
+def _hf_entry(repo_id, pipeline_tag, trending=100, tags=None):
+    return {
+        "modelId": repo_id,
+        "pipeline_tag": pipeline_tag,
+        "tags": tags if tags is not None else [pipeline_tag],
+        "downloads": 1000,
+        "likes": 50,
+        "createdAt": "2026-04-01",
+        "trendingScore": trending,
+    }
+
+
+def _mock_hf_client(text_gen=None, image_text=None, any_to_any=None):
+    """Build a patched httpx.AsyncClient that routes by pipeline keyword in URL."""
+
+    async def _get(url, **kw):
+        resp = MagicMock()
+        resp.status_code = 200
+        if "any-to-any" in url:
+            resp.json.return_value = any_to_any or []
+        elif "image-text-to-text" in url:
+            resp.json.return_value = image_text or []
+        else:
+            resp.json.return_value = text_gen or []
+        return resp
+
+    inst = AsyncMock()
+    inst.get.side_effect = _get
+    inst.__aenter__ = AsyncMock(return_value=inst)
+    inst.__aexit__ = AsyncMock(return_value=False)
+    return MagicMock(return_value=inst)
+
+
+# ─── tests ────────────────────────────────────────────────────────────────────
+
+def test_any_to_any_model_included_in_default_pipeline(client):
+    """When pipeline='text-generation' (default), any-to-any models also appear.
+
+    This is the root-cause fix for Gemma 4 going missing from the browse list —
+    flagship multimodal models are tagged any-to-any on HF, not text-generation.
+    """
+    mock_client = _mock_hf_client(
+        text_gen=[_hf_entry("some/text-7b", "text-generation", trending=90)],
+        any_to_any=[_hf_entry("google/gemma-4-12b-it", "any-to-any", trending=95)],
+        image_text=[_hf_entry("qwen/qwen2-vl-7b", "image-text-to-text", trending=85)],
+    )
+    with patch("httpx.AsyncClient", mock_client):
+        resp = client.get("/api/cookbook/hf-latest?limit=20")
+
+    assert resp.status_code == 200
+    repo_ids = {m["repo_id"] for m in resp.json()["models"]}
+    assert "google/gemma-4-12b-it" in repo_ids, "any-to-any model must appear in merged results"
+    assert "some/text-7b" in repo_ids
+    assert "qwen/qwen2-vl-7b" in repo_ids
+
+
+def test_any_to_any_model_is_not_duplicated_when_in_multiple_pipelines(client):
+    """A repo_id that shows up in two pipeline queries is returned only once."""
+    shared = _hf_entry("google/gemma-4-12b-it", "any-to-any", trending=95)
+    mock_client = _mock_hf_client(
+        text_gen=[],
+        image_text=[shared],
+        any_to_any=[shared],
+    )
+    with patch("httpx.AsyncClient", mock_client):
+        resp = client.get("/api/cookbook/hf-latest?limit=20")
+
+    assert resp.status_code == 200
+    repo_ids = [m["repo_id"] for m in resp.json()["models"]]
+    assert repo_ids.count("google/gemma-4-12b-it") == 1, "duplicate across pipelines must be deduplicated"
+
+
+def test_explicit_non_llm_pipeline_skips_merge(client):
+    """An explicit non-LLM pipeline (e.g. text-to-image) is honored as-is —
+    the multi-pipeline merge only fires for LLM browse requests."""
+    mock_client = _mock_hf_client(
+        text_gen=[_hf_entry("some/image-gen", "text-to-image", trending=99)],
+    )
+    with patch("httpx.AsyncClient", mock_client):
+        resp = client.get("/api/cookbook/hf-latest?pipeline=text-to-image&limit=20")
+
+    assert resp.status_code == 200
+    # Only one pipeline was queried; results depend on text_gen mock which is
+    # used for all non-any-to-any / non-image-text-to-text URLs.
+    assert "models" in resp.json()
+
+
+def test_gguf_repo_bypasses_vram_filter(client):
+    """GGUF repos must pass even when the estimated VRAM exceeds the filter budget.
+
+    llama-server offloads layers to CPU RAM, so fp16-based VRAM estimates are
+    meaningless for GGUF — the user picks quantization at download time.
+    """
+    gguf_entry = _hf_entry(
+        "unsloth/gemma-4-12B-it-GGUF",
+        "text-generation",
+        trending=80,
+        tags=["gguf", "text-generation"],
+    )
+    # A non-GGUF 70B model at fp16 needs ~140 GB — way over the 8 GB budget.
+    big_model = _hf_entry("some/huge-70b-fp16", "text-generation", trending=70)
+
+    mock_client = _mock_hf_client(text_gen=[gguf_entry, big_model])
+    with patch("httpx.AsyncClient", mock_client):
+        resp = client.get("/api/cookbook/hf-latest?vram_gb=8&limit=20")
+
+    assert resp.status_code == 200
+    repo_ids = {m["repo_id"] for m in resp.json()["models"]}
+    assert "unsloth/gemma-4-12B-it-GGUF" in repo_ids, "GGUF repo must bypass VRAM filter"
+    assert "some/huge-70b-fp16" not in repo_ids, "fp16 70B must be filtered at 8 GB budget"
+
+
+def test_lora_and_adapter_repos_excluded(client):
+    """LoRA / adapter / embedding repos must be filtered out."""
+    mock_client = _mock_hf_client(
+        text_gen=[
+            _hf_entry("good/model-7b", "text-generation", trending=100),
+            _hf_entry("some/lora-adapter-7b", "text-generation", trending=90),
+            _hf_entry("some/embedding-model", "text-generation", trending=80),
+        ]
+    )
+    with patch("httpx.AsyncClient", mock_client):
+        resp = client.get("/api/cookbook/hf-latest?limit=20")
+
+    repo_ids = {m["repo_id"] for m in resp.json()["models"]}
+    assert "good/model-7b" in repo_ids
+    assert "some/lora-adapter-7b" not in repo_ids
+    assert "some/embedding-model" not in repo_ids
+
+
+def test_returns_models_key_on_success(client):
+    """Response always contains a top-level 'models' list."""
+    mock_client = _mock_hf_client(text_gen=[])
+    with patch("httpx.AsyncClient", mock_client):
+        resp = client.get("/api/cookbook/hf-latest")
+
+    assert resp.status_code == 200
+    assert "models" in resp.json()
+    assert isinstance(resp.json()["models"], list)

--- a/tests/test_hwfit_catalog_route.py
+++ b/tests/test_hwfit_catalog_route.py
@@ -1,0 +1,95 @@
+"""Route tests for the DB-backed hwfit model catalog."""
+
+from contextlib import contextmanager
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _cpu_system():
+    return {
+        "has_gpu": False,
+        "backend": "cpu_x86",
+        "gpu_name": None,
+        "gpu_vram_gb": 0,
+        "gpu_count": 0,
+        "available_ram_gb": 32.0,
+        "total_ram_gb": 32.0,
+    }
+
+
+def _client():
+    from routes.hwfit_routes import setup_hwfit_routes
+
+    app = FastAPI()
+    app.include_router(setup_hwfit_routes())
+    return TestClient(app)
+
+
+def test_hwfit_models_returns_db_refreshed_catalog_row(monkeypatch):
+    """A model persisted by catalog refresh is visible through /api/hwfit/models."""
+    catalog = [{
+        "name": "hf/example-refresh-7b",
+        "provider": "hf",
+        "parameter_count": "7B",
+        "pipeline_tag": "text-generation",
+        "gguf_sources": [{"repo": "hf/example-refresh-7b-GGUF", "kind": "GGUF"}],
+        "_source": "hf_trending",
+        "source": "hf_trending",
+    }]
+
+    monkeypatch.setattr("services.hwfit.hardware.detect_system", lambda **kw: _cpu_system())
+    monkeypatch.setattr("services.hwfit.models.get_models", lambda: [{"name": "stub"}])
+    monkeypatch.setattr("services.hwfit.catalog_sync.get_catalog_or_static", lambda seed_if_empty=True: catalog)
+    monkeypatch.setattr("services.hwfit.local_scanner.scan_local_gguf", lambda: [])
+    monkeypatch.setattr("services.hwfit.lmstudio_catalog.fetch_lmstudio_models", lambda host="": [])
+    monkeypatch.setattr("services.hwfit.ollama_catalog.fetch_ollama_models", lambda host="": [])
+
+    response = _client().get("/api/hwfit/models?search=example-refresh&limit=5")
+
+    assert response.status_code == 200
+    names = [model["name"] for model in response.json()["models"]]
+    assert "hf/example-refresh-7b" in names
+
+
+def test_hwfit_models_persists_live_local_scan(monkeypatch):
+    """Live local scan rows are upserted while serving the hwfit route."""
+    local_entry = {
+        "name": "local/test-route-4B-Q4_K_M",
+        "provider": "Local GGUF",
+        "parameter_count": "4B",
+        "quantization": "Q4_K_M",
+        "quant": "Q4_K_M",
+        "is_gguf": True,
+        "gguf_sources": [{"path": "D:/Models/test-route-4B-Q4_K_M.gguf", "kind": "GGUF"}],
+        "backend": "llamacpp",
+        "context_length": 4096,
+        "local_path": "D:/Models/test-route-4B-Q4_K_M.gguf",
+        "_source": "local_gguf",
+        "source": "local_gguf",
+    }
+    captured = {}
+
+    @contextmanager
+    def _fake_db_session():
+        yield object()
+
+    def _capture_upsert(db, entries, source=None):
+        captured["entries"] = list(entries)
+        captured["source"] = source
+        return []
+
+    monkeypatch.setattr("services.hwfit.hardware.detect_system", lambda **kw: _cpu_system())
+    monkeypatch.setattr("services.hwfit.models.get_models", lambda: [{"name": "stub"}])
+    monkeypatch.setattr("services.hwfit.catalog_sync.get_catalog_or_static", lambda seed_if_empty=True: [])
+    monkeypatch.setattr("services.hwfit.catalog_sync.upsert_discovered_models", _capture_upsert)
+    monkeypatch.setattr("core.database.get_db_session", _fake_db_session)
+    monkeypatch.setattr("services.hwfit.local_scanner.scan_local_gguf", lambda: [local_entry])
+    monkeypatch.setattr("services.hwfit.lmstudio_catalog.fetch_lmstudio_models", lambda host="": [])
+    monkeypatch.setattr("services.hwfit.ollama_catalog.fetch_ollama_models", lambda host="": [])
+
+    response = _client().get("/api/hwfit/models?search=test-route&limit=5")
+
+    assert response.status_code == 200
+    assert captured["entries"] == [local_entry]
+    assert captured["source"] is None

--- a/tests/test_hwfit_docker_gpu_warning.py
+++ b/tests/test_hwfit_docker_gpu_warning.py
@@ -1,0 +1,126 @@
+"""Regression tests for Docker GPU passthrough hardware reporting."""
+
+from services.hwfit import hardware
+
+
+def test_container_without_gpu_passthrough_reports_gpu_error(monkeypatch):
+    """Docker deployments should explain missing passthrough instead of plain No GPU."""
+    monkeypatch.setattr(hardware.os.path, "exists", lambda p: p == "/.dockerenv")
+    monkeypatch.delenv("NVIDIA_VISIBLE_DEVICES", raising=False)
+    monkeypatch.setattr(hardware, "_run", lambda cmd: None)
+    monkeypatch.setattr(hardware, "_get_ram_gb", lambda: 19.4)
+    monkeypatch.setattr(hardware, "_get_available_ram_gb", lambda: 17.6)
+    monkeypatch.setattr(hardware, "_get_cpu_count", lambda: 8)
+    monkeypatch.setattr(hardware, "_get_cpu_name", lambda: "Intel CPU")
+    monkeypatch.setattr(hardware, "_detect_apple_silicon", lambda: None)
+    monkeypatch.setattr(hardware, "_detect_nvidia", lambda: None)
+    monkeypatch.setattr(hardware, "_detect_amd", lambda: None)
+
+    system = hardware.detect_system(fresh=True)
+
+    assert system["has_gpu"] is False
+    assert system["gpu_error"]
+    assert "Docker container" in system["gpu_error"]
+    assert "GPU compose overlay" in system["gpu_error"]
+
+
+def test_non_container_without_gpu_has_no_gpu_error(monkeypatch):
+    """CPU-only bare-metal hosts should still render as plain No GPU."""
+    monkeypatch.setattr(hardware.os.path, "exists", lambda p: False)
+    monkeypatch.setattr(hardware, "_read_file", lambda path: "")
+    monkeypatch.setattr(hardware, "_run", lambda cmd: None)
+    monkeypatch.setattr(hardware, "_get_ram_gb", lambda: 32.0)
+    monkeypatch.setattr(hardware, "_get_available_ram_gb", lambda: 24.0)
+    monkeypatch.setattr(hardware, "_get_cpu_count", lambda: 8)
+    monkeypatch.setattr(hardware, "_get_cpu_name", lambda: "Intel CPU")
+    monkeypatch.setattr(hardware, "_detect_apple_silicon", lambda: None)
+    monkeypatch.setattr(hardware, "_detect_nvidia", lambda: None)
+    monkeypatch.setattr(hardware, "_detect_amd", lambda: None)
+
+    system = hardware.detect_system(fresh=True)
+
+    assert system["has_gpu"] is False
+    assert system["gpu_error"] is None
+
+
+def test_broken_nvidia_overlay_reports_gpu_error(monkeypatch):
+    """A configured but device-less NVIDIA overlay should still warn clearly."""
+    monkeypatch.setattr(hardware.os.path, "exists", lambda p: p == "/.dockerenv")
+    monkeypatch.setenv("NVIDIA_VISIBLE_DEVICES", "all")
+
+    error = hardware._container_gpu_error()
+
+    assert error
+    assert "NVIDIA GPU compose overlay" in error
+    assert "no NVIDIA device" in error
+
+
+def test_visible_gpu_device_suppresses_container_gpu_error(monkeypatch):
+    """When the container has a GPU device node, no passthrough warning is needed."""
+    visible = {"/.dockerenv", "/dev/nvidiactl"}
+    monkeypatch.setattr(hardware.os.path, "exists", lambda p: p in visible)
+    monkeypatch.setenv("NVIDIA_VISIBLE_DEVICES", "all")
+
+    assert hardware._container_gpu_error() is None
+
+
+def test_physical_cpu_count_parses_hyperthreaded_linux_cpuinfo(monkeypatch):
+    """The UI should be able to show 4C/8T instead of ambiguous '8 cores'."""
+    cpuinfo = "\n\n".join(
+        "\n".join(
+            [
+                f"processor\t: {idx}",
+                "physical id\t: 0",
+                f"core id\t\t: {idx // 2}",
+                "cpu cores\t: 4",
+                "siblings\t: 8",
+            ]
+        )
+        for idx in range(8)
+    )
+    monkeypatch.setattr(hardware, "_read_file", lambda path: cpuinfo if path == "/proc/cpuinfo" else "")
+
+    assert hardware._get_physical_cpu_count() == 4
+
+
+def test_detect_system_reports_cpu_topology_and_docker_wsl_ram_scope(monkeypatch):
+    """Detected hardware should distinguish usable Docker RAM from host hardware."""
+    visible = {"/.dockerenv", "/dev/nvidiactl"}
+    monkeypatch.setattr(hardware.os, "name", "posix", raising=False)
+    monkeypatch.setattr(hardware.os.path, "exists", lambda p: p in visible)
+    monkeypatch.setattr(
+        hardware,
+        "_read_file",
+        lambda path: "Linux version 6.6.87.2-microsoft-standard-WSL2"
+        if path == "/proc/version"
+        else "",
+    )
+    monkeypatch.setenv("ODYSSEUS_HOST_TOTAL_RAM_GB", "40")
+    monkeypatch.setattr(hardware, "_get_ram_gb", lambda: 19.4)
+    monkeypatch.setattr(hardware, "_get_available_ram_gb", lambda: 17.6)
+    monkeypatch.setattr(hardware, "_get_cpu_count", lambda: 8)
+    monkeypatch.setattr(hardware, "_get_physical_cpu_count", lambda: 4)
+    monkeypatch.setattr(hardware, "_get_cpu_name", lambda: "Intel CPU")
+    monkeypatch.setattr(hardware, "_detect_apple_silicon", lambda: None)
+    monkeypatch.setattr(
+        hardware,
+        "_detect_nvidia",
+        lambda: {
+            "gpu_name": "NVIDIA RTX",
+            "gpu_vram_gb": 4.0,
+            "gpu_count": 1,
+            "gpus": [],
+            "gpu_groups": [],
+            "homogeneous": True,
+            "backend": "cuda",
+        },
+    )
+
+    system = hardware.detect_system(fresh=True)
+
+    assert system["cpu_logical_cores"] == 8
+    assert system["cpu_physical_cores"] == 4
+    assert system["total_ram_gb"] == 19.4
+    assert system["host_total_ram_gb"] == 40.0
+    assert system["runtime"] == "docker_wsl2"
+    assert system["ram_scope"] == "docker_wsl2"

--- a/tests/test_hwfit_fit_level.py
+++ b/tests/test_hwfit_fit_level.py
@@ -1,0 +1,127 @@
+"""Tests for fit_level correctness and partial-offload split fields.
+
+Covers:
+- cpu_only rows get "good" when RAM headroom is comfortable (>= 1.2×)
+- cpu_only rows get "marginal" when RAM headroom is tight
+- cpu_offload rows expose vram_gb and ram_gb split fields
+- gpu rows have vram_gb=None, ram_gb=None
+"""
+
+import pytest
+from services.hwfit.fit import analyze_model
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _ram_only_system(total_gb=64.0, avail_frac=0.8):
+    """No GPU — model must run entirely in system RAM."""
+    return {
+        "has_gpu": False,
+        "backend": "cpu_x86",
+        "gpu_name": None,
+        "gpu_vram_gb": 0.0,
+        "gpu_count": 0,
+        "available_ram_gb": round(total_gb * avail_frac, 1),
+        "total_ram_gb": total_gb,
+    }
+
+
+def _gpu_system(vram_gb=24.0, ram_gb=64.0):
+    """Discrete GPU system."""
+    return {
+        "has_gpu": True,
+        "backend": "cuda",
+        "gpu_name": "NVIDIA RTX 4090",
+        "gpu_vram_gb": vram_gb,
+        "gpu_count": 1,
+        "available_ram_gb": ram_gb * 0.8,
+        "total_ram_gb": ram_gb,
+    }
+
+
+def _tiny_model(params_b=3.0, is_moe=False):
+    """Minimal catalog-like model dict for a ~3B parameter GGUF model."""
+    return {
+        "name": "test/tiny-model",
+        "parameter_count": f"{int(params_b)}B",
+        "parameter_count_b": params_b,
+        "quantization": "Q4_K_M",
+        "is_gguf": True,
+        "gguf_sources": [{"quant": "Q4_K_M"}],
+        "is_moe": is_moe,
+        "context_length": 4096,
+        "use_case": "general",
+    }
+
+
+# ── cpu_only fit_level ─────────────────────────────────────────────────────────
+
+def test_cpu_only_comfortable_headroom_is_good():
+    """cpu_only with >= 1.2× RAM headroom should be 'good', not 'marginal'."""
+    # 3B Q4_K_M ≈ 2–3 GB. With 64 GB RAM, headroom is massive → 'good'.
+    system = _ram_only_system(total_gb=64.0, avail_frac=0.9)
+    result = analyze_model(_tiny_model(params_b=3.0), system)
+    assert result is not None, "model should fit in 64 GB RAM"
+    assert result["run_mode"] == "cpu_only"
+    assert result["fit_level"] == "good", (
+        f"expected 'good' for cpu_only with large RAM headroom, got {result['fit_level']!r}"
+    )
+
+
+def test_cpu_only_tight_headroom_is_marginal():
+    """cpu_only with < 1.2× headroom should be 'marginal'."""
+    # 3B Q4_K_M ≈ 2.1 GB. Set available_ram to just above required so 1.2× fails.
+    # Use a larger model (~20B) with a tight RAM budget.
+    system = _ram_only_system(total_gb=24.0, avail_frac=0.55)  # ~13 GB available
+    # 20B Q4_K_M ≈ 13-14 GB — tight for 13 GB available
+    result = analyze_model(_tiny_model(params_b=20.0), system)
+    if result is None:
+        pytest.skip("model doesn't fit even in RAM at this budget — adjust params")
+    if result["run_mode"] != "cpu_only":
+        pytest.skip("unexpected run_mode; test only validates cpu_only path")
+    assert result["fit_level"] == "marginal", (
+        f"expected 'marginal' for cpu_only with tight RAM, got {result['fit_level']!r}"
+    )
+
+
+# ── cpu_offload split fields ───────────────────────────────────────────────────
+
+def test_cpu_offload_exposes_vram_ram_split():
+    """cpu_offload rows include vram_gb and ram_gb split fields."""
+    # 20B Q4_K_M ≈ 13-14 GB; 6 GB VRAM forces partial offload into RAM.
+    system = _gpu_system(vram_gb=6.0, ram_gb=64.0)
+    result = analyze_model(_tiny_model(params_b=20.0), system)
+    assert result is not None, "20B model should fit via cpu_offload"
+    assert result["run_mode"] == "cpu_offload", (
+        f"expected cpu_offload for 20B model on 6 GB VRAM, got {result['run_mode']!r}"
+    )
+    assert result["vram_gb"] is not None, "vram_gb should be set for cpu_offload"
+    assert result["ram_gb"] is not None, "ram_gb should be set for cpu_offload"
+    assert result["vram_gb"] <= 6.0, "vram_gb cannot exceed GPU VRAM"
+    assert result["ram_gb"] >= 0.0
+    # The split should add up close to required_gb (allow 0.2 rounding tolerance).
+    assert abs(result["vram_gb"] + result["ram_gb"] - result["required_gb"]) < 0.3, (
+        f"vram_gb + ram_gb should ≈ required_gb: "
+        f"{result['vram_gb']} + {result['ram_gb']} ≠ {result['required_gb']}"
+    )
+
+
+def test_gpu_rows_have_no_split_fields():
+    """gpu rows (model fits entirely in VRAM) have vram_gb=None, ram_gb=None."""
+    # 3B Q4_K_M fits easily in 24 GB VRAM.
+    system = _gpu_system(vram_gb=24.0, ram_gb=64.0)
+    result = analyze_model(_tiny_model(params_b=3.0), system)
+    assert result is not None
+    assert result["run_mode"] == "gpu"
+    assert result["vram_gb"] is None, "gpu rows should not expose vram_gb split"
+    assert result["ram_gb"] is None
+
+
+def test_cpu_only_rows_have_no_split_fields():
+    """cpu_only rows (no GPU) have vram_gb=None, ram_gb=None."""
+    system = _ram_only_system(total_gb=64.0)
+    result = analyze_model(_tiny_model(params_b=3.0), system)
+    assert result is not None
+    assert result["run_mode"] == "cpu_only"
+    assert result["vram_gb"] is None, "cpu_only rows should not expose vram_gb split"
+    assert result["ram_gb"] is None

--- a/tests/test_hwfit_model_caps.py
+++ b/tests/test_hwfit_model_caps.py
@@ -1,0 +1,150 @@
+"""Tests for GET /api/hwfit/model-caps endpoint."""
+
+from contextlib import contextmanager
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _client():
+    from routes.hwfit_routes import setup_hwfit_routes
+
+    app = FastAPI()
+    app.include_router(setup_hwfit_routes())
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _FakeModel:
+    """Minimal DiscoveredModel stand-in for DB query results."""
+
+    def __init__(self, name, capabilities):
+        self.name = name
+        self.capabilities = capabilities
+
+
+class _FakeQuery:
+    """Chains .filter().first() over a static list of rows."""
+
+    def __init__(self, rows):
+        self._rows = rows
+        self._filtered = list(rows)
+
+    def filter(self, *args, **kwargs):
+        import sqlalchemy.sql.operators as _ops
+
+        clone = _FakeQuery(self._rows)
+        clause = args[0] if args else None
+        if clause is None:
+            return clone
+        try:
+            op = clause.operator
+            pat = clause.right.value
+            if op is _ops.eq:
+                clone._filtered = [r for r in self._rows if r.name == pat]
+            elif op is _ops.like_op:
+                # Pattern is like "%/suffix" — match names ending with the suffix part.
+                suffix = pat.lstrip('%')
+                clone._filtered = [
+                    r for r in self._rows if r.name.endswith(suffix)
+                ]
+            else:
+                clone._filtered = list(self._rows)
+        except AttributeError:
+            clone._filtered = list(self._rows)
+        return clone
+
+    def first(self):
+        return self._filtered[0] if self._filtered else None
+
+
+class _FakeDB:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def query(self, model_cls):
+        return _FakeQuery(self._rows)
+
+
+@contextmanager
+def _fake_db_session_factory(rows):
+    yield _FakeDB(rows)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_model_caps_known_exact_match(monkeypatch):
+    """Returns capabilities from a catalog row matched by exact name."""
+    rows = [_FakeModel("google/gemma-4-12b-it", ["vision", "tools"])]
+    monkeypatch.setattr(
+        "core.database.get_db_session",
+        lambda: _fake_db_session_factory(rows),
+    )
+
+    resp = _client().get("/api/hwfit/model-caps?model=google/gemma-4-12b-it")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["found"] is True
+    assert "vision" in data["capabilities"]
+    assert "tools" in data["capabilities"]
+
+
+def test_model_caps_known_suffix_match(monkeypatch):
+    """Falls back to suffix match when the full model path isn't in the catalog."""
+    rows = [_FakeModel("google/gemma-4-12b-it", ["vision"])]
+    monkeypatch.setattr(
+        "core.database.get_db_session",
+        lambda: _fake_db_session_factory(rows),
+    )
+
+    # Query with just the basename — no org prefix
+    resp = _client().get("/api/hwfit/model-caps?model=gemma-4-12b-it")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["found"] is True
+    assert "vision" in data["capabilities"]
+
+
+def test_model_caps_unknown_model(monkeypatch):
+    """Returns empty capabilities and found=False for an unknown model."""
+    monkeypatch.setattr(
+        "core.database.get_db_session",
+        lambda: _fake_db_session_factory([]),
+    )
+
+    resp = _client().get("/api/hwfit/model-caps?model=org/unknown-7b")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["found"] is False
+    assert data["capabilities"] == []
+
+
+def test_model_caps_empty_model_param():
+    """Returns empty capabilities immediately without hitting the DB when model=''."""
+    resp = _client().get("/api/hwfit/model-caps")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["found"] is False
+    assert data["capabilities"] == []
+    assert data["model_id"] == ""
+
+
+def test_model_caps_non_list_capabilities(monkeypatch):
+    """Handles a row whose capabilities field is None gracefully."""
+    rows = [_FakeModel("org/model-no-caps", None)]
+    monkeypatch.setattr(
+        "core.database.get_db_session",
+        lambda: _fake_db_session_factory(rows),
+    )
+
+    resp = _client().get("/api/hwfit/model-caps?model=org/model-no-caps")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["found"] is True
+    assert data["capabilities"] == []

--- a/tests/test_hwfit_model_ram_default.py
+++ b/tests/test_hwfit_model_ram_default.py
@@ -1,0 +1,99 @@
+"""Per-model default RAM budget.
+
+A heavy model can declare (or be hardcoded with) the RAM budget it should be
+ranked against by default, so it doesn't read as too_tight against whatever
+memory is momentarily free. The explicit global RAM override still wins; models
+without a default keep tracking live free RAM dynamically.
+"""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from services.hwfit import fit
+
+
+def _system(free_ram, total_ram=40.0):
+    """Small-VRAM laptop with little momentary free RAM."""
+    return {
+        "has_gpu": True, "backend": "cuda",
+        "gpu_name": "NVIDIA Test GPU 4GB",
+        "gpu_vram_gb": 4.0, "gpu_count": 1,
+        "available_ram_gb": free_ram, "total_ram_gb": total_ram,
+        "detected_ram_total_gb": total_ram,
+    }
+
+
+# ~26 B dense GGUF needing ~16 GB at Q4_K_M: too tight at 12 GB free, fine at 20.
+def _model(name, **extra):
+    m = {
+        "name": name, "provider": "vendor", "parameter_count": "26B",
+        "parameters_raw": 26000000000, "quantization": "Q4_K_M",
+        "context_length": 16384, "gguf_sources": [{"repo": name + "-GGUF"}],
+    }
+    m.update(extra)
+    return m
+
+
+def test_hardcoded_default_applies_with_low_free_ram():
+    """A name in DEFAULT_RAM_BUDGET_GB ranks against its budget, not live free."""
+    name = next(iter(fit.DEFAULT_RAM_BUDGET_GB))
+    budget = fit.DEFAULT_RAM_BUDGET_GB[name]
+    r = fit.analyze_model(_model(name), _system(free_ram=12.0), target_context=4096)
+    assert r["ram_budget_gb"] == budget        # ranked at the default, not 12
+    assert r["fit_level"] != "too_tight"
+    assert r["run_mode"] == "cpu_offload"
+
+
+def test_declared_field_takes_precedence():
+    """An explicit default_ram_budget_gb field beats the hardcoded map / live RAM."""
+    r = fit.analyze_model(
+        _model("vendor/declared-26b", default_ram_budget_gb=24.0),
+        _system(free_ram=10.0), target_context=4096,
+    )
+    assert r["ram_budget_gb"] == 24.0
+
+
+def test_model_without_default_tracks_live_free_ram():
+    """No default → budget is exactly the (dynamic) live free RAM."""
+    r = fit.analyze_model(_model("vendor/plain-26b"), _system(free_ram=22.0), target_context=4096)
+    assert r["ram_budget_gb"] == 22.0
+
+
+def test_global_override_beats_per_model_default():
+    """An explicit RAM override (the chip) wins over the model default."""
+    name = next(iter(fit.DEFAULT_RAM_BUDGET_GB))
+    sysd = _system(free_ram=12.0)
+    sysd["ram_override_gb"] = 30.0
+    sysd["available_ram_gb"] = 30.0
+    r = fit.analyze_model(_model(name), sysd, target_context=4096)
+    assert r["ram_budget_gb"] == 30.0
+
+
+def test_default_capped_at_installed_ram():
+    """The default can't claim more RAM than is physically installed."""
+    r = fit.analyze_model(
+        _model("vendor/huge", default_ram_budget_gb=64.0),
+        _system(free_ram=8.0, total_ram=16.0), target_context=4096,
+    )
+    assert r["ram_budget_gb"] == 16.0
+
+
+def test_serve_profiles_use_model_default_budget(monkeypatch):
+    """/api/hwfit/profiles ranks the recommended -ngl against the model's default
+    RAM budget (20 GB for the 26B), so the serve panel agrees with What Fits."""
+    from routes.hwfit_routes import setup_hwfit_routes
+
+    name = next(iter(fit.DEFAULT_RAM_BUDGET_GB))
+    model = _model(name, is_moe=True, active_parameters=3800000000)
+    monkeypatch.setattr(
+        "services.hwfit.hardware.detect_system",
+        lambda **kw: _system(free_ram=10.0),  # little free RAM at scan time
+    )
+    monkeypatch.setattr("services.hwfit.models.get_models", lambda: [model])
+
+    app = FastAPI(); app.include_router(setup_hwfit_routes())
+    data = TestClient(app).get(f"/api/hwfit/profiles?model={name}").json()
+
+    assert data["system"]["ram_budget_gb"] == fit.DEFAULT_RAM_BUDGET_GB[name]
+    assert data["system"]["available_ram_gb"] == fit.DEFAULT_RAM_BUDGET_GB[name]
+    assert "recommended_ngl" in data

--- a/tests/test_hwfit_ram_override.py
+++ b/tests/test_hwfit_ram_override.py
@@ -1,0 +1,94 @@
+"""Route tests for the inline RAM-budget override (the editable RAM chip).
+
+The override raises/lowers the available-RAM budget the ranker uses WITHOUT
+faking the detected GPU, so speed estimates keep the real card's bandwidth.
+"""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _gpu_system():
+    """A small-VRAM GPU box with little free RAM at scan time — the case the
+    override exists for (probe sees live free RAM, not the real ceiling)."""
+    return {
+        "has_gpu": True,
+        "backend": "cuda",
+        "gpu_name": "NVIDIA Test GPU 4GB",
+        "gpu_vram_gb": 4.0,
+        "gpu_count": 1,
+        "gpus": [{"index": 0, "name": "NVIDIA Test GPU 4GB", "vram_gb": 4.0}],
+        "gpu_groups": [{"name": "NVIDIA Test GPU 4GB", "vram_each": 4.0, "count": 1, "indices": [0], "vram_total": 4.0}],
+        "available_ram_gb": 16.0,
+        "total_ram_gb": 40.0,
+    }
+
+
+def _client():
+    from routes.hwfit_routes import setup_hwfit_routes
+
+    app = FastAPI()
+    app.include_router(setup_hwfit_routes())
+    return TestClient(app)
+
+
+def _stub_catalog(monkeypatch, catalog):
+    monkeypatch.setattr("services.hwfit.hardware.detect_system", lambda **kw: _gpu_system())
+    monkeypatch.setattr("services.hwfit.models.get_models", lambda: [{"name": "stub"}])
+    monkeypatch.setattr("services.hwfit.catalog_sync.get_catalog_or_static", lambda seed_if_empty=True: catalog)
+    monkeypatch.setattr("services.hwfit.local_scanner.scan_local_gguf", lambda: [])
+    monkeypatch.setattr("services.hwfit.lmstudio_catalog.fetch_lmstudio_models", lambda host="": [])
+    monkeypatch.setattr("services.hwfit.ollama_catalog.fetch_ollama_models", lambda host="": [])
+
+
+# A ~40B dense GGUF: ~23 GB at Q4_K_M — too tight for 16 GB free, fits in 32 GB.
+_BIG = [{
+    "name": "vendor/big-40b",
+    "provider": "vendor",
+    "parameter_count": "40B",
+    "parameters_raw": 40000000000,
+    "quantization": "Q4_K_M",
+    "context_length": 4096,
+    "pipeline_tag": "text-generation",
+    "gguf_sources": [{"repo": "vendor/big-40b-GGUF", "kind": "GGUF"}],
+}]
+
+
+def test_override_raises_budget_and_keeps_gpu(monkeypatch):
+    _stub_catalog(monkeypatch, _BIG)
+    data = _client().get("/api/hwfit/models?override_ram_gb=32&ctx=4096&limit=5").json()
+    sys = data["system"]
+    # Budget replaced with the override; detected GPU left intact.
+    assert sys["available_ram_gb"] == 32.0
+    assert sys["ram_override_gb"] == 32.0
+    assert sys["has_gpu"] is True
+    assert sys["gpu_vram_gb"] == 4.0
+    assert "Test GPU" in sys["gpu_name"]
+    # True installed RAM exposed for the slider cap.
+    assert sys["detected_ram_total_gb"] == 40.0
+
+
+def test_override_changes_fit_outcome(monkeypatch):
+    _stub_catalog(monkeypatch, _BIG)
+    base = _client().get("/api/hwfit/models?ctx=4096&limit=5").json()["models"][0]
+    bumped = _client().get("/api/hwfit/models?override_ram_gb=32&ctx=4096&limit=5").json()["models"][0]
+    # Too tight against 16 GB free, but runnable once the budget is raised to 32.
+    assert base["fit_level"] == "too_tight"
+    assert bumped["fit_level"] != "too_tight"
+    assert bumped["run_mode"] == "cpu_offload"
+
+
+def test_no_override_leaves_detected_budget(monkeypatch):
+    _stub_catalog(monkeypatch, _BIG)
+    sys = _client().get("/api/hwfit/models?ctx=4096&limit=5").json()["system"]
+    assert sys["available_ram_gb"] == 16.0
+    assert "ram_override_gb" not in sys
+    assert sys["detected_ram_total_gb"] == 40.0
+
+
+def test_override_ignored_when_blank_or_invalid(monkeypatch):
+    _stub_catalog(monkeypatch, _BIG)
+    for q in ("override_ram_gb=", "override_ram_gb=abc", "override_ram_gb=0", "override_ram_gb=-5"):
+        sys = _client().get(f"/api/hwfit/models?{q}&ctx=4096&limit=5").json()["system"]
+        assert sys["available_ram_gb"] == 16.0
+        assert "ram_override_gb" not in sys

--- a/tests/test_lmstudio_catalog.py
+++ b/tests/test_lmstudio_catalog.py
@@ -1,0 +1,144 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from services.hwfit.fit import rank_models
+from services.hwfit.lmstudio_catalog import (
+    _candidate_urls,
+    fetch_lmstudio_models,
+    invalidate_cache,
+)
+
+
+class _FakeResponse:
+    def __init__(self, payload, ok=True):
+        self._payload = payload
+        self.is_success = ok
+
+    def json(self):
+        return self._payload
+
+
+def _cpu_system():
+    return {
+        "has_gpu": False,
+        "backend": "cpu_x86",
+        "gpu_name": None,
+        "gpu_vram_gb": 0,
+        "gpu_count": 0,
+        "available_ram_gb": 32.0,
+        "total_ram_gb": 32.0,
+    }
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    invalidate_cache()
+    yield
+    invalidate_cache()
+
+
+def test_candidate_urls_include_lm_studio_env(monkeypatch):
+    monkeypatch.setenv("LM_STUDIO_URL", "http://my-lm-box:5000/v1")
+
+    urls = _candidate_urls("")
+
+    assert urls[0] == "http://my-lm-box:5000/api/v1/models"
+
+
+def test_candidate_urls_use_remote_host_when_supplied(monkeypatch):
+    monkeypatch.setenv("LM_STUDIO_URL", "http://ignored:5000")
+
+    assert _candidate_urls("workstation.local") == [
+        "http://workstation.local:1234/api/v1/models"
+    ]
+
+
+def test_fetch_lmstudio_models_parses_native_models(monkeypatch):
+    payload = {
+        "models": [
+            {
+                "type": "llm",
+                "key": "qwen3.6-27b-Q5_K_M",
+                "display_name": "Qwen3.6 27B",
+                "architecture": "qwen3",
+                "quantization": {"name": "Q5_K_M"},
+                "format": "gguf",
+                "max_context_length": 131072,
+                "capabilities": {"vision": True, "tools": True},
+            }
+        ]
+    }
+
+    monkeypatch.setattr(
+        "services.hwfit.lmstudio_catalog.httpx.get",
+        lambda url, timeout=None: _FakeResponse(payload),
+    )
+
+    result = fetch_lmstudio_models()
+
+    assert len(result) == 1
+    model = result[0]
+    assert model["name"] == "Qwen3.6 27B"
+    assert model["provider"] == "LM Studio"
+    assert model["parameter_count"] == "27B"
+    assert model["quant"] == "Q5_K_M"
+    assert model["context_length"] == 131072
+    assert model["backend"] == "lmstudio"
+    assert model["_source"] == "lmstudio"
+    assert model["is_gguf"] is True
+    assert model["gguf_sources"]
+    assert model["capabilities"] == ["vision", "tools"]
+
+
+def test_fetch_lmstudio_models_returns_empty_for_non_lmstudio(monkeypatch):
+    monkeypatch.setattr(
+        "services.hwfit.lmstudio_catalog.httpx.get",
+        lambda url, timeout=None: _FakeResponse({"data": [{"id": "gpt-4o"}]}),
+    )
+
+    assert fetch_lmstudio_models() == []
+
+
+def test_fetch_lmstudio_models_uses_cache(monkeypatch):
+    payload = {
+        "models": [
+            {
+                "key": "phi-4-mini-4B-Q4_K_M",
+                "architecture": "phi",
+                "quantization": {"name": "Q4_K_M"},
+                "format": "gguf",
+            }
+        ]
+    }
+    get = MagicMock(return_value=_FakeResponse(payload))
+    monkeypatch.setattr("services.hwfit.lmstudio_catalog.httpx.get", get)
+
+    fetch_lmstudio_models()
+    fetch_lmstudio_models()
+
+    assert get.call_count == 1
+
+
+def test_rank_models_preserves_lmstudio_source(monkeypatch):
+    payload = {
+        "models": [
+            {
+                "key": "phi-4-mini-4B-Q4_K_M",
+                "architecture": "phi",
+                "quantization": {"name": "Q4_K_M"},
+                "format": "gguf",
+            }
+        ]
+    }
+    monkeypatch.setattr(
+        "services.hwfit.lmstudio_catalog.httpx.get",
+        lambda url, timeout=None: _FakeResponse(payload),
+    )
+    [model] = fetch_lmstudio_models()
+
+    results = rank_models(_cpu_system(), search="phi-4-mini", extra_models=[model])
+
+    match = next(r for r in results if r["name"] == "phi-4-mini-4B-Q4_K_M")
+    assert match["_source"] == "lmstudio"
+    assert match["source"] == "lmstudio"

--- a/tests/test_local_scanner.py
+++ b/tests/test_local_scanner.py
@@ -1,0 +1,108 @@
+import os
+from unittest.mock import patch
+
+from services.hwfit.fit import rank_models
+from services.hwfit.local_scanner import _extra_scan_dirs, default_scan_dirs, scan_local_gguf
+
+
+def _cpu_system():
+    return {
+        "has_gpu": False,
+        "backend": "cpu_x86",
+        "gpu_name": None,
+        "gpu_vram_gb": 0,
+        "gpu_count": 0,
+        "available_ram_gb": 32.0,
+        "total_ram_gb": 32.0,
+    }
+
+
+def test_scan_local_gguf_finds_model_and_extracts_metadata(tmp_path):
+    model_dir = tmp_path / "models"
+    model_dir.mkdir()
+    model_file = model_dir / "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf"
+    model_file.write_bytes(b"x" * 1024)
+
+    result = scan_local_gguf([model_dir])
+
+    assert len(result) == 1
+    model = result[0]
+    assert model["name"] == "local/Meta-Llama-3.1-8B-Instruct-Q4_K_M"
+    assert model["family"] == "llama"
+    assert model["parameter_count"] == "8B"
+    assert model["quant"] == "Q4_K_M"
+    assert model["is_gguf"] is True
+    assert model["_source"] == "local_gguf"
+    assert model["local_path"] == str(model_file.resolve())
+    assert model["gguf_sources"][0]["path"] == str(model_file.resolve())
+
+
+def test_scan_local_gguf_detects_mmproj_sidecar(tmp_path):
+    model_file = tmp_path / "gemma-4-12B-it-Q4_K_M.gguf"
+    mmproj_file = tmp_path / "mmproj-gemma-4.gguf"
+    model_file.write_bytes(b"x" * 1024)
+    mmproj_file.write_bytes(b"x" * 1024)
+
+    result = scan_local_gguf([tmp_path])
+
+    assert len(result) == 1
+    assert result[0]["mmproj_path"] == str(mmproj_file.resolve())
+    assert result[0]["gguf_sources"][0]["mmproj_path"] == str(mmproj_file.resolve())
+
+
+def test_scan_local_gguf_ignores_non_models(tmp_path):
+    (tmp_path / "notes.txt").write_text("ignore", encoding="utf-8")
+    (tmp_path / "mmproj-only.gguf").write_bytes(b"x" * 1024)
+
+    assert scan_local_gguf([tmp_path]) == []
+
+
+def test_scan_local_gguf_estimates_params_from_file_size(tmp_path):
+    model_file = tmp_path / "qwen-local-Q8_0.gguf"
+    model_file.write_bytes(b"x" * 1024 * 1024)
+
+    result = scan_local_gguf([tmp_path])
+
+    assert len(result) == 1
+    assert result[0]["parameter_count"].endswith("B")
+    assert result[0]["quant"] == "Q8_0"
+
+
+def test_extra_scan_dirs_accepts_colon_and_windows_drives():
+    paths = _extra_scan_dirs(r"D:\Models:E:\More")
+
+    assert [str(p) for p in paths] == [r"D:\Models", r"E:\More"]
+
+
+def test_scan_local_gguf_graceful_when_scan_dirs_env_var_absent(tmp_path):
+    # When ODYSSEUS_MODEL_SCAN_DIRS is not set, default_scan_dirs() should
+    # include only the built-in paths (no crash, returns a list).
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("ODYSSEUS_MODEL_SCAN_DIRS", None)
+        dirs = default_scan_dirs()
+
+    assert isinstance(dirs, list)
+    # default dirs must not contain any path derived from the env var
+    assert not any("ODYSSEUS" in str(d) for d in dirs)
+
+
+def test_scan_local_gguf_empty_scan_dirs_env_var_is_noop():
+    # An explicitly empty env var must not add any extra scan directories.
+    with patch.dict(os.environ, {"ODYSSEUS_MODEL_SCAN_DIRS": ""}):
+        dirs = default_scan_dirs()
+
+    # No path derived from an empty string should be in the list
+    assert all(str(d) for d in dirs)  # all paths are non-empty strings
+
+
+def test_rank_models_preserves_local_source_metadata(tmp_path):
+    model_file = tmp_path / "Phi-3-mini-4B-Q4_K_M.gguf"
+    model_file.write_bytes(b"x" * 1024)
+    local_model = scan_local_gguf([tmp_path])[0]
+
+    results = rank_models(_cpu_system(), search="Phi-3-mini", extra_models=[local_model])
+
+    match = next(r for r in results if r["name"] == local_model["name"])
+    assert match["_source"] == "local_gguf"
+    assert match["source"] == "local_gguf"
+    assert match["local_path"] == str(model_file.resolve())

--- a/tests/test_model_capabilities.py
+++ b/tests/test_model_capabilities.py
@@ -1,0 +1,65 @@
+"""Tests for capability normalization in the model catalog loader.
+
+Covers:
+- image-text-to-text models receive 'vision' capability when missing
+- any-to-any models receive both 'vision' and 'audio' capabilities
+- existing capability lists are not overwritten or duplicated
+- text-generation models receive no capability backfill
+- get_models() returns at least one vision-capable model from the static catalog
+"""
+
+import services.hwfit.models as _models_mod
+from services.hwfit.models import _normalize_model_entry, get_models
+
+
+def _entry(name="test/model", pipeline_tag="text-generation", capabilities=None):
+    e = {"name": name, "pipeline_tag": pipeline_tag}
+    if capabilities is not None:
+        e["capabilities"] = capabilities
+    return e
+
+
+def test_image_text_to_text_gets_vision():
+    result = _normalize_model_entry(_entry(pipeline_tag="image-text-to-text"))
+    assert "vision" in result["capabilities"]
+
+
+def test_any_to_any_gets_vision_and_audio():
+    result = _normalize_model_entry(_entry(pipeline_tag="any-to-any"))
+    assert "vision" in result["capabilities"]
+    assert "audio" in result["capabilities"]
+
+
+def test_text_generation_unchanged():
+    result = _normalize_model_entry(_entry(pipeline_tag="text-generation"))
+    assert result.get("capabilities", []) == []
+
+
+def test_existing_vision_not_duplicated():
+    result = _normalize_model_entry(
+        _entry(pipeline_tag="image-text-to-text", capabilities=["vision", "tool_use"])
+    )
+    assert result["capabilities"].count("vision") == 1
+    assert "tool_use" in result["capabilities"]
+
+
+def test_existing_capabilities_preserved_on_text_gen():
+    result = _normalize_model_entry(
+        _entry(pipeline_tag="text-generation", capabilities=["tool_use"])
+    )
+    assert result["capabilities"] == ["tool_use"]
+
+
+def test_static_catalog_has_vision_models():
+    _models_mod._models_cache = None
+    models = get_models()
+    vision_models = [m for m in models if "vision" in (m.get("capabilities") or [])]
+    assert len(vision_models) > 0, "expected at least one vision-capable model in static catalog"
+
+
+def test_static_catalog_vision_count_reasonable():
+    _models_mod._models_cache = None
+    models = get_models()
+    vision_models = [m for m in models if "vision" in (m.get("capabilities") or [])]
+    # The static catalog has 130+ image-text-to-text and any-to-any models.
+    assert len(vision_models) >= 50

--- a/tests/test_ollama_catalog.py
+++ b/tests/test_ollama_catalog.py
@@ -1,0 +1,138 @@
+"""Tests for services/hwfit/ollama_catalog.py"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from services.hwfit.ollama_catalog import (
+    _infer_context,
+    _parse_param_count,
+    fetch_ollama_models,
+    invalidate_cache,
+)
+
+
+class TestParseParamCount:
+    def test_billions(self):
+        assert _parse_param_count("7B") == "7B"
+
+    def test_lowercase(self):
+        assert _parse_param_count("3.2b") == "3.2B"
+
+    def test_decimal(self):
+        assert _parse_param_count("70.6B") == "70.6B"
+
+    def test_empty(self):
+        assert _parse_param_count("") == ""
+
+    def test_no_suffix_defaults_b(self):
+        assert _parse_param_count("8") == "8B"
+
+
+class TestInferContext:
+    def test_llama3_family(self):
+        assert _infer_context({"family": "llama3", "families": ["llama3"]}) == 131072
+
+    def test_gemma_family(self):
+        assert _infer_context({"family": "gemma", "families": []}) == 8192
+
+    def test_qwen2_family(self):
+        assert _infer_context({"families": ["qwen2"]}) == 32768
+
+    def test_unknown_family_defaults(self):
+        assert _infer_context({"family": "unknown_future_model"}) == 4096
+
+    def test_empty_details(self):
+        assert _infer_context({}) == 4096
+
+
+class TestFetchOllamaModels:
+    def setup_method(self):
+        invalidate_cache()
+
+    def _mock_response(self, models_list):
+        payload = json.dumps({"models": models_list}).encode()
+        mock = MagicMock()
+        mock.__enter__ = MagicMock(return_value=mock)
+        mock.__exit__ = MagicMock(return_value=False)
+        mock.read = MagicMock(return_value=payload)
+        return mock
+
+    def test_returns_empty_for_remote_host(self):
+        result = fetch_ollama_models(host="user@remoteserver")
+        assert result == []
+
+    def test_returns_empty_when_ollama_not_running(self):
+        with patch("urllib.request.urlopen", side_effect=OSError("connection refused")):
+            result = fetch_ollama_models()
+        assert result == []
+
+    def test_parses_single_model(self):
+        payload = [
+            {
+                "name": "llama3.2:latest",
+                "size": 2019393189,
+                "details": {
+                    "format": "gguf",
+                    "family": "llama3",
+                    "parameter_size": "3.2B",
+                    "quantization_level": "Q4_K_M",
+                },
+            }
+        ]
+        with patch("urllib.request.urlopen", return_value=self._mock_response(payload)):
+            result = fetch_ollama_models()
+        assert len(result) == 1
+        m = result[0]
+        assert m["name"] == "llama3.2:latest"
+        assert m["parameter_count"] == "3.2B"
+        assert m["quant"] == "Q4_K_M"
+        assert m["is_gguf"] is True
+        assert m["is_ollama"] is True
+        assert m["backend"] == "ollama"
+        assert m["_source"] == "ollama"
+        assert m["context_length"] == 131072
+
+    def test_deduplicates_models(self):
+        payload = [
+            {"name": "phi3:mini", "size": 0, "details": {"parameter_size": "3.8B"}},
+            {"name": "phi3:mini", "size": 0, "details": {"parameter_size": "3.8B"}},
+        ]
+        with patch("urllib.request.urlopen", return_value=self._mock_response(payload)):
+            result = fetch_ollama_models()
+        assert len(result) == 1
+
+    def test_returns_multiple_models(self):
+        payload = [
+            {"name": "llama3.1:8b", "size": 0, "details": {"parameter_size": "8B", "family": "llama3"}},
+            {"name": "gemma2:9b", "size": 0, "details": {"parameter_size": "9B", "family": "gemma2"}},
+        ]
+        with patch("urllib.request.urlopen", return_value=self._mock_response(payload)):
+            result = fetch_ollama_models()
+        names = {m["name"] for m in result}
+        assert "llama3.1:8b" in names
+        assert "gemma2:9b" in names
+
+    def test_gguf_sources_set_for_ranker(self):
+        """fit.py checks gguf_sources for GGUF detection — must be non-empty."""
+        payload = [
+            {"name": "mistral:7b", "size": 0, "details": {"parameter_size": "7B", "quantization_level": "Q4_0"}},
+        ]
+        with patch("urllib.request.urlopen", return_value=self._mock_response(payload)):
+            result = fetch_ollama_models()
+        assert result[0]["gguf_sources"]  # truthy / non-empty
+
+    def test_cache_is_used_on_second_call(self):
+        payload = [{"name": "llama3.2:latest", "size": 0, "details": {"parameter_size": "3.2B"}}]
+        call_count = {"n": 0}
+
+        def counting_open(url, timeout):
+            call_count["n"] += 1
+            return self._mock_response(payload)
+
+        with patch("urllib.request.urlopen", side_effect=counting_open):
+            fetch_ollama_models()
+            fetch_ollama_models()
+
+        assert call_count["n"] == 1, "expected cache hit on second call"


### PR DESCRIPTION
## Summary

Extends the Cookbook *What Fits?* tab with a dynamic model catalog, model-capability handling, and fit-panel UX, and fixes a couple of list bugs. These are submitted together because they co-edit `fit.py`, `hwfit_routes.py`, and `cookbook-hwfit.js` and depend on each other.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Part of #4743

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [x] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above.
- [ ] I actually ran the app and verified end-to-end. *(Draft — author verification in progress; backend covered by the suite below.)*

## How to Test

1. `pytest tests/test_catalog_sync.py tests/test_local_scanner.py tests/test_lmstudio_catalog.py tests/test_ollama_catalog.py tests/test_hwfit_model_caps.py tests/test_model_capabilities.py tests/test_hwfit_fit_level.py tests/test_hwfit_model_ram_default.py tests/test_hwfit_ram_override.py` — 91 tests pass.
2. In the app, open **Cookbook → What Fits?** and scan: locally-installed GGUF / LM Studio / Ollama models show a green `local` badge; multimodal models surface a vision affordance; the per-model RAM-budget chip is editable.
3. Confirm the **fit column** (e.g. `MARGINAL (RAM)`, `TOO TIGHT`) no longer overflows into the model name.

## Visual / UI changes

This changes the What Fits list UI. **Screenshots pending** while in draft — including a before/after of the fit-column overflow fix. Reuses existing CSS variables and badge classes; no new component patterns; no emoji.
