### PR TITLE
fix(tools): raise ValueError when tool args JSON is not an object

### DIFF
--- a/src/tool_utils.py
+++ b/src/tool_utils.py
@@ -60,6 +60,10 @@ def _parse_tool_args(content):
         args = content
     else:
         args = {}
+    if not isinstance(args, dict):
+        raise ValueError(
+            f"tool args must be a JSON object, got {type(args).__name__}: {content!r}"
+        )
     # Unwrap {"body": {...}} envelope, but only if `body` is the sole key
     # and points at a dict. We don't want to clobber a legitimate `body`
     # field on tools where it's a real arg (e.g. send_email body text).

--- a/tests/test_parse_tool_args.py
+++ b/tests/test_parse_tool_args.py
@@ -1,0 +1,59 @@
+"""Tests for _parse_tool_args in src.tool_utils."""
+
+import pytest
+from src.tool_utils import _parse_tool_args
+
+
+def test_dict_string():
+    assert _parse_tool_args('{"key": "val"}') == {"key": "val"}
+
+
+def test_empty_string_returns_empty_dict():
+    assert _parse_tool_args("") == {}
+    assert _parse_tool_args("   ") == {}
+
+
+def test_dict_passthrough():
+    d = {"a": 1}
+    assert _parse_tool_args(d) is d
+
+
+def test_body_envelope_unwrapped():
+    inner = {"action": "do_thing", "arg": 1}
+    assert _parse_tool_args({"body": inner}) == inner
+
+
+def test_body_envelope_not_unwrapped_without_action():
+    # "body" key present but inner dict has no "action" — keep as-is
+    d = {"body": {"text": "hello"}}
+    assert _parse_tool_args(d) == d
+
+
+def test_array_raises():
+    with pytest.raises(ValueError, match="JSON object"):
+        _parse_tool_args("[1, 2, 3]")
+
+
+def test_int_raises():
+    with pytest.raises(ValueError, match="JSON object"):
+        _parse_tool_args("42")
+
+
+def test_bool_raises():
+    with pytest.raises(ValueError, match="JSON object"):
+        _parse_tool_args("true")
+
+
+def test_null_raises():
+    with pytest.raises(ValueError, match="JSON object"):
+        _parse_tool_args("null")
+
+
+def test_bad_json_raises():
+    with pytest.raises(ValueError):
+        _parse_tool_args("{bad json}")
+
+
+def test_non_string_non_dict_returns_empty_dict():
+    # None, list, int passed directly (not as JSON string)
+    assert _parse_tool_args(None) == {}


### PR DESCRIPTION
Fixes #5043

## Linked Issue
Fixes #5043

## Type of Change
- [x] Bug fix

## Summary
`_parse_tool_args` (src/tool_utils.py) accepted any valid JSON, not just objects. A tool call whose args were a JSON array, int, bool, or null passed straight through unchecked. Every caller then calls `.get()` on the result (or unpacks it as a dict), so non-dict input crashed with `AttributeError`/`TypeError` deep inside an unrelated tool, instead of failing cleanly at the parse boundary.

## Fix
After decoding, check `isinstance(args, dict)`. If not, raise `ValueError` - the same exception type the function already raises for malformed JSON. Every existing caller already wraps this call in `try/except ValueError`, so the error now surfaces as a normal tool-call failure message instead of an unhandled crash.

## Checklist
- [x] I searched existing issues and pull requests before opening this one
- [x] One focused fix, no unrelated changes
- [x] Added/updated tests

## How to Test
1. `python -m pytest tests/test_parse_tool_args.py -v` - 11 tests, all passing.
2. Manually: call `_parse_tool_args('[1,2,3]')`, `_parse_tool_args('42')`, `_parse_tool_args('true')`, `_parse_tool_args('null')` - each now raises `ValueError("tool args must be a JSON object...")` instead of returning the raw non-dict value.
3. Not a visual/UI change - no screenshots needed.