### PR TITLE
fix(agent): preserve bare email tool parity

### DIFF
--- a/src/tool_execution.py
+++ b/src/tool_execution.py
@@ -907,6 +907,9 @@ async def _execute_tool_block_impl(
             if _args_error is not None:
                 result = {"error": _args_error, "exit_code": 1}
             else:
+                if owner:
+                    args = dict(args)
+                    args[_EMAIL_MCP_OWNER_ARG] = owner
                 result = await mcp.call_tool(qualified, args)
         else:
             result = {"error": "MCP manager not available", "exit_code": 1}

--- a/static/js/chatRenderer.js
+++ b/static/js/chatRenderer.js
@@ -425,6 +425,23 @@ const TOOL_CALL_RE = /\[TOOL_CALL\][\s\S]*?\[\/TOOL_CALL\]/gi;
 let EXEC_FENCE_RE = null;
 const EXEC_FENCE_NON_TOOL = new Set(['bash', 'python']);
 
+function escapeRegex(source) {
+  return String(source).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function stripExecutedFence(match, tag, inline, body) {
+  const inlineArgs = (inline || '').trim();
+  if (!inlineArgs) return '';
+  const bodyText = (body || '').trim();
+  const content = bodyText ? `${inlineArgs}\n${bodyText}` : inlineArgs;
+  try {
+    JSON.parse(content);
+  } catch {
+    return match;
+  }
+  return '';
+}
+
 async function loadExecFenceRegex() {
   try {
     const res = await fetch('/api/tools', { credentials: 'same-origin' });
@@ -434,7 +451,10 @@ async function loadExecFenceRegex() {
       .filter((id) => id && !EXEC_FENCE_NON_TOOL.has(id));
     if (tags.length) {
       EXEC_FENCE_RE = new RegExp(
-        '```(?:' + tags.join('|') + ')\\s*\\n[\\s\\S]*?```', 'gi'
+        '```(' + tags.map(escapeRegex).join('|') + ')(?![\\w-])' +
+        '[ \\t]*([\\[{][^\\n]*?)?[ \\t]*(?=\\r?\\n|```)' +
+        '\\r?\\n?([\\s\\S]*?)```',
+        'gi'
       );
     }
   } catch (err) {
@@ -889,7 +909,7 @@ export function roleTimestamp(when) {
  */
 export function stripToolBlocks(text) {
   let cleaned = text.replace(TOOL_CALL_RE, '');
-  if (EXEC_FENCE_RE) cleaned = cleaned.replace(EXEC_FENCE_RE, '');
+  if (EXEC_FENCE_RE) cleaned = cleaned.replace(EXEC_FENCE_RE, stripExecutedFence);
   cleaned = cleaned.replace(DSML_TOOL_RE, '');
   cleaned = cleaned.replace(DSML_STRAY_RE, '');
   cleaned = cleaned.replace(XML_TOOL_CALL_RE, '');

--- a/tests/test_live_strip_email_tool_fences.py
+++ b/tests/test_live_strip_email_tool_fences.py
@@ -20,6 +20,7 @@ the behavioral tests exercise an equivalent Python regex built straight from the
 backend ``TOOL_TAGS`` — the same source the live regex now derives from — and
 source-level guards assert the frontend keeps no hard-coded list.
 """
+import json
 import re
 from pathlib import Path
 
@@ -46,18 +47,48 @@ def _exec_fence_regex() -> re.Pattern:
     derives from: the backend TOOL_TAGS (served via /api/tools) minus bash/python."""
     tags = _tool_tags() - _NON_STRIPPED
     assert tags, "TOOL_TAGS is empty"
-    return re.compile(r"```(?:" + "|".join(sorted(tags)) + r")\s*\n[\s\S]*?```", re.IGNORECASE)
+    return re.compile(
+        r"```(" + "|".join(re.escape(tag) for tag in sorted(tags)) + r")(?![\w-])"
+        r"[ \t]*([{\[][^\n]*?)?[ \t]*(?=\r?\n|```)\r?\n?([\s\S]*?)```",
+        re.IGNORECASE,
+    )
+
+
+def _strip_live_exec_fences(text: str) -> str:
+    rx = _exec_fence_regex()
+
+    def repl(match: re.Match) -> str:
+        inline = (match.group(2) or "").strip()
+        if not inline:
+            return ""
+        body = (match.group(3) or "").strip()
+        content = f"{inline}\n{body}" if body else inline
+        try:
+            json.loads(content)
+        except (TypeError, ValueError):
+            return match.group(0)
+        return ""
+
+    return rx.sub(repl, text)
 
 
 def test_strips_executed_email_tool_fences():
-    rx = _exec_fence_regex()
     # The exact shape the reporter observed lingering in the live bubble.
     text = 'Here are emails\n\n```list_emails\n{"max_results":10}\n```'
-    assert rx.sub("", text).strip() == "Here are emails"
+    assert _strip_live_exec_fences(text).strip() == "Here are emails"
+
+
+def test_strips_executed_inline_email_tool_fences():
+    text = 'Here are accounts\n\n```list_email_accounts {}\n```'
+    assert _strip_live_exec_fences(text).strip() == "Here are accounts"
+
+
+def test_strips_multiline_inline_json_email_fences():
+    text = 'Here are emails\n\n```list_emails {"folder": "INBOX",\n"max_results": 2}\n```'
+    assert _strip_live_exec_fences(text).strip() == "Here are emails"
 
 
 def test_strips_every_named_email_tool_fence():
-    rx = _exec_fence_regex()
     email_tools = [
         "list_email_accounts", "send_email", "list_emails", "read_email",
         "reply_to_email", "bulk_email", "archive_email", "delete_email",
@@ -65,22 +96,28 @@ def test_strips_every_named_email_tool_fence():
     ]
     for tool in email_tools:
         fence = f"```{tool}\n{{}}\n```"
-        assert rx.sub("", fence).strip() == "", f"{tool} fence not stripped"
+        assert _strip_live_exec_fences(fence).strip() == "", f"{tool} fence not stripped"
 
 
 def test_preserves_existing_web_search_stripping():
-    rx = _exec_fence_regex()
     fence = '```web_search\n{"q":"x"}\n```'
-    assert rx.sub("", fence).strip() == ""
+    assert _strip_live_exec_fences(fence).strip() == ""
 
 
 def test_does_not_strip_bash_or_python_code_examples():
     """bash/python fences are deliberately excluded — they are legitimate code
     examples a user may have asked the model to show, not tool invocations."""
-    rx = _exec_fence_regex()
     for lang in sorted(_NON_STRIPPED):
         example = f"```{lang}\nls -la\n```"
-        assert rx.sub("", example) == example, f"{lang} example wrongly stripped"
+        assert _strip_live_exec_fences(example) == example, f"{lang} example wrongly stripped"
+
+
+def test_does_not_strip_invalid_inline_json_metadata():
+    for example in (
+        '```list_email_accounts {title="setup"}\n```',
+        '```web_search {query="odysseus"}\n```',
+    ):
+        assert _strip_live_exec_fences(example) == example
 
 
 def test_frontend_keeps_no_hardcoded_tool_list():
@@ -98,6 +135,10 @@ def test_frontend_keeps_no_hardcoded_tool_list():
     assert "/api/tools" in source, (
         "chatRenderer.js must fetch the tool set from /api/tools to build "
         "EXEC_FENCE_RE."
+    )
+    assert "JSON.parse(content)" in source, (
+        "chatRenderer.js must validate inline JSON before stripping same-line "
+        "tool fences so Markdown metadata stays visible."
     )
     # The bash/python carve-out must survive the move to the runtime list.
     m = re.search(r"EXEC_FENCE_NON_TOOL\s*=\s*new Set\(\[(?P<body>.*?)\]\)", source, re.DOTALL)

--- a/tests/test_review_regressions.py
+++ b/tests/test_review_regressions.py
@@ -918,7 +918,9 @@ async def test_plan_mode_blocks_mutating_email_aliases_without_mcp_inventory(mon
         disabled_tools=denied,
     )
     assert result["exit_code"] == 0
-    assert mcp.calls == [("mcp__email__search_emails", {"query": "x"})]
+    assert mcp.calls == [
+        ("mcp__email__search_emails", {"query": "x", "_odysseus_owner": "admin-user"}),
+    ]
 
 
 @pytest.mark.asyncio
@@ -937,7 +939,9 @@ async def test_bare_email_dispatch_empty_content_calls_with_empty_args(monkeypat
         owner="admin-user",
     )
     assert result["exit_code"] == 0
-    assert mcp.calls == [("mcp__email__list_email_accounts", {})]
+    assert mcp.calls == [
+        ("mcp__email__list_email_accounts", {"_odysseus_owner": "admin-user"}),
+    ]
 
 
 @pytest.mark.asyncio
@@ -991,6 +995,27 @@ async def test_email_mcp_dispatch_includes_hidden_owner(monkeypatch):
     )
 
     assert desc == "mcp: mcp__email__list_emails"
+    assert result["exit_code"] == 0
+    assert fake.calls == [
+        ("mcp__email__list_emails", {"folder": "INBOX", "_odysseus_owner": "alice"}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_bare_email_mcp_dispatch_includes_hidden_owner(monkeypatch):
+    import src.tool_execution as tool_execution
+    from src.tool_execution import execute_tool_block
+
+    fake = _FakeMcpManager()
+    monkeypatch.setattr(tool_execution, "_owner_is_admin", lambda owner: True)
+    monkeypatch.setattr(tool_execution, "get_mcp_manager", lambda: fake)
+
+    desc, result = await execute_tool_block(
+        SimpleNamespace(tool_type="list_emails", content='{"folder":"INBOX"}'),
+        owner="alice",
+    )
+
+    assert desc == "email: list_emails"
     assert result["exit_code"] == 0
     assert fake.calls == [
         ("mcp__email__list_emails", {"folder": "INBOX", "_odysseus_owner": "alice"}),


### PR DESCRIPTION
## Summary

Preserve authenticated owner scope when Agent mode emits bare built-in email aliases, and keep live chat stripping aligned with the same-line inline JSON fences the backend now executes after #3681. The change is narrow: bare email aliases now match the qualified `mcp__email__*` owner path, and `stripToolBlocks()` removes executed `list_email_accounts {}`-style fences without stripping invalid Markdown metadata.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #5069

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) - this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

Not run: live app/browser/email validation. This touches live chat rendering, so a screenshot or short clip is still needed before marking the PR ready for review.

## How to Test

Run the focused owner and live-strip regressions:

```bash
python3 -m pytest \
  tests/test_review_regressions.py::test_bare_email_mcp_dispatch_includes_hidden_owner \
  tests/test_review_regressions.py::test_email_mcp_dispatch_includes_hidden_owner \
  tests/test_review_regressions.py::test_bare_email_dispatch_empty_content_calls_with_empty_args \
  tests/test_review_regressions.py::test_plan_mode_blocks_mutating_email_aliases_without_mcp_inventory \
  tests/test_live_strip_email_tool_fences.py \
  -q
```

Run syntax and whitespace checks:

```bash
python3 -m py_compile \
  src/tool_execution.py \
  tests/test_live_strip_email_tool_fences.py \
  tests/test_review_regressions.py
node --check static/js/chatRenderer.js
git diff --check
```

I also ran the adjacent parser/email/live-strip regression slice with the six existing unrelated `core.log_safety` import failures deselected: 69 passed, 6 deselected, 1 warning.

Manual reviewer check: run the app, trigger an Agent-mode `list_email_accounts {}` tool call, and confirm the executed fence is not left visible in the live bubble.

## Visual / UI changes - REQUIRED if you touched anything that renders

This changes live chat rendering behavior in `static/js/chatRenderer.js`, but does not add styling, layout, labels, or components.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: no styling, classes, labels, layout, colors, fonts, or component markup changed.
- [x] **No new component patterns.** This only changes live stripping of already-executed tool syntax.
- [x] **I am not an LLM agent submitting a bulk PR.** Companion issue is opened first; this is a focused single-fix PR, not a bulk submission.

### Screenshots / clips

N/A