### PR TITLE
fix(mobile): stack the model-comparison grid into one column on phones

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -38356,3 +38356,13 @@ body.theme-frosted .modal {
 .log-line-default {
   color: var(--fg, #9cdef2);
 }
+
+/* The model-comparison grid hard-codes 2-4 equal columns with no phone
+   breakpoint that stacks them, so at 390px two models render ~178px columns and
+   four render ~88px columns. Each column is a full scrolling chat (code blocks,
+   tool output, vote footer), so the text is unreadably over-wrapped and clipped.
+   On phones, stack the panes into a single scrollable column instead. */
+@media (max-width: 768px) {
+  .compare-grid[data-cols] { grid-template-columns: 1fr !important; overflow-y: auto; }
+  .compare-pane { min-height: 60dvh; }
+}


### PR DESCRIPTION
## Summary

The model-comparison grid hard-codes 2-4 equal columns (`.compare-grid[data-cols]`) with no phone breakpoint, so at 390px two models render in ~178px columns and four in ~88px columns. Each column is a full scrolling chat, so text over-wraps to one or two words per line and code blocks and pane titles are clipped. On phones (<=768px) this stacks the panes into a single scrollable column (`grid-template-columns: 1fr`) with a readable `min-height: 60dvh` per pane. Desktop multi-column layout is unchanged.

## Target branch
- [x] This PR targets **`dev`**, not `main`.

## Linked Issue
Fixes #4978

## Type of Change
- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist
- [x] I searched open issues and PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated changes.
- [x] I actually ran the app and verified the change on a 390px mobile viewport and on desktop.

Note: opened the linked issue first, per the LLM-agent policy in CONTRIBUTING.

## How to Test
1. `docker compose up -d --build`, open the app.
2. Open the Compare view, add 2-4 panes (any models), send a prompt.
3. Narrow to a phone viewport (real phone or Chrome DevTools at 390x844). Before: 2-4 cramped columns, text over-wrapped, code/titles clipped. After: panes stack one per row in a single scrollable column, fully readable.
4. Widen to a desktop width (>768px): the multi-column grid is unchanged.

File changed: `static/style.css` (one `@media (max-width: 768px)` block).

## Visual / UI changes
- [x] Mobile + desktop screenshots below. No new colors/sizes/classes — only `grid-template-columns`/`overflow`/`min-height` on the existing `.compare-grid`/`.compare-pane`. No emoji.

### Screenshots / clips
Mobile, 390px, 3 panes — left = `dev` (cramped columns), right = fix (stacked column):

![compare mobile before/after](https://raw.githubusercontent.com/BrunooMoniz/odysseus-fork/mobile-pr-shots/shots/r7-compare-compare.png)

Desktop (>768px) is unaffected — multi-column layout preserved:

![compare desktop](https://raw.githubusercontent.com/BrunooMoniz/odysseus-fork/mobile-pr-shots/shots/r7-compare-desktop.png)
