### PR TITLE
fix(tools): guard _parse_tool_args against non-dict JSON values

### DIFF
--- a/src/tool_utils.py
+++ b/src/tool_utils.py
@@ -60,6 +60,12 @@ def _parse_tool_args(content):
         args = content
     else:
         args = {}
+    # Guard: json.loads can return a list, int, or other non-dict JSON value.
+    # Every caller does args.get("action") / args["key"], which crashes with
+    # AttributeError on a list or TypeError on an int. Coerce to empty dict
+    # so the caller falls through to its "missing action" error path cleanly.
+    if not isinstance(args, dict):
+        args = {}
     # Unwrap {"body": {...}} envelope, but only if `body` is the sole key
     # and points at a dict. We don't want to clobber a legitimate `body`
     # field on tools where it's a real arg (e.g. send_email body text).


### PR DESCRIPTION
## Summary

`_parse_tool_args()` uses `json.loads()` which can return non-dict JSON values (list, int, bool, string) when an LLM emits valid JSON that isn't a dict (e.g. `[1,2]` or `42`). Every caller does `args.get("action")`, crashing with `AttributeError` on non-dict types. This PR adds an `isinstance(args, dict)` guard after `json.loads` to coerce non-dict values to `{}`, so callers fall through to their "missing action" error path cleanly instead of crashing the tool round.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #5043

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Open a Python shell in the project root
2. Verify non-dict values are coerced instead of crashing callers:

```python
from src.tool_utils import _parse_tool_args

assert _parse_tool_args('[1, 2, 3]') == {}    # was: caller AttributeError
assert _parse_tool_args('42') == {}            # was: caller AttributeError
assert _parse_tool_args('true') == {}          # was: caller AttributeError
assert _parse_tool_args('"hello"') == {}       # was: caller KeyError
assert _parse_tool_args('{"action": "list"}') == {"action": "list"}  # still works
print("All assertions passed")
```

3. In the running app, drive a chat with a small local model that emits a malformed tool call (bare JSON array as arguments) — the tool now responds with the normal "missing action" error message instead of a 500 in the agent loop.