### PR TITLE
fix(model-context): add Xiaomi MiMo context window lengths

### DIFF
--- a/src/model_context.py
+++ b/src/model_context.py
@@ -220,6 +220,11 @@ KNOWN_CONTEXT_WINDOWS = {
     'hermes': 131072,
     'nous-hermes': 131072,
 
+    # --- Xiaomi MiMo ---
+    'mimo-v2.5-pro': 1048576,
+    'mimo-v2.5': 1048576,
+    'mimo': 1048576,
+
     # --- Open community ---
     'dolphin': 32768,
     'mythomax': 4096,


### PR DESCRIPTION
## Summary

`KNOWN_CONTEXT_WINDOWS` in `src/model_context.py` had no Xiaomi MiMo entries, so the UI fell back to the 128K default for models that actually expose a 1M-token window. This adds `mimo-v2.5-pro`, `mimo-v2.5`, and `mimo` keyed at 1,048,576 tokens, matching the official Xiaomi MiMo context spec.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #4578

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Configure a Xiaomi MiMo OpenAI-compatible endpoint (e.g. base URL `https://api.xiaomimimo.com/v1`) and pick a `mimo-v2.5-pro` / `mimo-v2.5` / `mimo` model in the chat model selector.
2. **Before:** the context-window badge shows the 128,000 default because the model id is unknown to `_lookup_known()`.
3. **After:** the badge shows 1,048,576 (1M), and any limits/sliders derived from the context window match.
4. Static checks already run: `python -m py_compile src/model_context.py` passes, and the longest-key-first substring match in `_lookup_known()` resolves `mimo-v2.5-pro` to its specific entry rather than the bare `mimo` key.
