### PR TITLE
fix(agent): fall back to keyword tool selection when retrieval times out

### DIFF
--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -2532,11 +2532,17 @@ async def stream_agent_loop(
                         )
                         logger.info(f"[tool-rag] Retrieved tools for query: {sorted(_relevant_tools - ALWAYS_AVAILABLE)}")
                     except asyncio.TimeoutError:
+                        # Leave _relevant_tools unset so the keyword fallback
+                        # below still runs. Hard-coding ALWAYS_AVAILABLE here
+                        # skipped the deterministic keyword hints whenever the
+                        # embedding backend was slow (e.g. a remote endpoint
+                        # cold-loading its model), silently stripping email/
+                        # calendar tools from queries that named them outright.
                         logger.warning(
-                            "[tool-rag] Retrieval exceeded %.1fs; falling back to always-available tools",
+                            "[tool-rag] Retrieval exceeded %.1fs; falling back to keyword tool selection",
                             _TOOL_SELECTION_TIMEOUT_SECONDS,
                         )
-                        _relevant_tools = set(ALWAYS_AVAILABLE)
+                        _relevant_tools = None
         except Exception as e:
             logger.warning(f"[tool-rag] Retrieval failed, using keyword fallback: {e}")
             _relevant_tools = None


### PR DESCRIPTION
## Summary

The retrieval-timeout branch in agent tool selection hard-codes `_relevant_tools = set(ALWAYS_AVAILABLE)`, which silently skips the deterministic `_KEYWORD_HINTS` fallback below (the `if not _relevant_tools` guard sees a non-empty set). When the embedding backend is slow — e.g. an OpenAI-compatible endpoint whose model must cold-load (Ollama unloads after ~5 min idle; the reload takes >1.5 s) — every query hits the 1.5 s timeout, and a user asking "list my 5 latest emails" gets a model with only 3 tools (`manage_memory`, `ask_user`, `update_plan`), which then tells them it has no email access.

Fix: on `asyncio.TimeoutError`, leave `_relevant_tools` as `None` so the existing keyword fallback runs — same `ALWAYS_AVAILABLE` baseline plus the keyword hints, mirroring exactly what the generic `except Exception` branch two lines down already does. One-line behaviour change in `src/agent_loop.py` plus an updated log message.

Found while debugging a real setup (remote embeddings on a LAN Ollama box); the log signature was `[tool-rag] Retrieval exceeded 1.5s` on every request after any idle period.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #5190

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate. Closest neighbours are #4048 (no-ChromaDB path) and #3934 (low-signal gate); this PR is specifically the retrieval-*timeout* branch.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run the tool-selection test suites — both pass (15 passed):

   ```bash
   python -m pytest tests/test_tool_rag_keyword_hints.py tests/test_api_call_integration_routing.py -q
   ```

2. Reproduce the live scenario: set `EMBEDDING_URL` to an OpenAI-compatible embedding endpoint that takes >1.5 s to respond — easiest is Ollama on another machine that has been idle >5 min, so the embedding model must cold-load. Start the app (`uvicorn app:app`), open Agent mode, and ask `list my 5 latest emails`.
   - **Before this fix:** the log shows `[tool-rag] Retrieval exceeded 1.5s; falling back to always-available tools`, and the model answers that it has no email access.
   - **With this fix:** the log shows `falling back to keyword tool selection` followed by `[tool-rag] Keyword fallback selected: [...]` including the email tools, and the model lists the emails.
3. No slow backend handy? Temporarily set `_TOOL_SELECTION_TIMEOUT_SECONDS = 0.001` in `src/agent_loop.py` to force the timeout branch and observe the same before/after difference.

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable — server-side tool-selection logic only; nothing that renders is touched.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language.
- [ ] **No new component patterns.**
- [ ] **I am not an LLM agent submitting a bulk PR.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
