### PR TITLE
fix(calendar): accept time-first datetimes ("3pm tomorrow") in _parse_dt

### DIFF
--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -434,6 +434,20 @@ def _parse_dt(s: str) -> datetime:
         if t is not None:
             return base.replace(hour=t[0], minute=t[1])
 
+    # time-first: "3pm today", "9am tomorrow", "11pm tonight"
+    # (parity with parse_due_for_user, which handles these via the same form)
+    m = _re.match(r'^(.+?)\s+(today|tonight|tomorrow|tmrw|yesterday)$', lower)
+    if m:
+        time_part, word = m.group(1).strip(), m.group(2)
+        base = today
+        if word in ("tomorrow", "tmrw"):
+            base = today + timedelta(days=1)
+        elif word == "yesterday":
+            base = today - timedelta(days=1)
+        t = _parse_time(time_part)
+        if t is not None:
+            return base.replace(hour=t[0], minute=t[1])
+
     # next <weekday> [at] TIME
     weekdays = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]
     m = _re.match(r'^next\s+(\w+)(?:\s+at)?\s*(.*)$', lower)

--- a/tests/test_calendar_parse_dt_time_first.py
+++ b/tests/test_calendar_parse_dt_time_first.py
@@ -1,0 +1,31 @@
+"""Regression: _parse_dt must understand "time-first" phrasings like parse_due_for_user does.
+
+parse_due_for_user accepts both day-first ("tomorrow at 9am") and time-first
+("9am tomorrow") forms, but _parse_dt (the parser _parse_dt_pair falls back to
+for calendar event start/end) only handled the day-first form. A time-first
+start like "3pm tomorrow" missed every branch and fell through to dateutil,
+which raises ParserError on "3pm tomorrow", so creating an event with that
+phrasing failed. Time-first is now handled identically to its day-first
+equivalent, mirroring the sibling reminder parser.
+"""
+from routes.calendar_routes import _parse_dt
+
+
+def test_time_first_today_equals_day_first():
+    assert _parse_dt("3pm today") == _parse_dt("today at 3pm")
+
+
+def test_time_first_tomorrow_equals_day_first():
+    assert _parse_dt("9am tomorrow") == _parse_dt("tomorrow at 9am")
+
+
+def test_time_first_with_minutes_equals_day_first():
+    assert _parse_dt("2:30pm tomorrow") == _parse_dt("tomorrow at 2:30pm")
+
+
+def test_time_first_tonight_maps_to_today():
+    assert _parse_dt("11pm tonight") == _parse_dt("today at 11pm")
+
+
+def test_time_first_yesterday_equals_day_first():
+    assert _parse_dt("8am yesterday") == _parse_dt("yesterday at 8am")


### PR DESCRIPTION
## Summary

`_parse_dt` (the natural-language datetime fallback that `_parse_dt_pair` uses for calendar event start/end) only handled day-first phrasings like "tomorrow at 3pm". Time-first phrasings — "3pm tomorrow", "9am tomorrow", "2:30pm tomorrow" — matched no branch and fell through to `dateutil.parser`, which raises `ParserError` on them, so creating a calendar event with that wording failed. This adds a time-first branch mirroring the sibling reminder parser `parse_due_for_user`, which already accepts exactly these forms, plus a regression test asserting time-first parses identically to its day-first equivalent.

## Target branch

- [x] This PR targets `dev`, not `main`.

## Linked Issue

No dedicated issue. Related: the sibling reminder parser `parse_due_for_user` gained the same time-first support in #3302 — this brings `_parse_dt` to parity. (An earlier parity gap for the word "tonight" was likewise closed for `_parse_dt`.)

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate (no existing PR touches `_parse_dt` time-first parsing).
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — one parser branch plus a regression test, nothing else.
- [ ] Ran the app end-to-end — this is a pure parser change verified by unit tests rather than a full app run (see How to Test).

## How to Test

```
python -m pytest tests/test_calendar_parse_dt_time_first.py tests/test_calendar_parse_dt_tonight.py -q
```

All pass (5 new time-first cases + the existing "tonight" siblings). The new tests are clock-independent equivalences, e.g. `_parse_dt("3pm tomorrow") == _parse_dt("tomorrow at 3pm")`. Before this change `_parse_dt("3pm tomorrow")` raised `ValueError` (dateutil `ParserError`); after, it returns the same datetime as the day-first form.

## Visual / UI changes

None — backend parser change only, no HTML/CSS/JS/UI.
