### PR TITLE
fix(agent): confine glob literal lookups to the search root

### DIFF
--- a/src/agent_tools/filesystem_tools.py
+++ b/src/agent_tools/filesystem_tools.py
@@ -288,11 +288,26 @@ class GlobTool:
             base = os.path.abspath(root)
             if not os.path.isdir(base):
                 return None, f"glob: {root}: not a directory"
+            rbase = os.path.realpath(base)
             norm_pat = pattern.replace("\\", "/")
             # Fast path: literal pattern (no wildcards) → direct path lookup.
             if not any(c in norm_pat for c in "*?["):
-                cand = os.path.normpath(os.path.join(base, norm_pat))
-                if os.path.exists(cand):
+                cand = os.path.realpath(os.path.join(base, norm_pat))
+                # Keep the literal lookup inside the search root. os.path.join
+                # lets an absolute pattern (or one containing ../) escape `base`,
+                # which would turn glob into an existence/path oracle for
+                # arbitrary host files — bypassing the workspace/allowlist
+                # confinement that _resolve_search_root applies to the root.
+                # An escaping literal falls through to the walk, which only ever
+                # yields paths under base.
+                nbase = os.path.normcase(rbase)
+                try:
+                    inside = cand == rbase or os.path.commonpath(
+                        [os.path.normcase(cand), nbase]
+                    ) == nbase
+                except ValueError:
+                    inside = False
+                if inside and os.path.exists(cand):
                     return [cand], None
                 # Literal not at exact path — fall through to walk so
                 # e.g. "foo.py" still matches at any depth (like rglob).

--- a/tests/test_workspace_confine.py
+++ b/tests/test_workspace_confine.py
@@ -141,6 +141,33 @@ async def test_grep_and_ls_confined_e2e(ws, admin):
 
 
 @pytest.mark.asyncio
+async def test_glob_confined_e2e(ws, admin):
+    """glob's literal fast-path must stay inside the workspace. A pattern with
+    ../ or an absolute path outside the root would otherwise leak the existence
+    and full path of arbitrary host files (an oracle), even though read_file
+    blocks reading them."""
+    with open(os.path.join(ws, "found.py"), "w") as f:
+        f.write("x")
+    _, r = await execute_tool_block(_block("glob", json.dumps({"pattern": "found.py"})), owner="a", workspace=ws)
+    assert r["exit_code"] == 0 and "found.py" in r["output"]
+
+    # a secret outside the workspace must not be discoverable via glob
+    outside = tempfile.mkdtemp()
+    secret = os.path.join(outside, "secret.txt")
+    with open(secret, "w") as f:
+        f.write("nope")
+    # An escaping pattern must come back as "No files" (the not-found message),
+    # not as a match that returns the file's path. The not-found message echoes
+    # the pattern the model supplied, so the signal is the absence of a match,
+    # not the absence of the path string.
+    rel = os.path.relpath(secret, os.path.realpath(ws))
+    _, r = await execute_tool_block(_block("glob", json.dumps({"pattern": rel})), owner="a", workspace=ws)
+    assert r["exit_code"] == 0 and "No files" in r["output"] and secret not in r["output"]
+    _, r = await execute_tool_block(_block("glob", json.dumps({"pattern": secret})), owner="a", workspace=ws)
+    assert r["exit_code"] == 0 and "No files" in r["output"]
+
+
+@pytest.mark.asyncio
 async def test_subprocess_cwd_is_workspace_e2e(ws, admin):
     """python tool runs with cwd = workspace (OS-agnostic probe)."""
     _, r = await execute_tool_block(_block("python", "import os; print(os.getcwd())"), owner="a", workspace=ws)


### PR DESCRIPTION
## Summary

The `glob` agent tool could return the full path and confirm the existence of files **outside** the active workspace / allowed roots, while `read_file`, `write_file`, `grep`, and `ls` all stayed confined. `GlobTool` resolves its search root through `_resolve_search_root` (which confines it), but the literal fast-path then joined the model-supplied `pattern` straight onto that root with `os.path.join` + `normpath` and returned the result as soon as it existed — no containment check. An absolute pattern, or one with `../`, escaped the root, turning `glob` into a filesystem existence/path oracle that bypasses the confinement boundary (the agent file tools' threat model is prompt-injection in an admin chat — see the docstring in `src/tool_execution.py`).

The fix confines the literal candidate to the search root with a `commonpath` containment check (case-normalised, so it holds on case-insensitive filesystems). A literal that escapes the root falls through to the existing `os.walk` matcher, which only ever yields paths under the root, so legitimate behaviour — bare literals matching at any depth like `rglob`, nested literals, and wildcard patterns — is unchanged. The wildcard path was already confined.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #5009

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Bind a workspace (or rely on the default data-dir allowlist) and create a secret file outside it, e.g. `/tmp/outside/secret.txt`.
2. Call the `glob` tool with `{"pattern": "../outside/secret.txt"}` (or the absolute path to the secret).
3. Before the fix: `glob` returns the absolute path of `secret.txt`, confirming it exists, even though `read_file` on that same path is rejected as outside the workspace.
4. After the fix: `glob` returns `No files matching …`, and an in-workspace lookup (`{"pattern": "found.py"}` for a file in the workspace) still resolves normally.

Automated: `pytest tests/test_workspace_confine.py` — the new `test_glob_confined_e2e` fails on the unpatched tree and passes with the fix.

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI/`static/` changes — backend tool path handling only.
