### PR TITLE
ci: add CodeQL advanced setup to scan pull requests before merge

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,8 @@ on:
     branches: [dev, main]
   pull_request:
     branches: [dev]
+  schedule:
+    - cron: "17 3 * * 1"
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+name: CodeQL
+
+# Advanced setup so CodeQL also runs on pull requests (including from forks),
+# surfacing findings before merge instead of only after a change lands on dev.
+on:
+  push:
+    branches: [dev, main]
+  pull_request:
+    branches: [dev]
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, javascript-typescript, python]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/docs/security-ci.md
+++ b/docs/security-ci.md
@@ -7,10 +7,9 @@ benefit.
 
 ## What runs, and why
 
-Most checks live in files under `.github/workflows/`. CodeQL is configured
-through GitHub's code scanning default setup, so it appears as a dynamic GitHub
-workflow instead of a checked-in workflow file. They run automatically; you do
-not start them.
+Most checks live in files under `.github/workflows/`. CodeQL uses the
+checked-in advanced configuration in `.github/workflows/codeql.yml`. They run
+automatically; you do not start them.
 
 | Check | What it protects against | Blocks a merge? |
 |---|---|---|
@@ -90,14 +89,9 @@ let the workflows run on one pull request first, then add them here.
 2. Turn on **Dependency graph** (usually on by default for public repos) -- this
    powers Dependency review and Dependabot.
 3. Turn on **Dependabot alerts** and **Dependabot security updates**.
-4. Under **Code scanning**, use **Set up -> Default** for CodeQL. GitHub then
-   runs CodeQL as a dynamic workflow without the fork-token limitations that
-   affect checked-in advanced workflows.
-
-   Do not also add a checked-in CodeQL workflow while default setup is enabled:
-   GitHub rejects advanced CodeQL uploads when default setup is active. If the
-   project later needs an advanced CodeQL workflow, disable default setup first
-   and keep only one CodeQL publishing path active.
+4. Under **Code scanning**, keep **Default setup** disabled. CodeQL is
+   configured by `.github/workflows/codeql.yml`; enabling default setup at the
+   same time causes GitHub to reject uploads from the checked-in workflow.
 
 ## Keeping it current
 


### PR DESCRIPTION
## Summary
Moves CodeQL from GitHub's default setup to advanced setup by adding `.github/workflows/codeql.yml`. Default setup only scans pushes and same-repo branches, so it never scans pull requests from forks, which is where nearly all contributor PRs come from. Today that means CodeQL findings only appear after a change is merged into `dev`, and the fix lands on maintainers rather than the author. This workflow runs CodeQL on pull requests targeting `dev` (and on pushes to `dev` and `main`), so findings surface on the PR before merge. The check is advisory and does not block merges.

The languages (`actions`, `javascript-typescript`, `python`) and the default query suite match what default setup runs today, so the alert set does not change. Actions are pinned to the same SHAs already used elsewhere in this repo.

**Draft on purpose.** Advanced setup and default setup cannot run at the same time: while default setup is enabled, this workflow runs but its upload is rejected, so its CodeQL check will show red until a repo admin disables default setup in the repo settings. Keep this as a draft until that switch is made, then it can be marked ready and merged.

## Linked Issue
Fixes #5249

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] CI / tooling / build
- [ ] Documentation

## Checklist
- [x] I searched existing issues and PRs and this is not a duplicate.
- [x] No visual change: this touches only `.github/workflows`, so no screenshot applies.

## How to Test
Verified end to end on a fork before opening this. To reproduce after default setup is disabled:
1. Open a PR to `dev` that adds a known-bad pattern, for example an inefficient regex like `re.compile(r"^(a+)+$")`.
2. Confirm the three CodeQL jobs (`actions`, `javascript-typescript`, `python`) run on the PR.
3. Confirm the finding is reported on the PR before merge.
On the fork test, a deliberate `py/redos` in a fork PR was flagged on the PR itself, before merge.
