### PR TITLE
fix(chat): guard agent_max_tool_calls against non-numeric settings.json values

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -1255,7 +1255,14 @@ def setup_chat_routes(
                 try:
                     from src.settings import get_setting
                     from src.agent_tools import MAX_AGENT_ROUNDS as _DEFAULT_ROUNDS
-                    _tool_budget = int(get_setting("agent_max_tool_calls", 0))
+                    # Per-message tool budget from settings; guard defensively in
+                    # case settings.json was hand-edited to a non-numeric value
+                    # (the HTTP admin endpoint validates, but direct edits bypass
+                    # it). 0 = unlimited, matching auth_routes set_settings().
+                    try:
+                        _tool_budget = int(get_setting("agent_max_tool_calls", 0))
+                    except (TypeError, ValueError):
+                        _tool_budget = 0
                     # Per-message round cap from settings; clamp defensively in
                     # case settings.json was hand-edited to a bad value.
                     try:

--- a/tests/test_agent_tool_budget_nonnumeric.py
+++ b/tests/test_agent_tool_budget_nonnumeric.py
@@ -1,0 +1,70 @@
+"""Regression: agent_max_tool_calls must not crash chat_stream when settings.json
+holds a non-numeric string (e.g. {"agent_max_tool_calls": "unlimited"}).
+
+The HTTP admin endpoint validates/clamps this value, but a hand-edited or
+agent-written data/settings.json bypasses that. The read sits inside the agent
+streaming try-block whose only handler catches (CancelledError, GeneratorExit) —
+NOT ValueError — so an unguarded int() would propagate and break the SSE stream.
+It must be guarded like the agent_max_rounds read four lines below.
+"""
+import ast
+from pathlib import Path
+
+import pytest
+
+_CHAT_ROUTES = Path(__file__).resolve().parent.parent / "routes" / "chat_routes.py"
+
+
+def _tool_budget_read_is_guarded(source: str) -> bool:
+    """True if a `try` that assigns `_tool_budget` also catches ValueError."""
+    tree = ast.parse(source)
+    chat_stream = next(
+        (n for n in ast.walk(tree)
+         if isinstance(n, ast.AsyncFunctionDef) and n.name == "chat_stream"),
+        None,
+    )
+    assert chat_stream is not None, "chat_stream function not found"
+    for try_node in ast.walk(chat_stream):
+        if not isinstance(try_node, ast.Try):
+            continue
+        # Only the immediate try body — not nested trys — should own the assignment.
+        assigns_budget = any(
+            isinstance(t, ast.Name) and t.id == "_tool_budget"
+            for stmt in try_node.body if isinstance(stmt, ast.Assign)
+            for t in stmt.targets
+        )
+        if not assigns_budget:
+            continue
+        catches_value_error = any(
+            (isinstance(h.type, ast.Name) and h.type.id == "ValueError")
+            or (isinstance(h.type, ast.Tuple)
+                and any(isinstance(e, ast.Name) and e.id == "ValueError" for e in h.type.elts))
+            for h in try_node.handlers
+        )
+        if catches_value_error:
+            return True
+    return False
+
+
+def test_tool_budget_read_is_wrapped_in_try_except():
+    source = _CHAT_ROUTES.read_text(encoding="utf-8")
+    assert _tool_budget_read_is_guarded(source), (
+        "_tool_budget = int(get_setting('agent_max_tool_calls', 0)) must be wrapped in "
+        "try/except (ValueError) like the agent_max_rounds read, so a non-numeric "
+        "settings.json value cannot crash chat_stream during agent init"
+    )
+
+
+@pytest.mark.parametrize("raw, expected", [
+    ("unlimited", 0), ("", 0), (None, 0), ("25", 25), (12, 12),
+])
+def test_tool_budget_coercion_falls_back_to_zero(raw, expected):
+    # Mirrors the guarded read: a bad/non-numeric value -> 0 (unlimited).
+    def get_setting(_key, default):
+        return raw if raw is not None else default
+
+    try:
+        tool_budget = int(get_setting("agent_max_tool_calls", 0))
+    except (TypeError, ValueError):
+        tool_budget = 0
+    assert tool_budget == expected


### PR DESCRIPTION
## Summary

In `chat_stream`'s agent-mode branch, the per-message tool budget was read with `int(get_setting("agent_max_tool_calls", 0))` (routes/chat_routes.py:1258) with no error handling. The HTTP admin endpoint validates/clamps this value, but a hand-edited or agent-written `data/settings.json` (e.g. `{"agent_max_tool_calls": "unlimited"}`) bypasses that. The read sits inside the agent streaming `try` block whose only handler catches `(asyncio.CancelledError, GeneratorExit)` — not `ValueError` — so a non-numeric value made `int()` raise and broke the SSE chat stream during agent init. The very next setting (`agent_max_rounds`) is already guarded the same way, so this was an inconsistent-hardening oversight. This wraps the read in `try/except (TypeError, ValueError)` falling back to `0` (= unlimited).

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4836

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. _(Verified via a unit test that AST-asserts the read is guarded + a coercion check; the bug is in the agent-init path of a streaming endpoint.)_

## How to Test

- `python -m pytest tests/test_agent_tool_budget_nonnumeric.py` → 6 passed.
  - `test_tool_budget_read_is_wrapped_in_try_except` parses `routes/chat_routes.py` and asserts the `_tool_budget` read is inside a `try` that catches `ValueError` (like `agent_max_rounds`). It **fails before the fix** (the read was only inside the outer try that catches `CancelledError`/`GeneratorExit`) and **passes after**.
  - `test_tool_budget_coercion_falls_back_to_zero` pins the contract: `"unlimited"`/`""`/`None` → `0` (unlimited), `"25"`→25, `12`→12.
- `python -m py_compile routes/chat_routes.py` → clean.

## Visual / UI changes

N/A — backend-only change (`routes/chat_routes.py` + a new test). Disclosure: agent-assisted PR; issue #4836 opened first per CONTRIBUTING; single focused fix.
