### PR TITLE
fix(markdown): stop currency dollars rendering as KaTeX inline math

### DIFF
--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -661,8 +661,11 @@ export function mdToHtml(src, opts) {
         return placeholder;
       } catch (e) { return match; }
     });
-    // Inline math: $...$  (not preceded/followed by $ or digit, not spanning multiple lines)
-    s = s.replace(/(?<!\$)\$(?!\$)([^\$\n]+?)\$(?!\$)/g, (match, math) => {
+    // Inline math: $...$ — single line only, and Pandoc-style delimiter rules so
+    // currency doesn't render as math ("$5 to $10"): the opening $ must be
+    // immediately followed by a non-space, the closing $ must be immediately
+    // preceded by a non-space and not followed by a digit.
+    s = s.replace(/(?<![\$\d])\$(?!\$)(?=\S)([^\$\n]+?)(?<=\S)\$(?!\$|\d)/g, (match, math) => {
       try {
         const raw = math.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>');
         const placeholder = `___MATH_BLOCK_${mathBlocks.length}___`;

--- a/tests/test_markdown_rendering_js.py
+++ b/tests/test_markdown_rendering_js.py
@@ -18,12 +18,24 @@ def node_available():
         pytest.skip("node binary not on PATH")
 
 
-def _run_markdown_case(markdown: str, render_expr: str = "mod.mdToHtml(input)"):
+def _run_markdown_case(markdown: str, render_expr: str = "mod.mdToHtml(input)", with_katex: bool = False):
     script = textwrap.dedent(
         r"""
         import fs from 'node:fs';
 
         globalThis.window = { location: { origin: 'http://localhost' }, katex: null };
+        if (__WITH_KATEX__) {
+          // Minimal stand-in for the CDN katex global: wraps the source so tests
+          // can assert what was (or wasn't) handed to KaTeX.
+          const katexStub = {
+            renderToString(src, opts) {
+              const display = !!(opts && opts.displayMode);
+              return `<span class="katex" data-display="${display}">${src}</span>`;
+            },
+          };
+          globalThis.window.katex = katexStub;
+          globalThis.katex = katexStub;
+        }
         globalThis.document = {
           readyState: 'loading',
           addEventListener() {},
@@ -77,7 +89,9 @@ def _run_markdown_case(markdown: str, render_expr: str = "mod.mdToHtml(input)"):
         const input = JSON.parse(process.argv[1]);
         console.log(JSON.stringify({ html: __RENDER_EXPR__ }));
         """
-    ).replace("__RENDER_EXPR__", render_expr)
+    ).replace("__RENDER_EXPR__", render_expr).replace(
+        "__WITH_KATEX__", "true" if with_katex else "false"
+    )
     result = subprocess.run(
         ["node", "--input-type=module", "-e", script, json.dumps(markdown)],
         cwd=_REPO,
@@ -198,6 +212,33 @@ def test_inline_code_content_is_html_escaped(node_available):
 
     assert "<code>&lt;b&gt;$1 &amp; &#39;q&#39;&lt;/b&gt;</code>" in html
     assert "<b>" not in html
+
+
+def test_currency_dollar_amounts_are_not_rendered_as_math(node_available):
+    # "$5 to $10" used to pair the two dollar signs as inline-math delimiters
+    # and render "5 to" through KaTeX. Pandoc-style rules now reject it: the
+    # closing $ is preceded by a space and followed by a digit.
+    html = _run_markdown_case(
+        "The price rose from $5 to $10 overnight.", with_katex=True
+    )
+
+    assert 'class="katex"' not in html
+    assert "$5" in html
+    assert "$10" in html
+
+
+def test_inline_math_still_renders_through_katex(node_available):
+    html = _run_markdown_case("Pythagoras: $x^2 + y^2 = z^2$ holds.", with_katex=True)
+
+    assert '<span class="katex" data-display="false">x^2 + y^2 = z^2</span>' in html
+    assert "$" not in html
+
+
+def test_display_math_still_renders_through_katex(node_available):
+    html = _run_markdown_case("$$\\frac{a}{b}$$", with_katex=True)
+
+    assert 'data-display="true"' in html
+    assert "$$" not in html
 
 
 def test_dotted_python_import_paths_are_not_autolinked(node_available):


### PR DESCRIPTION
## Summary

The inline `$...$` pass in `static/js/markdown.js` paired any two single dollars on a line, so currency like "$10 to $50" rendered "10 to" through KaTeX — permanently in the final render, and with visible flicker during streaming since the tail is re-rendered on every delta. The regex now follows Pandoc-style delimiter rules: the opening `$` must be immediately followed by a non-space, and the closing `$` must be immediately preceded by a non-space and not followed by a digit. Currency no longer matches; real math (`$x^2 + y^2 = z^2$`, `$$...$$`, `\(...\)`, `\[...\]`) renders as before.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #5130 

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Start the app and ask for a reply containing two dollar amounts on one line, e.g. "Repeat after me: $10 to $50."
2. Verify the amounts stay literal text during streaming and in the final render (no KaTeX flicker).
3. Ask for math, e.g. "show me the Pythagorean theorem in LaTeX with $...$ and $$...$$" — verify both still render through KaTeX.
4. `uv run --with-requirements requirements.txt pytest tests/test_markdown_rendering_js.py -q` → 13 passed (3 new: currency stays literal, inline math renders, display math renders; the node harness gained an opt-in KaTeX stub since it previously ran with `katex: null`).
```bash
uv run --with-requirements requirements.txt pytest tests/test_markdown_rendering_js.py -q
```

## Visual / UI changes

- [x] **Screenshot or short clip** of the change in the running app, attached below.
- [x] **Style match**: no CSS/HTML/style changes — only the math-delimiter regex in `static/js/markdown.js`.
- [x] **No new component patterns.**
- [x] **I am not an LLM agent submitting a bulk PR.**
### Screenshots / clips

**Before**

<img width="800" height="311" alt="Pasted 2026-07-02 at 6 26 09 PM" src="https://github.com/user-attachments/assets/52a8b0d5-8304-47b4-8327-f6a4884222de" />

**After**

<img width="805" height="199" alt="Pasted 2026-07-02 at 6 27 01 PM" src="https://github.com/user-attachments/assets/86600cda-64a6-42ba-8fcc-4eec229d9a0a" />

