### PR TITLE
test(cookbook): add adopt host validation regression coverage

### DIFF
--- a/tests/test_codex_ssh_host_validation.py
+++ b/tests/test_codex_ssh_host_validation.py
@@ -199,7 +199,8 @@ async def test_documents_pagination_out_of_range_offset_returns_empty_page():
     assert result["next_offset"] is None
 
 
-def test_adopt_rejects_ssh_option_host_before_shell(monkeypatch):
+@pytest.mark.parametrize("host_field", ["host", "remote_host"])
+def test_adopt_rejects_ssh_option_host_before_shell(monkeypatch, host_field):
     calls = []
 
     async def fail_if_shell_runs(*args, **kwargs):
@@ -212,7 +213,7 @@ def test_adopt_rejects_ssh_option_host_before_shell(monkeypatch):
     body = {
         "tmux_session": "serve_abc123",
         "model": "org/model",
-        "host": "-oProxyCommand=sh",
+        host_field: "-oProxyCommand=sh",
     }
 
     with pytest.raises(HTTPException) as exc:


### PR DESCRIPTION
## Summary

Adds regression coverage for the Codex Cookbook adopt route so both accepted host field names, `host` and `remote_host`, reject invalid option-shaped values before any remote-serving command can be started. The route source already validates this on current `dev`; this PR pins the alias behavior so it does not regress.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #5223

## Type of Change

- [ ] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs - this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

App-live validation was not run because this is test-only regression coverage and no runtime UI behavior changed.

## How to Test

1. Run `pytest tests/test_codex_ssh_host_validation.py tests/test_route_validators.py`.
2. Confirm the adopt-route regression covers both `host` and `remote_host`.
3. Confirm invalid option-shaped values raise `HTTPException(400)` before remote command creation.

## Visual / UI changes - REQUIRED if you touched anything that renders

No visual rendering files were changed.

### Screenshots / clips

Not applicable.
