### PR TITLE
fix(security): sanitize email rich body render path

### DIFF
--- a/static/js/document.js
+++ b/static/js/document.js
@@ -2378,20 +2378,27 @@ import { bindMenuDismiss, dismissOrRemove } from './escMenuStack.js';
   }
 
   // ── WYSIWYG email body helpers ──
+  function _emailPlainTextToHtml(text) {
+    const d = document.createElement('div');
+    d.textContent = text == null ? '' : String(text);
+    return d.innerHTML.replace(/\n/g, '<br>');
+  }
+
   function _emailBodyToHtml(text) {
     const t = (text || '').trim();
     if (!t) return '';
     // If it already contains a formatting/structural HTML tag, it's a saved
-    // WYSIWYG body — use it verbatim. (Checking a leading '<' isn't enough: a
+    // WYSIWYG body — sanitize it before rendering. (Checking a leading '<' isn't enough: a
     // rich body often starts with plain text, e.g. "Hi <b>there</b>".)
-    if (/<\/?(b|i|u|s|strong|em|del|strike|a|p|div|br|ul|ol|li|h[1-3]|blockquote|span|code|pre)\b[^>]*>/i.test(t)) return t;
+    if (/<\/?(b|i|u|s|strong|em|del|strike|a|p|div|br|ul|ol|li|h[1-3]|blockquote|span|code|pre)\b[^>]*>/i.test(t)) {
+      return markdownModule.sanitizeAllowedHtml
+        ? markdownModule.sanitizeAllowedHtml(t)
+        : _emailPlainTextToHtml(t);
+    }
     // Email body: keep author-typed `:shortcode:` text literal. Issue #345
     // (shortcode → emoji) is scoped to chat; do not rewrite colons in mail.
     try { return markdownModule.mdToHtml(text, { shortcodes: false }); }
-    catch (_) {
-      const d = document.createElement('div'); d.textContent = text;
-      return d.innerHTML.replace(/\n/g, '<br>');
-    }
+    catch (_) { return _emailPlainTextToHtml(text); }
   }
   // Mirror the rich body's plain text into the hidden textarea so the existing
   // send / draft / change-detection plumbing (which reads the textarea) stays

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -133,7 +133,7 @@ function _cleanAllowedHtmlOnce(htmlString) {
   return tpl.innerHTML;
 }
 
-function sanitizeAllowedHtml(html) {
+export function sanitizeAllowedHtml(html) {
   const raw = String(html == null ? '' : html);
   // Non-browser context (e.g. a future SSR/Node import): fail closed by
   // escaping rather than trusting the markup.
@@ -824,6 +824,7 @@ export function renderMermaid(container) {
 const markdownModule = {
   escapeHtml,
   mdToHtml,
+  sanitizeAllowedHtml,
   squashOutsideCode,
   renderContent,
   processWithThinking,

--- a/tests/test_markdown_dom_xss_helpers.py
+++ b/tests/test_markdown_dom_xss_helpers.py
@@ -23,3 +23,16 @@ def test_markdown_raw_html_sanitizer_strips_scriptable_css():
     assert "if (name === 'style')" in src
     assert r"javascript:|vbscript:|data:|expression\(" in src
     assert "el.removeAttribute(attr.name);" in src
+
+
+def test_email_rich_body_render_path_reuses_raw_html_sanitizer():
+    markdown_src = (_REPO / "static" / "js" / "markdown.js").read_text(encoding="utf-8")
+    document_src = (_REPO / "static" / "js" / "document.js").read_text(encoding="utf-8")
+    email_body_helper = document_src.split("function _emailBodyToHtml(text)", 1)[1].split(
+        "  // Mirror the rich body's plain text", 1
+    )[0]
+
+    assert "export function sanitizeAllowedHtml(html)" in markdown_src
+    assert "sanitizeAllowedHtml," in markdown_src
+    assert "markdownModule.sanitizeAllowedHtml(t)" in email_body_helper
+    assert "return t;" not in email_body_helper


### PR DESCRIPTION
## Summary

Sanitizes saved WYSIWYG email body HTML before rendering it back into the email composer. The compose path previously treated rich email bodies containing formatting tags as trusted HTML and assigned the result into `innerHTML`, which is what CodeQL flagged in `static/js/document.js`.

This reuses the existing raw-HTML sanitizer from `static/js/markdown.js` instead of adding a second sanitizer, exports it through the markdown module, and keeps the plain-text fallback escaped. I also added a focused regression guard so the email rich-body render path does not go back to returning raw HTML.

Related CodeQL alerts:
- https://github.com/pewdiepie-archdaemon/odysseus/security/code-scanning/575
- https://github.com/pewdiepie-archdaemon/odysseus/security/code-scanning/576
- https://github.com/pewdiepie-archdaemon/odysseus/security/code-scanning/577

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #5214

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs - this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

From the repository root, run the focused Docker regression set:

    docker compose run --rm --no-deps --entrypoint python -e PYTHONDONTWRITEBYTECODE=1 --volume "${PWD}:/app" odysseus -m pytest -q -p no:cacheprovider tests/test_markdown_dom_xss_helpers.py tests/test_security_regressions.py

Expected result: `101 passed`.

Syntax checks:

    node --check static/js/document.js
    node --check static/js/markdown.js

Manual Docker UI check:

1. Run `docker compose up -d --build`.
2. Open `http://localhost:7000`.
3. Log in.
4. Open Email -> New Email.
5. Type into the rich email body editor.

Expected: the email composer opens, the rich body remains editable, and the browser console has no warnings/errors from this path.

Verified locally:
- `node --check static/js/document.js`: passed
- `node --check static/js/markdown.js`: passed
- Docker regression set: `101 passed, 1 warning`
- Docker UI check: email composer opened and rich body accepted text
- Browser console check: no warning/error logs from the compose path

## Visual / UI changes - REQUIRED if you touched anything that renders

This touches the email composer render path in `static/js/document.js`, but does not change intended visual styling. It sanitizes saved rich HTML before rendering it into the existing composer.

### Screenshots / clips

<img width="1329" height="912" alt="odysseus-email-compose-sanitizer-check" src="https://github.com/user-attachments/assets/180a04ea-a25b-463c-a639-efa83a9f7f75" />