### PR TITLE
fix(script): reject blank ownerless claim owner

### DIFF
--- a/scripts/claim_ownerless.py
+++ b/scripts/claim_ownerless.py
@@ -27,12 +27,18 @@ def claim_json_entries(entries, owner):
     return count
 
 
+def owner_arg(argv):
+    if len(argv) < 2 or not argv[1].strip():
+        return None
+    return argv[1].strip()
+
+
 def main():
-    if len(sys.argv) < 2:
+    owner = owner_arg(sys.argv)
+    if not owner:
         print("Usage: python scripts/claim_ownerless.py <username>")
         sys.exit(1)
 
-    owner = sys.argv[1]
     print(f"Claiming all ownerless data for: {owner}\n")
 
     # 1. Memories (JSON files)

--- a/tests/test_claim_ownerless_json.py
+++ b/tests/test_claim_ownerless_json.py
@@ -1,4 +1,4 @@
-from scripts.claim_ownerless import claim_json_entries
+from scripts.claim_ownerless import claim_json_entries, owner_arg
 
 
 def test_claim_json_entries_skips_invalid_rows():
@@ -16,3 +16,9 @@ def test_claim_json_entries_skips_invalid_rows():
         None,
         {"id": "b", "owner": "already"},
     ]
+
+
+def test_owner_arg_rejects_blank_owner():
+    assert owner_arg(["claim_ownerless.py"]) is None
+    assert owner_arg(["claim_ownerless.py", "   "]) is None
+    assert owner_arg(["claim_ownerless.py", " admin "]) == "admin"


### PR DESCRIPTION
## Summary

`claim_ownerless.py` accepts the owner from argv before writing ownerless JSON and database rows. A blank argument like `"   "` should not start that write path. This trims the owner argument and exits with the existing usage message when it is missing or blank.

## Linked Issue

Part of #1883.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`, the current default branch.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the app starts. Type-checks and unit tests are not enough.

## How to Test

1. `./venv/bin/python -m pytest -q tests/test_claim_ownerless_json.py`
2. `./venv/bin/python -m py_compile scripts/claim_ownerless.py tests/test_claim_ownerless_json.py`
3. `git diff --check origin/dev...HEAD`
4. `AUTH_ENABLED=false LOCALHOST_BYPASS=true ODYSSEUS_INPROCESS_POLLERS=0 ODYSSEUS_INPROCESS_TASKS=0 ./venv/bin/python -m uvicorn app:app --host 127.0.0.1 --port 7046`, then `GET /api/version`

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI/render path touched.

### Screenshots / clips

N/A
