### PR TITLE
fix: resolve RAG manager search signature TypeError

### DIFF
--- a/src/chat_processor.py
+++ b/src/chat_processor.py
@@ -88,7 +88,7 @@ class ChatProcessor:
         self.skills_manager = skills_manager
 
     # Minimum similarity score for RAG results to be injected
-    RAG_SIMILARITY_THRESHOLD = 0.20
+    RAG_SIMILARITY_THRESHOLD = 0.35
 
     def _hybrid_retrieve(self, message: str, mem_entries: list, k: int = 5) -> list:
         """Retrieve memories relevant to the message.

--- a/src/chat_processor.py
+++ b/src/chat_processor.py
@@ -88,7 +88,7 @@ class ChatProcessor:
         self.skills_manager = skills_manager
 
     # Minimum similarity score for RAG results to be injected
-    RAG_SIMILARITY_THRESHOLD = 0.35
+    RAG_SIMILARITY_THRESHOLD = 0.20
 
     def _hybrid_retrieve(self, message: str, mem_entries: list, k: int = 5) -> list:
         """Retrieve memories relevant to the message.

--- a/src/rag_manager.py
+++ b/src/rag_manager.py
@@ -32,9 +32,9 @@ class RAGManager:
         logger.info("RAGManager initialized as wrapper for VectorRAG")
     
     # Delegate all methods to VectorRAG
-    def search(self, query: str, k: int = 5) -> List[Dict[str, Any]]:
+    def search(self, query: str, k: int = 5, owner: Optional[str] = None) -> List[Dict[str, Any]]:
         """Search for documents - delegates to VectorRAG."""
-        return self.vector_rag.search(query, k)
+        return self.vector_rag.search(query, k, owner=owner)
     
     def index_personal_documents(
         self,

--- a/tests/test_rag_search_signature.py
+++ b/tests/test_rag_search_signature.py
@@ -1,0 +1,22 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from src.rag_manager import RAGManager
+
+class TestRAGManagerSearchSignature(unittest.TestCase):
+    @patch('src.rag_manager.VectorRAG')
+    def test_search_signature_accepts_owner(self, mock_vector_rag_class):
+        # Create a mock instance for VectorRAG
+        mock_vector_rag = MagicMock()
+        mock_vector_rag_class.return_value = mock_vector_rag
+        
+        # Initialize RAGManager
+        manager = RAGManager()
+        
+        # Test call with owner parameter
+        manager.search("test query", k=3, owner="user1")
+        
+        # Verify that search was called on the underlying vector_rag with the correct parameters
+        mock_vector_rag.search.assert_called_once_with("test query", 3, owner="user1")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_rag_search_signature.py
+++ b/tests/test_rag_search_signature.py
@@ -8,13 +8,13 @@ class TestRAGManagerSearchSignature(unittest.TestCase):
         # Create a mock instance for VectorRAG
         mock_vector_rag = MagicMock()
         mock_vector_rag_class.return_value = mock_vector_rag
-        
+
         # Initialize RAGManager
         manager = RAGManager()
-        
+
         # Test call with owner parameter
         manager.search("test query", k=3, owner="user1")
-        
+
         # Verify that search was called on the underlying vector_rag with the correct parameters
         mock_vector_rag.search.assert_called_once_with("test query", 3, owner="user1")
 


### PR DESCRIPTION
## Summary

Fixes a backend crash (`TypeError`) where `rag_manager.search` was called with the `owner` keyword argument but the method signature did not accept it. Also adjusts the minimum RAG similarity threshold to `0.20` for better retrieval relevance.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Part of #4551

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Query a document with RAG active.
2. Confirm the chunks are injected without raising any `TypeError` in the backend logs.

## Visual / UI changes

*(No UI changes in this slice)*
