### PR TITLE
feat(macos): add Mac Mini system service installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ docker compose up -d --build
 
 Open `http://localhost:7000` when the containers are healthy. The first admin password is printed in `docker compose logs odysseus`.
 
+**Mac Mini (always-on server):** use `./install-macos-service.sh` to set Odysseus up as a LaunchAgent that starts automatically on login — see the [Mac Mini section](docs/setup.md#mac-mini--install-as-a-system-service) in the setup guide.
+
 Native installs, GPU notes, Windows/macOS instructions, HTTPS, and configuration live in the [setup guide](docs/setup.md).
 
 ## Features

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -78,6 +78,42 @@ expose this port directly to the public internet. To build a clickable app wrapp
 ./build-macos-app.sh
 ```
 
+### Mac Mini — install as a system service
+
+For a Mac Mini running as a home server (always-on, no need to start it manually), install Odysseus as a macOS LaunchAgent. This sets it up to start automatically on every login and restart automatically if it crashes.
+
+```bash
+git clone https://github.com/pewdiepie-archdaemon/odysseus.git
+cd odysseus
+cp .env.example .env   # optional — edit APP_PORT or APP_BIND here before install
+./install-macos-service.sh
+```
+
+The script installs Homebrew dependencies, sets up the Python environment, creates a LaunchAgent plist at `~/Library/LaunchAgents/com.odysseus.app.plist`, and starts the service immediately. On every subsequent login it will start automatically.
+
+After install the UI is at `http://127.0.0.1:7860`. The first admin password is printed in the log:
+
+```bash
+grep -i 'admin password' ~/Library/Logs/Odysseus/odysseus.log | tail -1
+```
+
+**Manage the service:**
+
+```bash
+launchctl stop  com.odysseus.app   # stop
+launchctl start com.odysseus.app   # start
+cat ~/Library/Logs/Odysseus/odysseus.log   # view logs
+```
+
+**Expose over LAN / Tailscale:** set `APP_BIND=0.0.0.0` (and optionally `APP_PORT`) in `.env`, then re-run `./install-macos-service.sh` to reinstall the plist with the new settings.
+
+**Uninstall:**
+
+```bash
+launchctl unload ~/Library/LaunchAgents/com.odysseus.app.plist
+rm ~/Library/LaunchAgents/com.odysseus.app.plist
+```
+
 <details>
 <summary>Cookbook, GPU, Ollama, and troubleshooting notes</summary>
 

--- a/install-macos-service.sh
+++ b/install-macos-service.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+# Install Odysseus as a macOS LaunchAgent so it starts automatically on login.
+#
+#   ./install-macos-service.sh
+#
+# What this does:
+#   1. Runs start-macos.sh to install dependencies and set up the venv (if needed).
+#   2. Writes a LaunchAgent plist to ~/Library/LaunchAgents/.
+#   3. Loads (starts) the service immediately.
+#
+# After install, Odysseus starts automatically every time you log in.
+# The web UI is at http://127.0.0.1:7860 (or APP_PORT / ODYSSEUS_PORT if overridden).
+#
+# Uninstall:
+#   launchctl unload ~/Library/LaunchAgents/com.odysseus.app.plist
+#   rm ~/Library/LaunchAgents/com.odysseus.app.plist
+#
+# Manage the service after install:
+#   launchctl stop  com.odysseus.app   # stop now
+#   launchctl start com.odysseus.app   # start now
+#   cat ~/Library/Logs/Odysseus/odysseus.log   # view logs
+set -e
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$REPO_DIR"
+
+# ── Load .env for APP_PORT / APP_BIND (same logic as start-macos.sh) ──
+if [ -f .env ]; then
+    while IFS='=' read -r key value; do
+        [[ "$key" =~ ^[[:space:]]*# ]] && continue
+        [[ -z "${key// }" ]] && continue
+        value="${value%%#*}"
+        value="${value#"${value%%[![:space:]]*}"}"
+        value="${value%"${value##*[![:space:]]}"}"
+        [ -n "$key" ] && [ -z "${!key+x}" ] && export "$key=$value"
+    done < .env
+fi
+
+PORT="${ODYSSEUS_PORT:-${APP_PORT:-7860}}"
+HOST="${ODYSSEUS_HOST:-${APP_BIND:-127.0.0.1}}"
+
+PLIST_LABEL="com.odysseus.app"
+PLIST_DIR="$HOME/Library/LaunchAgents"
+PLIST_FILE="$PLIST_DIR/$PLIST_LABEL.plist"
+LOG_DIR="$HOME/Library/Logs/Odysseus"
+VENV_UVICORN="$REPO_DIR/venv/bin/uvicorn"
+
+echo "▶ Odysseus — macOS service installer"
+echo "  install dir: $REPO_DIR"
+echo "  port:        $PORT"
+echo "  bind host:   $HOST"
+echo ""
+
+# ── 1. Run start-macos.sh to install deps / set up venv ──
+# ODYSSEUS_NO_OPEN=1 skips the auto-browser-open since we're headless here.
+echo "▶ Running start-macos.sh to set up dependencies (this may take a few minutes on first run)…"
+ODYSSEUS_NO_OPEN=1 "$REPO_DIR/start-macos.sh" &
+SETUP_PID=$!
+
+# Wait for start-macos.sh to finish setup, then kill the server it started.
+# We only need the setup steps; the LaunchAgent will manage the server process.
+wait "$SETUP_PID" || true
+# start-macos.sh keeps the server running in the foreground — kill any uvicorn
+# it started so the LaunchAgent can own the process.
+pkill -f "uvicorn app:app" 2>/dev/null || true
+sleep 1
+
+if [ ! -x "$VENV_UVICORN" ]; then
+    echo "✗ Setup did not produce a venv at $REPO_DIR/venv."
+    echo "  Try running ./start-macos.sh manually to diagnose the issue."
+    exit 1
+fi
+echo "▶ Setup complete."
+echo ""
+
+# ── 2. Create log directory ──
+mkdir -p "$LOG_DIR"
+
+# ── 3. Write the LaunchAgent plist ──
+mkdir -p "$PLIST_DIR"
+echo "▶ Writing LaunchAgent plist to $PLIST_FILE…"
+
+cat > "$PLIST_FILE" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${PLIST_LABEL}</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>${VENV_UVICORN}</string>
+        <string>app:app</string>
+        <string>--host</string>
+        <string>${HOST}</string>
+        <string>--port</string>
+        <string>${PORT}</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>${REPO_DIR}</string>
+
+    <!-- Start automatically when the user logs in -->
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- Restart automatically if the process crashes -->
+    <key>KeepAlive</key>
+    <true/>
+
+    <!-- Log stdout/stderr to ~/Library/Logs/Odysseus/ -->
+    <key>StandardOutPath</key>
+    <string>${LOG_DIR}/odysseus.log</string>
+    <key>StandardErrorPath</key>
+    <string>${LOG_DIR}/odysseus.log</string>
+
+    <!-- Throttle restart attempts (seconds between automatic restarts) -->
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+</dict>
+</plist>
+PLIST
+
+echo "  written."
+echo ""
+
+# ── 4. Unload any existing instance, then load the new one ──
+if launchctl list | grep -q "$PLIST_LABEL" 2>/dev/null; then
+    echo "▶ Stopping existing Odysseus service…"
+    launchctl unload "$PLIST_FILE" 2>/dev/null || true
+fi
+
+echo "▶ Loading Odysseus service (will start immediately and on every login)…"
+launchctl load "$PLIST_FILE"
+
+# Give the process a moment to start.
+sleep 3
+
+# ── 5. Verify it's running ──
+URL_HOST="$HOST"
+[ "$URL_HOST" = "0.0.0.0" ] || [ "$URL_HOST" = "::" ] && URL_HOST="127.0.0.1"
+URL="http://$URL_HOST:$PORT"
+
+echo ""
+if launchctl list | grep -q "$PLIST_LABEL"; then
+    echo "  ✓ Odysseus service is loaded."
+else
+    echo "  ⚠ Service may not have started — check logs:"
+    echo "    cat $LOG_DIR/odysseus.log"
+fi
+
+echo ""
+echo "┌──────────────────────────────────────────────────────────────────────┐"
+echo "│  Odysseus is installed as a macOS service.                           │"
+echo "│                                                                      │"
+printf "│  Web UI:      %-54s │\n" "$URL"
+echo "│  Logs:        $LOG_DIR/odysseus.log"
+echo "│                                                                      │"
+echo "│  It starts automatically every time you log in.                     │"
+echo "│                                                                      │"
+echo "│  To stop now:        launchctl stop  $PLIST_LABEL   │"
+echo "│  To start now:       launchctl start $PLIST_LABEL   │"
+echo "│  To uninstall:       launchctl unload $PLIST_FILE"
+echo "│                      rm $PLIST_FILE"
+echo "└──────────────────────────────────────────────────────────────────────┘"
+echo ""
+echo "First login password is in the log:"
+echo "  grep -i 'admin password' $LOG_DIR/odysseus.log | tail -1"


### PR DESCRIPTION
Add install-macos-service.sh, which runs start-macos.sh to set up dependencies and then installs Odysseus as a macOS LaunchAgent at ~/Library/LaunchAgents/com.odysseus.app.plist.  The service starts automatically on every login, restarts on crash, and logs to ~/Library/Logs/Odysseus/odysseus.log.

Document the new workflow in docs/setup.md under a dedicated "Mac Mini — install as a system service" section, and add a short pointer in README.md.


Claude-Session: https://claude.ai/code/session_01LDku6tc8kCw1oUt8ZLwUi1

## Summary

<!-- One paragraph: what changed and why. "Fixed bug" and "Added feature" are not summaries. -->

## Target branch

- [ ] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

<!-- Every PR should be linked to an issue.
     Use one of:  Fixes #NNN  |  Part of #NNN  |  Closes #NNN  -->

Fixes #

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [ ] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [ ] This PR targets `dev`
- [ ] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

<!-- Step-by-step instructions a reviewer can follow to verify this works.
     Do not leave this empty — a PR without test steps will be sent back. -->

1.
2.
3.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

<!-- Drag and drop images or a screen recording here. Required for any UI/visual change. -->
