### PR TITLE
fix(email): don't probe IMAP for send-only (SMTP-only) accounts

### DIFF
--- a/routes/email_helpers.py
+++ b/routes/email_helpers.py
@@ -40,6 +40,16 @@ from src.secret_storage import decrypt as _decrypt
 logger = logging.getLogger(__name__)
 
 
+class EmailNotConfiguredError(RuntimeError):
+    """Raised when an IMAP operation is attempted on an account that has no
+    inbox configured (e.g. a send-only / SMTP-only account).
+
+    Subclasses RuntimeError so existing broad ``except Exception`` handlers
+    keep working; callers that want to treat "no inbox" as an empty result
+    rather than a failure can catch this type specifically.
+    """
+
+
 def _xoauth2_raw(user: str, access_token: str) -> str:
     """The SASL XOAUTH2 initial-response string (unencoded).
 
@@ -928,6 +938,14 @@ def _imap_connect(account_id: str | None = None, owner: str = "",
     # `timeout` is overridable so short-lived callers (e.g. the service-health
     # probe) can impose a tighter budget than the default IMAP timeout.
     cfg = _get_email_config(account_id, owner=owner)
+    # Send-only (SMTP-only) account: no IMAP host means there is no inbox to
+    # read. Bail out with a clear, typed error instead of handing an empty
+    # host to imaplib — IMAP4("", 993) silently dials localhost:993 and fails
+    # with a confusing "[Errno 111] Connection refused" on every inbox poll.
+    if not cfg.get("imap_host"):
+        raise EmailNotConfiguredError(
+            f"IMAP is not configured for account {cfg.get('account_name') or 'default'!r}"
+        )
     # Connection mode:
     #   STARTTLS on → plain + upgrade
     #   STARTTLS off + port 993 → implicit SSL (IMAPS)

--- a/routes/email_routes.py
+++ b/routes/email_routes.py
@@ -46,6 +46,7 @@ from routes.email_helpers import (
     _send_smtp_message, _smtp_security_mode,
     _IMAP_TIMEOUT_SECONDS, _open_imap_connection,
     make_oauth_state, verify_oauth_state,
+    EmailNotConfiguredError,
     _imap_connect, _imap, _decode_header, _detect_sent_folder, _detect_drafts_folder,
     _extract_attachment_text, _list_attachments_from_msg, _has_visible_attachments, _is_likely_signature_image_attachment,
     _extract_attachment_to_disk, _extract_html, _extract_text,
@@ -1014,6 +1015,11 @@ def setup_email_routes():
                 logger.debug(f"Bulk summary attach skipped: {_summary_err}")
 
             return {"emails": emails, "total": total, "folder": folder, "offset": offset}
+        except EmailNotConfiguredError:
+            # Send-only (SMTP-only) account: there is no inbox to read, so the
+            # poll returns an empty list instead of a per-minute error. SMTP
+            # send is unaffected.
+            return {"emails": [], "total": 0, "folder": folder, "offset": offset}
         except Exception as e:
             logger.error(f"Failed to list emails: {e}")
             detail = str(e).strip()

--- a/tests/test_email_send_only_no_inbox.py
+++ b/tests/test_email_send_only_no_inbox.py
@@ -1,0 +1,75 @@
+"""A send-only (SMTP-only) account has no inbox to read.
+
+`_imap_connect` must fail fast with a clear, typed error instead of handing an
+empty host to imaplib — `imaplib.IMAP4("", 993)` silently dials localhost:993
+and surfaces a confusing "[Errno 111] Connection refused" on every inbox poll.
+"""
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+_tmp_data = Path(tempfile.mkdtemp(prefix="odysseus-email-send-only-test-"))
+os.environ.setdefault("DATA_DIR", str(_tmp_data))
+os.environ.setdefault("DATABASE_URL", f"sqlite:///{_tmp_data / 'app.db'}")
+
+import routes.email_helpers as helpers
+from routes.email_helpers import EmailNotConfiguredError, _imap_connect
+
+
+_SEND_ONLY_CFG = {
+    "account_id": "acct-send-only",
+    "account_name": "send-only",
+    "smtp_host": "smtp.example.org",
+    "smtp_port": 465,
+    "smtp_user": "noreply@example.org",
+    "smtp_password": "secret",
+    "imap_host": "",          # <- the send-only marker
+    "imap_port": 993,
+    "imap_user": "",
+    "imap_password": "",
+    "imap_starttls": True,
+    "from_address": "noreply@example.org",
+}
+
+
+def test_not_configured_error_is_runtime_error():
+    # Subclassing RuntimeError keeps existing broad `except Exception` handlers
+    # working while letting the inbox poll catch this case specifically.
+    assert issubclass(EmailNotConfiguredError, RuntimeError)
+
+
+def test_imap_connect_send_only_raises_and_never_dials(monkeypatch):
+    monkeypatch.setattr(helpers, "_get_email_config", lambda *a, **k: dict(_SEND_ONLY_CFG))
+
+    def _boom(*a, **k):  # opening a connection means we dialed an empty host
+        raise AssertionError("send-only account must not open an IMAP connection")
+
+    monkeypatch.setattr(helpers, "_open_imap_connection", _boom)
+
+    with pytest.raises(EmailNotConfiguredError):
+        _imap_connect("acct-send-only")
+
+
+def test_imap_connect_with_host_still_connects(monkeypatch):
+    # Guard must not regress normal accounts: a configured imap_host still
+    # reaches _open_imap_connection.
+    cfg = dict(_SEND_ONLY_CFG, imap_host="imap.example.org", imap_user="u", imap_password="p")
+    monkeypatch.setattr(helpers, "_get_email_config", lambda *a, **k: cfg)
+
+    opened = {}
+
+    class _FakeConn:
+        def login(self, user, password):
+            opened["login"] = (user, password)
+
+    def _fake_open(host, port, *, starttls, timeout):
+        opened["host"] = host
+        return _FakeConn()
+
+    monkeypatch.setattr(helpers, "_open_imap_connection", _fake_open)
+
+    conn = _imap_connect("acct-with-imap")
+    assert opened["host"] == "imap.example.org"
+    assert isinstance(conn, _FakeConn)


### PR DESCRIPTION
## Summary

A send-only (SMTP-only) email account has no inbox, but the inbox list path still called `_imap_connect`, which handed an empty `imap_host` to `imaplib`. `imaplib.IMAP4("", 993)` silently dials `localhost:993` and fails with `[Errno 111] Connection refused`, so the email panel's ~60s poll logged a `Failed to list emails` ERROR every minute and returned a `Mail operation failed` error to the UI. This makes `_imap_connect` fail fast with a typed `EmailNotConfiguredError` when no `imap_host` is set, and the inbox list returns an empty result for that case instead of an error. SMTP send is unaffected.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4829

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

Reproduced on `dev` in a container (`AUTH_ENABLED=false`, `ODYSSEUS_INPROCESS_POLLERS=0`):

1. Create a send-only account:
   `POST /api/email/accounts` with `{"name":"send-only","smtp_host":"smtp.example.org","smtp_port":465,"smtp_user":"noreply@example.org","smtp_password":"x","from_address":"noreply@example.org","is_default":true}`
2. `GET /api/email/list?folder=INBOX&limit=50&filter=unread`

**Before (dev):**
```
{"emails":[],"total":0,"error":"Mail operation failed: [Errno 111] Connection refused"}
routes.email_routes - ERROR - Failed to list emails: [Errno 111] Connection refused
```

**After (this PR):**
```
{"emails":[],"total":0,"folder":"INBOX","offset":0}
```
No error logged across repeated polls.

Unit test added: `tests/test_email_send_only_no_inbox.py` — asserts `_imap_connect` raises `EmailNotConfiguredError` and never opens a connection for a send-only account, and still connects normally when `imap_host` is set.

```
python -m pytest tests/test_email_send_only_no_inbox.py tests/test_email_imap_timeout.py \
  tests/test_email_polly_imap_leak.py tests/test_email_fallback_reconnect.py -q
# 11 passed
```

## Visual / UI changes

None — backend only. No rendering, CSS, or `static/js/` changes.
