### PR TITLE
test: split endpoint resolver tests

### DIFF
--- a/tests/test_endpoint_resolver_headers.py
+++ b/tests/test_endpoint_resolver_headers.py
@@ -1,0 +1,16 @@
+"""Tests for endpoint_resolver — request header construction."""
+from src.endpoint_resolver import build_headers
+
+
+class TestBuildHeaders:
+    def test_no_key(self):
+        assert build_headers(None, "https://api.openai.com/v1") == {}
+
+    def test_openai_bearer(self):
+        assert build_headers("sk-abc", "https://api.openai.com/v1") == {"Authorization": "Bearer sk-abc"}
+
+    def test_anthropic_headers(self):
+        assert build_headers("sk-ant-abc", "https://api.anthropic.com") == {"x-api-key": "sk-ant-abc", "anthropic-version": "2023-06-01"}
+
+    def test_empty_key(self):
+        assert build_headers("", "https://api.openai.com/v1") == {}

--- a/tests/test_endpoint_resolver_models.py
+++ b/tests/test_endpoint_resolver_models.py
@@ -1,0 +1,67 @@
+"""Tests for endpoint_resolver — endpoint/model selection and enabled-model filtering."""
+import json
+
+from src.endpoint_resolver import (
+    _first_chat_model,
+    _endpoint_hidden_models,
+    _endpoint_enabled_models,
+)
+
+
+class _Ep:
+    """Minimal ModelEndpoint stand-in for the model-picking helpers."""
+    def __init__(self, cached=None, hidden=None):
+        self.cached_models = json.dumps(cached) if cached is not None else None
+        self.hidden_models = json.dumps(hidden) if hidden is not None else None
+
+
+class TestFirstChatModel:
+    def test_skips_embedding_and_tts(self):
+        models = ["text-embedding-ada-002", "whisper-large-v3", "gpt-4o"]
+        assert _first_chat_model(models) == "gpt-4o"
+
+    def test_falls_back_to_first_when_all_non_chat(self):
+        assert _first_chat_model(["whisper-large-v3"]) == "whisper-large-v3"
+
+    def test_empty(self):
+        assert _first_chat_model([]) is None
+
+
+class TestEnabledModels:
+    def test_excludes_hidden(self):
+        # The Groq repro: 16 models, only gpt-oss-120b enabled.
+        cached = [
+            "openai/gpt-oss-safeguard-20b", "canopylabs/orpheus-arabic-saudi",
+            "whisper-large-v3", "openai/gpt-oss-120b",
+        ]
+        hidden = [
+            "openai/gpt-oss-safeguard-20b", "canopylabs/orpheus-arabic-saudi",
+            "whisper-large-v3",
+        ]
+        ep = _Ep(cached=cached, hidden=hidden)
+        assert _endpoint_enabled_models(ep) == ["openai/gpt-oss-120b"]
+
+    def test_no_hidden_returns_all(self):
+        ep = _Ep(cached=["a", "b"], hidden=None)
+        assert _endpoint_enabled_models(ep) == ["a", "b"]
+
+    def test_picker_never_selects_disabled_model(self):
+        # Regression: a disabled model listed first must not be auto-picked.
+        cached = ["canopylabs/orpheus-arabic-saudi", "openai/gpt-oss-120b"]
+        hidden = ["canopylabs/orpheus-arabic-saudi"]
+        ep = _Ep(cached=cached, hidden=hidden)
+        assert _first_chat_model(_endpoint_enabled_models(ep)) == "openai/gpt-oss-120b"
+
+    def test_stale_configured_model_is_discarded(self):
+        # A configured model that's been disabled is dropped, falling through
+        # to the first enabled chat model.
+        ep = _Ep(
+            cached=["canopylabs/orpheus-arabic-saudi", "openai/gpt-oss-120b"],
+            hidden=["canopylabs/orpheus-arabic-saudi"],
+        )
+        configured = "canopylabs/orpheus-arabic-saudi"
+        if configured in _endpoint_hidden_models(ep):
+            configured = ""
+        if not configured:
+            configured = _first_chat_model(_endpoint_enabled_models(ep))
+        assert configured == "openai/gpt-oss-120b"

--- a/tests/test_endpoint_resolver_urls.py
+++ b/tests/test_endpoint_resolver_urls.py
@@ -1,16 +1,10 @@
-"""Tests for endpoint_resolver — pure functions tested directly."""
-import json
-
+"""Tests for endpoint_resolver — URL normalization and URL construction."""
 import pytest
 
 from src.endpoint_resolver import (
-    _first_chat_model,
-    _endpoint_hidden_models,
-    _endpoint_enabled_models,
     normalize_base,
     build_chat_url,
     build_models_url,
-    build_headers,
 )
 
 
@@ -99,76 +93,3 @@ class TestBuildModelsUrl:
     def test_rejects_query_or_fragment_base(self, bad_base):
         with pytest.raises(ValueError, match="query or fragment"):
             build_models_url(bad_base)
-
-
-class TestBuildHeaders:
-    def test_no_key(self):
-        assert build_headers(None, "https://api.openai.com/v1") == {}
-
-    def test_openai_bearer(self):
-        assert build_headers("sk-abc", "https://api.openai.com/v1") == {"Authorization": "Bearer sk-abc"}
-
-    def test_anthropic_headers(self):
-        assert build_headers("sk-ant-abc", "https://api.anthropic.com") == {"x-api-key": "sk-ant-abc", "anthropic-version": "2023-06-01"}
-
-    def test_empty_key(self):
-        assert build_headers("", "https://api.openai.com/v1") == {}
-
-
-class _Ep:
-    """Minimal ModelEndpoint stand-in for the model-picking helpers."""
-    def __init__(self, cached=None, hidden=None):
-        self.cached_models = json.dumps(cached) if cached is not None else None
-        self.hidden_models = json.dumps(hidden) if hidden is not None else None
-
-
-class TestFirstChatModel:
-    def test_skips_embedding_and_tts(self):
-        models = ["text-embedding-ada-002", "whisper-large-v3", "gpt-4o"]
-        assert _first_chat_model(models) == "gpt-4o"
-
-    def test_falls_back_to_first_when_all_non_chat(self):
-        assert _first_chat_model(["whisper-large-v3"]) == "whisper-large-v3"
-
-    def test_empty(self):
-        assert _first_chat_model([]) is None
-
-
-class TestEnabledModels:
-    def test_excludes_hidden(self):
-        # The Groq repro: 16 models, only gpt-oss-120b enabled.
-        cached = [
-            "openai/gpt-oss-safeguard-20b", "canopylabs/orpheus-arabic-saudi",
-            "whisper-large-v3", "openai/gpt-oss-120b",
-        ]
-        hidden = [
-            "openai/gpt-oss-safeguard-20b", "canopylabs/orpheus-arabic-saudi",
-            "whisper-large-v3",
-        ]
-        ep = _Ep(cached=cached, hidden=hidden)
-        assert _endpoint_enabled_models(ep) == ["openai/gpt-oss-120b"]
-
-    def test_no_hidden_returns_all(self):
-        ep = _Ep(cached=["a", "b"], hidden=None)
-        assert _endpoint_enabled_models(ep) == ["a", "b"]
-
-    def test_picker_never_selects_disabled_model(self):
-        # Regression: a disabled model listed first must not be auto-picked.
-        cached = ["canopylabs/orpheus-arabic-saudi", "openai/gpt-oss-120b"]
-        hidden = ["canopylabs/orpheus-arabic-saudi"]
-        ep = _Ep(cached=cached, hidden=hidden)
-        assert _first_chat_model(_endpoint_enabled_models(ep)) == "openai/gpt-oss-120b"
-
-    def test_stale_configured_model_is_discarded(self):
-        # A configured model that's been disabled is dropped, falling through
-        # to the first enabled chat model.
-        ep = _Ep(
-            cached=["canopylabs/orpheus-arabic-saudi", "openai/gpt-oss-120b"],
-            hidden=["canopylabs/orpheus-arabic-saudi"],
-        )
-        configured = "canopylabs/orpheus-arabic-saudi"
-        if configured in _endpoint_hidden_models(ep):
-            configured = ""
-        if not configured:
-            configured = _first_chat_model(_endpoint_enabled_models(ep))
-        assert configured == "openai/gpt-oss-120b"


### PR DESCRIPTION
## Summary

Splits the endpoint resolver tests into focused files by resolver concern.

This PR is test-only and behavior-preserving. It replaces the original monolithic `tests/test_endpoint_resolver.py` with three focused files:

- `tests/test_endpoint_resolver_urls.py`
  - `TestNormalizeBase`
  - `TestBuildChatUrl`
  - `TestBuildModelsUrl`

- `tests/test_endpoint_resolver_headers.py`
  - `TestBuildHeaders`

- `tests/test_endpoint_resolver_models.py`
  - `_Ep`
  - `TestFirstChatModel`
  - `TestEnabledModels`

No production code changed. Test names, assertions, parametrization, and expected values were preserved.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4953

Part of #2523

Follows #4932 / #4933

Follows #4934 / #4935

## Type of Change

- [ ] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [x] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Scope

In scope:

- split `tests/test_endpoint_resolver.py` into focused endpoint resolver test files;
- remove the original file after all tests are moved;
- preserve all original logical test coverage.

Out of scope:

- no production code changes;
- no CI workflow changes;
- no root `tests/conftest.py` changes;
- no helper framework changes;
- no endpoint resolver production refactor;
- no assertion rewrites;
- no skip or xfail markers;
- no calendar helper work;
- no provider endpoint work;
- no service health work.

## Checklist

- [x] I searched open issues and open PRs - this is not a duplicate.
- [x] This PR targets `dev`.
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [x] No runtime behavior changes.
- [x] No unrelated file moves or import rewrites.
- [x] I ran focused tests locally.
- [x] I ran full test collection locally.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end.

Note: I did not mark the runtime app checkbox because this is a test-only file split with no production or rendered behavior changes.

## How to Test

Command:

    .venv/bin/python -m py_compile \
      tests/test_endpoint_resolver_headers.py \
      tests/test_endpoint_resolver_models.py \
      tests/test_endpoint_resolver_urls.py

Result:

- passed

Command:

    .venv/bin/python -m pytest \
      tests/test_endpoint_resolver_headers.py \
      tests/test_endpoint_resolver_models.py \
      tests/test_endpoint_resolver_urls.py \
      --collect-only -q

Result:

- 38 tests collected

Command:

    .venv/bin/python -m pytest \
      tests/test_endpoint_resolver_headers.py \
      tests/test_endpoint_resolver_models.py \
      tests/test_endpoint_resolver_urls.py \
      -q

Result:

- 38 passed

Command:

    .venv/bin/python tests/run_order_report.py --seed 123 -- \
      tests/test_endpoint_resolver_headers.py \
      tests/test_endpoint_resolver_models.py \
      tests/test_endpoint_resolver_urls.py \
      -q

Result:

- 38 passed
- seed 123: no failures

Command:

    .venv/bin/python -m pytest tests/test_taxonomy.py tests/test_run_focus.py -q

Result:

- 80 passed

Command:

    .venv/bin/python -m pytest --collect-only -q tests

Result:

- 4146 tests collected

Command:

    git diff --check

Result:

- passed

## Visual / UI changes

N/A - test-only cleanup; no UI, CSS, HTML, SVG, static JS, or rendered output changed.
