### PR TITLE
fix(search): extract non-ASCII capitalized names in _extract_entities

### DIFF
--- a/services/search/query.py
+++ b/services/search/query.py
@@ -34,8 +34,14 @@ def _extract_entities(query: str) -> Dict[str, List[str]]:
     cleaned = query
     if qtype:
         cleaned = re.sub(rf"^{qtype}\b", "", cleaned, flags=re.I).strip()
-    for token in re.findall(r"\b[A-Z][a-zA-Z]+\b", cleaned):
-        entities["names"].append(token)
+    # Unicode-aware capitalized-word (name) detection. The old [A-Z][a-zA-Z]+
+    # class missed non-ASCII names like "İstanbul"/"Zürich" (dropped) and
+    # "São" (shredded). Keep the ASCII behaviour — the word boundary already
+    # excludes camelCase mid-word capitals — by requiring an all-alphabetic
+    # token of length > 1 whose first character is uppercase.
+    for token in re.findall(r"\b\w+\b", cleaned):
+        if len(token) > 1 and token[0].isupper() and token.isalpha():
+            entities["names"].append(token)
     for year in re.findall(r"\b(?:19|20)\d{2}\b", cleaned):
         entities["dates"].append(year)
     month_day_year = re.findall(

--- a/tests/test_search_query_unicode_names.py
+++ b/tests/test_search_query_unicode_names.py
@@ -1,0 +1,31 @@
+"""Regression: _extract_entities must find non-ASCII capitalized names.
+
+The name extractor used the ASCII-only class [A-Z][a-zA-Z]+, so a query like
+"İstanbul weather" or "Zürich hotels" yielded no name entities at all, and
+"São Paulo" lost "São" — non-English/accented place and proper names were
+silently dropped from query enhancement. Detection is now Unicode-aware;
+ASCII behaviour (including camelCase mid-word capitals not counting as names)
+is preserved.
+"""
+from services.search.query import _extract_entities
+
+
+def _names(q):
+    return _extract_entities(q)["names"]
+
+
+def test_non_ascii_names_are_extracted():
+    assert "İstanbul" in _names("İstanbul weather")
+    assert "Zürich" in _names("Zürich hotels")
+    assert set(_names("trip to São Paulo")) >= {"São", "Paulo"}
+
+
+def test_ascii_names_unchanged():
+    assert _names("What did Alice do in 2024") == ["Alice"]
+    assert _names("news about OpenAI and Google") == ["OpenAI", "Google"]
+
+
+def test_lowercase_camelcase_and_numbers_are_not_names():
+    assert _names("the iphone price") == []
+    assert _names("iPhone price") == []       # mid-word capital is not a name
+    assert _names("top 50 albums") == []


### PR DESCRIPTION
## Summary

`_extract_entities` pulls "name" entities from a search query for query enhancement, using the ASCII-only class `\b[A-Z][a-zA-Z]+\b`. Non-ASCII names were therefore dropped or shredded: `"İstanbul weather"` and `"Zürich hotels"` yielded **no** names at all, and `"São Paulo"` lost `"São"` (only `"Paulo"` survived). Non-English / accented place and proper names silently missed enhancement. Detection is now Unicode-aware — match Unicode words and keep the alphabetic, uppercase-initial ones. ASCII behaviour is preserved (the word boundary already excludes camelCase mid-word capitals like `iPhone`, and digits/mixed tokens are excluded).

## Target branch

- [x] This PR targets `dev`, not `main`.

## Linked Issue

No dedicated issue. Part of the broader non-ASCII handling gaps (cf. #2135, #3514) — this one specifically drops non-English capitalized names from search query enhancement.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — not a duplicate (no PR touches `_extract_entities` name extraction).
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — the name-token loop plus a regression test.
- [ ] Ran the app end-to-end — pure extraction logic verified by unit tests rather than a full app run (see How to Test).

## How to Test

```
python -m pytest tests/test_search_query_unicode_names.py tests/test_search_query_entities_nonstring.py -q
```

All pass. `_extract_entities("İstanbul weather")["names"]` now contains `"İstanbul"` (previously empty); `"trip to São Paulo"` yields both `"São"` and `"Paulo"`; ASCII cases are unchanged (`"What did Alice do in 2024"` → `["Alice"]`, `"iPhone price"` → `[]`), and year/date extraction is unaffected.

## Visual / UI changes

None — backend query-parsing logic only.
