### PR TITLE
docs: remove completed troubleshooting cookbook task from ROADMAP

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,7 +12,6 @@ the codebase, you are probably right to stay away.
   and WSL all need coverage.
 
 - Integration audit: do integrations even work? Confirm what works, what needs setup docs, and what should be removed or hidden. 
-- Self-host troubleshooting cookbook. Document the weird 30-second fixes that otherwise become 30-minute searches: Dovecot cleartext auth for local stacks, ntfy Android Instant Delivery for non-ntfy.sh servers, clipboard limits on plain-HTTP Tailscale URLs, Radicale collection URLs, and similar traps.
 - Cookbook reliability on other computers. This is probably the area most likely to need work across different machines, GPUs, drivers, shells, and Python environments.
 - Cookbook SGLang support across platforms. Make sure SGLang setup/serve works
   predictably on Linux, Windows/WSL, macOS where possible, Docker, and common


### PR DESCRIPTION
## Summary

The self-host troubleshooting cookbook task has been implemented in docs/setup.md under Common self-host traps (PR #4834). Removes the completed item from ROADMAP.md.

## Linked Issue

Fixes #4900

## Type of Change

- [x] Documentation only

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets dev
- [x] My changes are limited to the scope described above.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Read ROADMAP.md — the troubleshooting cookbook item should be gone
2. Verify docs/setup.md contains the Common self-host traps section