### PR TITLE
fix(email): return clean empty results for SMTP-only accounts without IMAP

### DIFF
--- a/routes/email_helpers.py
+++ b/routes/email_helpers.py
@@ -919,6 +919,10 @@ def _open_imap_connection(host: str, port: int, *, starttls: bool, timeout: int 
     imaplib._MAXLINE = 50_000_000
     return conn
 
+class _NoImapError(ConnectionError):
+    """Raised when the selected account has no IMAP configured (send-only)."""
+
+
 def _imap_connect(account_id: str | None = None, owner: str = "",
                   timeout: int = _IMAP_TIMEOUT_SECONDS):
     # SECURITY: passing `owner` scopes the fallback config lookup so a brand
@@ -928,6 +932,8 @@ def _imap_connect(account_id: str | None = None, owner: str = "",
     # `timeout` is overridable so short-lived callers (e.g. the service-health
     # probe) can impose a tighter budget than the default IMAP timeout.
     cfg = _get_email_config(account_id, owner=owner)
+    if not cfg.get("imap_host"):
+        raise _NoImapError("IMAP not configured — add an Email Account with IMAP in Settings or set env vars")
     # Connection mode:
     #   STARTTLS on → plain + upgrade
     #   STARTTLS off + port 993 → implicit SSL (IMAPS)

--- a/routes/email_routes.py
+++ b/routes/email_routes.py
@@ -44,7 +44,7 @@ from routes.email_helpers import (
     _q, _attach_compose_uploads, _cleanup_compose_uploads,
     _load_settings, _save_settings, _get_email_config,
     _send_smtp_message, _smtp_security_mode,
-    _IMAP_TIMEOUT_SECONDS, _open_imap_connection,
+    _IMAP_TIMEOUT_SECONDS, _open_imap_connection, _NoImapError,
     make_oauth_state, verify_oauth_state,
     _imap_connect, _imap, _decode_header, _detect_sent_folder, _detect_drafts_folder,
     _extract_attachment_text, _list_attachments_from_msg, _has_visible_attachments, _is_likely_signature_image_attachment,
@@ -708,6 +708,9 @@ def setup_email_routes():
         conn = None
         try:
             conn = _imap_connect(account_id, owner=owner)
+        except _NoImapError:
+            return {"emails": [], "total": 0, "folder": folder}
+        try:
             select_status, _ = conn.select(_q(folder), readonly=True)
             if select_status != "OK":
                 return {"emails": [], "total": 0, "folder": folder, "error": f"Folder not found: {folder}"}


### PR DESCRIPTION
## Summary

SMTP-only email accounts logged "Failed to list emails" because `_list_emails_sync` called `_imap_connect` which crashed with an unhandled error when `imap_host` was not configured. This adds a `_NoImapError` exception raised by `_imap_connect` when IMAP is not set up, and catches it in `_list_emails_sync` to return clean empty results instead of crashing.

## Linked Issue

Fixes #4829

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I searched existing issues and PRs; this is not a duplicate
- [x] My change preserves existing behavior

## How to Test

1. Pull the branch
2. Restart the app: `python -m uvicorn app:app --host 127.0.0.1 --port 7000`
3. Verify the server starts without any new import errors
4. Run syntax check: `python -m py_compile routes/email_helpers.py routes/email_routes.py`