### PR TITLE
fix(docs): correct broken backup-restore link in setup.md

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -445,4 +445,4 @@ All user data lives in `data/` (gitignored): `app.db` (sessions, messages, docum
 `memory.json`, `presets.json`, `uploads/`, `personal_docs/`, `chroma/`, `settings.json`.
 
 To back up or restore everything in `data/`, see the
-[Backup & Restore guide](docs/backup-restore.md).
+[Backup & Restore guide](backup-restore.md).


### PR DESCRIPTION
## Summary

The backup and restore documentation link at the end of `setup.md` pointed to `docs/backup-restore.md`, a relative path that resolved to the wrong directory (`docs/docs/backup-restore.md`) and returned a 404. Changed to `backup-restore.md`, which correctly references the same-directory file.

## Linked Issue

Fixes #4926

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Other

## Checklist

- [x] I searched existing issues and PRs before opening this one
- [x] My changes follow the project style
- [x] My changes are minimal and focused

## How to Test

1. Open `docs/setup.md`
2. Scroll to the bottom of the page
3. Click the "Backup and Restore" link
4. Verify it navigates to `docs/backup-restore.md` (not `docs/docs/backup-restore.md`)
5. Confirm the page loads without a 404