### PR TITLE
fix(agent): dispatch bare-named built-in email tools (#4769)

### DIFF
--- a/src/tool_execution.py
+++ b/src/tool_execution.py
@@ -21,7 +21,7 @@ from typing import Any, Awaitable, Callable, Dict, Optional, Tuple
 
 
 
-from src.tool_security import is_public_blocked_tool, owner_is_admin_or_single_user
+from src.tool_security import is_public_blocked_tool, owner_is_admin_or_single_user, BUILTIN_EMAIL_TOOLS
 from src.tool_policy import ToolPolicy
 from src.constants import MAX_OUTPUT_CHARS, MAX_READ_CHARS, MAX_DIFF_LINES, DATA_DIR
 from src.tool_utils import _truncate, get_mcp_manager
@@ -640,6 +640,20 @@ async def _execute_tool_block_impl(
         }
         logger.warning("Public tool policy blocked owner=%r tool=%s", owner, tool)
         return desc, result
+
+    # Built-in email tools are dispatched via the internal email MCP, so they
+    # resolve under the mcp__email__ namespace below. A model may emit the call
+    # in either form: native function calls and <invoke>/<tool_code> already
+    # canonicalize to mcp__email__ (via function_call_to_tool_block), but the
+    # fenced ```list_emails / [TOOL_CALL] paths parse to the bare name (those
+    # names are also in TOOL_TAGS). The bare form had no dispatch case and fell
+    # through to "Unknown tool type: list_emails" (#4769). Normalize to the
+    # mcp__email__ form here — AFTER the security gates above, which match on the
+    # bare names in tool_security, so disable/plan-mode/admin/public checks still
+    # apply (is_public_blocked_tool gates the bare BUILTIN_EMAIL_TOOLS names too,
+    # so a non-admin can't reach the email MCP via the bare form).
+    if tool in BUILTIN_EMAIL_TOOLS:
+        tool = f"mcp__email__{tool}"
 
     # ask_user: the agent poses a multiple-choice question to the user to get a
     # decision/clarification. This is a pure UI-control marker — no subprocess,

--- a/src/tool_schemas.py
+++ b/src/tool_schemas.py
@@ -14,6 +14,7 @@ from typing import Optional
 
 from src.agent_tools import ToolBlock, TOOL_TAGS
 from src.tool_parsing import _TOOL_NAME_MAP
+from src.tool_security import BUILTIN_EMAIL_TOOLS
 
 logger = logging.getLogger(__name__)
 
@@ -1222,15 +1223,13 @@ def function_call_to_tool_block(name: str, arguments: str) -> Optional[ToolBlock
         return None
 
     tool_type = _TOOL_NAME_MAP.get(name, name)
-    _BUILTIN_EMAIL_TOOLS = {"list_email_accounts", "send_email", "list_emails", "read_email", "reply_to_email",
-                            "archive_email", "delete_email", "mark_email_read", "bulk_email", "download_attachment"}
 
     # Some models emit valid JSON that isn't an object (e.g. a bare array
     # ["ls -la"], string, or number) as function arguments. Most local tools keep
     # the legacy empty-object coercion for stream robustness, but email MCP tools
     # must fail closed so a malformed call cannot read the default mailbox.
     if not isinstance(args, dict):
-        if tool_type.startswith("mcp__email__") or name in _BUILTIN_EMAIL_TOOLS:
+        if tool_type.startswith("mcp__email__") or name in BUILTIN_EMAIL_TOOLS:
             logger.warning(f"Non-object email function call arguments for {name}: {args!r}; rejecting")
             return None
         logger.warning(f"Non-object function call arguments for {name}: {args!r}; treating as empty")
@@ -1241,7 +1240,7 @@ def function_call_to_tool_block(name: str, arguments: str) -> Optional[ToolBlock
         content = json.dumps(args) if args else "{}"
         return ToolBlock(tool_type, content)
     # Email tools are implemented as MCP — route them to email
-    if name in _BUILTIN_EMAIL_TOOLS:
+    if name in BUILTIN_EMAIL_TOOLS:
         return ToolBlock(f"mcp__email__{name}", json.dumps(args) if args else "{}")
     if tool_type not in TOOL_TAGS:
         logger.warning(f"Unknown function call: {name}")

--- a/src/tool_security.py
+++ b/src/tool_security.py
@@ -8,6 +8,24 @@ from typing import Optional, Set
 logger = logging.getLogger(__name__)
 
 
+# The built-in email tools, by their bare names. They are implemented as an
+# internal "email" MCP server, so at dispatch time they resolve under the
+# mcp__email__ namespace (see tool_execution). But depending on how a model
+# emits the call, a tool block can carry EITHER form:
+#   - mcp__email__list_emails — native function calls and <invoke>/<tool_code>
+#     parse paths, which canonicalize via function_call_to_tool_block; and
+#   - list_emails (bare) — fenced ```list_emails / [TOOL_CALL] parse paths,
+#     since these names are also in TOOL_TAGS so the bare form parses too.
+# Security gates (disabled_tools, plan mode, admin/public denylists) match on
+# these bare names, so keep them bare here; the dispatcher normalizes the bare
+# form to mcp__email__ only after those gates have run (#4769).
+BUILTIN_EMAIL_TOOLS = frozenset({
+    "list_email_accounts", "send_email", "list_emails", "read_email",
+    "reply_to_email", "archive_email", "delete_email", "mark_email_read",
+    "bulk_email", "download_attachment",
+})
+
+
 # Tools regular/public users must not execute directly. These either expose
 # server/runtime access, sensitive user data, external messaging, persistent
 # state changes, or generic loopback/integration surfaces.
@@ -163,7 +181,18 @@ def is_public_blocked_tool(tool_name: Optional[str]) -> bool:
         return False
     if not isinstance(tool_name, str):
         return True
-    return tool_name in NON_ADMIN_BLOCKED_TOOLS or tool_name.startswith("mcp__")
+    # Built-in email tools are admin-only. The dispatcher normalizes a bare email
+    # name (e.g. list_emails) to its mcp__email__ form only AFTER this gate runs,
+    # and the email MCP itself only owner-scopes the mailbox without re-checking
+    # admin — so a bare name must be blocked here too, otherwise a non-admin could
+    # emit the fenced/[TOOL_CALL] bare form to reach an email tool that the mcp__
+    # prefix rule below would have blocked in its canonical form. Gate on the same
+    # BUILTIN_EMAIL_TOOLS set the dispatcher normalizes, so the two cannot drift.
+    return (
+        tool_name in NON_ADMIN_BLOCKED_TOOLS
+        or tool_name in BUILTIN_EMAIL_TOOLS
+        or tool_name.startswith("mcp__")
+    )
 
 
 def owner_is_admin_or_single_user(owner: Optional[str]) -> bool:

--- a/tests/test_email_tool_dispatch.py
+++ b/tests/test_email_tool_dispatch.py
@@ -1,0 +1,150 @@
+"""Issue #4769 — built-in email tools emitted as bare names must dispatch.
+
+Email tools (list_emails, read_email, …) are implemented as an internal "email"
+MCP server, so they execute under the mcp__email__ namespace. But they are also
+in TOOL_TAGS, so a local model can name them in two ways:
+
+  - mcp__email__list_emails — native function calls and <invoke>/<tool_code>
+    parse paths, which canonicalize via function_call_to_tool_block; and
+  - list_emails (bare) — the fenced ```list_emails / [TOOL_CALL] parse paths.
+
+The dispatcher only had a case for the mcp__email__ form, so a bare email tool
+fell through to `Unknown tool type: list_emails` and never ran — the exact
+failure local Ollama users hit (#4769). execute_tool_block now normalizes the
+bare form to mcp__email__ AFTER the security gates (which match the bare names),
+so the call dispatches while disable/plan-mode/admin checks still apply.
+"""
+import asyncio
+import sys
+from unittest.mock import MagicMock
+
+# The agent-tool stack pulls in heavy DB/auth deps at import; stub them just long
+# enough to import, then restore. Mirrors tests/test_unknown_tool_calls.py. We do
+# NOT pop src.tool_execution (popping it rebinds the module object and breaks
+# attribute monkeypatching).
+_ABSENT = object()
+_AGENT_MODULES = ["src.agent_tools", "src.tool_parsing", "src.tool_schemas"]
+_STUBBED = [
+    "sqlalchemy", "sqlalchemy.orm", "sqlalchemy.ext", "sqlalchemy.ext.declarative",
+    "sqlalchemy.ext.hybrid", "sqlalchemy.sql", "sqlalchemy.sql.expression",
+    "src.database", "core.models", "core.database", "core.auth",
+]
+_saved_stubs = {name: sys.modules.get(name, _ABSENT) for name in _STUBBED}
+
+for _mod in _AGENT_MODULES:
+    sys.modules.pop(_mod, None)
+for _mod in _STUBBED:
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+import pytest  # noqa: E402
+import src.agent_tools  # noqa: E402,F401
+import src.tool_execution as te  # noqa: E402
+from src.agent_tools import ToolBlock  # noqa: E402
+from src.tool_parsing import parse_tool_blocks  # noqa: E402
+from src.tool_schemas import function_call_to_tool_block  # noqa: E402
+from src.tool_security import BUILTIN_EMAIL_TOOLS  # noqa: E402
+
+# Drop the stubs we installed so they do not leak into later tests.
+for _name, _original in _saved_stubs.items():
+    if _original is _ABSENT:
+        sys.modules.pop(_name, None)
+    else:
+        sys.modules[_name] = _original
+
+
+class _RecordingMCP:
+    """Stand-in MCP manager that records the qualified tool name it was asked
+    to run and returns a benign success payload."""
+
+    def __init__(self):
+        self.calls = []
+
+    async def call_tool(self, tool, args):
+        self.calls.append((tool, args))
+        return {"output": "ok", "exit_code": 0}
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+@pytest.mark.parametrize("name", sorted(BUILTIN_EMAIL_TOOLS))
+def test_bare_email_tool_dispatches_to_email_mcp(name, monkeypatch):
+    """A bare email tool name routes to the email MCP instead of failing with
+    'Unknown tool type'."""
+    mcp = _RecordingMCP()
+    monkeypatch.setattr(te, "get_mcp_manager", lambda: mcp)
+    # Treat the caller as authorized so the public/admin gate doesn't pre-empt
+    # the dispatch we're exercising.
+    monkeypatch.setattr(te, "_owner_is_admin", lambda owner: True)
+
+    desc, result = _run(te.execute_tool_block(ToolBlock(name, "{}"), owner="admin"))
+
+    assert mcp.calls, f"{name} did not reach the email MCP"
+    assert mcp.calls[0][0] == f"mcp__email__{name}"
+    assert "Unknown tool type" not in (result.get("error") or "")
+    assert result.get("exit_code") == 0
+
+
+def test_bare_email_tool_still_blocked_when_disabled(monkeypatch):
+    """Normalization happens AFTER the security gates: a bare email tool the
+    user disabled is blocked by its bare name and never reaches the MCP."""
+    mcp = _RecordingMCP()
+    monkeypatch.setattr(te, "get_mcp_manager", lambda: mcp)
+    monkeypatch.setattr(te, "_owner_is_admin", lambda owner: True)
+
+    desc, result = _run(te.execute_tool_block(
+        ToolBlock("list_emails", "{}"),
+        disabled_tools={"list_emails"},
+        owner="admin",
+    ))
+
+    assert "BLOCKED" in desc
+    assert result["exit_code"] == 1
+    assert not mcp.calls, "disabled email tool must not reach the MCP"
+
+
+def test_native_and_invoke_paths_already_canonical():
+    """function_call_to_tool_block (native + <invoke>/<tool_code>) canonicalizes
+    bare email names to mcp__email__ — the shared BUILTIN_EMAIL_TOOLS constant."""
+    for name in BUILTIN_EMAIL_TOOLS:
+        block = function_call_to_tool_block(name, "{}")
+        assert block is not None and block.tool_type == f"mcp__email__{name}"
+
+
+def test_fenced_and_toolcall_paths_emit_email_tool_blocks():
+    """The bare-producing parse paths still surface email calls as tool blocks
+    (a bare name that the dispatcher then normalizes), rather than dropping or
+    mangling them."""
+    fenced = parse_tool_blocks("```list_emails\n{}\n```")
+    assert [b.tool_type for b in fenced] == ["list_emails"]
+
+    tool_call = parse_tool_blocks('[TOOL_CALL]{tool => "list_emails", args => {}}[/TOOL_CALL]')
+    assert [b.tool_type for b in tool_call] == ["list_emails"]
+
+    # <invoke> already canonicalizes.
+    invoke = parse_tool_blocks('<invoke name="list_emails"></invoke>')
+    assert [b.tool_type for b in invoke] == ["mcp__email__list_emails"]
+
+
+@pytest.mark.parametrize("name", sorted(BUILTIN_EMAIL_TOOLS))
+def test_bare_email_tool_blocked_for_non_admin(name, monkeypatch):
+    """A non-admin must not reach an email MCP tool via the bare fenced /
+    [TOOL_CALL] form. The dispatcher normalizes bare -> mcp__email__ only AFTER
+    the public gate, so the public gate must block the bare name. Without that,
+    the six email tools NOT in NON_ADMIN_BLOCKED_TOOLS (delete_email, bulk_email,
+    archive_email, download_attachment, mark_email_read, list_email_accounts) —
+    previously protected only by the mcp__ prefix rule on their canonical form —
+    would escalate, since the email MCP only owner-scopes the mailbox and does not
+    re-check admin. Threat model: email is admin-only for non-admins."""
+    mcp = _RecordingMCP()
+    monkeypatch.setattr(te, "get_mcp_manager", lambda: mcp)
+    monkeypatch.setattr(te, "_owner_is_admin", lambda owner: False)
+
+    desc, result = _run(te.execute_tool_block(ToolBlock(name, "{}"), owner="alice"))
+
+    assert "BLOCKED" in desc, f"{name} not blocked for non-admin"
+    assert result["exit_code"] == 1
+    assert "admin" in (result.get("error") or "").lower()
+    assert not mcp.calls, f"{name} reached the email MCP as a non-admin"


### PR DESCRIPTION
## Summary

Built-in email tools (`list_emails`, `read_email`, …) are implemented as an internal "email" MCP server, so they execute under the `mcp__email__` namespace. They are *also* in `TOOL_TAGS`, so a model can name them two ways: native function calls and the `<invoke>`/`<tool_code>` parse paths canonicalize to `mcp__email__list_emails` (via `function_call_to_tool_block`), but the fenced ` ```list_emails ` and `[TOOL_CALL]` parse paths produce the **bare** name `list_emails`. `execute_tool_block` only had a dispatch case for the `mcp__email__` form, so a bare email tool fell through to the catch-all `Unknown tool type: list_emails` and never ran. Local models that emit fenced tool calls (e.g. Ollama `qwen2.5`, `gemma2`) hit this on every email tool. This PR normalizes the bare form to `mcp__email__` in the dispatcher **after** the security gates (so disable/plan-mode/admin/**public** checks, which match the bare names, still apply), and factors the email-tool name set into one shared `tool_security.BUILTIN_EMAIL_TOOLS` constant used by both the dispatcher and the function-call converter.

## Security

The normalization sits **after** the public/admin gate, so the gate must recognize the bare names. `is_public_blocked_tool` now blocks the bare `BUILTIN_EMAIL_TOOLS` names (gating on the same shared constant the dispatcher normalizes, so the two can't drift). Without this, the six email tools that are **not** in `NON_ADMIN_BLOCKED_TOOLS` — `delete_email`, `bulk_email`, `archive_email`, `download_attachment`, `mark_email_read`, `list_email_accounts` — were protected for non-admins only by the `mcp__` prefix rule on their *canonical* form; a non-admin could otherwise emit the bare fenced form to reach them (the email MCP only owner-scopes the mailbox and does not re-check admin). Per the threat model, email tools are admin-only for non-admins.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4769

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] Verified end-to-end through the real parse → dispatch path (see below). The reporter's full repro needs a live Ollama model + connected Gmail account, which isn't available in CI; the added test drives the real `execute_tool_block` so the dispatch fix is exercised deterministically.

## How to Test

Root cause is in the parse→dispatch path, so it reproduces deterministically without a live model:

```python
import src.agent_tools
from src.tool_parsing import parse_tool_blocks
# A local/fenced model calling an email tool parses to the BARE name:
blocks = parse_tool_blocks("```list_emails\n{}\n```")
print([b.tool_type for b in blocks])   # ['list_emails']  (not mcp__email__list_emails)
```

- **Before:** `execute_tool_block(ToolBlock("list_emails", "{}"))` returns `{"error": "Unknown tool type: list_emails", "exit_code": 1}` — exactly the reporter's `Tool executed: unknown: list_emails -> exit_code=1`.
- **After:** the same block normalizes to `mcp__email__list_emails` and dispatches to the email MCP.

End-to-end app repro (matches the issue): connect Gmail via IMAP, enable the email tools, select a local Ollama model, and ask "fetch my unread emails" — the agent now lists the inbox instead of failing with `LIST_EMAILS failed — Unknown tool type: list_emails`.

Automated: `pytest tests/test_email_tool_dispatch.py` — **23 cases**: every bare email tool routes to the email MCP; a *disabled* bare email tool **and a non-admin caller** are both still blocked before reaching the MCP (proving the normalization sits after the security gates); the native/`<invoke>` paths stay canonical. The non-admin block test is red/green-verified — without the gate fix, exactly the six `mcp__`-only-protected tools fail. The security-relevant suite (auth / plan-mode / public-block / email / admin) passes locally (943 cases); the full suite runs in CI.

## Visual / UI changes

None — backend tool-dispatch only.
