### PR TITLE
fix(security): match the sensitive-file deny-list case-insensitively

### DIFF
--- a/src/tool_execution.py
+++ b/src/tool_execution.py
@@ -71,25 +71,35 @@ _SENSITIVE_FILE_PATTERNS: tuple[str, ...] = (
     "known_hosts",
 )
 
+# Case-folded views used for matching. On a case-insensitive filesystem
+# (Windows, default macOS) ".SSH/AUTHORIZED_KEYS" and ".env" resolve to the
+# same protected files as their lowercase forms, so the deny-list has to fold
+# case before comparing — the sibling resolver already normcases paths for the
+# same reason. casefold (not os.path.normcase) because normcase is a no-op on
+# POSIX, which is exactly where the macOS read-exfil path lives.
+_SENSITIVE_BASENAMES_CF: frozenset[str] = frozenset(b.casefold() for b in _SENSITIVE_BASENAMES)
+_SENSITIVE_FILE_PATTERNS_CF: frozenset[str] = frozenset(p.casefold() for p in _SENSITIVE_FILE_PATTERNS)
+
 
 def _is_sensitive_path(resolved: str) -> bool:
     """Return True if *resolved* falls under a sensitive directory or
     matches a sensitive filename — regardless of what root it sits under.
+
+    Matching is case-insensitive: on Windows / default macOS a case-variant
+    name (``.SSH``, ``AUTHORIZED_KEYS``, ``Id_Rsa``) points at the same file as
+    the lowercase form, so a case-sensitive check would let it slip past the
+    deny-list in every file tool that relies on it.
     """
-    parts = resolved.split(os.sep)
-    filenames: set[str] = {parts[-1]} if parts else set()
+    parts = [p.casefold() for p in resolved.split(os.sep)]
+    filename = parts[-1] if parts else ""
 
     # Check if any path component is a sensitive directory.
     for part in parts:
-        if part in _SENSITIVE_BASENAMES:
+        if part in _SENSITIVE_BASENAMES_CF:
             return True
 
     # Check filename against known sensitive files.
-    for pat in _SENSITIVE_FILE_PATTERNS:
-        if pat in filenames:
-            return True
-
-    return False
+    return filename in _SENSITIVE_FILE_PATTERNS_CF
 
 
 def _tool_path_roots() -> list[str]:

--- a/tests/test_tool_path_confinement.py
+++ b/tests/test_tool_path_confinement.py
@@ -57,6 +57,27 @@ def test_non_sensitive_path():
     assert not _is_sensitive_path("/home/user/projects/file.py")
 
 
+def test_sensitive_case_insensitive():
+    """On case-insensitive filesystems (Windows, default macOS) a case-variant
+    name resolves to the same protected file, so the deny-list must match
+    regardless of case. Built with os.path.join so the separator is right on
+    both POSIX and Windows.
+    """
+    from src.tool_execution import _is_sensitive_path
+    # sensitive directory, varied case
+    assert _is_sensitive_path(os.path.join("home", "u", ".SSH", "authorized_keys"))
+    assert _is_sensitive_path(os.path.join("home", "u", ".Gnupg", "pubring.kbx"))
+    # sensitive filename, varied case
+    assert _is_sensitive_path(os.path.join("ws", "AUTHORIZED_KEYS"))
+    assert _is_sensitive_path(os.path.join("ws", "Id_Rsa"))
+    assert _is_sensitive_path(os.path.join("ws", ".ENV"))
+    assert _is_sensitive_path(os.path.join("ws", ".Env"))
+    # both dir and file varied
+    assert _is_sensitive_path(os.path.join("home", "u", ".SSH", "AUTHORIZED_KEYS"))
+    # an ordinary file with none of the sensitive names is still allowed
+    assert not _is_sensitive_path(os.path.join("ws", "Readme.md"))
+
+
 # ── Unit tests on _resolve_tool_path ─────────────────────────────────
 
 def test_blocks_etc_shadow():


### PR DESCRIPTION
## Summary

`_is_sensitive_path` (`src/tool_execution.py`) — the deny-list that `read_file`, `write_file`, `edit_file`, `grep` (#5013) and `glob` (#5094) all rely on — compared path components against lowercase literals. On a case-insensitive filesystem (Windows, default macOS) a case-variant name (`.SSH`, `AUTHORIZED_KEYS`, `Id_Rsa`, `.ENV`) points at the same protected file but slipped straight through, defeating the deny-list in all five tools at once. A prompt-injected agent could `write_file AUTHORIZED_KEYS` (SSH key injection) or read/clobber `.ENV` even though the canonical name is blocked.

Root cause: `parts = resolved.split(os.sep)` was matched directly against `_SENSITIVE_BASENAMES` / `_SENSITIVE_FILE_PATTERNS` with no case folding. The sibling resolver `_resolve_tool_path_in_workspace` already normcases paths "so containment holds on case-insensitive filesystems (Windows, default macOS)" — the deny-list just never got the same treatment.

Fix: case-fold the path parts and match against case-folded views of the two sets. `casefold` rather than `os.path.normcase` on purpose — normcase is a no-op on POSIX, which is exactly where the macOS read-exfil path lives. The source-of-truth lists stay lowercase and readable; the folded frozensets are derived once. Behaviour on case-sensitive Linux is unchanged except that a file literally named e.g. `ID_RSA` is now also treated as sensitive — an acceptable, intentional false-positive for a security deny-list.

Out of scope (separate follow-up): `grep`'s ripgrep path builds `--glob !*id_rsa*` exclusions that are themselves case-sensitive; that is a distinct layer from this deny-list and is left for its own change to keep this scoped.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #5096

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate. (#5013/#5094/#5012 fix which tools consult the list; this fixes how the list itself matches. #2360 was a different gap — Odysseus's own secret files.)
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I verified the change end-to-end through the real tool dispatcher (`execute_tool_block`) with a bound workspace — see steps below. No app UI is involved.

## How to Test

1. Bind a workspace.
2. Before the fix: `write_file` with path `.ENV`, `AUTHORIZED_KEYS`, or `Id_Rsa` writes the file (the canonical lowercase names are correctly rejected); afterwards `read_file .env` returns the content written to `.ENV` on a case-insensitive FS.
3. After the fix: all of those are rejected with "inside a sensitive directory … or matches a sensitive filename", and nothing is written.
4. `pytest tests/test_tool_path_confinement.py::test_sensitive_case_insensitive` — passes with the fix, fails without it. Full `test_tool_path_confinement.py` + `test_workspace_confine.py` failure set is byte-identical to clean `dev` (the pre-existing failures are POSIX-path/temp-dir assumptions specific to a Windows dev box; they pass on the Linux CI runner).