### PR TITLE
docs(setup): add a self-host troubleshooting cookbook of common traps

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -299,6 +299,16 @@ To expose Odysseus on a local network or Tailscale with HTTPS:
    ```
 4. Install the `mkcert` CA on any other device you want to access Odysseus from (e.g., for iOS, email the `rootCA.pem` to yourself, install the profile, and trust it in Certificate Trust Settings).
 
+### Common self-host traps (30-second fixes)
+A grab-bag of small gotchas that otherwise turn into long debugging sessions.
+
+- **`AUTH_ENABLED=false` is ignored / you're still forced to log in (Windows).** If you edited `.env` in Notepad it may have saved a UTF-8 **BOM**, turning the first key into `﻿AUTH_ENABLED` so it is never matched. Odysseus loads `.env` with `encoding="utf-8-sig"` to tolerate a leading BOM, but the safe fix is to re-save `.env` as **UTF-8 without BOM** (VS Code: *Save with Encoding → UTF-8*).
+- **macOS: the app isn't at `http://localhost:7000`.** macOS AirPlay Receiver usually holds port `7000`, so the macOS start script serves on **`7860`** instead — open `http://localhost:7860`. To use `7000`, free it (System Settings → General → AirDrop & Handoff → turn off *AirPlay Receiver*) and set `APP_PORT=7000`.
+- **Copy buttons do nothing over a plain-HTTP Tailscale/LAN URL.** Browsers only expose the clipboard API (`navigator.clipboard`) on **secure origins** — HTTPS, or `localhost`. Over `http://100.x.y.z:7860` it is blocked. Serve over HTTPS (see *HTTPS + LAN/Tailscale exposure* above); `localhost` is exempt, so copy still works on the host itself.
+- **Self-hosted ntfy reminders don't reach your phone.** Two things: (1) the bundled ntfy binds to loopback by default — to reach it from your phone set `NTFY_BIND` to your host/Tailscale IP and `NTFY_BASE_URL` to the same server URL in `.env`, then recreate the ntfy container (see the `NTFY_*` block in `.env.example`); (2) in the ntfy **Android** app, subscribe to the topic with **Instant delivery** enabled — non-`ntfy.sh` servers don't get instant push otherwise.
+- **Local mail (Dovecot) login fails: "Plaintext authentication disallowed on non-encrypted connections."** Your IMAP/SMTP server is refusing cleartext auth over an unencrypted link. Prefer enabling TLS on the mail server; on a trusted LAN only, you can allow cleartext (Dovecot: `disable_plaintext_auth = no`).
+- **Calendar/contacts (Radicale) won't sync.** Point Odysseus at the **full collection URL** with its trailing slash — e.g. `http://host:5232/<user>/<collection-id>/` — not just the server root. Radicale shows this address for each calendar/address book in its web UI.
+
 ### Optional Dependencies
 `requirements-optional.txt` contains packages that unlock extra features. It is not installed by default.
 


### PR DESCRIPTION
## Summary

The ROADMAP asks for a self-host troubleshooting cookbook of the "weird 30-second fixes that otherwise become 30-minute searches." `docs/setup.md` covered `chromadb-client` conflicts and HTTPS/Tailscale, but not the named traps. This adds a **"Common self-host traps (30-second fixes)"** subsection under Troubleshooting covering: the UTF-8 BOM `.env` gotcha (grounded in `app.py`'s `utf-8-sig` loader), macOS AirPlay holding port 7000 (start script uses 7860), the plain-HTTP Tailscale/LAN clipboard limitation (cross-links the existing HTTPS section), self-hosted ntfy delivery (`NTFY_BIND`/`NTFY_BASE_URL` from `.env.example` + the ntfy Android Instant-delivery toggle), Dovecot cleartext-auth on LAN mail stacks, and Radicale full-collection-URL sync.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4833

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [x] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. _(Docs-only change — no app behavior changes.)_

## How to Test

- It's a docs-only change to `docs/setup.md` (one new subsection). Render the Markdown and confirm it reads correctly under **Troubleshooting & Advanced Setup**.
- Each entry is grounded in current repo behavior: the `.env` BOM note matches `app.py:31-37` (`load_dotenv(encoding="utf-8-sig")`); ntfy matches the `NTFY_BIND`/`NTFY_BASE_URL` block in `.env.example` and the hint in `routes/auth_routes.py`; the 7860/AirPlay note matches `start-macos.sh` and the existing macOS section.
- No code paths touched, so no tests or build changes.

## Visual / UI changes

N/A — documentation only, nothing renders in the app. Disclosure: this is an agent-assisted PR; issue #4833 was opened first per CONTRIBUTING, and it is a single focused docs change.
