### PR TITLE
fix(reminders): sanitize ntfy Title header to ASCII

### DIFF
--- a/routes/note_routes.py
+++ b/routes/note_routes.py
@@ -479,7 +479,11 @@ async def dispatch_reminder(
                 base = intg["base_url"].rstrip("/")
                 topic = settings.get("reminder_ntfy_topic") or "reminders"
                 ntfy_body = synthesis or note_body or title
-                hdrs = {"Title": title or "Reminder", "Priority": "high", "Tags": "bell"}
+                # HTTP headers must be ASCII; ntfy's Title header is sent raw,
+                # so emoji/non-ASCII titles raise UnicodeEncodeError and the
+                # reminder silently fails. Replace unsupported chars with "?".
+                _clean_title = (title or "Reminder").encode("ascii", "replace").decode("ascii")
+                hdrs = {"Title": _clean_title, "Priority": "high", "Tags": "bell"}
                 api_key = intg.get("api_key", "")
                 if api_key:
                     hdrs["Authorization"] = f"Bearer {api_key}"

--- a/routes/note_routes.py
+++ b/routes/note_routes.py
@@ -479,10 +479,7 @@ async def dispatch_reminder(
                 base = intg["base_url"].rstrip("/")
                 topic = settings.get("reminder_ntfy_topic") or "reminders"
                 ntfy_body = synthesis or note_body or title
-                # HTTP headers must be ASCII; ntfy's Title header is sent raw,
-                # so emoji/non-ASCII titles raise UnicodeEncodeError and the
-                # reminder silently fails. Replace unsupported chars with "?"
-                # and truncate to 200 chars to stay within header limits.
+                # ntfy Title is an ASCII HTTP header; sanitize Unicode and cap its length.
                 _clean_title = (title or "Reminder").encode("ascii", "replace").decode("ascii")[:200]
                 hdrs = {"Title": _clean_title, "Priority": "high", "Tags": "bell"}
                 api_key = intg.get("api_key", "")

--- a/routes/note_routes.py
+++ b/routes/note_routes.py
@@ -481,8 +481,9 @@ async def dispatch_reminder(
                 ntfy_body = synthesis or note_body or title
                 # HTTP headers must be ASCII; ntfy's Title header is sent raw,
                 # so emoji/non-ASCII titles raise UnicodeEncodeError and the
-                # reminder silently fails. Replace unsupported chars with "?".
-                _clean_title = (title or "Reminder").encode("ascii", "replace").decode("ascii")
+                # reminder silently fails. Replace unsupported chars with "?"
+                # and truncate to 200 chars to stay within header limits.
+                _clean_title = (title or "Reminder").encode("ascii", "replace").decode("ascii")[:200]
                 hdrs = {"Title": _clean_title, "Priority": "high", "Tags": "bell"}
                 api_key = intg.get("api_key", "")
                 if api_key:


### PR DESCRIPTION
## Summary
The ntfy reminder channel sets the notification `Title` HTTP header directly from the note title. HTTP headers must be ASCII, so a title containing emoji or other non-ASCII characters causes `httpx` to raise `UnicodeEncodeError`. The exception is caught by the surrounding try/except and only logged as a warning, so the reminder silently fails — no notification is ever delivered.

This sanitizes the title with `encode("ascii", "replace")` before placing it in the header, replacing unsupported characters with `?`. The note body is unaffected (sent as request content, not a header) and continues to support full UTF-8.

## Target branch
- [x] This PR targets **`dev`**, not `main`.

## Linked Issue
Fixes #5207

## Type of Change
- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist
- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I ran `python -m py_compile routes/note_routes.py` — passes.

## How to Test
1. Configure an ntfy integration (Settings → Integrations, preset `ntfy`, base_url + topic).
2. Create a note whose title contains a non-ASCII char, e.g. `Meeting ☕ follow-up`.
3. Trigger its reminder (set due time to now).
4. Before fix: no notification arrives; server log shows `UnicodeEncodeError` / "Reminder ntfy send failed".
5. After fix: notification arrives with title `Meeting ? follow-up`; the body retains the original UTF-8 text.

## Visual / UI changes
N/A — backend reminder dispatch only; no rendering changes.