### PR TITLE
fix(tasks): scope manage_tasks mutations to an exact task owner

### DIFF
--- a/src/tools/system.py
+++ b/src/tools/system.py
@@ -356,7 +356,11 @@ async def do_manage_tasks(content: str, owner: Optional[str] = None) -> Dict:
             task = db.query(ScheduledTask).filter(ScheduledTask.id == task_id).first()
             if not task:
                 return {"error": f"Task {task_id} not found", "exit_code": 1}
-            if owner and task.owner and task.owner != owner:
+            # Strict ownership: the old `task.owner and task.owner != owner`
+            # skipped the check on an owner-less task (created in no-login mode
+            # or before the legacy-owner sweep), letting any authenticated user
+            # reach it. `list` already scopes to an exact owner match.
+            if owner and task.owner != owner:
                 return {"error": "Access denied", "exit_code": 1}
 
             changed = []
@@ -402,7 +406,7 @@ async def do_manage_tasks(content: str, owner: Optional[str] = None) -> Dict:
             task = db.query(ScheduledTask).filter(ScheduledTask.id == task_id).first()
             if not task:
                 return {"error": f"Task {task_id} not found", "exit_code": 1}
-            if owner and task.owner and task.owner != owner:
+            if owner and task.owner != owner:
                 return {"error": "Access denied", "exit_code": 1}
             name = task.name
             db.delete(task)
@@ -416,7 +420,7 @@ async def do_manage_tasks(content: str, owner: Optional[str] = None) -> Dict:
             task = db.query(ScheduledTask).filter(ScheduledTask.id == task_id).first()
             if not task:
                 return {"error": f"Task {task_id} not found", "exit_code": 1}
-            if owner and task.owner and task.owner != owner:
+            if owner and task.owner != owner:
                 return {"error": "Access denied", "exit_code": 1}
 
             if action == "pause":
@@ -437,7 +441,7 @@ async def do_manage_tasks(content: str, owner: Optional[str] = None) -> Dict:
             task = db.query(ScheduledTask).filter(ScheduledTask.id == task_id).first()
             if not task:
                 return {"error": f"Task {task_id} not found", "exit_code": 1}
-            if owner and task.owner and task.owner != owner:
+            if owner and task.owner != owner:
                 return {"error": "Access denied", "exit_code": 1}
 
             from src.event_bus import get_task_scheduler

--- a/tests/test_manage_tasks_owner_scope.py
+++ b/tests/test_manage_tasks_owner_scope.py
@@ -1,0 +1,139 @@
+"""manage_tasks mutations must fail closed on owner-less / cross-owner tasks.
+
+The edit/delete/pause/run actions of ``do_manage_tasks`` previously gated with
+``if owner and task.owner and task.owner != owner``. The middle term made the
+check a no-op whenever the task had no owner — the state a scheduled task is in
+when it was created in no-login mode (or via the localhost middleware bypass)
+before the periodic legacy-owner sweep reassigns it to the admin user. So any
+authenticated user's agent could edit, delete, pause, or *run* another tenant's
+owner-less task. The sibling ``list`` action already scopes with an exact
+``ScheduledTask.owner == owner`` filter, so the mutators were strictly more
+permissive than the reader.
+"""
+
+import json
+import tempfile
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import NullPool
+
+from tests.helpers.import_state import clear_fake_database_modules
+
+clear_fake_database_modules()
+
+import core.database as cdb
+from core.database import ScheduledTask
+from src.tools.system import do_manage_tasks
+
+_TMPDB = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+_ENGINE = create_engine(
+    f"sqlite:///{_TMPDB.name}",
+    connect_args={"check_same_thread": False},
+    poolclass=NullPool,
+)
+cdb.Base.metadata.create_all(_ENGINE)
+_TS = sessionmaker(bind=_ENGINE, autoflush=False, autocommit=False)
+# do_manage_tasks does `from core.database import SessionLocal` at call time,
+# so patching the module attribute is enough to point it at the temp DB.
+cdb.SessionLocal = _TS
+
+
+def _seed(task_id, owner):
+    db = _TS()
+    try:
+        db.add(ScheduledTask(
+            id=task_id, owner=owner, name=task_id, prompt="original",
+            task_type="llm", trigger_type="webhook", status="active",
+            output_target="session",
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+
+def _get(task_id):
+    db = _TS()
+    try:
+        return db.query(ScheduledTask).filter(ScheduledTask.id == task_id).first()
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_edit_denied_on_ownerless_task_for_authenticated_user():
+    _seed("ownerless-edit", None)
+    out = await do_manage_tasks(
+        json.dumps({"action": "edit", "task_id": "ownerless-edit", "prompt": "pwned"}),
+        owner="alice",
+    )
+    assert out["exit_code"] == 1 and out["error"] == "Access denied"
+    assert _get("ownerless-edit").prompt == "original"
+
+
+@pytest.mark.asyncio
+async def test_delete_denied_on_ownerless_task_for_authenticated_user():
+    _seed("ownerless-del", None)
+    out = await do_manage_tasks(
+        json.dumps({"action": "delete", "task_id": "ownerless-del"}),
+        owner="alice",
+    )
+    assert out["exit_code"] == 1 and out["error"] == "Access denied"
+    assert _get("ownerless-del") is not None
+
+
+@pytest.mark.asyncio
+async def test_pause_denied_on_ownerless_task_for_authenticated_user():
+    _seed("ownerless-pause", None)
+    out = await do_manage_tasks(
+        json.dumps({"action": "pause", "task_id": "ownerless-pause"}),
+        owner="alice",
+    )
+    assert out["exit_code"] == 1 and out["error"] == "Access denied"
+    assert _get("ownerless-pause").status == "active"
+
+
+@pytest.mark.asyncio
+async def test_run_denied_on_ownerless_task_for_authenticated_user():
+    _seed("ownerless-run", None)
+    out = await do_manage_tasks(
+        json.dumps({"action": "run", "task_id": "ownerless-run"}),
+        owner="alice",
+    )
+    assert out["exit_code"] == 1 and out["error"] == "Access denied"
+
+
+@pytest.mark.asyncio
+async def test_edit_denied_on_other_owners_task():
+    _seed("bob-task", "bob")
+    out = await do_manage_tasks(
+        json.dumps({"action": "edit", "task_id": "bob-task", "prompt": "pwned"}),
+        owner="alice",
+    )
+    assert out["exit_code"] == 1 and out["error"] == "Access denied"
+    assert _get("bob-task").prompt == "original"
+
+
+@pytest.mark.asyncio
+async def test_edit_allowed_for_matching_owner():
+    _seed("alice-task", "alice")
+    out = await do_manage_tasks(
+        json.dumps({"action": "edit", "task_id": "alice-task", "prompt": "updated"}),
+        owner="alice",
+    )
+    assert out["exit_code"] == 0
+    assert _get("alice-task").prompt == "updated"
+
+
+@pytest.mark.asyncio
+async def test_edit_allowed_in_no_login_mode():
+    # owner is None when auth is disabled — single-user mode keeps full access
+    # to shared (owner-less) tasks, exactly as `list` returns them unfiltered.
+    _seed("shared-task", None)
+    out = await do_manage_tasks(
+        json.dumps({"action": "edit", "task_id": "shared-task", "prompt": "updated"}),
+        owner=None,
+    )
+    assert out["exit_code"] == 0
+    assert _get("shared-task").prompt == "updated"


### PR DESCRIPTION
## Summary

The `manage_tasks` tool (`do_manage_tasks`, `src/tools/system.py`) gated the `edit`, `delete`, `pause`/`resume`, and `run` actions with `if owner and task.owner and task.owner != owner`. The middle `task.owner and` term turns the check into a no-op whenever the task has no owner — the state a scheduled task sits in when it was created in no-login mode (or via the localhost middleware bypass) before the periodic legacy-owner sweep reassigns it to the admin user. Until then, any authenticated user's agent could `edit`, `delete`, `pause`, or `run` another tenant's owner-less task by id; `edit`+`run` is the worst case, rewriting the task's prompt and executing it in the scheduler's agent context. The `list` action in the same function already scopes with an exact `ScheduledTask.owner == owner` filter, so owner-less tasks are invisible to the reader but fully reachable by the mutators. This drops the middle term so the four guards fail closed on owner-less rows for authenticated callers, matching `list` and the calendar/notes/gallery/session null-owner gates in `tests/test_null_owner_gates.py`. Auth disabled (`owner` falsy) and same-owner access are unchanged.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #5263

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. `python -m pytest tests/test_manage_tasks_owner_scope.py -q` — 7 pass.
2. Revert just the four guards in `src/tools/system.py` back to `if owner and task.owner and task.owner != owner:` and rerun: the four `*_denied_on_ownerless_task_*` cases fail — the `run` case reaches the scheduler instead of returning `Access denied`, proving the bypass — while the same-owner and no-login positive cases still pass.
3. End-to-end: with `uvicorn app:app` and AUTH enabled, seed an owner-less `scheduled_tasks` row, then as an authenticated user have the agent call `manage_tasks {"action": "run", "task_id": "<id>"}` (also `edit`/`delete`/`pause`). Before the fix the action succeeds; after, it returns `Access denied`.

<!-- No UI/visual changes: this PR only touches src/tools/system.py and a test. -->
