### PR TITLE
docs: Fixed a broken link to the backup-restore.md inside of the setup.md.

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -445,4 +445,4 @@ All user data lives in `data/` (gitignored): `app.db` (sessions, messages, docum
 `memory.json`, `presets.json`, `uploads/`, `personal_docs/`, `chroma/`, `settings.json`.
 
 To back up or restore everything in `data/`, see the
-[Backup & Restore guide](docs/backup-restore.md).
+[Backup & Restore guide](backup-restore.md).


### PR DESCRIPTION
## Summary

setup.md contained a broken link to the backup-restore.md in the **Data** section. This commit fixes it.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4926 

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [x] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

<!-- Step-by-step instructions a reviewer can follow to verify this works.
     Do not leave this empty — a PR without test steps will be sent back. -->

1. Go to setup guide at https://github.com/pewdiepie-archdaemon/odysseus/blob/dev/docs/setup.md
2. Go all the way down to the **Data** section.
3. Click [Backup & Restore guide](https://github.com/pewdiepie-archdaemon/odysseus/blob/dev/docs/docs/backup-restore.md)

- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.
