### PR TITLE
fix(embeddings): clear error on malformed response and close the HTTP client

### DIFF
--- a/src/embeddings.py
+++ b/src/embeddings.py
@@ -56,6 +56,16 @@ class EmbeddingClient:
         # endpoint (embedding a short string returns in well under a second).
         self._client = httpx.Client(timeout=httpx.Timeout(connect=3.0, read=10.0, write=5.0, pool=3.0))
 
+    def close(self) -> None:
+        """Release the pooled HTTP connection. Idempotent; safe to call twice."""
+        self._client.close()
+
+    def __enter__(self) -> "EmbeddingClient":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()
+
     def get_sentence_embedding_dimension(self) -> int:
         """Probe the endpoint for embedding dimension if not yet known."""
         if self._dim is not None:
@@ -89,7 +99,14 @@ class EmbeddingClient:
             embeddings = data.get("data", [])
             embeddings.sort(key=lambda e: e.get("index", 0))
             for emb in embeddings:
-                all_vecs.append(emb["embedding"])
+                vec = emb.get("embedding") if isinstance(emb, dict) else None
+                if vec is None:
+                    raise ValueError(
+                        f"Malformed embedding response from {self.url} "
+                        f"(model={self.model}): expected an 'embedding' field, got "
+                        f"keys {sorted(emb) if isinstance(emb, dict) else type(emb).__name__}"
+                    )
+                all_vecs.append(vec)
 
         vecs = np.array(all_vecs, dtype="float32")
 
@@ -233,6 +250,7 @@ def get_embedding_client():
     # Try the HTTP embedding API — unless we already found it down this process
     # (avoids paying the connect timeout again on every RAG/memory/tool probe).
     if not _http_embed_down:
+        client = None
         try:
             client = EmbeddingClient()
             client.get_sentence_embedding_dimension()  # health check
@@ -240,6 +258,10 @@ def get_embedding_client():
             return client
         except Exception as e:
             _http_embed_down = True
+            # The probe client is being discarded; close it so its pooled
+            # httpx connection isn't leaked for the life of the process.
+            if client is not None:
+                client.close()
             logger.warning(f"HTTP embedding API unavailable ({e}); using local FastEmbed for the rest of this process")
 
     # Fall back to local fastembed

--- a/tests/test_embedding_lanes.py
+++ b/tests/test_embedding_lanes.py
@@ -397,6 +397,11 @@ def test_custom_lane_uses_http_down_latch(monkeypatch):
         def get_sentence_embedding_dimension(self):
             raise RuntimeError("endpoint down")
 
+        def close(self):
+            # Mirror the real EmbeddingClient: the factory now closes the probe
+            # client when the endpoint is down so its httpx pool isn't leaked.
+            pass
+
     class LocalFastEmbed(FakeEmbedder):
         def __init__(self):
             super().__init__(384, "mini", "local://fastembed")

--- a/tests/test_embeddings_client.py
+++ b/tests/test_embeddings_client.py
@@ -1,0 +1,101 @@
+"""Issue #4590 — EmbeddingClient must fail clearly on a malformed response and
+must not leak its httpx.Client.
+
+Two defects:
+  * `encode()` did `emb["embedding"]`, so a response object missing that field
+    raised a bare `KeyError` with no hint of which endpoint/model misbehaved.
+  * the `httpx.Client` opened in `__init__` had no close()/context-manager, and
+    `get_embedding_client()` dropped the probe client on the floor when the
+    endpoint was down — leaking its pooled connection for the whole process.
+
+These tests use a fake httpx client, so no network or embedding server is
+needed.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.embeddings import EmbeddingClient
+import src.embeddings as embeddings
+
+
+def _resp(payload):
+    r = MagicMock()
+    r.raise_for_status = MagicMock()
+    r.json = MagicMock(return_value=payload)
+    return r
+
+
+def test_encode_raises_clear_error_on_missing_embedding_field():
+    client = EmbeddingClient(url="http://embed.test/v1/embeddings", model="all-minilm")
+    client._client = MagicMock()
+    client._client.post.return_value = _resp({"data": [{"index": 0}]})  # no 'embedding'
+
+    with pytest.raises(ValueError) as excinfo:
+        client.encode(["hello"])
+
+    msg = str(excinfo.value)
+    assert "embedding" in msg
+    assert "http://embed.test/v1/embeddings" in msg
+    assert "all-minilm" in msg
+
+
+def test_encode_valid_response_still_returns_vectors():
+    client = EmbeddingClient(url="http://embed.test/v1/embeddings", model="all-minilm")
+    client._client = MagicMock()
+    client._client.post.return_value = _resp(
+        {"data": [{"embedding": [3.0, 4.0], "index": 0}]}
+    )
+
+    out = client.encode(["hello"], normalize_embeddings=False)
+
+    assert out.shape == (1, 2)
+    assert out.tolist() == [[3.0, 4.0]]
+
+
+def test_close_closes_underlying_client():
+    client = EmbeddingClient(url="http://embed.test", model="m")
+    client._client = MagicMock()
+
+    client.close()
+
+    client._client.close.assert_called_once()
+
+
+def test_context_manager_closes_on_exit():
+    client = EmbeddingClient(url="http://embed.test", model="m")
+    fake = MagicMock()
+    with client as c:
+        c._client = fake
+    fake.close.assert_called_once()
+
+
+def test_factory_closes_probe_client_when_endpoint_down(monkeypatch):
+    embeddings.reset_http_embed_state()
+    created = []
+
+    class _FakeProbe:
+        def __init__(self, *a, **k):
+            self.url = "http://embed.test"
+            self.model = "m"
+            self.closed = False
+            created.append(self)
+
+        def get_sentence_embedding_dimension(self):
+            raise RuntimeError("connection refused")
+
+        def close(self):
+            self.closed = True
+
+    def _no_fastembed(*a, **k):
+        raise ImportError("fastembed not installed")
+
+    monkeypatch.setattr(embeddings, "EmbeddingClient", _FakeProbe)
+    monkeypatch.setattr(embeddings, "FastEmbedClient", _no_fastembed)
+    monkeypatch.setattr(embeddings, "_load_persisted_endpoint", lambda: {})
+
+    result = embeddings.get_embedding_client()
+
+    assert result is None  # both HTTP and FastEmbed unavailable
+    assert created and created[0].closed is True  # probe client was closed, not leaked


### PR DESCRIPTION
 ## Summary

  EmbeddingClient.encode() read each result with emb["embedding"], so an OpenAI-shaped embedding response missing that field raised a bare KeyError that named neither the endpoint nor the model — useless for
  diagnosing a misbehaving embedding server. Separately, the httpx.Client opened in __init__ was never closed: the class had no close()/context-manager, and get_embedding_client() discarded the probe client
  when the endpoint was down, leaking its pooled connection for the life of the process.

  - src/embeddings.py: in encode(), read the embedding with .get() and raise a ValueError naming the URL, model, and the keys actually present when the field is missing. Add close() plus __enter__/__exit__
  to EmbeddingClient so the HTTP client can be released. In get_embedding_client(), close the probe client on the down-endpoint path before latching to FastEmbed.
  - tests/test_embeddings_client.py: regression tests for the clear malformed-response error, an unchanged valid response, close()/context-manager, and the factory closing the probe client when the endpoint
  is down.
  - tests/test_embedding_lanes.py: give the DownClient fake a no-op close() so it mirrors the real EmbeddingClient API the factory now calls.

  ## Linked Issue

  Fixes #4590

  ## Type of Change

  - [x] Bug fix (non-breaking — fixes a confirmed issue)

  ## Checklist

  - [x] I searched existing issues and PRs — this is not a duplicate.

  ## How to Test

  Run `pytest tests/test_embeddings_client.py -v` — 5 tests pass: a malformed response (missing `embedding` field) now raises a clear ValueError naming the URL/model/observed keys instead of a bare KeyError;
  a valid response still returns the expected vectors; close() releases the underlying httpx client; the context-manager form closes on exit; and get_embedding_client() closes the probe client when the
  endpoint is down. The full embedding suite (45 tests across test_embeddings*.py / test_embedding_*.py) stays green.
