### PR TITLE
fix(email): normalize trailing/leading commas in recipient fields

### DIFF
--- a/routes/email_routes.py
+++ b/routes/email_routes.py
@@ -402,9 +402,14 @@ def _envelope_recipients(*fields: str) -> list:
     strings. A naive `field.split(",")` corrupts display names that contain a
     comma (e.g. `"Smith, John" <john@corp.com>`, the canonical Outlook form):
     it splits into `"Smith` and `John" <john@corp.com>`, breaking delivery.
-    email.utils.getaddresses parses the address grammar correctly."""
+    email.utils.getaddresses parses the address grammar correctly. We trim
+    leading/trailing whitespace and commas from each field first, so a stray
+    boundary comma (e.g. `"alice@x.com,"`) does not cause getaddresses to emit
+    a malformed entry that collapses to an empty address and silently drops
+    the recipient."""
     out = []
-    for _name, addr in email.utils.getaddresses([f for f in fields if f]):
+    cleaned = (f.strip(", \t\r\n") for f in fields if f)
+    for _name, addr in email.utils.getaddresses([f for f in cleaned if f]):
         addr = (addr or "").strip()
         if addr:
             out.append(addr)

--- a/tests/test_email_envelope_recipients.py
+++ b/tests/test_email_envelope_recipients.py
@@ -24,3 +24,23 @@ def test_to_cc_bcc_combined_and_none_safe():
 
 def test_empty_and_none_fields():
     assert email_routes._envelope_recipients("", None) == []
+
+
+def test_trailing_comma_is_tolerated():
+    # Regression for #4562: a stray trailing comma in the To field made
+    # getaddresses emit a malformed tuple and the only recipient was dropped,
+    # so SMTP raised SMTPRecipientsRefused({}) and the UI surfaced "{}".
+    assert email_routes._envelope_recipients("alice@example.com,") == ["alice@example.com"]
+
+
+def test_leading_comma_is_tolerated():
+    assert email_routes._envelope_recipients(",alice@example.com") == ["alice@example.com"]
+
+
+def test_trailing_comma_with_display_name():
+    assert email_routes._envelope_recipients('"Smith, John" <john@corp.com>,') == ["john@corp.com"]
+
+
+def test_trailing_comma_across_to_cc_bcc():
+    got = email_routes._envelope_recipients("alice@example.com,", "bob@example.com,", "carol@example.com,")
+    assert got == ["alice@example.com", "bob@example.com", "carol@example.com"]


### PR DESCRIPTION
## Summary

  Sending an email whose To field contains a stray trailing comma (e.g. "alice@example.com,") fails silently in the compose UI with the opaque error "{}". Root cause:
  email.utils.getaddresses(["alice@example.com,"]) emits a malformed entry that collapses to an empty address inside _envelope_recipients, so the only recipient is dropped and smtplib raises
  SMTPRecipientsRefused({}) — which is what surfaces in the UI as "{}".

  The fix cleans the field boundaries before parsing rather than replacing the RFC-compliant parser, which is still needed for the "Smith, John" <john@corp.com> display-name case the function already
  documents:

  - routes/email_routes.py: in _envelope_recipients, strip leading/trailing whitespace and commas from each non-empty field before passing it to email.utils.getaddresses. The existing `if addr:` filter is
  kept as defence in depth. Both call sites (the /send endpoint and the scheduled-send task) pass raw strings, so the contract is unchanged.
  - tests/test_email_envelope_recipients.py: add regression tests for trailing-comma, leading-comma, trailing-comma-with-display-name, and trailing-comma across To/Cc/Bcc.

  ## Linked Issue

  Fixes #4562

  ## Type of Change

  - [x] Bug fix (non-breaking — fixes a confirmed issue)

  ## Checklist

  - [x] I searched existing issues and PRs — this is not a duplicate.

  ## How to Test

  Run `pytest tests/test_email_envelope_recipients.py -v` — 8 tests pass (4 new: trailing comma, leading comma, trailing comma after a quoted display name, and trailing comma across To/Cc/Bcc). To see the
  original bug, put a valid recipient with a stray trailing comma (e.g. `alice@example.com,`) in the To field of Compose and Send: before the fix the UI shows `{}` (smtplib.SMTPRecipientsRefused({})); after
  it, the message sends.