### PR TITLE
fix(email): clear bulk selection on context change

### DIFF
--- a/static/js/emailLibrary.js
+++ b/static/js/emailLibrary.js
@@ -950,8 +950,20 @@ function _libCachePut(key, value) {
   }
 }
 
+function _resetBulkSelectionForContextChange({ rerender = false } = {}) {
+  const hadSelection = !!(state._selectedUids && state._selectedUids.size);
+  const wasSelectMode = !!state._selectMode;
+  if (state._selectedUids) state._selectedUids.clear();
+  state._selectMode = false;
+  if (hadSelection || wasSelectMode) {
+    _updateBulkBar();
+    if (rerender) _renderGrid();
+  }
+}
+
 function _resetEmailListForFreshLoad() {
   _exitEmailReaderModeForList();
+  _resetBulkSelectionForContextChange();
   state._libOffset = 0;
   state._libEmails = [];
   state._libTotal = 0;
@@ -2406,6 +2418,7 @@ function _clearFilterPillSideEffect() {
 
 function _addSearchPill(pill) {
   if (!pill) return;
+  _resetBulkSelectionForContextChange({ rerender: true });
   if (!Array.isArray(state._libSearchPills)) state._libSearchPills = [];
   // Dedup by email (contact), text (text pill), or filter value.
   if (pill.type === 'contact') {
@@ -2431,6 +2444,7 @@ function _addSearchPill(pill) {
 
 function _removeSearchPillAt(idx) {
   if (!Array.isArray(state._libSearchPills)) return;
+  _resetBulkSelectionForContextChange({ rerender: true });
   const removed = state._libSearchPills[idx];
   state._libSearchPills.splice(idx, 1);
   if (removed && removed.type === 'filter') _clearFilterPillSideEffect();
@@ -2588,6 +2602,7 @@ async function _initEmailSearchChipBar() {
   // directly.
   let _libSearchTypingTimer = null;
   input.addEventListener('input', async () => {
+    _resetBulkSelectionForContextChange({ rerender: true });
     state._libSearchDraft = input.value;
     await _refreshSuggestions();
     if (_libSearchTypingTimer) clearTimeout(_libSearchTypingTimer);
@@ -2723,6 +2738,7 @@ window.addEventListener('click', (e) => {
 
 async function _doSearch() {
   _exitEmailReaderModeForList();
+  _resetBulkSelectionForContextChange({ rerender: true });
   const seq = ++_libSearchSeq;
   const q = state._libSearch.trim();
   if (q.length < 2) {

--- a/tests/test_email_library_bulk_actions.py
+++ b/tests/test_email_library_bulk_actions.py
@@ -12,6 +12,16 @@ def _bulk_action_source() -> str:
     return text[start:end]
 
 
+def _function_source(name: str) -> str:
+    text = _EMAIL_LIBRARY.read_text(encoding="utf-8")
+    start = text.index(f"function {name}")
+    next_function = text.find("\nfunction ", start + 1)
+    next_async = text.find("\nasync function ", start + 1)
+    candidates = [idx for idx in (next_function, next_async) if idx != -1]
+    end = min(candidates) if candidates else len(text)
+    return text[start:end]
+
+
 def test_email_bulk_read_unread_calls_provider_write_routes():
     """Bulk read/unread must persist to IMAP/provider, not only mutate UI state.
 
@@ -34,3 +44,33 @@ def test_email_bulk_read_unread_checks_backend_success_before_syncing_cache():
     assert "data?.success === false" in src
     assert "throw new Error(data?.error" in src
     assert "_libCacheWriteBack()" in src
+
+
+def test_email_context_changes_clear_bulk_selection_state():
+    """IMAP UIDs are folder/account scoped, so stale bulk selections must die.
+
+    Folder, account, filter, quick-filter, attachment, and search basis changes
+    must exit select mode before the next list/search view can run bulk actions.
+    """
+    text = _EMAIL_LIBRARY.read_text(encoding="utf-8")
+    reset_src = _function_source("_resetBulkSelectionForContextChange")
+    fresh_src = _function_source("_resetEmailListForFreshLoad")
+    add_pill_src = _function_source("_addSearchPill")
+    remove_pill_src = _function_source("_removeSearchPillAt")
+    search_src = text[text.index("async function _doSearch()"):text.index("// Custom dropdown", text.index("async function _doSearch()"))]
+
+    assert "state._selectedUids.clear()" in reset_src
+    assert "state._selectMode = false" in reset_src
+    assert "_updateBulkBar()" in reset_src
+
+    assert "_resetBulkSelectionForContextChange()" in fresh_src
+    assert "_resetBulkSelectionForContextChange({ rerender: true })" in add_pill_src
+    assert "_resetBulkSelectionForContextChange({ rerender: true })" in remove_pill_src
+    assert "_resetBulkSelectionForContextChange({ rerender: true })" in search_src
+
+    assert "state._libFolder = e.target.value;" in text
+    assert "state._libFilter = e.target.value;" in text
+    assert "state._libHasAttachments = !state._libHasAttachments;" in text
+    assert "state._libAccountId = btn.dataset.accId || null;" in text
+    assert text.count("_loadEmailsFresh();") >= 5
+    assert "state._libSearchDraft = input.value;" in text


### PR DESCRIPTION
## Summary

Clears email library bulk-selection state whenever the list context changes, including folder, account, filter, attachment filter, quick filter, and search basis changes. This prevents selected IMAP UIDs from one scope being reused against another visible mailbox or filtered result set.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #5228

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs - this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

A short screen recording was captured for browser validation. The available CLI/API path cannot upload GitHub issue or PR attachments directly, so the clip still needs to be attached through the GitHub web UI before this draft is marked ready.

## How to Test

1. Run `node --check static/js/emailLibrary.js`.
2. Run `pytest -q tests/test_email_library_bulk_actions.py`.
3. In the email library, select messages, change folder/account/filter/search context, and confirm the bulk bar and selected UID set clear before another bulk action is possible.

## Visual / UI changes - REQUIRED if you touched anything that renders

This touches email-library frontend behavior but does not add visual styling, layout, colors, icons, or new component patterns.

- [ ] Screenshot or short clip of the change in the running app is attached below.
- [x] Style match: the change uses the existing email library UI and does not introduce new styling.
- [x] No new component patterns.

### Screenshots / clips
[Screencast_20260705_033142.webm](https://github.com/user-attachments/assets/085088e3-d29b-45b8-84f4-654e52f41fce)