### PR TITLE
fix(mcp): guard DbTokenStorage against non-dict oauth_tokens JSON

### DIFF
--- a/src/mcp_oauth.py
+++ b/src/mcp_oauth.py
@@ -96,7 +96,9 @@ class DbTokenStorage:
         try:
             srv = db.query(McpServer).filter(McpServer.id == self.server_id).first()
             if srv and srv.oauth_tokens:
-                return json.loads(srv.oauth_tokens)
+                parsed = json.loads(srv.oauth_tokens)
+                if isinstance(parsed, dict):
+                    return parsed
         finally:
             db.close()
         return {}
@@ -111,6 +113,8 @@ class DbTokenStorage:
             if srv is None:
                 return
             data = json.loads(srv.oauth_tokens) if srv.oauth_tokens else {}
+            if not isinstance(data, dict):
+                data = {}
             data[key] = value
             srv.oauth_tokens = json.dumps(data)
             db.commit()

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 from src import mcp_oauth
 
 
@@ -79,3 +80,53 @@ def test_db_token_storage_round_trip():
     t = asyncio.run(go())
     assert t.access_token == "abc"
     assert srv.oauth_tokens is not None  # persisted as JSON
+
+
+def _fake_storage(oauth_tokens):
+    class FakeSrv:
+        pass
+
+    srv = FakeSrv()
+    srv.oauth_tokens = oauth_tokens
+
+    class FakeQuery:
+        def filter(self, *a):
+            return self
+
+        def first(self):
+            return srv
+
+    class FakeSession:
+        def query(self, *a):
+            return FakeQuery()
+
+        def commit(self):
+            pass
+
+        def close(self):
+            pass
+
+    return srv, mcp_oauth.DbTokenStorage("srv-1", session_factory=lambda: FakeSession())
+
+
+def test_load_falls_back_to_empty_dict_for_non_dict_json():
+    # A corrupted/migrated oauth_tokens column holding a JSON array, not an
+    # object, must not crash _load()'s callers with AttributeError.
+    _srv, storage = _fake_storage('["stale", "data"]')
+    assert storage._load() == {}
+
+
+def test_get_tokens_returns_none_for_non_dict_oauth_tokens():
+    _srv, storage = _fake_storage("42")
+
+    async def go():
+        return await storage.get_tokens()
+
+    assert asyncio.run(go()) is None
+
+
+def test_update_recovers_from_non_dict_oauth_tokens():
+    # _update() must not raise TypeError trying to item-assign into a list.
+    srv, storage = _fake_storage('["stale", "data"]')
+    storage._update("tokens", {"access_token": "new"})
+    assert json.loads(srv.oauth_tokens) == {"tokens": {"access_token": "new"}}


### PR DESCRIPTION
Fixes #5082

## Linked Issue
Fixes #5082

## Type of Change
- [x] Bug fix

## Summary
`DbTokenStorage._load()` and `_update()` (`src/mcp_oauth.py`) parsed `srv.oauth_tokens` with `json.loads()` but never verified the result was a dict. If the column ever held a JSON array or primitive (DB corruption, manual edit, migration drift), `_load()`'s callers crashed with `AttributeError` on `.get()` (`get_tokens`/`get_client_info` at lines 122/130), and `_update()` crashed with `TypeError` trying to `data[key] = value` on a list/string/int.

## Fix
Validate the parsed value is a dict in both `_load()` and `_update()`, falling back to `{}` when it isn't - the same recovery shape already used elsewhere in this codebase for corrupted JSON blobs.

## Checklist
- [x] I searched existing issues and pull requests before opening this one
- [x] One focused fix, no unrelated changes
- [x] Added/updated tests

## How to Test
1. `python -m pytest tests/test_mcp_oauth.py -v` - 3 new tests (`test_load_falls_back_to_empty_dict_for_non_dict_json`, `test_get_tokens_returns_none_for_non_dict_oauth_tokens`, `test_update_recovers_from_non_dict_oauth_tokens`) plus the 5 existing tests, all 8 pass.
2. Verified the new tests actually catch the bug: reverted only `src/mcp_oauth.py` (`git stash push -- src/mcp_oauth.py`), reran - all 3 new tests failed with the exact `AttributeError`/`TypeError` described in the issue. Restored the fix and reran - all pass.
3. Ran `tests/test_security_regressions.py` for regressions - the handful of pre-existing failures there are unrelated (a `UnicodeDecodeError` from an unrelated fixture reading a non-Latin-1 file on Windows, reproduced identically with this fix reverted, so unrelated to this change).
4. Not a visual/UI change - no screenshots needed.