### PR TITLE
fix(agent): trigger web domain when user asks to open or summarize research

### DIFF
--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -654,7 +654,7 @@ _API_HOSTS = frozenset([
     "api.githubcopilot.com",
 ])
 _MCP_KEYWORDS = frozenset(["mcp", "browse", "browser", "website", "calendar", "event", "email",
-                           "gmail", "screenshot", "navigate", "click", "miniflux", "rss", "feed"])
+                           "gmail", "screenshot", "navigate", "click", "miniflux", "rss", "feed", "research"])
 _ADMIN_SCHEMA_NAMES = frozenset([
     "manage_session", "manage_skills", "manage_tasks",
     "manage_endpoints", "manage_mcp", "manage_webhooks", "manage_tokens",


### PR DESCRIPTION
## Summary

Adds the keyword `"research"` to the agent request classification triggers (`_MCP_KEYWORDS`). This ensures that the Web and Research domain tools are correctly loaded when users query research features (e.g. asking to open or summarize research cards).

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #5164

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [x] New feature (non-breaking — adds new behaviour)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

Verify in chat that asking to open or summarize research cards loads the correct domain tools.

## Checks Run

- Run pytest suite: `pytest tests/test_agent_loop.py` (All Passed).