### PR TITLE
fix(ai): offload blocking _resolve_model off the event loop

### DIFF
--- a/mcp_servers/image_gen_server.py
+++ b/mcp_servers/image_gen_server.py
@@ -73,7 +73,7 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
         if not model_spec:
             for candidate in ("gpt-image-1.5", "gpt-image-1", "dall-e-3"):
                 try:
-                    _resolve_model(candidate)
+                    await asyncio.to_thread(_resolve_model, candidate)
                     model_spec = candidate
                     break
                 except ValueError:
@@ -81,7 +81,7 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
             if not model_spec:
                 return [TextContent(type="text", text="Error: No image model found. Configure one in Admin.")]
 
-        url, model_id, headers = _resolve_model(model_spec)
+        url, model_id, headers = await asyncio.to_thread(_resolve_model, model_spec)
 
         is_gpt_image = "gpt-image" in model_id.lower()
         base_url = url.replace("/chat/completions", "").replace("/v1/messages", "").rstrip("/")

--- a/routes/preset_routes.py
+++ b/routes/preset_routes.py
@@ -1,5 +1,6 @@
 """Preset routes — /api/presets GET, /api/presets/custom POST, user templates CRUD."""
 
+import asyncio
 import logging
 import uuid
 from typing import Dict, Any, List
@@ -102,7 +103,7 @@ def setup_preset_routes(preset_manager) -> APIRouter:
         try:
             model_spec = data.get("model") or ""
             user = effective_user(request)
-            url, model, headers = _resolve_model(model_spec, owner=user)
+            url, model, headers = await asyncio.to_thread(_resolve_model, model_spec, owner=user)
             result = await llm_call_async(url, model, messages, temperature=0.8, max_tokens=500, headers=headers)
             return {"success": True, "prompt": result.strip()}
         except Exception as e:

--- a/src/agent_tools/model_interaction_tools.py
+++ b/src/agent_tools/model_interaction_tools.py
@@ -10,6 +10,7 @@ Shared helpers that still live in ``src.ai_interaction`` and are used by tools
 not yet migrated (``_resolve_model``, ``AI_CHAT_TIMEOUT``) are imported lazily
 inside the functions to avoid an import cycle at module load.
 """
+import asyncio
 import logging
 from typing import Dict, Optional
 
@@ -46,7 +47,7 @@ async def chat_with_model(content: str, session_id: Optional[str] = None, owner:
         return {"error": "No message provided (line 2+ is the message)"}
 
     try:
-        url, model, headers = _resolve_model(model_spec, owner=owner)
+        url, model, headers = await asyncio.to_thread(_resolve_model, model_spec, owner=owner)
     except ValueError as e:
         return {"error": str(e)}
 
@@ -90,7 +91,7 @@ async def ask_teacher(content: str, session_id: Optional[str] = None, owner: Opt
             return {"error": "No teacher model configured. Specify a model name or set teacher_model in settings."}
 
     try:
-        url, model, headers = _resolve_model(model_spec, owner=owner)
+        url, model, headers = await asyncio.to_thread(_resolve_model, model_spec, owner=owner)
     except ValueError as e:
         return {"error": str(e)}
 

--- a/src/agent_tools/session_tools.py
+++ b/src/agent_tools/session_tools.py
@@ -8,6 +8,7 @@ The session manager is a runtime-set singleton in src.ai_interaction, so each
 function fetches it via get_session_manager() (imported here); _resolve_model and
 AI_CHAT_TIMEOUT are reused from there too.
 """
+import asyncio
 import json
 import logging
 import uuid
@@ -40,7 +41,7 @@ async def create_session(content: str, session_id: Optional[str] = None, owner: 
         return {"error": "Session name cannot be empty"}
 
     try:
-        url, model, headers = _resolve_model(model_spec, owner=owner)
+        url, model, headers = await asyncio.to_thread(_resolve_model, model_spec, owner=owner)
     except ValueError as e:
         return {"error": str(e)}
 

--- a/src/ai_interaction.py
+++ b/src/ai_interaction.py
@@ -14,6 +14,7 @@ These are agent tools — the LLM writes fenced code blocks and they execute
 through the standard agent_tools.py pipeline.
 """
 
+import asyncio
 import json
 import logging
 import uuid
@@ -228,7 +229,7 @@ async def do_pipeline(content: str, session_id: Optional[str] = None, owner: Opt
         if not model_spec or not instruction:
             return {"error": f"Step {i + 1}: both 'model' and 'instruction' are required"}
         try:
-            url, model, headers = _resolve_model(model_spec, owner=owner)
+            url, model, headers = await asyncio.to_thread(_resolve_model, model_spec, owner=owner)
             resolved.append((url, model, headers, instruction))
         except ValueError as e:
             return {"error": f"Step {i + 1}: {e}"}
@@ -625,7 +626,7 @@ async def do_ui_control(content: str, session_id: Optional[str] = None, owner: O
 
         # Resolve the model to validate it exists
         try:
-            url, model_id, headers = _resolve_model(model_spec, owner=owner)
+            url, model_id, headers = await asyncio.to_thread(_resolve_model, model_spec, owner=owner)
         except ValueError as e:
             return {"error": str(e)}
 
@@ -915,7 +916,7 @@ async def do_generate_image(content: str, session_id: Optional[str] = None, owne
     if not model_spec:
         for candidate in ("gpt-image-1.5", "gpt-image-1", "dall-e-3"):
             try:
-                _resolve_model(candidate, owner=owner)
+                await asyncio.to_thread(_resolve_model, candidate, owner=owner)
                 model_spec = candidate
                 break
             except ValueError:
@@ -957,7 +958,7 @@ async def do_generate_image(content: str, session_id: Optional[str] = None, owne
 
     # Resolve the model to find the right endpoint
     try:
-        url, model_id, headers = _resolve_model(model_spec, owner=owner)
+        url, model_id, headers = await asyncio.to_thread(_resolve_model, model_spec, owner=owner)
     except ValueError:
         return {"error": f"No endpoint found with image model '{model_spec}'. "
                 "Configure an OpenAI-compatible endpoint with image generation support."}

--- a/src/teacher_escalation.py
+++ b/src/teacher_escalation.py
@@ -235,7 +235,7 @@ async def _call_teacher(teacher_model_spec: str, prompt: str,
     from src.llm_core import llm_call_async
     from src.ai_interaction import _resolve_model, _TEACHER_SYSTEM_PROMPT
     try:
-        url, model, headers = _resolve_model(teacher_model_spec, owner=owner)
+        url, model, headers = await asyncio.to_thread(_resolve_model, teacher_model_spec, owner=owner)
     except Exception as e:
         logger.warning(f"teacher endpoint not resolvable ({teacher_model_spec!r}): {e}")
         return None
@@ -524,7 +524,7 @@ async def run_teacher_inline(
     # Resolve teacher endpoint
     try:
         from src.ai_interaction import _resolve_model
-        teacher_url, teacher_model, teacher_headers = _resolve_model(teacher_spec, owner=owner)
+        teacher_url, teacher_model, teacher_headers = await asyncio.to_thread(_resolve_model, teacher_spec, owner=owner)
     except Exception as e:
         logger.warning(f"teacher endpoint not resolvable ({teacher_spec!r}): {e}")
         yield (

--- a/tests/test_ai_interaction_owner_scope.py
+++ b/tests/test_ai_interaction_owner_scope.py
@@ -25,9 +25,10 @@ def test_model_listing_and_image_fallback_are_owner_scoped():
 
     assert "owner: Optional[str] = None" in list_body
     assert "owner_filter(query, ModelEndpoint, owner)" in list_body
-    assert "_resolve_model(candidate, owner=owner)" in image_body
+    # _resolve_model is offloaded to a worker thread (#4589) but stays owner-scoped.
+    assert "asyncio.to_thread(_resolve_model, candidate, owner=owner)" in image_body
     assert "owner_filter(_img_q, ModelEndpoint, owner)" in image_body
-    assert "_resolve_model(model_spec, owner=owner)" in image_body
+    assert "asyncio.to_thread(_resolve_model, model_spec, owner=owner)" in image_body
 
 
 # chat_with_model, list_models and ask_teacher moved to the registry (#3629)

--- a/tests/test_resolve_model_offloaded.py
+++ b/tests/test_resolve_model_offloaded.py
@@ -1,0 +1,61 @@
+"""Issue #4589 — _resolve_model does a blocking httpx.get, so calling it
+directly from an async handler stalls the whole event loop for the duration of
+the probe. The async call sites now wrap it in asyncio.to_thread.
+
+do_pipeline is used as the representative handler: _resolve_model is the first
+real work it does, and a ValueError returns early before any LLM call, so these
+tests drive the offload path without a live model endpoint.
+"""
+
+import asyncio
+import threading
+import time
+
+import src.ai_interaction as ai
+
+
+async def test_do_pipeline_resolves_model_off_the_event_loop(monkeypatch):
+    # A deliberately blocking _resolve_model that records how many copies run
+    # at once. If it ran on the event loop, the first call would block the loop
+    # and the second could not start — peak concurrency would be 1.
+    state = {"active": 0, "peak": 0}
+    lock = threading.Lock()
+
+    def slow_resolve(spec, owner=None):
+        with lock:
+            state["active"] += 1
+            state["peak"] = max(state["peak"], state["active"])
+        time.sleep(0.2)
+        with lock:
+            state["active"] -= 1
+        raise ValueError("no such model")  # early-return path, no LLM call
+
+    monkeypatch.setattr(ai, "_resolve_model", slow_resolve)
+
+    content = '[{"model": "m", "instruction": "go"}]'
+    results = await asyncio.gather(
+        ai.do_pipeline(content, owner="u"),
+        ai.do_pipeline(content, owner="u"),
+    )
+
+    assert all("error" in r for r in results)
+    assert state["peak"] == 2, "resolutions did not overlap — call still blocks the loop"
+
+
+async def test_do_pipeline_uses_offloaded_resolution_result(monkeypatch):
+    # The offload must also return the resolved tuple, not just propagate errors.
+    monkeypatch.setattr(
+        ai, "_resolve_model",
+        lambda spec, owner=None: ("http://x/v1/chat/completions", "resolved-model", {}),
+    )
+
+    async def fake_llm(url, model, messages, **kwargs):
+        return f"output from {model}"
+
+    monkeypatch.setattr("src.llm_core.llm_call_async", fake_llm)
+
+    result = await ai.do_pipeline('[{"model": "m", "instruction": "go"}]', owner="u")
+
+    assert "error" not in result, result
+    # The model the offloaded _resolve_model returned made it through to the call.
+    assert "resolved-model" in str(result)


### PR DESCRIPTION
## Summary

  _resolve_model probes each candidate endpoint's model list with a blocking httpx.get (src/ai_interaction.py). It is synchronous by design — four sync callers depend on that — but twelve async handlers
  across six modules were awaiting it inline, so every probe ran on the event loop and stalled all other in-flight requests for up to the 5s probe timeout.

  The fix keeps _resolve_model synchronous and wraps each async call site in asyncio.to_thread(...), so the blocking probe runs in a worker thread and the loop stays responsive. The owner argument is
  preserved at every site, so model resolution stays owner-scoped.

  - src/ai_interaction.py: offload the four calls in do_pipeline, do_ui_control, and do_generate_image (add the asyncio import).
  - src/teacher_escalation.py: offload the calls in _call_teacher and run_teacher_inline.
  - src/agent_tools/model_interaction_tools.py: offload the calls in chat_with_model and ask_teacher (add the asyncio import).
  - src/agent_tools/session_tools.py: offload the call in create_session (add the asyncio import).
  - routes/preset_routes.py: offload the call in expand_character_prompt (add the asyncio import).
  - mcp_servers/image_gen_server.py: offload the two calls in call_tool.

  Deliberately NOT included: the sync wrappers _resolve_vl_model (src/document_processor.py) and _resolve_audit_models (routes/skills_routes.py). They call _resolve_model too, but are themselves synchronous
  and have a mix of sync and async callers (e.g. src/builtin_actions.py), so they must be offloaded at each async caller rather than here — out of scope for this issue, which is about _resolve_model's direct
  async call sites.

  ## Linked Issue

  Fixes #4589

  ## Type of Change

  - [x] Bug fix (non-breaking — fixes a confirmed issue)

  ## Checklist

  - [x] I searched existing issues and PRs — this is not a duplicate.

  ## How to Test

  Run `pytest tests/test_resolve_model_offloaded.py -v` — 2 tests pass: two concurrent do_pipeline calls whose _resolve_model is a deliberately blocking stub reach a peak concurrency of 2 (they overlap in
  worker threads; if the call still ran on the event loop the first would block it and peak would be 1), and a successful offloaded resolution still flows its result through. The touched-module suites
  (test_ai_interaction_owner_scope.py, test_model_interaction_registry.py, test_session_tools_registry.py, test_preset_expand_owner_scope.py, etc.) stay green — 100 tests in total.

