### PR TITLE
fix(security): apply sensitive-file deny-list to grep tool (#5011)

### DIFF
--- a/src/agent_tools/filesystem_tools.py
+++ b/src/agent_tools/filesystem_tools.py
@@ -333,7 +333,13 @@ class GlobTool:
 
 class GrepTool:
     async def execute(self, content: str, ctx: dict) -> dict:
-        from src.tool_execution import _resolve_tool_path, _resolve_search_root, _truncate
+        from src.tool_execution import (
+            _SENSITIVE_FILE_PATTERNS,
+            _is_sensitive_path,
+            _resolve_tool_path,
+            _resolve_search_root,
+            _truncate,
+        )
         args: Dict[str, Any] = {}
         _s = (content or "").strip()
         if _s.startswith("{"):
@@ -369,6 +375,8 @@ class GrepTool:
                     cmd.append("--ignore-case")
                 if glob_pat:
                     cmd += ["--glob", glob_pat]
+                for _pat in _SENSITIVE_FILE_PATTERNS:
+                    cmd += ["--glob", f"!*{_pat}*"]
                 for _d in _CODENAV_SKIP_DIRS:
                     cmd += ["--glob", f"!**/{_d}/**"]
                 cmd += ["--regexp", pattern, root]
@@ -399,6 +407,8 @@ class GrepTool:
             for fp in file_iter:
                 if len(hits) >= max_hits:
                     break
+                if _is_sensitive_path(os.path.realpath(fp)):
+                    continue
                 try:
                     with open(fp, "r", encoding="utf-8", errors="strict") as f:
                         for i, line in enumerate(f, 1):


### PR DESCRIPTION
## Summary

The grep tool bypasses the sensitive-file deny-list that read_file, write_file, and edit_file all respect. A model-injected prompt can use `grep` to read the contents of `id_rsa`, `.env`, `authorized_keys`, `known_hosts`, and other sensitive files even though the deny-list correctly blocks direct reads of those files.

**Fix**: Two code paths in `_grep()` updated in `src/agent_tools/filesystem_tools.py`:
1. **ripgrep path**: Adds `--glob !*<pattern>*` exclusions for each entry in `_SENSITIVE_FILE_PATTERNS`.
2. **Python os.walk path**: Skips files where `_is_sensitive_path(os.path.realpath(fp))` returns true.

## Linked Issue

Fixes #5011

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Other

## Checklist

- [x] I searched existing issues and PRs before opening this one
- [x] My changes follow the project style
- [x] My changes are minimal and focused

## How to Test

1. Create a test directory with a `normal.txt` (contents: `needle here`) and sensitive files like `id_rsa`, `.env`, `authorized_keys`, `known_hosts`
2. Run `grep` with pattern `needle` over the directory
3. Verify `normal.txt` matches are returned
4. Verify `id_rsa`, `.env`, `authorized_keys`, `known_hosts` do NOT appear in the output (same deny-list protection as `read_file` and `write_file`)
5. The existing test suite in `tests/test_code_nav_tools.py` covers normal grep functionality and continues to pass