### PR TITLE
fix(email/frontend): propagate owner on bare email dispatch + strip inline-args fences live (follow-up to #3681)

### DIFF
--- a/src/tool_execution.py
+++ b/src/tool_execution.py
@@ -907,6 +907,14 @@ async def _execute_tool_block_impl(
             if _args_error is not None:
                 result = {"error": _args_error, "exit_code": 1}
             else:
+                # Mirror the qualified mcp__email__ path below: the email MCP
+                # server uses the hidden owner to scope visible accounts and to
+                # fail closed when multiple owners are configured. Without it a
+                # bare alias runs ownerless and can hit the default/global
+                # mailbox or be rejected on multi-owner installs.
+                if owner:
+                    args = dict(args)
+                    args[_EMAIL_MCP_OWNER_ARG] = owner
                 result = await mcp.call_tool(qualified, args)
         else:
             result = {"error": "MCP manager not available", "exit_code": 1}

--- a/static/js/chatRenderer.js
+++ b/static/js/chatRenderer.js
@@ -433,8 +433,14 @@ async function loadExecFenceRegex() {
       .map((t) => t.id)
       .filter((id) => id && !EXEC_FENCE_NON_TOOL.has(id));
     if (tags.length) {
+      // Mirror the backend's _TOOL_BLOCK_RE shape: after the tag, optional
+      // same-line inline JSON args ({…}/[…]) may precede the newline — the
+      // backend now executes that inline-args form (```list_email_accounts {}),
+      // so the live stripper must remove it too, not just the classic
+      // tag-then-newline form, or the raw fence lingers until reload (#3993).
       EXEC_FENCE_RE = new RegExp(
-        '```(?:' + tags.join('|') + ')\\s*\\n[\\s\\S]*?```', 'gi'
+        '```(?:' + tags.join('|') + ')(?![\\w-])[ \\t]*(?:[{\\[][^\\n]*?)?[ \\t]*(?=\\r?\\n|```)\\r?\\n?[\\s\\S]*?```',
+        'gi'
       );
     }
   } catch (err) {

--- a/tests/test_live_strip_email_tool_fences.py
+++ b/tests/test_live_strip_email_tool_fences.py
@@ -43,10 +43,19 @@ def _tool_tags() -> set[str]:
 
 def _exec_fence_regex() -> re.Pattern:
     """Rebuild EXEC_FENCE_RE's behavior from the same source the live regex now
-    derives from: the backend TOOL_TAGS (served via /api/tools) minus bash/python."""
+    derives from: the backend TOOL_TAGS (served via /api/tools) minus bash/python.
+
+    Mirrors chatRenderer.js's EXEC_FENCE_RE, which itself mirrors the backend
+    _TOOL_BLOCK_RE: the tag may be followed by same-line inline JSON args
+    ({…}/[…]) before the newline (the executable inline-args form), not only the
+    classic tag-then-newline shape."""
     tags = _tool_tags() - _NON_STRIPPED
     assert tags, "TOOL_TAGS is empty"
-    return re.compile(r"```(?:" + "|".join(sorted(tags)) + r")\s*\n[\s\S]*?```", re.IGNORECASE)
+    return re.compile(
+        r"```(?:" + "|".join(sorted(tags)) + r")(?![\w-])"
+        r"[ \t]*(?:[{\[][^\n]*?)?[ \t]*(?=\r?\n|```)\r?\n?[\s\S]*?```",
+        re.IGNORECASE,
+    )
 
 
 def test_strips_executed_email_tool_fences():
@@ -66,6 +75,45 @@ def test_strips_every_named_email_tool_fence():
     for tool in email_tools:
         fence = f"```{tool}\n{{}}\n```"
         assert rx.sub("", fence).strip() == "", f"{tool} fence not stripped"
+
+
+def test_strips_executed_inline_args_email_fence():
+    """The backend now executes same-line JSON fences (```list_email_accounts {}
+    / ```list_emails {"max_results":10}), so the live stripper must remove that
+    inline-args form too — otherwise the raw executed fence lingers in the live
+    bubble until reload (#3993 class)."""
+    rx = _exec_fence_regex()
+    for text in (
+        'Done.\n\n```list_email_accounts {}\n```',
+        'Done.\n\n```list_emails {"max_results":10}\n```',
+        'Done.\n\n```search_emails {"query": "alice"}\n```',
+    ):
+        assert rx.sub("", text).strip() == "Done.", text
+
+
+def test_inline_args_does_not_strip_bash_python_examples():
+    """The inline-args allowance must not start stripping ```bash {title="x"} /
+    ```python {…} — those are fence attributes on real languages, carved out of
+    the live regex exactly like the backend keeps them display-only."""
+    rx = _exec_fence_regex()
+    for lang in sorted(_NON_STRIPPED):
+        example = f'```{lang} {{"title": "x"}}\nls -la\n```'
+        assert rx.sub("", example) == example, f"{lang} inline example wrongly stripped"
+
+
+def test_frontend_exec_fence_allows_inline_args():
+    """Root-cause guard tying this test to the JS: chatRenderer.js's
+    EXEC_FENCE_RE must accept optional same-line {…}/[…] args after the tag (the
+    backend's executable inline-args shape), not just tag-then-newline."""
+    source = _SRC.read_text(encoding="utf-8")
+    m = re.search(r"EXEC_FENCE_RE = new RegExp\((?P<body>.*?)\);", source, re.DOTALL)
+    assert m, "EXEC_FENCE_RE construction not found in chatRenderer.js"
+    body = m.group("body")
+    assert "[{" in body, (
+        "EXEC_FENCE_RE must allow optional same-line {…}/[…] inline args after "
+        "the tag so executed inline-args fences strip live (#3993); got a "
+        "pattern that still requires tag-then-newline only."
+    )
 
 
 def test_preserves_existing_web_search_stripping():

--- a/tests/test_review_regressions.py
+++ b/tests/test_review_regressions.py
@@ -918,7 +918,9 @@ async def test_plan_mode_blocks_mutating_email_aliases_without_mcp_inventory(mon
         disabled_tools=denied,
     )
     assert result["exit_code"] == 0
-    assert mcp.calls == [("mcp__email__search_emails", {"query": "x"})]
+    assert mcp.calls == [
+        ("mcp__email__search_emails", {"query": "x", "_odysseus_owner": "admin-user"}),
+    ]
 
 
 @pytest.mark.asyncio
@@ -937,7 +939,33 @@ async def test_bare_email_dispatch_empty_content_calls_with_empty_args(monkeypat
         owner="admin-user",
     )
     assert result["exit_code"] == 0
-    assert mcp.calls == [("mcp__email__list_email_accounts", {})]
+    # Empty-args call still carries the hidden owner (mirrors the qualified path).
+    assert mcp.calls == [
+        ("mcp__email__list_email_accounts", {"_odysseus_owner": "admin-user"}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_bare_email_dispatch_includes_hidden_owner(monkeypatch):
+    """A bare email alias (e.g. ```list_emails {...}``` from a fenced model)
+    must reach the MCP server with the hidden _odysseus_owner, exactly like the
+    qualified mcp__email__ path. Without it the email server can't scope visible
+    accounts to the request owner and fails closed on multi-owner installs."""
+    _install_admin_auth_stub(monkeypatch)
+    import src.tool_execution as tool_execution
+    from src.tool_execution import execute_tool_block
+
+    mcp = _FakeMcpManager()
+    monkeypatch.setattr(tool_execution, "get_mcp_manager", lambda: mcp)
+
+    desc, result = await execute_tool_block(
+        SimpleNamespace(tool_type="list_emails", content='{"folder": "INBOX"}'),
+        owner="alice",
+    )
+    assert result["exit_code"] == 0
+    assert mcp.calls == [
+        ("mcp__email__list_emails", {"folder": "INBOX", "_odysseus_owner": "alice"}),
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Follow-up to the review on #3681 (thanks @RaresKeY) — that PR merged, so its two remaining findings are addressed here against current `dev`.

### 1. (P2, email/owner) Bare email aliases dropped the authenticated owner before calling MCP
`src/tool_execution.py` — the bare-email alias branch (fenced models emitting ```` ```list_emails {…} ````) routed to `mcp__email__*` **without** the hidden `_odysseus_owner` argument that the qualified `mcp__email__` branch adds. The email MCP server uses that owner to scope visible accounts and to fail closed when multiple owners are configured, so bare-alias calls ran ownerless — multi-owner installs could reject them with the owner-required error despite an authenticated request owner, and single-owner installs could read the default/global mailbox.

Fix mirrors the qualified path: copy `args` and set `_odysseus_owner` when `owner` is present, before the bare branch calls MCP. Adds `test_bare_email_dispatch_includes_hidden_owner` (`list_emails`, `owner="alice"`, asserts the hidden owner reaches the MCP manager) and updates the two existing bare-dispatch assertions that were pinning the old ownerless shape.

### 2. (P3, frontend) Live stripping missed executed inline-argument fences
`static/js/chatRenderer.js` — the backend now executes same-line JSON fences (```` ```list_email_accounts {} ````), but `EXEC_FENCE_RE` still required a newline immediately after the tag, so an executed inline-args fence stayed rendered as a raw code block in the live bubble until reload (#3993 class; the persisted/backend-stripped path was already clean).

Fix mirrors the backend `_TOOL_BLOCK_RE` shape: allow an optional same-line `{…}`/`[…]` inline-args run after the tag before the newline. The `bash`/`python` carve-out is unchanged. Updates the Python mirror in `test_live_strip_email_tool_fences.py` to the same shape and adds inline-args strip regressions, a `bash`/`python` inline non-strip guard, and a source-level guard that the JS regex permits inline args.

### Validation
- Focused email/owner/parser/strip set green: `test_review_regressions` (bare + qualified owner, plan-mode, inline-args), `test_live_strip_email_tool_fences`, `test_email_owner_scope`, `test_email_registry_sync`, `test_fenced_inline_args`, `test_fenced_example_not_executed_for_native_models`, `test_function_call_non_object_args`, `test_plan_mode`, `test_redos_llm_parsers`, `test_redos_xml_tool_parsers` — all passing.
- `git diff --check` clean; `node --check static/js/chatRenderer.js` OK.
- **Not run:** full local pytest in this environment (some unrelated route modules don't import in the sandbox — they fail identically on a clean `dev`), and live app/browser/IMAP/SMTP + model-driven email-agent smoke. Those still want a human/CI pass.

*This PR was written via Claude and verified by a human.*
