### PR TITLE
fix(security): match grep's rg sensitive-file exclusions case-insensitively

### DIFF
--- a/src/agent_tools/filesystem_tools.py
+++ b/src/agent_tools/filesystem_tools.py
@@ -424,8 +424,12 @@ class GrepTool:
                     cmd.append("--ignore-case")
                 if glob_pat:
                     cmd += ["--glob", glob_pat]
+                # --iglob (not --glob) so the exclusion is case-insensitive:
+                # on a case-insensitive filesystem "ID_RSA"/"Known_Hosts"
+                # resolve to the same secret as their lowercase forms, and the
+                # Python fallback below already folds case via _is_sensitive_path.
                 for _pat in _SENSITIVE_FILE_PATTERNS:
-                    cmd += ["--glob", f"!*{_pat}*"]
+                    cmd += ["--iglob", f"!*{_pat}*"]
                 for _d in _CODENAV_SKIP_DIRS:
                     cmd += ["--glob", f"!**/{_d}/**"]
                 cmd += ["--regexp", pattern, root]

--- a/tests/test_code_nav_tools.py
+++ b/tests/test_code_nav_tools.py
@@ -91,6 +91,30 @@ def test_grep_python_fallback_when_no_rg(repo, monkeypatch):
     assert ".git/config" not in r["output"]
 
 
+@pytest.mark.skipif(shutil.which("rg") is None, reason="targets the ripgrep fast-path")
+def test_grep_skips_case_variant_sensitive_files_rg(repo):
+    """The rg fast-path must exclude deny-listed key files case-insensitively.
+
+    A file whose name is a case variant of a sensitive pattern (e.g. ID_RSA vs
+    id_rsa, Known_Hosts vs known_hosts) points at the same secret on a
+    case-insensitive filesystem, so grep must not return its contents. The
+    Python fallback already folds case via _is_sensitive_path; a plain --glob
+    exclusion is case-sensitive, so it would leak these — this pins the rg path.
+    """
+    token = "GREPSECRET_TOKEN_ZZZ"
+    with open(os.path.join(repo, "notes.txt"), "w") as f:
+        f.write(f"see {token}\n")
+    with open(os.path.join(repo, "ID_RSA"), "w") as f:
+        f.write(f"PRIVATE {token}\n")
+    with open(os.path.join(repo, "Known_Hosts"), "w") as f:
+        f.write(f"host {token}\n")
+    r = _run("grep", f'{{"pattern": "{token}", "path": "{repo}"}}')
+    assert r["exit_code"] == 0
+    assert "notes.txt" in r["output"]        # ordinary matches still returned
+    assert "ID_RSA" not in r["output"]        # case-variant key excluded
+    assert "Known_Hosts" not in r["output"]
+
+
 # ── glob ──────────────────────────────────────────────────────────────────
 
 def test_glob_py(repo):


### PR DESCRIPTION
## Summary

`grep` (`GrepTool._grep`, `src/agent_tools/filesystem_tools.py`) has two search paths. The pure-Python fallback filters every candidate file through `_is_sensitive_path`, which #5097 made case-insensitive. The ripgrep fast-path instead excludes the deny-listed key files by building `--glob "!*<pat>*"` for each entry in `_SENSITIVE_FILE_PATTERNS` (`id_rsa`, `id_ed25519`, `id_ecdsa`, `authorized_keys`, `known_hosts`).

ripgrep's `--glob` is **case-sensitive**, so those exclusions only match the lowercase names. On a case-insensitive filesystem (Windows, default macOS) a key stored under a case variant of its name — `ID_RSA`, `Known_Hosts`, `Authorized_Keys` — is the same file on disk but is not matched by the lowercase `--glob`, so ripgrep searches it and returns its contents. These names are non-dotfiles, so ripgrep's default hidden-file skipping does not cover them either.

The result: after #5097, the two grep paths disagree — the Python fallback refuses a case-variant key, but the ripgrep path (used whenever `rg` is on PATH) leaks its contents. Threat model is the same as #5097 / #5094 / #5013: a prompt-injected agent in workspace mode runs `grep` for a token and exfiltrates a private key that `read_file` already refuses.

This is the follow-up called out as a separate layer in the #5097 PR discussion.

## Fix

Switch the sensitive-pattern exclusions from `--glob` to `--iglob`, ripgrep's case-insensitive glob, so the deny-list matches regardless of filename case — mirroring the now case-folded `_is_sensitive_path` on the Python path. Scoped to the sensitive-pattern loop only; the code-navigation skip-dir globs are unchanged.

## Linked Issue

Fixes #5188

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I searched existing issues and pull requests before opening this one
- [x] My change follows the existing code style and patterns
- [x] I added tests that cover the new behaviour and the regression
- [x] I actually ran the app / tests with this change

## How to Test

1. On a machine with `rg` installed, create a search root containing a key file under a case-variant name, e.g. `ID_RSA` with contents `PRIVATE SECRET_TOKEN`, plus an ordinary `notes.txt` containing `SECRET_TOKEN`.
2. Run the grep tool for `SECRET_TOKEN` over that root.
3. Before the fix: the output includes `ID_RSA:1:PRIVATE SECRET_TOKEN` (the key contents leak). After the fix: only `notes.txt` is returned.
4. Automated: `python -m pytest tests/test_code_nav_tools.py::test_grep_skips_case_variant_sensitive_files_rg -q` (runs on CI where ripgrep is present; skips where `rg` is absent).
