### PR TITLE
fix(security): scope owner-less email accounts to a mailbox match in route guards

### DIFF
--- a/routes/email_helpers.py
+++ b/routes/email_helpers.py
@@ -349,7 +349,7 @@ def _assert_owns_account(account_id: str, owner: str) -> None:
             row = db.query(_EA).filter(_EA.id == account_id).first()
             if row is None:
                 raise HTTPException(404, "Account not found")
-            if row.owner and row.owner != owner:
+            if not _account_visible_to_owner(row, owner):
                 # Treat as 404 (not 403) so we don't leak existence.
                 raise HTTPException(404, "Account not found")
         finally:
@@ -361,6 +361,26 @@ def _assert_owns_account(account_id: str, owner: str) -> None:
         # through. 503 tells the caller to retry; logs preserve detail.
         logger.error(f"Account-owner check failed: {e}")
         raise HTTPException(503, "Account check failed")
+
+
+def _account_visible_to_owner(row, owner: str) -> bool:
+    """Whether an authenticated `owner` may act on this EmailAccount row.
+
+    Mirrors the SQL predicate in `_get_email_config`'s
+    `_owner_or_matching_legacy_account`: a caller sees an account they own, or a
+    legacy owner-less account (owner NULL/"") only when its own mailbox
+    (`imap_user` / `from_address`) is the caller's. `email_accounts` is the one
+    owner-scoped table deliberately left out of the legacy-owner migration
+    backfill, so ownerless rows persist on multi-user deploys — making this the
+    gate that keeps one tenant off another's imported mailbox and its decrypted
+    IMAP/SMTP credentials."""
+    row_owner = getattr(row, "owner", None) or ""
+    if row_owner:
+        return row_owner == owner
+    return owner in {
+        getattr(row, "imap_user", None) or "",
+        getattr(row, "from_address", None) or "",
+    }
 
 def _q(name: str) -> str:
     """Quote an IMAP mailbox name. Defensive: escapes `\\` and `"` and wraps
@@ -903,12 +923,13 @@ def _get_email_config(account_id: str | None = None, owner: str = "") -> dict:
         try:
             if account_id:
                 row = db.query(_EA).filter(_EA.id == account_id, _EA.enabled == True).first()  # noqa: E712
-                # If the resolved row belongs to a different owner, treat as
+                # If the resolved row isn't visible to this owner, treat as
                 # not-found rather than silently serving it. This is a defense
                 # in depth — `require_owner` already calls `_assert_owns_account`
                 # for query-param account_ids, but other callers (cookbook
-                # rules, scheduled poller) may not.
-                if row is not None and owner and row.owner and row.owner != owner:
+                # rules, scheduled poller) may not. Ownerless legacy rows are
+                # only visible on a mailbox match, same as the fallback below.
+                if row is not None and owner and not _account_visible_to_owner(row, owner):
                     row = None
             # Fallback path — restrict to this owner's accounts so we don't
             # leak another user's default mailbox to an unconfigured user.

--- a/tests/test_email_ownerless_account_owner_scope.py
+++ b/tests/test_email_ownerless_account_owner_scope.py
@@ -1,0 +1,117 @@
+"""Cross-tenant access control for legacy owner-less email accounts.
+
+`email_accounts` is the one owner-scoped table left out of the legacy-owner
+migration backfill (core/database.py), so rows with owner NULL/"" persist on a
+multi-user deploy — e.g. an account configured while auth was disabled, or an
+imported legacy row. The HTTP route guards (`_assert_owns_account` and the
+explicit-account_id path in `_get_email_config`) must scope such rows to a
+mailbox match, exactly like the `_owner_or_matching_legacy_account` fallback and
+the MCP `_account_visible_to_owner` gate. Otherwise any authenticated user can
+read/send/update-credentials/delete another tenant's imported mailbox.
+"""
+
+from unittest import mock
+
+import pytest
+from fastapi import HTTPException
+
+
+def _make_db():
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from core.database import Base
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(engine)
+    Factory = sessionmaker(bind=engine)
+    return Factory
+
+
+def _make_account(Factory, account_id, owner, imap_user, from_address="", is_default=False):
+    from core.database import EmailAccount
+    db = Factory()
+    row = EmailAccount(
+        id=account_id,
+        owner=owner,
+        name="Test",
+        enabled=True,
+        is_default=is_default,
+        imap_host="imap.example.com",
+        imap_port=993,
+        imap_user=imap_user,
+        smtp_host="smtp.example.com",
+        smtp_port=587,
+        smtp_user=imap_user,
+        from_address=from_address or imap_user,
+    )
+    db.add(row)
+    db.commit()
+    db.close()
+
+
+def test_assert_owns_account_rejects_ownerless_account_for_other_tenant():
+    """The core regression: a legacy owner-less mailbox is NOT accessible to an
+    authenticated caller whose own mailbox does not match it."""
+    from routes.email_helpers import _assert_owns_account
+    Factory = _make_db()
+    # owner="" (created while auth was disabled); mailbox belongs to victim.
+    _make_account(Factory, "acct-legacy", owner="", imap_user="victim@corp.com")
+
+    with mock.patch("core.database.SessionLocal", Factory):
+        with pytest.raises(HTTPException) as exc:
+            _assert_owns_account("acct-legacy", "attacker")
+    assert exc.value.status_code == 404
+
+
+def test_assert_owns_account_allows_owned_account():
+    from routes.email_helpers import _assert_owns_account
+    Factory = _make_db()
+    _make_account(Factory, "acct-bob", owner="bob", imap_user="bob@corp.com")
+    with mock.patch("core.database.SessionLocal", Factory):
+        _assert_owns_account("acct-bob", "bob")  # no raise
+
+
+def test_assert_owns_account_allows_ownerless_account_on_mailbox_match():
+    """Legacy-claim path stays intact: the user whose mailbox matches an
+    owner-less account may still act on it (imap_user or from_address)."""
+    from routes.email_helpers import _assert_owns_account
+    Factory = _make_db()
+    _make_account(Factory, "acct-legacy", owner="", imap_user="alice@corp.com")
+    with mock.patch("core.database.SessionLocal", Factory):
+        _assert_owns_account("acct-legacy", "alice@corp.com")  # no raise
+
+
+def test_assert_owns_account_noop_for_single_user_mode():
+    """owner == "" (unconfigured / single-user) accepts any account, unchanged."""
+    from routes.email_helpers import _assert_owns_account
+    Factory = _make_db()
+    _make_account(Factory, "acct-legacy", owner="", imap_user="whoever@corp.com")
+    with mock.patch("core.database.SessionLocal", Factory):
+        _assert_owns_account("acct-legacy", "")  # no raise
+
+
+def test_get_email_config_does_not_resolve_ownerless_account_for_other_tenant(monkeypatch):
+    """`_get_email_config(account_id=..., owner=...)` must not serve an
+    owner-less account (and its decrypted creds) to a non-matching tenant."""
+    import routes.email_helpers as eh
+    Factory = _make_db()
+    _make_account(Factory, "acct-legacy", owner="", imap_user="victim@corp.com", is_default=True)
+
+    # Make the settings.json / env fallback empty and deterministic.
+    monkeypatch.setattr(eh, "_load_settings", lambda: {}, raising=False)
+    for var in ("IMAP_HOST", "SMTP_HOST", "IMAP_USER", "SMTP_USER"):
+        monkeypatch.delenv(var, raising=False)
+
+    with mock.patch("core.database.SessionLocal", Factory):
+        cfg = eh._get_email_config(account_id="acct-legacy", owner="attacker")
+
+    assert cfg.get("account_id") != "acct-legacy"
+
+
+def test_get_email_config_resolves_ownerless_account_on_mailbox_match():
+    """The mailbox owner still resolves their claimable legacy account by id."""
+    import routes.email_helpers as eh
+    Factory = _make_db()
+    _make_account(Factory, "acct-legacy", owner="", imap_user="alice@corp.com")
+    with mock.patch("core.database.SessionLocal", Factory):
+        cfg = eh._get_email_config(account_id="acct-legacy", owner="alice@corp.com")
+    assert cfg.get("account_id") == "acct-legacy"


### PR DESCRIPTION
## Summary

I found that the HTTP email route ownership guard lets any authenticated user reach
a legacy **owner-less** email account. Both `_assert_owns_account` and the
explicit-`account_id` branch of `_get_email_config` (in `routes/email_helpers.py`)
checked ownership with `if row.owner and row.owner != owner`, which skips the check
completely when `row.owner` is NULL or `""`.

Those owner-less rows are a real, persistent state, not a transient one:
`email_accounts` is the single owner-scoped table that's left out of the
legacy-owner migration backfill in `core/database.py`, so an account made while
`AUTH_ENABLED=false` (`owner == ""`) or an imported legacy row (`owner IS NULL`)
never gets an owner. On a multi-user deploy, another authenticated user who names
such an account's id could read its mailbox, pull its **decrypted IMAP/SMTP
credentials** out of `_get_email_config`, send as it, overwrite its credentials via
`PUT /accounts/{account_id}`, or delete it via `DELETE /accounts/{account_id}` —
both handlers gate only on `_assert_owns_account`.

What convinced me this is an oversight rather than intended: two sibling paths
already do the right thing. The same-file fallback resolver
`_owner_or_matching_legacy_account` and the MCP gate `_account_visible_to_owner`
(its comment says it's "mirroring the HTTP email route fallback") both only expose
an owner-less account when its own mailbox — `imap_user` or `from_address` — matches
the caller. These two route guards just never applied that rule.

The fix pulls that row-level predicate into `_account_visible_to_owner(row, owner)`
and uses it in both guards, so an owner-less account is visible only on a mailbox
match. Owned accounts, the legacy-claim path (the mailbox owner keeps access), and
single-user mode (`owner == ""`) are all unchanged.

This is the HTTP route layer. #5234 fixes the same class on the MCP tool layer only
(`mcp_servers/email_server.py`) and doesn't touch `routes/email_helpers.py`, so this
is the complementary route-side half, not a duplicate.

## Target branch

- [x] This PR targets `dev`, not `main`.

## Linked Issue

Fixes #5237

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs - this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app / tests and verified the change works end-to-end.

## How to Test

1. `pytest tests/test_email_ownerless_account_owner_scope.py` — the six cases cover
   the fix and its guardrails. Two of them (the `_assert_owns_account` and
   `_get_email_config` cross-tenant cases) fail on `dev` and pass with this change;
   I confirmed that by stashing just the source edit.
2. `pytest tests/test_email_owner_scope.py tests/test_email_oauth.py tests/test_imap_leak_fixes.py tests/test_mcp_email_decode_header_spaces.py`
   to confirm nothing else in the email area regressed (75 passing together here).
3. Manual: on a multi-user setup, create an account with `owner=""` and
   `imap_user=victim@corp.com`, then as a different user call
   `PUT /api/email/accounts/{that_id}` with a new `imap_password`. Before this change
   it succeeds and rewrites the victim's creds; after, it returns 404.

## Visual / UI changes

No UI/rendering files were touched, so no screenshot applies.
