### PR TITLE
test: split provider detection tests

### DIFF
--- a/tests/test_provider_detection_builders.py
+++ b/tests/test_provider_detection_builders.py
@@ -1,4 +1,4 @@
-"""Provider detection tests (re: #768).
+"""Provider detection tests — build_chat_url / build_models_url routing (re: #768).
 
 These import the *real* helpers from ``src.llm_core`` (not local copies) so a
 regression in hostname matching is actually caught. The point of the change
@@ -11,72 +11,6 @@ import pytest
 from src import llm_core
 from src import endpoint_resolver
 from src.endpoint_resolver import build_chat_url, build_models_url
-
-
-class TestHostMatch:
-    def test_exact_host(self):
-        assert llm_core._host_match("https://anthropic.com/v1", "anthropic.com")
-
-    def test_subdomain(self):
-        assert llm_core._host_match("https://api.anthropic.com/v1", "anthropic.com")
-
-    def test_multiple_domains(self):
-        assert llm_core._host_match("https://api.together.ai/v1", "together.xyz", "together.ai")
-
-    def test_trailing_dot_fqdn(self):
-        # A fully-qualified host with a trailing dot is legal and resolvable.
-        assert llm_core._host_match("https://api.anthropic.com./v1", "anthropic.com")
-
-    def test_domain_in_path_does_not_match(self):
-        assert not llm_core._host_match("https://myproxy.internal/anthropic.com/v1", "anthropic.com")
-
-    def test_domain_in_query_does_not_match(self):
-        assert not llm_core._host_match("https://example.com/v1?ref=anthropic.com", "anthropic.com")
-
-    def test_lookalike_host_does_not_match(self):
-        assert not llm_core._host_match("https://anthropic.com.example/v1", "anthropic.com")
-
-    def test_none_and_empty_safe(self):
-        assert not llm_core._host_match(None, "anthropic.com")
-        assert not llm_core._host_match("", "anthropic.com")
-
-
-class TestDetectProviderRealHosts:
-    def test_chatgpt_subscription_codex_backend(self):
-        assert llm_core._detect_provider("https://chatgpt.com/backend-api/codex") == "chatgpt-subscription"
-        assert llm_core._detect_provider("https://chatgpt.com/backend-api/codex/responses") == "chatgpt-subscription"
-
-    def test_anthropic(self):
-        assert llm_core._detect_provider("https://api.anthropic.com") == "anthropic"
-
-    def test_openrouter(self):
-        assert llm_core._detect_provider("https://openrouter.ai/api/v1") == "openrouter"
-
-    def test_groq_openai_compat_path(self):
-        # Groq's base carries an /openai/v1 path; detection must still see the host.
-        assert llm_core._detect_provider("https://api.groq.com/openai/v1") == "groq"
-
-    def test_ollama_native_unchanged(self):
-        assert llm_core._detect_provider("https://ollama.com/api") == "ollama"
-
-    def test_unknown_host_defaults_to_openai(self):
-        assert llm_core._detect_provider("https://api.example.com/v1") == "openai"
-
-
-class TestDetectProviderRejectsSubstringFalsePositives:
-    """The regression that motivated #768: substring matching mislabeled these."""
-
-    def test_provider_domain_in_path(self):
-        assert llm_core._detect_provider("https://myproxy.internal/anthropic.com/v1") == "openai"
-
-    def test_provider_domain_in_query(self):
-        assert llm_core._detect_provider("https://example.com/v1?ref=anthropic.com") == "openai"
-
-    def test_lookalike_host(self):
-        assert llm_core._detect_provider("https://anthropic.com.example/v1") == "openai"
-
-    def test_none_safe(self):
-        assert llm_core._detect_provider(None) == "openai"
 
 
 class TestBuildersRejectLookalikeHosts:

--- a/tests/test_provider_detection_detect.py
+++ b/tests/test_provider_detection_detect.py
@@ -1,0 +1,47 @@
+"""Provider detection tests — _detect_provider real hosts and false-positive rejection (re: #768).
+
+These import the *real* helpers from ``src.llm_core`` (not local copies) so a
+regression in hostname matching is actually caught. The point of the change
+under test is that provider detection keys off the URL's *hostname*, not a
+substring of the whole URL — so a domain appearing in a path/query, or a
+look-alike host, must not be misclassified.
+"""
+from src import llm_core
+
+
+class TestDetectProviderRealHosts:
+    def test_chatgpt_subscription_codex_backend(self):
+        assert llm_core._detect_provider("https://chatgpt.com/backend-api/codex") == "chatgpt-subscription"
+        assert llm_core._detect_provider("https://chatgpt.com/backend-api/codex/responses") == "chatgpt-subscription"
+
+    def test_anthropic(self):
+        assert llm_core._detect_provider("https://api.anthropic.com") == "anthropic"
+
+    def test_openrouter(self):
+        assert llm_core._detect_provider("https://openrouter.ai/api/v1") == "openrouter"
+
+    def test_groq_openai_compat_path(self):
+        # Groq's base carries an /openai/v1 path; detection must still see the host.
+        assert llm_core._detect_provider("https://api.groq.com/openai/v1") == "groq"
+
+    def test_ollama_native_unchanged(self):
+        assert llm_core._detect_provider("https://ollama.com/api") == "ollama"
+
+    def test_unknown_host_defaults_to_openai(self):
+        assert llm_core._detect_provider("https://api.example.com/v1") == "openai"
+
+
+class TestDetectProviderRejectsSubstringFalsePositives:
+    """The regression that motivated #768: substring matching mislabeled these."""
+
+    def test_provider_domain_in_path(self):
+        assert llm_core._detect_provider("https://myproxy.internal/anthropic.com/v1") == "openai"
+
+    def test_provider_domain_in_query(self):
+        assert llm_core._detect_provider("https://example.com/v1?ref=anthropic.com") == "openai"
+
+    def test_lookalike_host(self):
+        assert llm_core._detect_provider("https://anthropic.com.example/v1") == "openai"
+
+    def test_none_safe(self):
+        assert llm_core._detect_provider(None) == "openai"

--- a/tests/test_provider_detection_host_match.py
+++ b/tests/test_provider_detection_host_match.py
@@ -1,0 +1,37 @@
+"""Provider detection tests — hostname matching helpers (re: #768).
+
+These import the *real* helpers from ``src.llm_core`` (not local copies) so a
+regression in hostname matching is actually caught. The point of the change
+under test is that provider detection keys off the URL's *hostname*, not a
+substring of the whole URL — so a domain appearing in a path/query, or a
+look-alike host, must not be misclassified.
+"""
+from src import llm_core
+
+
+class TestHostMatch:
+    def test_exact_host(self):
+        assert llm_core._host_match("https://anthropic.com/v1", "anthropic.com")
+
+    def test_subdomain(self):
+        assert llm_core._host_match("https://api.anthropic.com/v1", "anthropic.com")
+
+    def test_multiple_domains(self):
+        assert llm_core._host_match("https://api.together.ai/v1", "together.xyz", "together.ai")
+
+    def test_trailing_dot_fqdn(self):
+        # A fully-qualified host with a trailing dot is legal and resolvable.
+        assert llm_core._host_match("https://api.anthropic.com./v1", "anthropic.com")
+
+    def test_domain_in_path_does_not_match(self):
+        assert not llm_core._host_match("https://myproxy.internal/anthropic.com/v1", "anthropic.com")
+
+    def test_domain_in_query_does_not_match(self):
+        assert not llm_core._host_match("https://example.com/v1?ref=anthropic.com", "anthropic.com")
+
+    def test_lookalike_host_does_not_match(self):
+        assert not llm_core._host_match("https://anthropic.com.example/v1", "anthropic.com")
+
+    def test_none_and_empty_safe(self):
+        assert not llm_core._host_match(None, "anthropic.com")
+        assert not llm_core._host_match("", "anthropic.com")


### PR DESCRIPTION
## Summary

Splits the provider detection test file into focused test files.

This PR keeps the change test-only and behavior-preserving. It splits the existing provider detection coverage by responsibility:

- host matching coverage moves to `tests/test_provider_detection_host_match.py`;
- provider detection coverage moves to `tests/test_provider_detection_detect.py`;
- URL builder routing coverage moves to `tests/test_provider_detection_builders.py`.

No assertions were intentionally rewritten. Test names, class names, comments, and behavior are preserved. The two class-local `_stub_dns` fixtures stay local to the builder classes and are not deduplicated.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4932

Part of #2523

Follows #3983 / #3987

Follows #4385 / #4389

Follows #4390 / #4392

## Type of Change

- [ ] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [x] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Scope

In scope:

- delete `tests/test_provider_detection.py`;
- add `tests/test_provider_detection_host_match.py`;
- add `tests/test_provider_detection_detect.py`;
- add `tests/test_provider_detection_builders.py`;
- keep all 31 original tests accounted for;
- preserve existing assertions, test names, class names, comments, and behavior;
- preserve services/provider taxonomy for the new files.

Out of scope:

- no production code changes;
- no CI workflow changes;
- no root `tests/conftest.py` changes;
- no taxonomy changes;
- no skip or xfail markers;
- no helper extraction;
- no fixture deduplication;
- no unrelated provider test cleanup;
- no assertion rewrites.

## Checklist

- [x] I searched open issues and open PRs - this is not a duplicate.
- [x] This PR targets `dev`.
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [x] No runtime behavior changes.
- [x] No unrelated file moves or import rewrites.
- [x] I ran focused tests locally.
- [x] I ran full test collection locally.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end.

Note: I did not mark the runtime app checkbox because this is a test-only file split with no production or rendered behavior changes.

## How to Test

Command:

    .venv/bin/python -m py_compile \
      tests/test_provider_detection_host_match.py \
      tests/test_provider_detection_detect.py \
      tests/test_provider_detection_builders.py

Result:

- passed

Command:

    .venv/bin/python -m pytest \
      tests/test_provider_detection_host_match.py \
      tests/test_provider_detection_detect.py \
      tests/test_provider_detection_builders.py \
      --collect-only -q

Result:

- 31 tests collected

Command:

    .venv/bin/python -m pytest \
      tests/test_provider_detection_host_match.py \
      tests/test_provider_detection_detect.py \
      tests/test_provider_detection_builders.py \
      -q

Result:

- 31 passed

Command:

    .venv/bin/python tests/run_order_report.py --seed 123 -- \
      tests/test_provider_detection_host_match.py \
      tests/test_provider_detection_detect.py \
      tests/test_provider_detection_builders.py \
      -q

Result:

- 31 passed
- seed 123: no failures

Command:

    .venv/bin/python -m pytest tests/test_taxonomy.py tests/test_run_focus.py -q

Result:

- passed

Command:

    .venv/bin/python -m pytest --collect-only -q tests

Result:

- 4086 tests collected

Command:

    git diff --check

Result:

- passed

## Visual / UI changes

N/A - test-only refactor; no UI, CSS, HTML, SVG, static JS, or rendered output changed.
