### PR TITLE
fix(tools): guard do_api_call against non-dict JSON tool args

### DIFF
--- a/src/tools/system.py
+++ b/src/tools/system.py
@@ -483,6 +483,14 @@ async def do_api_call(content: str) -> Dict:
             except json.JSONDecodeError:
                 pass
 
+    # json.loads can succeed with a non-dict when the LLM emits a bare array
+    # or scalar like `[...]` or `5`. Every access below is args.get(...), which
+    # raises AttributeError on a list/int/str, so coerce to an empty dict and
+    # let the "no integration matching ''" path report it cleanly. Mirrors the
+    # guard in src.tool_utils._parse_tool_args.
+    if not isinstance(args, dict):
+        args = {}
+
     integration_name = args.get("integration", "")
     integrations = load_integrations()
     intg = next((i for i in integrations if i["id"] == integration_name

--- a/tests/test_do_api_call_non_dict.py
+++ b/tests/test_do_api_call_non_dict.py
@@ -1,0 +1,56 @@
+"""Regression: do_api_call must not crash when the LLM emits non-dict JSON.
+
+do_api_call parses its tool-block `content` with json.loads and then does
+args.get("integration"). json.loads succeeds on a valid JSON array or scalar
+(the model emits `["GET","/x"]` or `5`), leaving args a list/int/str and
+crashing every .get() with AttributeError. The guard coerces non-dict values
+to {} so the call falls through to the clean "no integration matching ''"
+error path instead.
+"""
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from src.tools.system import do_api_call
+
+
+def _run(content):
+    with patch("src.integrations.load_integrations", return_value=[]):
+        return asyncio.run(do_api_call(content))
+
+
+@pytest.mark.parametrize("content", ['[1, 2, 3]', '5', 'true', '"hello"', 'null'])
+def test_non_dict_json_does_not_crash(content):
+    # Before the guard these raised AttributeError/TypeError on args.get(...).
+    result = _run(content)
+    assert isinstance(result, dict)
+    assert result.get("exit_code") == 1
+    assert "No integration matching" in result.get("error", "")
+
+
+def test_dict_json_still_resolves_integration():
+    intg = {"id": "mini", "name": "Miniflux", "enabled": True}
+    with (
+        patch("src.integrations.load_integrations", return_value=[intg]),
+        patch("src.integrations.execute_api_call",
+              return_value={"exit_code": 0, "output": "ok"}) as ex,
+    ):
+        result = asyncio.run(do_api_call('{"integration": "mini", "method": "GET", "path": "/v1/feeds"}'))
+    assert result["exit_code"] == 0
+    ex.assert_called_once()
+    assert ex.call_args.args[0] == "mini"
+
+
+def test_line_based_fallback_still_works():
+    intg = {"id": "mini", "name": "Miniflux", "enabled": True}
+    with (
+        patch("src.integrations.load_integrations", return_value=[intg]),
+        patch("src.integrations.execute_api_call",
+              return_value={"exit_code": 0, "output": "ok"}) as ex,
+    ):
+        # Not JSON -> line-based parse: integration on line 1, "METHOD path" on line 2.
+        result = asyncio.run(do_api_call("Miniflux\nGET /v1/feeds"))
+    assert result["exit_code"] == 0
+    assert ex.call_args.args[1] == "GET"
+    assert ex.call_args.args[2] == "/v1/feeds"


### PR DESCRIPTION
## Summary

`do_api_call()` in `src/tools/system.py` parses the LLM's `api_call` tool block with `json.loads(content)` and then does `args.get("integration", "")` (plus `args.get("method")`, `args.get("path")`, …). The `try` only catches `json.JSONDecodeError`, so when the model emits **valid JSON that isn't an object** — `["GET","/x"]`, `5`, `true`, `"hello"` — `json.loads` succeeds, `args` is a list/int/str, and the next `.get()` raises `AttributeError`, which propagates uncaught out of the tool executor and crashes the agent turn.

This PR coerces a non-dict parse result to `{}` so the call falls through to the existing "No integration matching ''" error path. It mirrors the guard already in `src.tool_utils._parse_tool_args`; `do_api_call` can't just delegate to that helper because it has its own line-based fallback for non-JSON input, which is preserved.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #5260

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

```bash
python -m pytest tests/test_do_api_call_non_dict.py -v
```

7 tests: five non-dict JSON inputs (`[1,2,3]`, `5`, `true`, `"hello"`, `null`) now return a clean `{"exit_code": 1, "error": "No integration matching ''..."}` instead of raising; a well-formed dict still resolves the integration and calls `execute_api_call`; and the non-JSON line-based fallback (`Miniflux\nGET /v1/feeds`) still parses correctly.
