### PR TITLE
test(email): add agent draft owner isolation regression coverage

### DIFF
--- a/tests/test_email_owner_scope.py
+++ b/tests/test_email_owner_scope.py
@@ -539,6 +539,55 @@ async def test_pending_agent_draft_routes_do_not_expose_ownerless_rows(tmp_path,
     assert rows == [("draft-bob", "agent_draft"), ("draft-ownerless", "agent_draft")]
 
 
+@pytest.mark.asyncio
+async def test_pending_agent_draft_routes_block_cross_owner_actions(tmp_path, monkeypatch):
+    import routes.email_helpers as email_helpers
+    import routes.email_routes as email_routes
+
+    db_path = tmp_path / "scheduled_emails.db"
+    monkeypatch.setattr(email_helpers, "SCHEDULED_DB", db_path)
+    monkeypatch.setattr(email_routes, "SCHEDULED_DB", db_path)
+    email_helpers._init_scheduled_db()
+
+    conn = sqlite3.connect(db_path)
+    conn.executemany(
+        """
+        INSERT INTO scheduled_emails
+        (id, to_addr, subject, body, attachments, send_at, created_at, status, account_id, owner)
+        VALUES (?, ?, ?, ?, '[]', '9999-12-31T00:00:00', ?, 'agent_draft', ?, ?)
+        """,
+        [
+            ("draft-alice", "alice@example.com", "Alice", "alice body", "2026-01-01", "acct-a", "alice"),
+            ("draft-bob", "bob@example.com", "Bob", "bob body", "2026-01-02", "acct-b", "bob"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    router = email_routes.setup_email_routes()
+    list_pending = _route_endpoint(router, "/api/email/pending", "GET")
+    approve_pending = _route_endpoint(router, "/api/email/pending/{sid}/approve", "POST")
+    cancel_pending = _route_endpoint(router, "/api/email/pending/{sid}", "DELETE")
+
+    alice_rows = await list_pending(owner="alice")
+    assert [row["id"] for row in alice_rows["pending"]] == ["draft-alice"]
+
+    assert (await approve_pending("draft-bob", owner="alice"))["success"] is False
+    assert (await cancel_pending("draft-bob", owner="alice"))["success"] is False
+
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT id, status, send_at FROM scheduled_emails ORDER BY id",
+        ).fetchall()
+    finally:
+        conn.close()
+    assert rows == [
+        ("draft-alice", "agent_draft", "9999-12-31T00:00:00"),
+        ("draft-bob", "agent_draft", "9999-12-31T00:00:00"),
+    ]
+
+
 def test_scheduled_poller_resolves_config_with_row_owner(tmp_path, monkeypatch):
     import routes.email_helpers as email_helpers
     import routes.email_pollers as email_pollers


### PR DESCRIPTION
## Summary

Adds focused regression coverage proving pending browser email agent draft routes only list, approve, and cancel drafts for the authenticated owner. The test seeds Alice and Bob agent drafts, verifies Alice sees only her draft, and verifies Alice cannot approve or cancel Bob's draft.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #5224

## Type of Change

- [ ] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs - this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

App-live validation was not run because this is test-only regression coverage and no runtime UI behavior changed.

## How to Test

1. Run `pytest tests/test_email_owner_scope.py tests/test_mcp_email_decode_header_spaces.py`.
2. Confirm Alice can list her pending agent draft but cannot list Bob's.
3. Confirm Alice cannot approve or cancel Bob's agent draft and that Bob's draft remains pending.

## Visual / UI changes - REQUIRED if you touched anything that renders

No visual rendering files were changed.

### Screenshots / clips

Not applicable.
