### PR TITLE
fix(mcp): preserve PYTHONPATH for built-in Python servers

### DIFF
--- a/src/builtin_mcp.py
+++ b/src/builtin_mcp.py
@@ -104,6 +104,21 @@ def _spawn_bg(coro) -> asyncio.Task:
     return task
 
 
+def builtin_python_env(base_dir: str) -> dict[str, str]:
+    """Environment for built-in Python MCP subprocesses.
+
+    The app root must be importable so mcp_servers can import local modules, but
+    replacing PYTHONPATH entirely hides site-packages in container/dev launches
+    that rely on PYTHONPATH for their active environment.
+    """
+    existing = os.environ.get("PYTHONPATH", "")
+    parts = [base_dir]
+    for item in existing.split(os.pathsep):
+        if item and item not in parts:
+            parts.append(item)
+    return {"PYTHONPATH": os.pathsep.join(parts)}
+
+
 async def register_builtin_servers(mcp_manager):
     """Connect all built-in MCP servers to the manager."""
     if MCP_DISABLED:
@@ -121,7 +136,7 @@ async def register_builtin_servers(mcp_manager):
                 transport="stdio",
                 command=python,
                 args=[script_path],
-                env={"PYTHONPATH": base_dir},
+                env=builtin_python_env(base_dir),
             )
             if ok:
                 logger.info(f"Built-in MCP server registered: {name}")

--- a/src/mcp_manager.py
+++ b/src/mcp_manager.py
@@ -504,7 +504,7 @@ class McpManager:
     async def _reconnect_builtin(self, server_id: str) -> bool:
         """Tear down and reconnect a crashed builtin MCP server."""
         import sys
-        from src.builtin_mcp import _BUILTIN_SERVERS
+        from src.builtin_mcp import _BUILTIN_SERVERS, builtin_python_env
 
         if server_id not in _BUILTIN_SERVERS:
             return False
@@ -523,7 +523,7 @@ class McpManager:
                 transport="stdio",
                 command=sys.executable,
                 args=[script_path],
-                env={"PYTHONPATH": base_dir},
+                env=builtin_python_env(base_dir),
             )
             if ok:
                 logger.info(f"Reconnected builtin MCP server: {name}")

--- a/tests/test_builtin_mcp_pythonpath.py
+++ b/tests/test_builtin_mcp_pythonpath.py
@@ -1,0 +1,22 @@
+import os
+
+from src.builtin_mcp import builtin_python_env
+
+
+def test_builtin_python_env_preserves_existing_pythonpath(monkeypatch):
+    monkeypatch.setenv(
+        "PYTHONPATH",
+        os.pathsep.join(["/app/venv/lib/python3.13/site-packages", "/app", "/extra"]),
+    )
+
+    env = builtin_python_env("/app")
+
+    assert env == {
+        "PYTHONPATH": os.pathsep.join(["/app", "/app/venv/lib/python3.13/site-packages", "/extra"])
+    }
+
+
+def test_builtin_python_env_uses_app_root_without_existing_pythonpath(monkeypatch):
+    monkeypatch.delenv("PYTHONPATH", raising=False)
+
+    assert builtin_python_env("/srv/odysseus") == {"PYTHONPATH": "/srv/odysseus"}


### PR DESCRIPTION
## Summary

Preserve the inherited `PYTHONPATH` when built-in Python MCP servers are started or reconnected. The previous startup path replaced `PYTHONPATH` with only the Odysseus app root, which can hide environment-provided paths in source, container, Nix, or packaged launches and leave built-in servers such as email disconnected even when the integration is configured.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #5116 

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

Live validation was run in a temp Podman Odysseus UI instance with GreenMail IMAP/SMTP. Before the patch, the chat UI hit `MCP server not connected: email`; with the patch applied, `mcp__email__list_emails` succeeded from the UI and SMTP send plus IMAP readback worked against GreenMail.

Full suite not run. I ran syntax/diff checks on the clean PR branch; focused pytest could not run in the temporary host checkout because that Python environment did not have pytest/project dependencies installed.

## How to Test

1. Run the focused regression and syntax checks:

```bash
python -m pytest tests/test_builtin_mcp_pythonpath.py -q
python -m py_compile src/builtin_mcp.py src/mcp_manager.py tests/test_builtin_mcp_pythonpath.py
git diff --check
```

2. Start Odysseus from source or a container with a non-empty inherited `PYTHONPATH`, for example:

```bash
PYTHONPATH="/tmp/preexisting${PYTHONPATH:+:$PYTHONPATH}" uvicorn app:app --host 127.0.0.1 --port 8000
```

3. Configure an Email IMAP/SMTP integration, then ask the chat UI to list unread email. The email MCP tool should connect and return mail instead of failing with `MCP server not connected: email`.

## Visual / UI changes — REQUIRED if you touched anything that renders

N/A - backend-only MCP subprocess environment handling; no rendered UI changed.

### Screenshots / clips

N/A - no visual change.