### PR TITLE
fix(session): use utcnow_naive across session routes (#1116)

### DIFF
--- a/routes/session_routes.py
+++ b/routes/session_routes.py
@@ -162,7 +162,7 @@ def _persist_session_headers(session_id: str, headers: dict | None) -> None:
         db_session = db.query(DbSession).filter(DbSession.id == session_id).first()
         if db_session:
             db_session.headers = headers or {}
-            db_session.updated_at = datetime.utcnow()
+            db_session.updated_at = utcnow_naive()
             db.commit()
     except Exception:
         db.rollback()
@@ -223,8 +223,8 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
         # purge exists only to catch ghosts the frontend missed (tab close,
         # crash). Only clean up rows old enough to be definitely orphaned.
         try:
-            from datetime import datetime as _dt, timedelta as _td
-            _cutoff = _dt.utcnow() - _td(minutes=10)
+            from datetime import timedelta as _td
+            _cutoff = utcnow_naive() - _td(minutes=10)
             _purge_db = SessionLocal()
             try:
                 from core.database import ChatMessage as _DbMsg
@@ -470,7 +470,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
                 db_session = db.query(DbSession).filter(DbSession.id == sid).first()
                 if db_session:
                     db_session.folder = folder if folder else None
-                    db_session.updated_at = datetime.utcnow()
+                    db_session.updated_at = utcnow_naive()
                     db.commit()
                     result["folder"] = folder if folder else None
             finally:
@@ -517,7 +517,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
                     db_session.model = model
                     db_session.endpoint_url = endpoint_url
                     db_session.headers = session.headers or {}
-                    db_session.updated_at = datetime.utcnow()
+                    db_session.updated_at = utcnow_naive()
                     db.commit()
             finally:
                 db.close()
@@ -646,7 +646,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
                 db_session = db.query(DbSession).filter(DbSession.id == sid).first()
                 if db_session:
                     db_session.archived = True
-                    db_session.updated_at = datetime.utcnow()
+                    db_session.updated_at = utcnow_naive()
                     db.commit()
                     
                     # Update in memory if it exists
@@ -680,7 +680,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
             if not db_session:
                 raise HTTPException(404, f"Session {sid} not found")
             db_session.archived = False
-            db_session.updated_at = datetime.utcnow()
+            db_session.updated_at = utcnow_naive()
             db.commit()
             # Reload into session manager so it appears in the active list
             try:
@@ -890,7 +890,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
                 db_session = db.query(DbSession).filter(DbSession.id == session_id).first()
                 if db_session:
                     db_session.is_important = important
-                    db_session.updated_at = datetime.utcnow()
+                    db_session.updated_at = utcnow_naive()
                     db.commit()
 
                     # Update in memory if it exists
@@ -979,7 +979,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
             metadata={
                 "compacted": True,
                 "summarized_count": len(older),
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": utcnow_naive().isoformat(),
             },
         )
         new_history = [summary_msg] + recent
@@ -1256,7 +1256,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
                 db_session = db_session_q.first()
                 if db_session:
                     db_session.folder = folder_name
-                    db_session.updated_at = datetime.utcnow()
+                    db_session.updated_at = utcnow_naive()
                     updated += 1
             db.commit()
         except Exception as e:

--- a/tests/test_session_routes_utcnow.py
+++ b/tests/test_session_routes_utcnow.py
@@ -1,0 +1,11 @@
+"""Regression: session routes must not call datetime.utcnow() (#1116)."""
+
+import inspect
+
+import routes.session_routes as sr
+
+
+def test_session_routes_module_does_not_reference_utcnow():
+    source = inspect.getsource(sr)
+    assert "datetime.utcnow()" not in source
+    assert "_dt.utcnow()" not in source


### PR DESCRIPTION
## Summary

`routes/session_routes.py` still had eight `datetime.utcnow()` call sites (session `updated_at` stamps, incognito ghost purge cutoff, webhook payload timestamp). This replaces them all with `core.database.utcnow_naive`, consistent with the #1116 deprecation sweep and Python 3.14 readiness.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #1116

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and PRs — `routes/session_routes.py` had no other open utcnow fix PR (only unrelated i18n #4987).
- [x] This PR targets `dev`
- [x] Changes limited to utcnow call sites + regression test
- [ ] I actually ran the app end-to-end — verified via pytest only (timestamp helper swap).

## How to Test

1. `mkdir -p data`
2. `./venv/bin/python -m pytest -q tests/test_session_routes_utcnow.py tests/test_session_list_owner_scope.py tests/test_session_ghost_delete.py tests/test_session_manager_cleanup.py`
3. Confirm `routes/session_routes.py` has no `datetime.utcnow()` or `_dt.utcnow()` references.

## Visual / UI changes

N/A — backend only.