### PR TITLE
refactor(tools): migrate pipeline to the agent_tools registry (#3629)

### DIFF
--- a/src/agent_tools/__init__.py
+++ b/src/agent_tools/__init__.py
@@ -27,6 +27,7 @@ from .interaction_tools import AskUserTool, UpdatePlanTool
 from .model_interaction_tools import ChatWithModelTool, AskTeacherTool, ListModelsTool
 from .bg_job_tools import ManageBgJobsTool
 from .session_tools import CreateSessionTool, ListSessionsTool, SendToSessionTool, ManageSessionTool
+from .pipeline_tools import PipelineTool
 from .admin_tools import (
     ADMIN_TOOL_HANDLERS,
     do_manage_endpoints, do_manage_mcp, do_manage_webhooks,
@@ -60,6 +61,7 @@ TOOL_HANDLERS = {
     "list_sessions": ListSessionsTool().execute,
     "send_to_session": SendToSessionTool().execute,
     "manage_session": ManageSessionTool().execute,
+    "pipeline": PipelineTool().execute,
 }
 # Config/integration admin tools (manage_endpoints/mcp/webhooks/tokens/settings).
 TOOL_HANDLERS.update(ADMIN_TOOL_HANDLERS)

--- a/src/agent_tools/pipeline_tools.py
+++ b/src/agent_tools/pipeline_tools.py
@@ -1,0 +1,120 @@
+import asyncio
+import json
+import logging
+
+from typing import Dict, Optional
+from src.ai_interaction import _resolve_model, AI_CHAT_TIMEOUT, MAX_PIPELINE_STEPS
+
+logger = logging.getLogger(__name__)
+
+async def do_pipeline(content: str, session_id: Optional[str] = None, owner: Optional[str] = None) -> Dict:
+    """Execute a multi-step pipeline where each model's output feeds the next.
+
+    Content format (JSON):
+      {"steps": [
+        {"model": "model_a", "instruction": "Draft an essay about X"},
+        {"model": "model_b", "instruction": "Critique the following draft"},
+        {"model": "model_a", "instruction": "Revise based on this critique"}
+      ]}
+
+    Or line format:
+      Line 1: step1_model | step1_instruction
+      Line 2: step2_model | step2_instruction
+      ...
+    """
+    from src.llm_core import llm_call_async
+
+    # Try JSON parse first
+    steps = None
+    try:
+        data = json.loads(content.strip())
+        if isinstance(data, dict) and "steps" in data:
+            steps = data["steps"]
+        elif isinstance(data, list):
+            steps = data
+    except (json.JSONDecodeError, TypeError):
+        pass
+
+    # Fall back to line format: model | instruction
+    if not steps:
+        steps = []
+        for line in content.strip().split("\n"):
+            line = line.strip()
+            if not line:
+                continue
+            if "|" in line:
+                parts = line.split("|", 1)
+                steps.append({"model": parts[0].strip(), "instruction": parts[1].strip()})
+            else:
+                return {"error": "Each line must be: model | instruction (or use JSON format)"}
+
+    if not steps:
+        return {"error": "No pipeline steps provided"}
+    if len(steps) > MAX_PIPELINE_STEPS:
+        return {"error": f"Maximum {MAX_PIPELINE_STEPS} steps allowed"}
+
+    # Resolve all models first (fail fast)
+    resolved = []
+    for i, step in enumerate(steps):
+        model_spec = step.get("model", "").strip()
+        instruction = step.get("instruction", "").strip()
+        if not model_spec or not instruction:
+            return {"error": f"Step {i + 1}: both 'model' and 'instruction' are required"}
+        try:
+            url, model, headers = await asyncio.to_thread(_resolve_model, model_spec, owner=owner)
+            resolved.append((url, model, headers, instruction))
+        except ValueError as e:
+            return {"error": f"Step {i + 1}: {e}"}
+
+    # Execute pipeline
+    step_outputs = []
+    previous_output = None
+
+    try:
+        for i, (url, model, headers, instruction) in enumerate(resolved):
+            if previous_output:
+                user_content = (
+                    f"Previous step's output:\n\n{previous_output}\n\n"
+                    f"Your task: {instruction}"
+                )
+            else:
+                user_content = instruction
+
+            messages = [
+                {"role": "system", "content": f"You are step {i + 1} in a processing pipeline. {instruction}"},
+                {"role": "user", "content": user_content},
+            ]
+
+            response = await llm_call_async(
+                url, model, messages, headers=headers, timeout=AI_CHAT_TIMEOUT
+            )
+
+            step_outputs.append({
+                "step": i + 1,
+                "model": model,
+                "instruction": instruction,
+                "output": response[:5000] if len(response) > 5000 else response,
+            })
+
+            previous_output = response
+
+        # Build readable result
+        result_lines = [f"# Pipeline Results ({len(resolved)} steps)\n"]
+        for so in step_outputs:
+            result_lines.append(f"## Step {so['step']}: {so['model']}")
+            result_lines.append(f"*Instruction: {so['instruction']}*\n")
+            result_lines.append(so["output"])
+            result_lines.append("\n---\n")
+
+        return {
+            "results": "\n".join(result_lines),
+            "steps": step_outputs,
+            "final_output": previous_output,
+        }
+    except Exception as e:
+        logger.error(f"pipeline failed at step {len(step_outputs) + 1}: {e}")
+        return {"error": f"Pipeline failed at step {len(step_outputs) + 1}: {e}"}
+
+class PipelineTool:
+    async def execute(self, content: str, ctx: dict) -> Dict:
+        return await do_pipeline(content, ctx.get("session_id"), owner = ctx.get("owner"))

--- a/src/ai_interaction.py
+++ b/src/ai_interaction.py
@@ -167,8 +167,6 @@ def _resolve_model(spec: str, owner: Optional[str] = None) -> Tuple[str, str, Di
 # Tool implementations
 # ---------------------------------------------------------------------------
 
-
-
 async def stream_ai_tool(tool: str, content: str, session_id: Optional[str] = None, owner: Optional[str] = None):
     """Dispatcher for streaming AI tools. Yields events as async generator."""
     # Fallback: run non-streaming and yield final result
@@ -176,113 +174,11 @@ async def stream_ai_tool(tool: str, content: str, session_id: Optional[str] = No
     yield {"_final": True, "desc": desc, "result": result}
 
 
-async def do_pipeline(content: str, session_id: Optional[str] = None, owner: Optional[str] = None) -> Dict:
-    """Execute a multi-step pipeline where each model's output feeds the next.
-
-    Content format (JSON):
-      {"steps": [
-        {"model": "model_a", "instruction": "Draft an essay about X"},
-        {"model": "model_b", "instruction": "Critique the following draft"},
-        {"model": "model_a", "instruction": "Revise based on this critique"}
-      ]}
-
-    Or line format:
-      Line 1: step1_model | step1_instruction
-      Line 2: step2_model | step2_instruction
-      ...
-    """
-    from src.llm_core import llm_call_async
-
-    # Try JSON parse first
-    steps = None
-    try:
-        data = json.loads(content.strip())
-        if isinstance(data, dict) and "steps" in data:
-            steps = data["steps"]
-        elif isinstance(data, list):
-            steps = data
-    except (json.JSONDecodeError, TypeError):
-        pass
-
-    # Fall back to line format: model | instruction
-    if not steps:
-        steps = []
-        for line in content.strip().split("\n"):
-            line = line.strip()
-            if not line:
-                continue
-            if "|" in line:
-                parts = line.split("|", 1)
-                steps.append({"model": parts[0].strip(), "instruction": parts[1].strip()})
-            else:
-                return {"error": "Each line must be: model | instruction (or use JSON format)"}
-
-    if not steps:
-        return {"error": "No pipeline steps provided"}
-    if len(steps) > MAX_PIPELINE_STEPS:
-        return {"error": f"Maximum {MAX_PIPELINE_STEPS} steps allowed"}
-
-    # Resolve all models first (fail fast)
-    resolved = []
-    for i, step in enumerate(steps):
-        model_spec = step.get("model", "").strip()
-        instruction = step.get("instruction", "").strip()
-        if not model_spec or not instruction:
-            return {"error": f"Step {i + 1}: both 'model' and 'instruction' are required"}
-        try:
-            url, model, headers = await asyncio.to_thread(_resolve_model, model_spec, owner=owner)
-            resolved.append((url, model, headers, instruction))
-        except ValueError as e:
-            return {"error": f"Step {i + 1}: {e}"}
-
-    # Execute pipeline
-    step_outputs = []
-    previous_output = None
-
-    try:
-        for i, (url, model, headers, instruction) in enumerate(resolved):
-            if previous_output:
-                user_content = (
-                    f"Previous step's output:\n\n{previous_output}\n\n"
-                    f"Your task: {instruction}"
-                )
-            else:
-                user_content = instruction
-
-            messages = [
-                {"role": "system", "content": f"You are step {i + 1} in a processing pipeline. {instruction}"},
-                {"role": "user", "content": user_content},
-            ]
-
-            response = await llm_call_async(
-                url, model, messages, headers=headers, timeout=AI_CHAT_TIMEOUT
-            )
-
-            step_outputs.append({
-                "step": i + 1,
-                "model": model,
-                "instruction": instruction,
-                "output": response[:5000] if len(response) > 5000 else response,
-            })
-
-            previous_output = response
-
-        # Build readable result
-        result_lines = [f"# Pipeline Results ({len(resolved)} steps)\n"]
-        for so in step_outputs:
-            result_lines.append(f"## Step {so['step']}: {so['model']}")
-            result_lines.append(f"*Instruction: {so['instruction']}*\n")
-            result_lines.append(so["output"])
-            result_lines.append("\n---\n")
-
-        return {
-            "results": "\n".join(result_lines),
-            "steps": step_outputs,
-            "final_output": previous_output,
-        }
-    except Exception as e:
-        logger.error(f"pipeline failed at step {len(step_outputs) + 1}: {e}")
-        return {"error": f"Pipeline failed at step {len(step_outputs) + 1}: {e}"}
+def __getattr__(name):
+    if name == "do_pipeline":
+        from src.agent_tools.pipeline_tools import do_pipeline
+        return do_pipeline
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 # ---------------------------------------------------------------------------
@@ -1115,11 +1011,7 @@ async def dispatch_ai_tool(
 ) -> Tuple[str, Dict]:
     """Dispatch an AI interaction tool. Returns (description, result_dict)."""
 
-    if tool == "pipeline":
-        desc = "pipeline: running steps"
-        result = await do_pipeline(content, session_id, owner=owner)
-
-    elif tool == "manage_memory":
+    if tool == "manage_memory":
         action = content.split("\n")[0].strip()[:40]
         desc = f"manage_memory: {action}"
         result = await do_manage_memory(content, session_id, owner=owner)

--- a/src/tool_execution.py
+++ b/src/tool_execution.py
@@ -775,7 +775,15 @@ async def _execute_tool_block_impl(
         desc = f"{tool}: {first_line}" if first_line else tool
         result = await _document_tool_dispatch(tool, content, session_id, owner) \
             or {"error": f"{tool}: execution failed", "exit_code": 1}
-    elif tool in ("pipeline", "manage_memory", "ui_control"):
+    elif tool == "pipeline":
+        # Migrated to the agent_tools registry (#3629): dispatched through
+        # TOOL_HANDLERS with the owner/session ctx pipeline needs. The impl
+        # lives in src/agent_tools/pipeline_tools.py.
+        first_line = content.split(chr(10))[0].strip()[:60]
+        desc = f"{tool}: {first_line}" if first_line else tool
+        result = await _document_tool_dispatch(tool, content, session_id, owner) \
+            or {"error": f"{tool}: execution failed", "exit_code": 1}
+    elif tool in ("manage_memory", "ui_control"):
         from src.ai_interaction import dispatch_ai_tool
         desc, result = await dispatch_ai_tool(tool, content, session_id, owner=owner)
     elif tool == "manage_tasks":

--- a/tests/test_ai_interaction_owner_scope.py
+++ b/tests/test_ai_interaction_owner_scope.py
@@ -31,12 +31,12 @@ def test_model_listing_and_image_fallback_are_owner_scoped():
     assert "asyncio.to_thread(_resolve_model, model_spec, owner=owner)" in image_body
 
 
-# chat_with_model, list_models and ask_teacher moved to the registry (#3629)
-# and no longer route through dispatch_ai_tool; their owner threading is covered
-# by tests/test_model_interaction_registry.py. The remaining model-ish tools
-# still dispatched here:
+# chat_with_model, list_models, ask_teacher and pipeline moved to the registry
+# (#3629) and no longer route through dispatch_ai_tool; their owner threading is
+# covered by tests/test_model_interaction_registry.py and
+# tests/test_pipeline_tools_registry.py. The remaining model-ish tools still
+# dispatched here:
 @pytest.mark.parametrize("tool,content", [
-    ("pipeline", "gpt-test | summarize this"),
     ("ui_control", "switch_model gpt-test"),
 ])
 async def test_dispatch_passes_owner_to_model_tools(monkeypatch, tool, content):
@@ -46,11 +46,6 @@ async def test_dispatch_passes_owner_to_model_tools(monkeypatch, tool, content):
         seen[name] = {"content": content, "session_id": session_id, "owner": owner}
         return {"ok": True}
 
-    monkeypatch.setattr(
-        ai_interaction,
-        "do_pipeline",
-        lambda content, session_id=None, owner=None: capture("pipeline", content, session_id, owner),
-    )
     monkeypatch.setattr(
         ai_interaction,
         "do_ui_control",

--- a/tests/test_pipeline_tools_registry.py
+++ b/tests/test_pipeline_tools_registry.py
@@ -1,0 +1,29 @@
+import asyncio
+
+from src.agent_tools import TOOL_HANDLERS
+from src.agent_tools import pipeline_tools as pt
+from pathlib import Path
+
+def test_pipeline_registered():
+    assert "pipeline" in TOOL_HANDLERS, "pipeline missing from TOOL_HANDLERS"
+
+def test_pipeline_not_routed_via_dispatch_ai_tool():
+    source = (Path(__file__).resolve().parent.parent / "src" / "tool_execution.py").read_text(encoding="utf-8")
+    marker = "from src.ai_interaction import dispatch_ai_tool"
+    idx = source.index(marker)
+    branch_head = source.rfind("elif tool in (", 0, idx)
+    legacy_tuple = source[branch_head:idx]
+    
+    assert "pipeline" not in legacy_tuple, "pipeline still routed via dispatch_ai_tool"
+
+def test_pipeline_handler_threads_ctx(monkeypatch):
+    # PipelineTool.execute() must unpack session_id + owner from ctx into
+    # do_pipeline - guards the ctx adapter (would catch a mis-keyed ctx.get).
+    seen = {}
+    async def spy(content, session_id=None, owner=None):
+        seen.update(content=content, session_id=session_id, owner=owner)
+        return {"results": "ok"}
+    monkeypatch.setattr(pt, "do_pipeline", spy)
+    res = asyncio.run(pt.PipelineTool().execute("q", {"owner": "alice", "session_id": "s1"}))
+    assert res == {"results": "ok"}
+    assert seen == {"content": "q", "session_id": "s1", "owner": "alice"} 

--- a/tests/test_resolve_model_offloaded.py
+++ b/tests/test_resolve_model_offloaded.py
@@ -12,6 +12,7 @@ import threading
 import time
 
 import src.ai_interaction as ai
+from src.agent_tools import pipeline_tools as pt
 
 
 async def test_do_pipeline_resolves_model_off_the_event_loop(monkeypatch):
@@ -30,7 +31,11 @@ async def test_do_pipeline_resolves_model_off_the_event_loop(monkeypatch):
             state["active"] -= 1
         raise ValueError("no such model")  # early-return path, no LLM call
 
-    monkeypatch.setattr(ai, "_resolve_model", slow_resolve)
+    # do_pipeline moved to agent_tools.pipeline_tools (#3629), which imported
+    # _resolve_model into its own namespace — patch it on the imported module
+    # object (robust vs. other tests reloading the agent_tools package, which
+    # can drop the pipeline_tools submodule attribute a string target needs).
+    monkeypatch.setattr(pt, "_resolve_model", slow_resolve)
 
     content = '[{"model": "m", "instruction": "go"}]'
     results = await asyncio.gather(
@@ -45,7 +50,7 @@ async def test_do_pipeline_resolves_model_off_the_event_loop(monkeypatch):
 async def test_do_pipeline_uses_offloaded_resolution_result(monkeypatch):
     # The offload must also return the resolved tuple, not just propagate errors.
     monkeypatch.setattr(
-        ai, "_resolve_model",
+        pt, "_resolve_model",
         lambda spec, owner=None: ("http://x/v1/chat/completions", "resolved-model", {}),
     )
 


### PR DESCRIPTION
## Summary

Moves the `pipeline` tool out of `ai_interaction.py` into `src/agent_tools/pipeline_tools.py` and dispatches it through the `TOOL_HANDLERS` registry, matching the already-merged session/model-tool migrations for #3629. Behaviour is unchanged — this is a structural refactor that shrinks `ai_interaction.py` and removes `pipeline` from the legacy `dispatch_ai_tool` path.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Part of #3629

## Type of Change

- [x] Refactor / cleanup (behaviour unchanged)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

Behaviour-preserving refactor, covered by unit tests that mirror the session/model migrations:

docker compose run --rm --no-deps odysseus python -m pytest -q
  tests/test_pipeline_tools_registry.py
  tests/test_resolve_model_offloaded.py
  tests/test_ai_interaction_owner_scope.py

- `test_pipeline_registered` — `pipeline` is registered in `TOOL_HANDLERS`.
- `test_pipeline_not_routed_via_dispatch_ai_tool` — `pipeline` no longer routes through the legacy `dispatch_ai_tool` elif (guards the #4912-style fall-through).
- `test_pipeline_handler_threads_ctx` — the `PipelineTool` adapter forwards `session_id`/`owner` from `ctx` into `do_pipeline`.

Also verified live: booted `uvicorn app:app` on this branch and dispatched a `pipeline` tool block through `execute_tool_block` in the running app — it routes to `do_pipeline` (returns a pipeline-domain "model not found" error), while a genuinely unknown tool returns "Unknown tool". Confirms the registry rewire, not the legacy path.

Full suite is green except one pre-existing flaky test in `test_upload_handler_atomicity.py` (unrelated to this change — a different test in that file flakes per run, and it passes on clean `dev`).

## Visual / UI changes

N/A — no UI/rendering code touched.