### PR TITLE
fix(calendar): trust operator CA bundle in CalDAV test_connection

### DIFF
--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -925,8 +925,11 @@ def setup_calendar_routes() -> APIRouter:
             # requests/urllib3 behavior used by the CalDAV sync path.
             _ssl_ctx.verify_flags &= ~_ssl.VERIFY_X509_STRICT
             _ca_bundle = _os.environ.get("SSL_CERT_FILE") or _os.environ.get("REQUESTS_CA_BUNDLE")
-            if _ca_bundle and _os.path.isfile(_ca_bundle):
-                _ssl_ctx.load_verify_locations(_ca_bundle)
+            if _ca_bundle:
+                if _os.path.isfile(_ca_bundle):
+                    _ssl_ctx.load_verify_locations(_ca_bundle)
+                else:
+                    logger.warning("CalDAV test: CA bundle %s not found, using system CAs", _ca_bundle)
             async with httpx.AsyncClient(timeout=8.0, follow_redirects=False, trust_env=False, verify=_ssl_ctx) as cx:
                 r = await cx.request(
                     "PROPFIND", url,

--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -913,7 +913,21 @@ def setup_calendar_routes() -> APIRouter:
             '</d:prop></d:propfind>'
         )
         try:
-            async with httpx.AsyncClient(timeout=8.0, follow_redirects=False, trust_env=False) as cx:
+            # Build an SSL context that trusts the operator's custom CA bundle
+            # (SSL_CERT_FILE / REQUESTS_CA_BUNDLE) so self-signed CalDAV servers
+            # pass the pre-flight the same way they pass the real sync.
+            # trust_env=False is kept to block proxy/auth env leakage; the CA
+            # bundle is loaded explicitly instead.
+            import ssl as _ssl
+            _ssl_ctx = _ssl.create_default_context()
+            # Disable VERIFY_X509_STRICT so certs without a keyUsage extension
+            # (common in self-signed setups) are accepted, matching the
+            # requests/urllib3 behavior used by the CalDAV sync path.
+            _ssl_ctx.verify_flags &= ~_ssl.VERIFY_X509_STRICT
+            _ca_bundle = _os.environ.get("SSL_CERT_FILE") or _os.environ.get("REQUESTS_CA_BUNDLE")
+            if _ca_bundle and _os.path.isfile(_ca_bundle):
+                _ssl_ctx.load_verify_locations(_ca_bundle)
+            async with httpx.AsyncClient(timeout=8.0, follow_redirects=False, trust_env=False, verify=_ssl_ctx) as cx:
                 r = await cx.request(
                     "PROPFIND", url,
                     auth=(user, pw),

--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -851,7 +851,21 @@ def setup_calendar_routes() -> APIRouter:
             '</d:prop></d:propfind>'
         )
         try:
-            async with httpx.AsyncClient(timeout=8.0, follow_redirects=False, trust_env=False) as cx:
+            # Build an SSL context that trusts the operator's custom CA bundle
+            # (SSL_CERT_FILE / REQUESTS_CA_BUNDLE) so self-signed CalDAV servers
+            # pass the pre-flight the same way they pass the real sync.
+            # trust_env=False is kept to block proxy/auth env leakage; the CA
+            # bundle is loaded explicitly instead.
+            import ssl as _ssl
+            _ssl_ctx = _ssl.create_default_context()
+            # Disable VERIFY_X509_STRICT so certs without a keyUsage extension
+            # (common in self-signed setups) are accepted, matching the
+            # requests/urllib3 behavior used by the CalDAV sync path.
+            _ssl_ctx.verify_flags &= ~_ssl.VERIFY_X509_STRICT
+            _ca_bundle = _os.environ.get("SSL_CERT_FILE") or _os.environ.get("REQUESTS_CA_BUNDLE")
+            if _ca_bundle and _os.path.isfile(_ca_bundle):
+                _ssl_ctx.load_verify_locations(_ca_bundle)
+            async with httpx.AsyncClient(timeout=8.0, follow_redirects=False, trust_env=False, verify=_ssl_ctx) as cx:
                 r = await cx.request(
                     "PROPFIND", url,
                     auth=(user, pw),

--- a/tests/test_caldav_test_connection_ssl.py
+++ b/tests/test_caldav_test_connection_ssl.py
@@ -2,61 +2,170 @@
 
 The pre-flight used httpx with trust_env=False, which ignored
 SSL_CERT_FILE/REQUESTS_CA_BUNDLE. Self-signed CalDAV servers that the
-real sync accepts (via caldav lib → requests → honors bundle) were
+real sync accepts (via caldav lib -> requests -> honors bundle) were
 rejected by the test with CERTIFICATE_VERIFY_FAILED.
 
-These tests verify the SSL context construction without making real
-network calls.
+These tests exercise the *route handler* directly (via ASGI TestClient)
+and capture the verify= kwarg passed to httpx.AsyncClient, ensuring the
+route code — not a test-side duplicate — builds the SSL context correctly.
 """
 import os
 import ssl
-import tempfile
-from unittest.mock import patch
+import sys
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub heavy deps before importing routes (mirrors conftest pattern)
+# ---------------------------------------------------------------------------
+for mod in [
+    "sqlalchemy", "sqlalchemy.orm", "sqlalchemy.ext",
+    "sqlalchemy.ext.declarative", "sqlalchemy.ext.hybrid",
+    "sqlalchemy.sql", "sqlalchemy.sql.expression",
+    "src.database", "core.models", "core.database",
+    "caldav",
+]:
+    if mod not in sys.modules:
+        sys.modules[mod] = MagicMock()
 
 
-def _build_ssl_ctx(ssl_cert_file=None, requests_ca_bundle=None):
-    """Reproduce the SSL context construction from calendar_routes.test_connection."""
-    ctx = ssl.create_default_context()
-    ctx.verify_flags &= ~ssl.VERIFY_X509_STRICT
-    ca_bundle = ssl_cert_file or requests_ca_bundle
-    if ca_bundle and os.path.isfile(ca_bundle):
-        ctx.load_verify_locations(ca_bundle)
-    return ctx
+def _fake_response(status_code=207, headers=None):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.headers = headers or {}
+    return resp
 
 
-def test_verify_x509_strict_is_cleared():
-    ctx = _build_ssl_ctx()
-    assert not (ctx.verify_flags & ssl.VERIFY_X509_STRICT)
+@pytest.fixture()
+def client():
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from routes.calendar_routes import setup_calendar_routes
+
+    with patch("routes.calendar_routes._require_user", return_value="test-owner"):
+        router = setup_calendar_routes()
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
 
 
-def test_ssl_cert_file_takes_precedence(tmp_path):
-    # Create a dummy CA bundle (won't validate real certs, but load_verify_locations accepts it)
-    bundle = tmp_path / "ca-bundle.pem"
-    # Write a minimal self-signed cert for load_verify_locations to accept
-    import subprocess
-    result = subprocess.run(
-        ["openssl", "req", "-x509", "-newkey", "rsa:1024", "-keyout", "/dev/null",
-         "-out", str(bundle), "-days", "1", "-nodes", "-subj", "/CN=test"],
-        capture_output=True, timeout=10,
+def _make_fake_async_client(captured):
+    """Return a fake httpx.AsyncClient class that captures constructor kwargs."""
+    class FakeAsyncClient:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            pass
+
+        async def request(self, *a, **kw):
+            return _fake_response(207)
+
+    return FakeAsyncClient
+
+
+def _post_test(client, captured, env=None):
+    """POST /api/calendar/test with credentials in body so no DB lookup needed.
+
+    Patches httpx.AsyncClient at the real module level so the route's
+    ``import httpx; httpx.AsyncClient(...)`` picks up the fake class.
+    Also stubs validate_caldav_url (lazy-imported from src.caldav_sync).
+    """
+    fake_cls = _make_fake_async_client(captured)
+
+    # Stub the caldav_sync module so the lazy `from src.caldav_sync import validate_caldav_url`
+    # inside the route body resolves to a pass-through.
+    caldav_sync_stub = MagicMock()
+    caldav_sync_stub.validate_caldav_url = lambda u: u
+
+    ctx_managers = [
+        patch.object(httpx, "AsyncClient", fake_cls),
+        patch.dict(sys.modules, {"src.caldav_sync": caldav_sync_stub}),
+        patch("routes.calendar_routes._require_user", return_value="test-owner"),
+    ]
+    if env is not None:
+        ctx_managers.append(patch.dict(os.environ, env))
+
+    # Enter all context managers
+    for cm in ctx_managers:
+        cm.__enter__()
+    try:
+        return client.post(
+            "/api/calendar/test",
+            json={"url": "https://cal.example.com", "username": "u", "password": "p"},
+        )
+    finally:
+        for cm in reversed(ctx_managers):
+            cm.__exit__(None, None, None)
+
+
+# ---------------------------------------------------------------------------
+# Route-level tests
+# ---------------------------------------------------------------------------
+
+def test_route_passes_ssl_context_with_correct_flags(client):
+    """The route must pass an ssl.SSLContext to httpx.AsyncClient(verify=...)
+    with trust_env=False, follow_redirects=False, and VERIFY_X509_STRICT cleared."""
+    captured = {}
+    resp = _post_test(client, captured)
+
+    assert resp.status_code == 200
+    assert isinstance(captured.get("verify"), ssl.SSLContext), (
+        f"verify= should be an ssl.SSLContext, got {type(captured.get('verify'))}"
     )
-    if result.returncode != 0:
-        # openssl not available — skip gracefully
-        import pytest
-        pytest.skip("openssl not available")
+    assert captured.get("trust_env") is False
+    assert captured.get("follow_redirects") is False
+    ctx = captured["verify"]
+    assert not (ctx.verify_flags & ssl.VERIFY_X509_STRICT), (
+        "VERIFY_X509_STRICT must be cleared for self-signed CA compat"
+    )
 
-    ctx = _build_ssl_ctx(ssl_cert_file=str(bundle))
-    # Context should have loaded without error — the bundle is valid
+
+def test_route_ssl_cert_file_takes_precedence(client, tmp_path):
+    """SSL_CERT_FILE wins over REQUESTS_CA_BUNDLE when both are set."""
+    import subprocess
+
+    bundle_a = tmp_path / "a.pem"
+    bundle_b = tmp_path / "b.pem"
+    for b in (bundle_a, bundle_b):
+        result = subprocess.run(
+            ["openssl", "req", "-x509", "-newkey", "rsa:1024", "-keyout", "/dev/null",
+             "-out", str(b), "-days", "1", "-nodes", "-subj", "/CN=test"],
+            capture_output=True, timeout=10,
+        )
+        if result.returncode != 0:
+            pytest.skip("openssl not available")
+
+    captured = {}
+    env = {"SSL_CERT_FILE": str(bundle_a), "REQUESTS_CA_BUNDLE": str(bundle_b)}
+    resp = _post_test(client, captured, env=env)
+
+    assert resp.status_code == 200
+    assert isinstance(captured.get("verify"), ssl.SSLContext)
+
+
+def test_route_missing_bundle_does_not_crash(client):
+    """A nonexistent CA bundle path must not crash -- fall back to system CAs."""
+    captured = {}
+    resp = _post_test(client, captured, env={"SSL_CERT_FILE": "/nonexistent/ca-bundle.pem"})
+
+    assert resp.status_code == 200
+    ctx = captured["verify"]
+    assert isinstance(ctx, ssl.SSLContext)
     assert not (ctx.verify_flags & ssl.VERIFY_X509_STRICT)
 
 
-def test_missing_bundle_path_does_not_crash():
-    """A nonexistent CA bundle path must not crash — fall back to system CAs."""
-    ctx = _build_ssl_ctx(ssl_cert_file="/nonexistent/ca-bundle.pem")
-    # Should return a valid context using system defaults
-    assert isinstance(ctx, ssl.SSLContext)
+def test_route_empty_env_vars_use_system_defaults(client):
+    """Empty SSL_CERT_FILE and REQUESTS_CA_BUNDLE should not crash."""
+    captured = {}
+    resp = _post_test(client, captured, env={"SSL_CERT_FILE": "", "REQUESTS_CA_BUNDLE": ""})
 
-
-def test_empty_env_vars_use_system_defaults():
-    ctx = _build_ssl_ctx(ssl_cert_file="", requests_ca_bundle="")
+    assert resp.status_code == 200
+    ctx = captured["verify"]
     assert isinstance(ctx, ssl.SSLContext)
     assert not (ctx.verify_flags & ssl.VERIFY_X509_STRICT)

--- a/tests/test_caldav_test_connection_ssl.py
+++ b/tests/test_caldav_test_connection_ssl.py
@@ -120,26 +120,56 @@ def test_route_passes_ssl_context_with_correct_flags(client):
 
 
 def test_route_ssl_cert_file_takes_precedence(client, tmp_path):
-    """SSL_CERT_FILE wins over REQUESTS_CA_BUNDLE when both are set."""
-    import subprocess
+    """SSL_CERT_FILE is the exact bundle loaded when both variables are set."""
+    bundle_a = tmp_path / "ssl-cert-file.pem"
+    bundle_b = tmp_path / "requests-ca-bundle.pem"
+    bundle_a.write_text("ssl-cert-file", encoding="utf-8")
+    bundle_b.write_text("requests-ca-bundle", encoding="utf-8")
 
-    bundle_a = tmp_path / "a.pem"
-    bundle_b = tmp_path / "b.pem"
-    for b in (bundle_a, bundle_b):
-        result = subprocess.run(
-            ["openssl", "req", "-x509", "-newkey", "rsa:1024", "-keyout", "/dev/null",
-             "-out", str(b), "-days", "1", "-nodes", "-subj", "/CN=test"],
-            capture_output=True, timeout=10,
-        )
-        if result.returncode != 0:
-            pytest.skip("openssl not available")
+    loaded = []
 
+    class FakeSSLContext:
+        def __init__(self):
+            self.verify_flags = ssl.VERIFY_X509_STRICT
+
+        def load_verify_locations(self, cafile=None, capath=None, cadata=None):
+            loaded.append(
+                {
+                    "cafile": cafile,
+                    "capath": capath,
+                    "cadata": cadata,
+                }
+            )
+
+    ssl_context = FakeSSLContext()
     captured = {}
-    env = {"SSL_CERT_FILE": str(bundle_a), "REQUESTS_CA_BUNDLE": str(bundle_b)}
-    resp = _post_test(client, captured, env=env)
+    env = {
+        "SSL_CERT_FILE": str(bundle_a),
+        "REQUESTS_CA_BUNDLE": str(bundle_b),
+    }
+
+    with patch.object(
+        ssl,
+        "create_default_context",
+        return_value=ssl_context,
+    ):
+        resp = _post_test(client, captured, env=env)
 
     assert resp.status_code == 200
-    assert isinstance(captured.get("verify"), ssl.SSLContext)
+    assert resp.json() == {"ok": True}
+    assert loaded == [
+        {
+            "cafile": str(bundle_a),
+            "capath": None,
+            "cadata": None,
+        }
+    ]
+    assert captured.get("verify") is ssl_context
+    assert captured.get("trust_env") is False
+    assert captured.get("follow_redirects") is False
+    assert not (
+        ssl_context.verify_flags & ssl.VERIFY_X509_STRICT
+    )
 
 
 def test_route_missing_bundle_does_not_crash(client):

--- a/tests/test_caldav_test_connection_ssl.py
+++ b/tests/test_caldav_test_connection_ssl.py
@@ -1,0 +1,62 @@
+"""Regression: CalDAV test_connection must trust the operator's CA bundle.
+
+The pre-flight used httpx with trust_env=False, which ignored
+SSL_CERT_FILE/REQUESTS_CA_BUNDLE. Self-signed CalDAV servers that the
+real sync accepts (via caldav lib → requests → honors bundle) were
+rejected by the test with CERTIFICATE_VERIFY_FAILED.
+
+These tests verify the SSL context construction without making real
+network calls.
+"""
+import os
+import ssl
+import tempfile
+from unittest.mock import patch
+
+
+def _build_ssl_ctx(ssl_cert_file=None, requests_ca_bundle=None):
+    """Reproduce the SSL context construction from calendar_routes.test_connection."""
+    ctx = ssl.create_default_context()
+    ctx.verify_flags &= ~ssl.VERIFY_X509_STRICT
+    ca_bundle = ssl_cert_file or requests_ca_bundle
+    if ca_bundle and os.path.isfile(ca_bundle):
+        ctx.load_verify_locations(ca_bundle)
+    return ctx
+
+
+def test_verify_x509_strict_is_cleared():
+    ctx = _build_ssl_ctx()
+    assert not (ctx.verify_flags & ssl.VERIFY_X509_STRICT)
+
+
+def test_ssl_cert_file_takes_precedence(tmp_path):
+    # Create a dummy CA bundle (won't validate real certs, but load_verify_locations accepts it)
+    bundle = tmp_path / "ca-bundle.pem"
+    # Write a minimal self-signed cert for load_verify_locations to accept
+    import subprocess
+    result = subprocess.run(
+        ["openssl", "req", "-x509", "-newkey", "rsa:1024", "-keyout", "/dev/null",
+         "-out", str(bundle), "-days", "1", "-nodes", "-subj", "/CN=test"],
+        capture_output=True, timeout=10,
+    )
+    if result.returncode != 0:
+        # openssl not available — skip gracefully
+        import pytest
+        pytest.skip("openssl not available")
+
+    ctx = _build_ssl_ctx(ssl_cert_file=str(bundle))
+    # Context should have loaded without error — the bundle is valid
+    assert not (ctx.verify_flags & ssl.VERIFY_X509_STRICT)
+
+
+def test_missing_bundle_path_does_not_crash():
+    """A nonexistent CA bundle path must not crash — fall back to system CAs."""
+    ctx = _build_ssl_ctx(ssl_cert_file="/nonexistent/ca-bundle.pem")
+    # Should return a valid context using system defaults
+    assert isinstance(ctx, ssl.SSLContext)
+
+
+def test_empty_env_vars_use_system_defaults():
+    ctx = _build_ssl_ctx(ssl_cert_file="", requests_ca_bundle="")
+    assert isinstance(ctx, ssl.SSLContext)
+    assert not (ctx.verify_flags & ssl.VERIFY_X509_STRICT)

--- a/tests/test_caldav_test_connection_ssl.py
+++ b/tests/test_caldav_test_connection_ssl.py
@@ -17,18 +17,11 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-# ---------------------------------------------------------------------------
-# Stub heavy deps before importing routes (mirrors conftest pattern)
-# ---------------------------------------------------------------------------
-for mod in [
-    "sqlalchemy", "sqlalchemy.orm", "sqlalchemy.ext",
-    "sqlalchemy.ext.declarative", "sqlalchemy.ext.hybrid",
-    "sqlalchemy.sql", "sqlalchemy.sql.expression",
-    "src.database", "core.models", "core.database",
-    "caldav",
-]:
-    if mod not in sys.modules:
-        sys.modules[mod] = MagicMock()
+# No module-level sys.modules stubbing here: conftest pre-imports the real
+# sqlalchemy/core.database, and stubbing extras (e.g. caldav) at collection
+# time leaks MagicMocks into later tests in the same process — it made
+# test_caldav_redirect_hardening's real DAVClient a mock that never sent
+# the PROPFIND. The route's lazy imports are patched per-request instead.
 
 
 def _fake_response(status_code=207, headers=None):


### PR DESCRIPTION
## Summary

The CalDAV `test_connection` route used `httpx.AsyncClient(trust_env=False)`, which ignores `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE`. Self-signed CalDAV servers that the real sync accepts (via the `caldav` lib → `requests` → honors the bundle) were rejected by the pre-flight with `CERTIFICATE_VERIFY_FAILED`, so the settings page said "connection failed" for servers that sync fine. This PR builds an explicit `ssl.SSLContext`, loads the operator's CA bundle, clears `VERIFY_X509_STRICT` (matching requests/urllib3 behavior on self-signed certs), and passes the context as `verify=`. `trust_env=False` is preserved to keep blocking proxy/auth env leakage.

**Scope**: Route-level fix only. Docker `ENV` forwarding of `SSL_CERT_FILE` is a separate concern and out of scope for this PR.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4795
Fixes #4779

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run the route-level regression tests:

```bash
python -m pytest tests/test_caldav_test_connection_ssl.py -v
```

All 4 tests exercise the actual route handler via FastAPI TestClient and assert `httpx.AsyncClient` receives `verify=<ssl.SSLContext>` (with `VERIFY_X509_STRICT` cleared), `trust_env=False`, and `follow_redirects=False`. They cover SSL_CERT_FILE/REQUESTS_CA_BUNDLE precedence, missing-bundle fallback, and empty env vars.

2. End-to-end with a self-signed server: run Radicale behind a self-signed TLS cert, export `SSL_CERT_FILE=/path/to/ca.pem`, start Odysseus, and click "Test connection" in calendar settings — it now returns OK (previously `CERTIFICATE_VERIFY_FAILED`), matching what the actual sync already did.
