### PR TITLE
Add /think and /nothink sticky reasoning toggle

### DIFF
--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -795,6 +795,13 @@ import { wireArrowUpRecall, getLastUserMessageFromChatHistory } from './composer
       if (_inject.prefix) _finalMsgWithInject = _inject.prefix + ' ' + _finalMsgWithInject;
       if (_inject.suffix) _finalMsgWithInject = _finalMsgWithInject + ' ' + _inject.suffix;
 
+      // Sticky /nothink mode: append the suppression token to the payload only
+      // (the visible bubble keeps `finalMsg`) so reasoning models skip their
+      // chain-of-thought. Flipped via the /think and /nothink slash commands.
+      if (slashCommands.getThinkMode && !slashCommands.getThinkMode()) {
+        _finalMsgWithInject += ' /no_think';
+      }
+
       const fd = new FormData();
       fd.append('message', _finalMsgWithInject);
       fd.append('session', streamSessionId);

--- a/static/js/slashCommands.js
+++ b/static/js/slashCommands.js
@@ -27,6 +27,13 @@ import { PROVIDER_DEVICE_FLOWS, formatDeviceFlowError, runProviderDeviceFlow } f
 
 let API_BASE = '';
 let setupMode = false;
+// Sticky thinking mode for reasoning models (Qwen3, DeepSeek-R1, etc.). When
+// off, an `/no_think` suffix is appended to each outgoing message payload (not
+// the visible bubble) so the model skips its chain-of-thought. Flipped by the
+// /think and /nothink commands; persisted so it survives a reload.
+let thinkMode = (() => {
+  try { return localStorage.getItem('odysseus-think-mode') !== 'off'; } catch (_) { return true; }
+})();
 let pendingSetupApiKey = '';
 let pendingSetupProvider = null;
 let setupIntroShown = false;
@@ -1211,6 +1218,21 @@ async function _cmdToggleWeb(args, ctx) { const v = (args[0]||'').toLowerCase();
 async function _cmdToggleBash(args, ctx) { const v = (args[0]||'').toLowerCase(); if (v === 'on' || v === 'off') _applyToggle('bash', v); else _quickToggle('bash'); return true; }
 async function _cmdToggleRag(args, ctx) { const v = (args[0]||'').toLowerCase(); if (v === 'on' || v === 'off') _applyToggle('rag', v); else _quickToggle('rag'); return true; }
 async function _cmdToggleResearch(args, ctx) { const v = (args[0]||'').toLowerCase(); if (v === 'on' || v === 'off') _applyToggle('research', v); else _quickToggle('research'); return true; }
+
+function _setThinkMode(on) {
+  thinkMode = on;
+  try { localStorage.setItem('odysseus-think-mode', on ? 'on' : 'off'); } catch (_) {}
+}
+async function _cmdThink() {
+  _setThinkMode(true);
+  slashReply('🧠 Thinking <b>ON</b> — the model reasons before replying. Stays on until <code>/nothink</code>.');
+  return true;
+}
+async function _cmdNoThink() {
+  _setThinkMode(false);
+  slashReply('⚡ Thinking <b>OFF</b> — fast, direct replies. Stays off until <code>/think</code>. <span style="opacity:0.6">(reasoning models only)</span>');
+  return true;
+}
 async function _cmdToggleIncognito(args, ctx) {
   const sessions = sessionModule.getSessions();
   const sess = ctx.sid ? sessions.find(s => s.id === ctx.sid) : null;
@@ -5789,6 +5811,22 @@ const COMMANDS = {
     noUserBubble: true,
     usage: '/workspace [set <path> | clear | pick]',
   },
+  think: {
+    alias: ['reason'],
+    category: 'Quick toggles',
+    help: 'Reasoning ON for following messages (until /nothink)',
+    handler: _cmdThink,
+    noUserBubble: true,
+    usage: '/think',
+  },
+  nothink: {
+    alias: ['no-think', 'notthink', 'fast'],
+    category: 'Quick toggles',
+    help: 'Reasoning OFF for following messages (until /think)',
+    handler: _cmdNoThink,
+    noUserBubble: true,
+    usage: '/nothink',
+  },
   memory: {
     alias: ['m'],
     category: 'Memory',
@@ -6485,6 +6523,15 @@ export function getSetupMode() {
 }
 
 /**
+ * Whether reasoning/thinking is currently enabled. False means each outgoing
+ * message gets a `/no_think` suffix appended to its payload. Sticky until the
+ * user flips it with /think or /nothink.
+ */
+export function getThinkMode() {
+  return thinkMode;
+}
+
+/**
  * Clear setup mode (e.g. when a slash command is typed during setup).
  */
 export function clearSetupMode(preservePendingState = false) {
@@ -6501,6 +6548,7 @@ const slashCommands = {
   initSlashCommands,
   isCommand,
   getSetupMode,
+  getThinkMode,
   clearSetupMode,
   handleSlashCommand,
   handleSetupInput,


### PR DESCRIPTION
## What

Two new chat slash commands that flip a **sticky** reasoning mode for thinking models (Qwen3, DeepSeek-R1, etc.):

- **`/nothink`** (aliases `/no-think`, `/fast`) — turns reasoning OFF. Stays off for every following message until re-enabled.
- **`/think`** (alias `/reason`) — turns reasoning back ON.

## Why

Reasoning models emit chain-of-thought on every turn — even "hey". That's wasted tokens, slow replies, and real heat on low-power machines (e.g. a fanless M-series laptop). Users want to drop into a fast no-think mode for casual chat and flip reasoning back on for hard/research tasks, without editing config each time.

## How

- Adds a `thinkMode` flag in `slashCommands.js`, persisted to `localStorage` (survives reload), mirroring the existing `setupMode` pattern.
- When off, appends a `/no_think` suffix to the **outgoing message payload only** at the existing inject-suffix point in `chat.js` — the visible chat bubble stays clean.
- Sticky across messages until the user flips it.

No backend changes; relies on the model honoring the `/no_think` token (Qwen3 convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)