### PR TITLE
fix(tools): handle non-dict JSON values in _parse_tool_args (closes #5043)

### DIFF
--- a/src/tool_utils.py
+++ b/src/tool_utils.py
@@ -54,6 +54,8 @@ def _parse_tool_args(content):
     if isinstance(content, str):
         try:
             args = json.loads(content) if content.strip() else {}
+            if not isinstance(args, dict):
+                args = {}
         except (json.JSONDecodeError, TypeError) as e:
             raise ValueError(str(e))
     elif isinstance(content, dict):

--- a/tests/test_admin_tools_registry.py
+++ b/tests/test_admin_tools_registry.py
@@ -72,3 +72,8 @@ def test_parse_tool_args_lives_in_tool_utils_single_source():
     assert _parse_tool_args('{"action":"add"}') == {"action": "add"}
     # body-envelope unwrap still works
     assert _parse_tool_args('{"body":{"action":"x"}}') == {"action": "x"}
+
+    # non-dict JSON values should return {}
+    assert _parse_tool_args('[1, 2]') == {}
+    assert _parse_tool_args('42') == {}
+    assert _parse_tool_args('"hello"') == {}


### PR DESCRIPTION
## Summary

This PR updates `_parse_tool_args` to gracefully handle cases where the LLM emits a valid JSON string that parses to a native non-dict type (e.g., `[1, 2]`, `42`, or `"string"`). Previously, `json.loads` would successfully return these objects, and callers expecting a dictionary would crash with `AttributeError` or `KeyError` when attempting to access keys. Now, `_parse_tool_args` explicitly validates that the parsed JSON is a `dict`, and returns an empty dictionary `{}` if it is not, allowing callers to cleanly handle the missing action.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #5043

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run the test suite: `python3 -m pytest tests/test_admin_tools_registry.py` to ensure the new non-dict JSON tests pass.
2. Trigger an agent in the UI with a prompt specifically designed to return a JSON array instead of a dict for a tool call (e.g., "Output the JSON array `[1,2,3]` as your tool argument").
3. Verify that the agent handles the response gracefully instead of crashing with an `AttributeError`.

## Visual / UI changes — REQUIRED if you touched anything that renders

- [x] **No visual change.** This is a backend bug fix only.