### PR TITLE
fix(integrations): don't append a trailing slash when api_call path is '/'

### DIFF
--- a/src/integrations.py
+++ b/src/integrations.py
@@ -216,7 +216,14 @@ def _normalize_integration_base_url(base_url: Any) -> str:
 
 
 def _join_integration_url(base_url: str, path: str) -> str:
-    return urljoin(base_url.rstrip("/") + "/", path.lstrip("/"))
+    base = base_url.rstrip("/")
+    rel = path.lstrip("/")
+    if not rel:
+        # A bare "/" must resolve to the base URL itself, not base + "/".
+        # POST-to-base integrations (e.g. Discord webhooks) 404 on the
+        # trailing-slash variant of their URL.
+        return base
+    return urljoin(base + "/", rel)
 
 
 def load_integrations() -> List[Dict[str, Any]]:

--- a/tests/test_integrations_url_join.py
+++ b/tests/test_integrations_url_join.py
@@ -1,0 +1,117 @@
+"""Tests for integration URL construction in execute_api_call.
+
+Covers the trailing-slash regression from #5138: a bare "/" path must
+resolve to the base URL itself, not base + "/". Discord webhook URLs
+404 on the trailing-slash variant, so api_call against a
+POST-to-base integration silently failed.
+"""
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Minimal stubs so src.integrations can be imported without heavy deps
+# ---------------------------------------------------------------------------
+
+for mod_name in ("core", "core.atomic_io", "core.platform_compat"):
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = types.ModuleType(mod_name)
+
+core_atomic = sys.modules["core.atomic_io"]
+if not hasattr(core_atomic, "atomic_write_json"):
+    core_atomic.atomic_write_json = lambda *a, **kw: None  # type: ignore
+
+core_compat = sys.modules["core.platform_compat"]
+if not hasattr(core_compat, "safe_chmod"):
+    core_compat.safe_chmod = lambda *a, **kw: None  # type: ignore
+
+if "src.secret_storage" not in sys.modules:
+    stub = types.ModuleType("src.secret_storage")
+    stub.encrypt = lambda s: s  # type: ignore
+    stub.decrypt = lambda s: s  # type: ignore
+    stub.is_encrypted = lambda s: False  # type: ignore
+    sys.modules["src.secret_storage"] = stub
+
+if "src.constants" not in sys.modules:
+    stub_c = types.ModuleType("src.constants")
+    stub_c.DATA_DIR = "/tmp"  # type: ignore
+    stub_c.INTEGRATIONS_FILE = "/tmp/integrations_test.json"  # type: ignore
+    stub_c.SETTINGS_FILE = "/tmp/settings_test.json"  # type: ignore
+    sys.modules["src.constants"] = stub_c
+
+from src import integrations  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# _join_integration_url unit tests
+# ---------------------------------------------------------------------------
+
+WEBHOOK_BASE = "https://discord.com/api/webhooks/123/tokentokentoken"
+
+
+@pytest.mark.parametrize(
+    "base,path,expected",
+    [
+        # Bare "/" (the minimum path execute_api_call accepts) must not
+        # grow a trailing slash — Discord webhooks 404 on it (#5138).
+        (WEBHOOK_BASE, "/", WEBHOOK_BASE),
+        (WEBHOOK_BASE + "/", "/", WEBHOOK_BASE),
+        (WEBHOOK_BASE, "", WEBHOOK_BASE),
+        # Normal paths keep joining exactly as before.
+        ("http://api.example.com", "/items", "http://api.example.com/items"),
+        ("http://api.example.com/", "/items", "http://api.example.com/items"),
+        ("http://host/base", "/v1/me", "http://host/base/v1/me"),
+        # A deliberate trailing slash inside a non-empty path is preserved
+        # (e.g. linkding's /api/tags/, Home Assistant's /api/).
+        ("http://host", "/api/tags/", "http://host/api/tags/"),
+        ("http://host", "/api/", "http://host/api/"),
+    ],
+)
+def test_join_integration_url(base, path, expected):
+    assert integrations._join_integration_url(base, path) == expected
+
+
+# ---------------------------------------------------------------------------
+# Behavioral test through execute_api_call
+# ---------------------------------------------------------------------------
+
+DISCORD_INTEGRATION = {
+    "id": "discord_test",
+    "name": "Discord Webhook",
+    "enabled": True,
+    "base_url": WEBHOOK_BASE,
+    "auth_type": "none",
+    "api_key": "",
+    "auth_header": "",
+    "auth_param": "",
+    "description": "",
+    "preset": "discord_webhook",
+}
+
+
+@pytest.mark.asyncio
+async def test_api_call_root_path_has_no_trailing_slash():
+    mock_resp = MagicMock()
+    mock_resp.status_code = 204
+    mock_resp.headers = {"content-type": "text/plain"}
+    mock_resp.text = ""
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client.request = AsyncMock(return_value=mock_resp)
+
+    with (
+        patch.object(integrations, "_find_integration", return_value=DISCORD_INTEGRATION),
+        patch("httpx.AsyncClient", return_value=mock_client),
+    ):
+        result = await integrations.execute_api_call(
+            "discord_test", "POST", "/", body={"content": "test"}
+        )
+
+    assert result.get("exit_code") == 0
+    requested_url = mock_client.request.call_args.args[1]
+    assert requested_url == WEBHOOK_BASE
+    assert not requested_url.endswith("/")

--- a/tests/test_integrations_url_join.py
+++ b/tests/test_integrations_url_join.py
@@ -114,4 +114,3 @@ async def test_api_call_root_path_has_no_trailing_slash():
     assert result.get("exit_code") == 0
     requested_url = mock_client.request.call_args.args[1]
     assert requested_url == WEBHOOK_BASE
-    assert not requested_url.endswith("/")


### PR DESCRIPTION
## Summary

`_join_integration_url` in `src/integrations.py` built `urljoin(base + "/", "")` when the request path was a bare `/` — the minimum path `execute_api_call` accepts — so every request against a POST-to-base integration was sent to `base_url + "/"`. Discord rejects the trailing-slash variant of a webhook URL with `HTTP 404 Unknown Webhook (code 10015)`, making the integration look broken even though the stored base URL was correct (`_normalize_integration_base_url` already strips trailing slashes on save). The fix resolves a bare `/` (or empty) path to the base URL itself and keeps every other path joining exactly as before — including deliberate trailing slashes inside non-empty paths (linkding's `/api/tags/`, Home Assistant's `/api/`). The reminder webhook sender (`routes/note_routes.py`) and the `discord_webhook` connectivity test (`routes/auth_routes.py`) already posted to the bare base URL; `execute_api_call` was the remaining code path that re-added the slash.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #5138

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

Without a real Discord webhook, a local simulator that mimics Discord's slash-sensitivity makes the bug (and fix) observable end-to-end:

1. Run a webhook simulator that returns 204 on the exact path `/api/webhooks/123/tokentokentoken` and 404 on anything else (Discord treats the trailing-slash variant as an unknown webhook):

   ```python
   # discord_sim.py — python3 discord_sim.py
   from http.server import BaseHTTPRequestHandler, HTTPServer

   class H(BaseHTTPRequestHandler):
       def _h(self):
           ok = self.path == "/api/webhooks/123/tokentokentoken"
           print(self.command, self.path, "->", 204 if ok else 404, flush=True)
           self.send_response(204 if ok else 404); self.end_headers()
       do_GET = _h; do_POST = _h
       def log_message(self, *a): pass

   HTTPServer(("127.0.0.1", 9455), H).serve_forever()
   ```

2. Run the app (`uvicorn app:app`, manual venv install), log in as admin, and in **Settings → Integrations** add an integration with Base URL `http://127.0.0.1:9455/api/webhooks/123/tokentokentoken` (no preset / auth None).
3. Click **Test** on the integration (internally `execute_api_call(id, "GET", "/")` — the same URL construction the reported POST payload path uses).
4. **On `dev` before this patch:** the simulator logs `GET /api/webhooks/123/tokentokentoken/ -> 404` (note the trailing slash) and the UI reports `HTTP 404` — the reporter's exact symptom.
5. **With this patch:** the simulator logs `GET /api/webhooks/123/tokentokentoken -> 204` (no trailing slash) and the UI reports "Connection successful".

I ran exactly this before/after sequence against the running app on macOS (manual venv, Python 3.13); outputs matched steps 4 and 5.

Automated checks run:

```
./venv/bin/python -m pytest tests/test_integrations_url_join.py \
  tests/test_integrations_api_call_truncation.py \
  tests/test_integrations_store_shape.py \
  tests/test_api_call_integration_routing.py -q
# 39 passed
./venv/bin/python -m py_compile src/integrations.py
```

The new `tests/test_integrations_url_join.py` covers the bare-`/` regression plus the preserved behaviours (normal joins, base URLs with/without trailing slash, and deliberate trailing slashes inside non-empty paths), and asserts through `execute_api_call` with a mocked `httpx.AsyncClient` that a `POST /` against a Discord-shaped integration hits the exact base URL.

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable — backend-only change (`src/integrations.py` + tests); nothing that renders was touched.

- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.
