### PR TITLE
fix: add CUDA runtime check to _detect_nvidia to prevent false GPU detection (closes #831)

### DIFF
--- a/services/hwfit/hardware.py
+++ b/services/hwfit/hardware.py
@@ -109,6 +109,16 @@ def _detect_nvidia():
                 out = _run([_p, "--query-gpu=memory.total,name", "--format=csv,noheader,nounits"])
             if out:
                 break
+    # Additionally verify CUDA runtime is loadable by llama.cpp
+    if out:
+        # Test if CUDA libraries can be found by checking with ldconfig or similar
+        cuda_check = _run("ldconfig -p 2>/dev/null | grep -q libcuda && echo 'ok'")
+        if not cuda_check:
+            # Also check common default paths
+            cuda_check = _run("test -f /usr/lib/x86_64-linux-gnu/libcuda.so.1 && echo 'ok'")
+        if not cuda_check:
+            _last_gpu_error = "CUDA runtime not found (libcuda.so missing). GPU detection succeeded but llama.cpp will fallback to CPU."
+            out = None  # Signal that GPU is not fully usable
     if not out:
         return None
 


### PR DESCRIPTION
## What
When `_detect_nvidia()` finds nvidia-smi (e.g., from the host mounted into a container), it returns GPU information even when the CUDA runtime libraries (libcuda.so) are not available inside the container. This causes llama.cpp to attempt GPU inference but fail silently and fall back to CPU because the driver interface is missing. The user sees "Detected GPU: CUDA" but the actual GPU is not used.

## Fix
Added a verification step after the nvidia-smi check that tests whether the CUDA runtime library (libcuda.so) is actually loadable on the system. This uses `ldconfig -p` (which is available on most Linux systems and Docker containers) as the primary check, with a fallback to checking a common default path. If the library is not found, `_detect_nvidia()` returns `None` and sets `_last_gpu_error` with a clear message, enabling the calling code to either skip GPU or provide a meaningful error to the user instead of silently falling back to CPU.

Closes #831