### PR TITLE
fix(cookbook): preserve sshPort and platform in scheduled serve tasks

### DIFF
--- a/src/builtin_actions.py
+++ b/src/builtin_actions.py
@@ -2192,8 +2192,8 @@ async def action_cookbook_serve(
                     "ts": int(_time.time() * 1000),
                     "payload": {"repo_id": repo_id, "remote_host": host or "", "_cmd": cmd},
                     "remoteHost": host or "",
-                    "sshPort": "",
-                    "platform": "linux",
+                    "sshPort": str(srv.get("port") or ""),
+                    "platform": srv.get("platform") or "linux",
                     "_serveReady": False,
                     "_endpointAdded": False,
                 }


### PR DESCRIPTION
## Summary

When registering a scheduled Cookbook serve task, `builtin_actions.py` hardcoded `"sshPort": ""` and `"platform": "linux"` in the task payload, discarding the matched server entry's real SSH port and platform. Scheduled serves then targeted the wrong port/platform and failed to connect. This reads both values from the matched server config (`srv`) — `srv.get("port")` and `srv.get("platform")` — while preserving the original fallbacks (`""` and `"linux"`) when either is absent.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #4544

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate. (A related independent fix exists in #4545, which also adds a regression test; this PR is offered as a smaller, minimal alternative.)
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Configure a saved Cookbook server with a non-default SSH port (e.g. `2222`) and a non-Linux platform (e.g. `darwin`).
2. Schedule a serve task that targets that server.
3. **Before:** the registered task payload shows `sshPort: ""` and `platform: "linux"`, so the serve is launched against the wrong port/platform.
4. **After:** the payload shows `sshPort: "2222"` and `platform: "darwin"`, matching the saved server entry, and the serve connects. Servers missing a port/platform still fall back to `""` / `"linux"`.
5. Static check: `python -m py_compile src/builtin_actions.py` passes.
