### PR TITLE
fix(copilot): guard request_flags against a non-dict last message

### DIFF
--- a/src/copilot.py
+++ b/src/copilot.py
@@ -230,7 +230,10 @@ def request_flags(messages) -> tuple:
     """
     msgs = messages or []
     last = msgs[-1] if msgs else None
-    agent = bool(last) and last.get("role") != "user"
+    # A message element can be a non-dict (clients send `"messages": ["hi"]`);
+    # the vision loop below already guards each element with isinstance, so do
+    # the same here rather than call .get() on a bare string.
+    agent = isinstance(last, dict) and last.get("role") != "user"
     vision = False
     for m in msgs:
         content = m.get("content") if isinstance(m, dict) else None

--- a/tests/test_copilot.py
+++ b/tests/test_copilot.py
@@ -89,6 +89,18 @@ def test_request_flags_vision():
     assert vision is True
 
 
+def test_request_flags_non_dict_last_message_does_not_crash():
+    # A client can send a bare-string (non-dict) last element; before the
+    # isinstance guard this raised AttributeError on last.get("role").
+    assert copilot.request_flags(["hi"]) == (False, False)
+    assert copilot.request_flags([{"role": "user"}, "trailing"]) == (False, False)
+
+
+def test_request_flags_empty_and_none():
+    assert copilot.request_flags([]) == (False, False)
+    assert copilot.request_flags(None) == (False, False)
+
+
 def test_apply_request_headers_mutates():
     h = {"X-GitHub-Api-Version": "v"}
     copilot.apply_request_headers(h, [{"role": "tool", "content": "x"}])


### PR DESCRIPTION
## Summary

`request_flags()` in `src/copilot.py` derives `(agent, vision)` from an OpenAI-style message list and does `last.get("role")` after only a truthy check (`agent = bool(last) and last.get("role") != "user"`). The vision loop immediately below already guards each element with `isinstance(m, dict)`, so the code anticipates non-dict elements — but the `last` line does not. A client sending a bare-string last element (`"messages": ["hi"]`) triggers `AttributeError: 'str' object has no attribute 'get'`. Since `request_flags` runs on every Copilot-proxied request (via `apply_request_headers`), a malformed body crashes the proxy path.

This PR uses `isinstance(last, dict)` to match the loop's own guard.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #5273

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

```bash
python -m pytest tests/test_copilot.py -k request_flags -v
```

Adds `test_request_flags_non_dict_last_message_does_not_crash` (`["hi"]` and a dict-then-trailing-string list now return `(False, False)` instead of raising) and `test_request_flags_empty_and_none`. The existing `request_flags` user/agent/vision tests still pass.
