### PR TITLE
fix(agent): skip deny-listed sensitive files in grep

### DIFF
--- a/src/agent_tools/filesystem_tools.py
+++ b/src/agent_tools/filesystem_tools.py
@@ -333,7 +333,10 @@ class GlobTool:
 
 class GrepTool:
     async def execute(self, content: str, ctx: dict) -> dict:
-        from src.tool_execution import _resolve_tool_path, _resolve_search_root, _truncate
+        from src.tool_execution import (
+            _resolve_tool_path, _resolve_search_root, _truncate,
+            _is_sensitive_path, _SENSITIVE_BASENAMES, _SENSITIVE_FILE_PATTERNS,
+        )
         args: Dict[str, Any] = {}
         _s = (content or "").strip()
         if _s.startswith("{"):
@@ -371,6 +374,15 @@ class GrepTool:
                     cmd += ["--glob", glob_pat]
                 for _d in _CODENAV_SKIP_DIRS:
                     cmd += ["--glob", f"!**/{_d}/**"]
+                # Never search files the read-tool deny-list protects (.ssh,
+                # .env, id_rsa, ...). rg skips hidden files by default but still
+                # reads non-hidden key files (id_rsa, known_hosts), so exclude
+                # them explicitly — otherwise grep returns the contents of files
+                # read_file refuses to open.
+                for _b in _SENSITIVE_BASENAMES:
+                    cmd += ["--glob", f"!**/{_b}", "--glob", f"!**/{_b}/**"]
+                for _p in _SENSITIVE_FILE_PATTERNS:
+                    cmd += ["--glob", f"!**/{_p}"]
                 cmd += ["--regexp", pattern, root]
                 try:
                     import subprocess
@@ -391,11 +403,15 @@ class GrepTool:
             else:
                 file_iter = []
                 for dp, dns, fns in os.walk(root):
-                    dns[:] = [d for d in dns if d not in _CODENAV_SKIP_DIRS]
+                    dns[:] = [d for d in dns
+                              if d not in _CODENAV_SKIP_DIRS and d not in _SENSITIVE_BASENAMES]
                     for fn in fns:
                         if glob_pat and not fnmatch.fnmatch(fn, glob_pat):
                             continue
-                        file_iter.append(os.path.join(dp, fn))
+                        fp = os.path.join(dp, fn)
+                        if _is_sensitive_path(fp):
+                            continue
+                        file_iter.append(fp)
             for fp in file_iter:
                 if len(hits) >= max_hits:
                     break

--- a/tests/test_workspace_confine.py
+++ b/tests/test_workspace_confine.py
@@ -141,6 +141,30 @@ async def test_grep_and_ls_confined_e2e(ws, admin):
 
 
 @pytest.mark.asyncio
+async def test_grep_skips_sensitive_files_in_workspace(ws, admin):
+    """grep must honor the same sensitive-file deny-list as read_file. A key or
+    env file living inside the workspace would otherwise have its CONTENTS
+    returned by grep even though read_file refuses to open it (prompt-injection
+    secret exfil). The token is searched, not matched against names, so this
+    catches both the ripgrep and pure-Python grep paths."""
+    token = "SENSITIVE_TOKEN_4F2A"
+    with open(os.path.join(ws, "id_rsa"), "w") as f:
+        f.write(f"-----BEGIN KEY-----\n{token}\n")
+    os.makedirs(os.path.join(ws, ".ssh"), exist_ok=True)
+    with open(os.path.join(ws, ".ssh", "authorized_keys"), "w") as f:
+        f.write(f"ssh-rsa {token}\n")
+    with open(os.path.join(ws, "notes.txt"), "w") as f:  # ordinary file with same token
+        f.write(f"see {token} here\n")
+
+    _, r = await execute_tool_block(_block("grep", json.dumps({"pattern": token})), owner="a", workspace=ws)
+    assert r["exit_code"] == 0
+    # the ordinary file is still searchable; the key / authorized_keys are not
+    assert "notes.txt" in r["output"]
+    assert "id_rsa" not in r["output"]
+    assert "authorized_keys" not in r["output"]
+
+
+@pytest.mark.asyncio
 async def test_subprocess_cwd_is_workspace_e2e(ws, admin):
     """python tool runs with cwd = workspace (OS-agnostic probe)."""
     _, r = await execute_tool_block(_block("python", "import os; print(os.getcwd())"), owner="a", workspace=ws)


### PR DESCRIPTION
## Summary

`grep` returned the contents of files the sensitive-file deny-list is meant to protect (`id_rsa`, `.env`, `authorized_keys`, `known_hosts`, shell rc files) when they sit inside the search root, even though `read_file` / `write_file` / `edit_file` refuse to open the very same files. The deny-list (`_is_sensitive_path` in `src/tool_execution.py`) is applied when those tools resolve a path and when `grep` resolves its search *root*, but `grep`'s file walk never re-applied it to the files it actually searched. That made `grep` a way around the deny-list: a single search for a likely token over a workspace containing a `.env` or `id_rsa` returns the secret itself — prompt-injection in an admin chat turned into exfiltration. The pure-Python path searched everything; the ripgrep path skips hidden files by default but still read non-hidden keys like `id_rsa` and `known_hosts`.

The fix excludes deny-listed files in both code paths: ripgrep gets `--glob` exclusions for the sensitive basenames and filename patterns (mirroring the existing skip-dir exclusions a few lines above), and the `os.walk` fallback skips sensitive directories and files via the existing `_is_sensitive_path`. Searching ordinary files is unchanged. `ls` already skips dotfiles, so code-nav was already meant to hide these; this brings `grep` in line. (`glob` has a lower-severity path-enumeration variant that touches the same function as an open PR, so it's left for a separate change.)

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #5011

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Bind a workspace that contains `id_rsa` with a line like `PRIVATEKEYMATERIAL` (and optionally a `.env` with a secret).
2. `read_file id_rsa` — rejected as a sensitive path.
3. Before the fix: `grep` with `{"pattern": "PRIVATEKEYMATERIAL"}` returns `…/id_rsa:2:PRIVATEKEYMATERIAL` — the key contents.
4. After the fix: `grep` returns `No matches …`, while grepping an ordinary file in the same workspace still returns its matches.

Automated: `pytest tests/test_workspace_confine.py` — the new `test_grep_skips_sensitive_files_in_workspace` fails on the unpatched tree and passes with the fix, on both the ripgrep and pure-Python grep paths.

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI/`static/` changes — backend tool path handling only.
