### PR TITLE
fix(cookbook): recognize runtime --user installs by replaying user-site .pth hooks

### DIFF
--- a/routes/shell_routes.py
+++ b/routes/shell_routes.py
@@ -1063,8 +1063,19 @@ def setup_shell_routes() -> APIRouter:
         importlib.invalidate_caches()
         try:
             user_site = site.getusersitepackages()
-            if user_site and os.path.isdir(user_site) and user_site not in sys.path:
-                sys.path.append(user_site)
+            if user_site and os.path.isdir(user_site):
+                # Use addsitedir(), NOT a bare sys.path.append(). When a package
+                # is `pip install --user`'d at runtime (Cookbook → Install) the
+                # long-lived server process started before the user-site existed,
+                # so site never processed it — including its `.pth` hooks. On
+                # Python 3.12+ `distutils` is gone from stdlib and is only
+                # restored by setuptools' `distutils-precedence.pth`, which ships
+                # in user-site. basicsr (a realesrgan dep) does `import distutils`
+                # at import time, so a plain append left the package importable
+                # but `import distutils` failing → realesrgan probed as
+                # not-installed until a full process restart. addsitedir() replays
+                # the `.pth` files so the shim is active.
+                site.addsitedir(user_site)
         except Exception:
             pass
         if ssh_port and str(ssh_port).strip() not in ("", "22"):

--- a/tests/test_cookbook_dependency_completion_regression.py
+++ b/tests/test_cookbook_dependency_completion_regression.py
@@ -106,4 +106,9 @@ def test_local_dependency_probe_refreshes_user_site_visibility():
 
     assert "importlib.invalidate_caches()" in source
     assert "user_site = site.getusersitepackages()" in source
-    assert "if user_site and os.path.isdir(user_site) and user_site not in sys.path:" in source
+    # addsitedir (not a bare sys.path.append) so user-site `.pth` hooks are
+    # replayed when a package is installed into an already-running process —
+    # otherwise setuptools' distutils shim never activates and basicsr-based
+    # deps (realesrgan) probe as not-installed until a restart. See #4810.
+    assert "if user_site and os.path.isdir(user_site):" in source
+    assert "site.addsitedir(user_site)" in source


### PR DESCRIPTION
## Summary

Follow-up to #4694. The Real-ESRGAN build now succeeds, but the dependency was still shown as **not installed** in **Cookbook → Dependencies**, and a browser hard refresh never fixed it — only a full container restart did.

Root cause: the local optional-dep probe in `list_packages` decides "installed" by **importing the package in-process**. Cookbook installs optional deps with `pip install --user`, so the package lands in user-site along with setuptools' `distutils-precedence.pth`. On Python 3.12+ `distutils` is gone from the stdlib and is only restored by that `.pth`. When the dep is installed into an already-running server, user-site was never processed by `site`; the recovery used `sys.path.append(user_site)`, which makes modules importable but **does not execute user-site `.pth` files**. So `import basicsr` (a realesrgan dep) → `import distutils` raised `ModuleNotFoundError: No module named 'distutils'`, the probe caught it as `ImportError`, and realesrgan read as not-installed until a process restart.

Fix: use `site.addsitedir(user_site)` instead of `sys.path.append(user_site)` so user-site `.pth` hooks (incl. the setuptools distutils shim) are replayed when a package is installed into a running process.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4810

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

On the `python:3.14` image (`docker compose up -d --build`):

1. **Reproduce (before this PR):** with the server already running, install `realesrgan` from **Cookbook → Dependencies**. It builds/installs (`importlib.metadata.version("realesrgan") == "0.3.0"`), but the panel still shows it **not installed**, and a hard refresh doesn't help. Confirmed the in-process probe path fails:
   ```bash
   docker compose exec -u odysseus odysseus python -s -c \
     'import sys,site; sys.path.append(site.getusersitepackages()); import realesrgan'
   # ModuleNotFoundError: No module named 'distutils'
   ```
2. **With this PR:** the same probe path uses `site.addsitedir(...)` and resolves:
   ```bash
   docker compose exec -u odysseus odysseus python -s -c \
     'import sys,site; site.addsitedir(site.getusersitepackages()); import realesrgan; print("ok")'
   # ok
   ```
3. **Verify recognition:** reload the Dependencies panel — realesrgan shows **installed** without a restart. Confirmed via the exact local-probe path:
   ```bash
   docker compose exec -u odysseus odysseus python -c \
     'from src.optional_deps import prepare_optional_dependency_import as p; \
      import importlib, importlib.metadata as m; p("realesrgan"); \
      importlib.import_module("realesrgan"); print(m.version("realesrgan"))'
   # 0.3.0
   ```
4. **Confirm the `.pth` is user-site only:** `distutils-precedence.pth` exists in `/app/.local/lib/python3.14/site-packages/` but not in the main site-packages — which is why a plain `sys.path.append` left distutils unavailable.

## Visual / UI changes — REQUIRED if you touched anything that renders

N/A — no UI/rendering changes. Touches only `routes/shell_routes.py` (one line in the `list_packages` user-site prologue, plus an explanatory comment).
