### PR TITLE
fix(security): validate integration api_call URLs with the SSRF guard

### DIFF
--- a/src/integrations.py
+++ b/src/integrations.py
@@ -13,6 +13,7 @@ from core.atomic_io import atomic_write_json
 from core.platform_compat import safe_chmod
 from src.secret_storage import decrypt, encrypt, is_encrypted
 from src.constants import DATA_DIR, INTEGRATIONS_FILE, SETTINGS_FILE
+from src.url_safety import check_outbound_url
 
 log = logging.getLogger(__name__)
 
@@ -394,6 +395,19 @@ async def execute_api_call(
         return {"error": "Path must not contain a fragment", "exit_code": 1}
 
     url = _join_integration_url(base_url, path)
+
+    # SSRF guard — same check_outbound_url pattern as the reminder webhook
+    # branch, gallery, embeddings, and CardDAV. Always rejects link-local /
+    # metadata / reserved addresses; additionally rejects private and
+    # loopback targets when INTEGRATION_API_BLOCK_PRIVATE_IPS=true. Off by
+    # default because LAN integrations (Home Assistant, Miniflux, ntfy) are
+    # the primary use case. The path arrives from the api_call agent tool,
+    # so validate the joined URL, not just the stored base_url.
+    block_private = os.getenv("INTEGRATION_API_BLOCK_PRIVATE_IPS", "false").lower() == "true"
+    url_ok, url_reason = check_outbound_url(url, block_private=block_private)
+    if not url_ok:
+        return {"error": f"Integration URL rejected: {url_reason}", "exit_code": 1}
+
     method = method.upper()
 
     # Build headers

--- a/tests/test_integrations_api_call_truncation.py
+++ b/tests/test_integrations_api_call_truncation.py
@@ -82,6 +82,9 @@ async def _call(json_data, status=200):
 
     with (
         patch.object(integrations, "_find_integration", return_value=DUMMY_INTEGRATION),
+        # These tests cover response truncation, not URL safety — stub the
+        # SSRF guard so no unit test performs live DNS resolution.
+        patch.object(integrations, "check_outbound_url", return_value=(True, "ok")),
         patch("httpx.AsyncClient", return_value=mock_client),
     ):
         return await integrations.execute_api_call("test_integ", "GET", "/items")
@@ -97,6 +100,8 @@ async def _call_with_integration(integration, path="/items"):
 
     with (
         patch.object(integrations, "_find_integration", return_value=integration),
+        # Truncation tests, not URL-safety tests — keep them DNS-free.
+        patch.object(integrations, "check_outbound_url", return_value=(True, "ok")),
         patch("httpx.AsyncClient", return_value=mock_client),
     ):
         result = await integrations.execute_api_call("test_integ", "GET", path)

--- a/tests/test_integrations_ssrf_guard.py
+++ b/tests/test_integrations_ssrf_guard.py
@@ -1,0 +1,178 @@
+"""Tests for the SSRF guard in execute_api_call (#5143).
+
+The api_call agent tool lets the LLM drive requests against a
+user-configured integration base_url. The joined URL must pass
+src.url_safety.check_outbound_url before httpx connects:
+
+  (a) link-local / metadata addresses are rejected always
+  (b) private / loopback addresses pass by default (local-first)
+  (c) private / loopback addresses are rejected when
+      INTEGRATION_API_BLOCK_PRIVATE_IPS=true
+  (d) rejected URLs never reach the HTTP client
+
+All URLs use IP literals so no test depends on real DNS.
+"""
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Minimal stubs so src.integrations can be imported without heavy deps
+# ---------------------------------------------------------------------------
+
+for mod_name in ("core", "core.atomic_io", "core.platform_compat"):
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = types.ModuleType(mod_name)
+
+core_atomic = sys.modules["core.atomic_io"]
+if not hasattr(core_atomic, "atomic_write_json"):
+    core_atomic.atomic_write_json = lambda *a, **kw: None  # type: ignore
+
+core_compat = sys.modules["core.platform_compat"]
+if not hasattr(core_compat, "safe_chmod"):
+    core_compat.safe_chmod = lambda *a, **kw: None  # type: ignore
+
+if "src.secret_storage" not in sys.modules:
+    stub = types.ModuleType("src.secret_storage")
+    stub.encrypt = lambda s: s  # type: ignore
+    stub.decrypt = lambda s: s  # type: ignore
+    stub.is_encrypted = lambda s: False  # type: ignore
+    sys.modules["src.secret_storage"] = stub
+
+if "src.constants" not in sys.modules:
+    stub_c = types.ModuleType("src.constants")
+    stub_c.DATA_DIR = "/tmp"  # type: ignore
+    stub_c.INTEGRATIONS_FILE = "/tmp/integrations_test.json"  # type: ignore
+    stub_c.SETTINGS_FILE = "/tmp/settings_test.json"  # type: ignore
+    sys.modules["src.constants"] = stub_c
+
+from src import integrations  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _integration(base_url):
+    return {
+        "id": "ssrf_test",
+        "name": "SsrfTest",
+        "enabled": True,
+        "base_url": base_url,
+        "auth_type": "none",
+        "api_key": "",
+        "auth_header": "",
+        "auth_param": "",
+        "description": "",
+        "preset": "",
+    }
+
+
+async def _call(base_url, path="/status"):
+    """Run execute_api_call against a mocked httpx client.
+
+    Returns (result, request_mock) so tests can assert both the outcome and
+    whether an outbound request was attempted at all.
+    """
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.headers = {"content-type": "text/plain"}
+    mock_resp.text = "ok"
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client.request = AsyncMock(return_value=mock_resp)
+
+    with (
+        patch.object(integrations, "_find_integration", return_value=_integration(base_url)),
+        patch("httpx.AsyncClient", return_value=mock_client),
+    ):
+        result = await integrations.execute_api_call("ssrf_test", "GET", path)
+    return result, mock_client.request
+
+
+# ---------------------------------------------------------------------------
+# (a) link-local / metadata rejected always
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "http://169.254.169.254",  # cloud instance metadata
+        "http://169.254.170.2/v2",  # ECS task metadata
+    ],
+)
+async def test_link_local_rejected_by_default(base_url):
+    result, request = await _call(base_url)
+    assert result.get("exit_code") == 1
+    assert "rejected" in result.get("error", "").lower()
+    request.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# (b) local-first default: private / loopback pass
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "http://127.0.0.1:8123",  # loopback (local Home Assistant)
+        "http://192.168.1.50:8080",  # RFC-1918 LAN host
+        "http://10.0.0.5",  # RFC-1918
+    ],
+)
+async def test_private_allowed_by_default(base_url):
+    result, request = await _call(base_url)
+    assert result.get("exit_code") == 0
+    request.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_public_ip_allowed_even_under_lockdown(monkeypatch):
+    monkeypatch.setenv("INTEGRATION_API_BLOCK_PRIVATE_IPS", "true")
+    result, request = await _call("http://8.8.8.8")  # unambiguously public
+    assert result.get("exit_code") == 0
+    request.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# (c) lockdown knob: private / loopback rejected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "http://127.0.0.1:8123",
+        "http://192.168.1.50:8080",
+    ],
+)
+async def test_private_rejected_with_lockdown_knob(monkeypatch, base_url):
+    monkeypatch.setenv("INTEGRATION_API_BLOCK_PRIVATE_IPS", "true")
+    result, request = await _call(base_url)
+    assert result.get("exit_code") == 1
+    assert "rejected" in result.get("error", "").lower()
+    request.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# (d) guard runs on the joined URL, after path validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rejection_covers_llm_supplied_path(monkeypatch):
+    # The path is LLM-influenced; the host still comes from base_url, so a
+    # metadata base must be rejected regardless of what path is requested.
+    result, request = await _call("http://169.254.169.254", path="/latest/meta-data/")
+    assert result.get("exit_code") == 1
+    request.assert_not_called()


### PR DESCRIPTION
## Summary

`execute_api_call` in `src/integrations.py` — reachable by the LLM through the `api_call` agent tool — joined the integration's user-configured `base_url` with an LLM-controlled `path` and requested it with `httpx` directly, with no IP validation. Every other user-influenced outbound surface (gallery, embeddings, CardDAV, the reminder webhook branch) already runs `src.url_safety.check_outbound_url` before connecting; this one was never given the guard. An integration whose `base_url` points at `http://169.254.169.254` was requested server-side, with the integration's auth headers attached, on any `api_call` invocation — the classic cloud instance-metadata credential-exfil vector. This adds the same pre-connect validation the other surfaces use: link-local / metadata / reserved addresses are always rejected, and private / loopback targets are additionally rejected when `INTEGRATION_API_BLOCK_PRIVATE_IPS=true`, following the existing per-surface knob pattern (`EMBEDDING_…`, `IMAGE_…`, `CARDDAV_…`, `REMINDER_WEBHOOK_…`). The default stays permissive for private ranges because LAN integrations (Home Assistant, Miniflux, ntfy) are the primary use case, exactly as `url_safety.py`'s module docstring prescribes. Scope note: this covers the missing pre-connect validation only — the validate-then-connect DNS-rebinding TOCTOU is #5146 and applies to a different sender.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #5143

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

Ran the app (manual venv install, Python 3.13, macOS) and exercised the guard through **Settings → Integrations → Test** (which internally calls `execute_api_call`) in three scenarios:

1. **Metadata address rejected (default):** integration with Base URL `http://169.254.169.254` → Test returns immediately (~16 ms, no outbound attempt):
   `{"ok":false,"message":"Integration URL rejected: link-local address blocked (SSRF metadata risk): 169.254.169.254"}`
   (Unguarded, this hangs for the full 30 s httpx timeout while attempting to reach the metadata service.)
2. **Local-first default preserved:** integration pointing at a local HTTP server (`http://127.0.0.1:9456`) → `{"ok":true,"message":"Connection successful"}` — LAN/loopback integrations keep working out of the box.
3. **Lockdown knob:** restart with `INTEGRATION_API_BLOCK_PRIVATE_IPS=true` → the same loopback integration is rejected:
   `{"ok":false,"message":"Integration URL rejected: private/loopback address blocked: 127.0.0.1"}`

Automated checks:

```
./venv/bin/python -m pytest tests/test_integrations_ssrf_guard.py \
  tests/test_integrations_api_call_truncation.py \
  tests/test_integrations_store_shape.py \
  tests/test_api_call_integration_routing.py -q
# 39 passed
./venv/bin/python -m py_compile src/integrations.py
```

New `tests/test_integrations_ssrf_guard.py` covers: link-local/metadata rejected always (including an LLM-supplied metadata path), private/loopback allowed by default, private/loopback rejected under the knob, public addresses allowed even under lockdown, and — via the mocked client — that rejected URLs never reach `httpx`. All test URLs are IP literals, so no test depends on live DNS; the existing truncation tests (which assert on `api.example.com` URLs) stub the guard for the same reason.

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable — backend-only change (`src/integrations.py` + tests); nothing that renders was touched.

- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.
