### PR TITLE
fix(llm-core): prevent cache-affinity fields from reaching Cerebras

### DIFF
--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -677,6 +677,8 @@ def _detect_provider(url: str) -> str:
     from src.copilot import is_copilot_base
     if is_copilot_base(url):
         return "copilot"
+    if _host_match(url, "cerebras.ai"):
+        return "cerebras"
     if _host_match(url, "mistral.ai"):
         return "mistral"
     return "openai"
@@ -763,6 +765,8 @@ def _provider_label(url: str) -> str:
     if is_chatgpt_subscription_base(url): return "ChatGPT Subscription"
     from src.copilot import is_copilot_base
     if is_copilot_base(url): return "GitHub Copilot"
+    if _host_match(url, "cerebras.ai"):
+        return "cerebras"
     if _host_match(url, "mistral.ai"): return "Mistral"
     if _host_match(url, "deepseek.com"): return "DeepSeek"
     if _host_match(url, "nvidia.com"): return "NVIDIA"

--- a/tests/test_cerebras_cache_affinity.py
+++ b/tests/test_cerebras_cache_affinity.py
@@ -1,0 +1,27 @@
+"""Regression test for issue #4640.
+
+Cerebras endpoints must not receive llama.cpp-specific fields
+(session_id, cache_prompt) even when endpoint_kind is misconfigured as 'local'.
+"""
+import importlib
+
+
+def test_detect_provider_recognizes_cerebras():
+    """_detect_provider should return 'cerebras' for api.cerebras.ai URLs."""
+    llm_core = importlib.import_module("src.llm_core")
+    assert llm_core._detect_provider("https://api.cerebras.ai/v1") == "cerebras"
+
+
+def test_cerebras_not_self_hosted():
+    """_is_self_hosted_openai_compatible should be False for Cerebras."""
+    llm_core = importlib.import_module("src.llm_core")
+    assert llm_core._is_self_hosted_openai_compatible("https://api.cerebras.ai/v1") is False
+
+
+def test_apply_local_cache_affinity_skips_cerebras():
+    """_apply_local_cache_affinity must not add session_id/cache_prompt for Cerebras."""
+    llm_core = importlib.import_module("src.llm_core")
+    payload = {"messages": []}
+    llm_core._apply_local_cache_affinity(payload, "https://api.cerebras.ai/v1", "test-session-123")
+    assert "session_id" not in payload, "session_id leaked into Cerebras payload"
+    assert "cache_prompt" not in payload, "cache_prompt leaked into Cerebras payload"


### PR DESCRIPTION
## Summary

Cerebras cloud endpoints (`api.cerebras.ai`) were not recognised by `_detect_provider()`, so when such an endpoint was configured with kind `local` they fell through to the self-hosted path and received llama.cpp-only fields (`session_id`, `cache_prompt`) that Cerebras rejects. This registers `cerebras.ai` as a first-class provider in both `_detect_provider()` and `_provider_label()`. Once the provider resolves to `cerebras`, `_is_self_hosted_openai_compatible()` short-circuits to `False` at its first guard, so `_apply_local_cache_affinity()` no longer attaches the unsupported fields — and the endpoint is also labelled "cerebras" in the UI/logs instead of the generic fallback.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #4640

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate. (A related independent fix exists in #4641; this PR additionally corrects the provider **label** shown in the UI, not just the cache-affinity gating.)
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Add an OpenAI-compatible endpoint with base URL `https://api.cerebras.ai/v1` and any Cerebras model, configured with endpoint kind `local` (the configuration that triggers the bug).
2. Send a chat message and inspect the outgoing request payload (debug logging or a debugging proxy).
3. **Before:** the payload contains `session_id` and `cache_prompt`, and Cerebras returns an error about the unknown fields.
4. **After:** `_detect_provider()` returns `cerebras`, so `_apply_local_cache_affinity()` skips; `session_id`/`cache_prompt` are absent and the request succeeds. The endpoint is also displayed as "cerebras".
5. Regression tests: `pytest tests/test_cerebras_cache_affinity.py -q` — verifies provider detection, that Cerebras is not classified self-hosted, and that no affinity fields leak into the payload (run by CI).
