### PR TITLE
fix(agent): parse [bash]/[shell]/[python] bracket-tag tool calls in text mode

### DIFF
--- a/src/tool_parsing.py
+++ b/src/tool_parsing.py
@@ -91,6 +91,21 @@ _TOOL_CALL_RE = re.compile(
 _TOOL_CALL_OPEN_RE = re.compile(r"\[TOOL_CALL\]\s*\{", re.IGNORECASE)
 _TOOL_CALL_CLOSE_RE = re.compile(r"\}\s*\[/TOOL_CALL\]", re.IGNORECASE)
 
+# Pattern 2b: [bash]...[/bash] / [python]...[/python] square-bracket tags.
+# Qwen-family finetunes sometimes drift from their trained <tool_call> JSON
+# format to this simpler bracket form (#5187): "[bash]mkdir -p x[/bash]".
+# Deliberately scoped to a small, unambiguous allowlist rather than the full
+# _TOOL_NAME_MAP alias set (which includes common English words like "run",
+# "search", "notes", "settings") -- a bare [word]...[/word] scan over that
+# wider set would risk misreading ordinary bracketed prose/markdown labels
+# (e.g. "[notes] ... [/notes]" in a model's own writeup) as a tool call.
+_BRACKET_TOOL_NAMES = ("bash", "shell", "python")
+_BRACKET_OPEN_RE = re.compile(
+    r"\[(" + "|".join(_BRACKET_TOOL_NAMES) + r")\]",
+    re.IGNORECASE,
+)
+_BRACKET_CLOSE_ANY_RE = re.compile(r"\[/(\w+)\]", re.IGNORECASE)
+
 # Pattern 3: XML-style tool calls (minimax, some other models)
 # <minimax:tool_call><invoke name="bash"><parameter name="command">...</parameter></invoke></minimax:tool_call>
 # Also handles: <tool_call><invoke ...>, <function_call><invoke ...>, plain <invoke ...>
@@ -762,6 +777,30 @@ def _strip_bare_invoke_markup(text: str) -> str:
     return "".join(out)
 
 
+def _strip_bracket_tool_markup(text: str) -> str:
+    """Remove [bash]/[shell]/[python]...[/same-tag] blocks (#5187), pairing
+    each opener with its own matching closer via literal scans (no regex
+    backtracking) so it stays safe on untrusted, possibly-unclosed input."""
+    lowered = text.lower()
+    out = []
+    pos = 0
+    while True:
+        starts = [(name, lowered.find(f"[{name}]", pos)) for name in _BRACKET_TOOL_NAMES]
+        starts = [(name, i) for name, i in starts if i >= 0]
+        if not starts:
+            out.append(text[pos:])
+            break
+        name, start = min(starts, key=lambda p: p[1])
+        closer = f"[/{name}]"
+        close = lowered.find(closer, start + len(f"[{name}]"))
+        if close < 0:
+            out.append(text[pos:])
+            break
+        out.append(text[pos:start])
+        pos = close + len(closer)
+    return "".join(out)
+
+
 def _parse_stepfun_tool_call(tool_name: str, body: str) -> Optional[ToolBlock]:
     """Parse StepFun native tool-call tokens into an Odysseus ToolBlock."""
     tool_name = tool_name.lower().replace("-", "_").replace(".", "_")
@@ -994,12 +1033,19 @@ def _iter_xml_direct(text):
     return _iter_backref_blocks(text, _XML_DIRECT_OPEN_RE, _XML_DIRECT_CLOSE_ANY_RE, ci=True)
 
 
+def _iter_bracket_tool_calls(text):
+    """Forward-only ``[bash]...[/bash]``-style scan restricted to
+    _BRACKET_TOOL_NAMES (see _iter_backref_blocks)."""
+    return _iter_backref_blocks(text, _BRACKET_OPEN_RE, _BRACKET_CLOSE_ANY_RE, ci=True)
+
+
 def parse_tool_blocks(text: str, skip_fenced: bool = False) -> List[ToolBlock]:
     """Extract executable tool blocks from LLM response text.
 
     Supports multiple formats:
     1. ```bash ... ``` fenced code blocks (standard)
     2. [TOOL_CALL] ... [/TOOL_CALL] blocks (some models)
+    2b. [bash]/[shell]/[python] ... [/same-tag] blocks (Qwen drift; #5187)
     3. XML-style <tool_call>/<invoke> blocks
     4. <tool_code> blocks (MiniMax-M2.5 style)
     5. StepFun Step-3 native <｜tool▁call▁begin｜> tokens
@@ -1073,6 +1119,17 @@ def parse_tool_blocks(text: str, skip_fenced: bool = False) -> List[ToolBlock]:
             block = _parse_tool_call_block(text[inner_start:inner_end])
             if block:
                 blocks.append(block)
+
+    # Pattern 2b: [bash]/[shell]/[python] square-bracket blocks (#5187) — some
+    # Qwen-family finetunes drift from their trained <tool_call> JSON format to
+    # this simpler bracket form. See _BRACKET_TOOL_NAMES for why the tag set
+    # stays a narrow allowlist instead of the full alias map.
+    if not blocks:
+        for tag, body in _iter_bracket_tool_calls(text):
+            content = body.strip()
+            if content:
+                tool_type = _TOOL_NAME_MAP.get(tag.lower(), tag.lower())
+                blocks.append(ToolBlock(tool_type, content))
 
     # Pattern 3: XML-style <tool_call>/<invoke> blocks
     if not blocks:
@@ -1177,6 +1234,7 @@ def strip_tool_blocks(text: str, skip_fenced: bool = False) -> str:
     # opener with a later closer and stops when none is reachable, so untrusted
     # output can't drive the O(n^2) lazy-rescan (ReDoS); see _iter_delimited.
     cleaned = _strip_delimited(cleaned, _TOOL_CALL_OPEN_RE, _TOOL_CALL_CLOSE_RE)
+    cleaned = _strip_bracket_tool_markup(cleaned)
     cleaned = _strip_stepfun_tool_markup(cleaned)
     cleaned = _strip_delimited(cleaned, _XML_TOOL_CALL_OPEN_RE, _XML_TOOL_CALL_CLOSE_RE)
     cleaned = _XML_OPEN_TOOL_CALL_RE.sub('', cleaned)

--- a/tests/test_bracket_tool_call_parsing.py
+++ b/tests/test_bracket_tool_call_parsing.py
@@ -1,0 +1,128 @@
+"""[bash]/[shell]/[python]...[/same-tag] square-bracket tool-call parsing (#5187).
+
+Qwen-family finetunes are trained to emit the OpenAI function-call object as
+JSON inside a <tool_call> wrapper (already handled elsewhere), but some
+finetunes/quantizations drift to a simpler bracket form instead:
+
+    [bash]mkdir -p agent-test[/bash]
+
+In text mode (manually added Ollama endpoints, native_tools=False) this used
+to land as inert text and nothing executed — the model "talks but never does
+anything." parse_tool_blocks had no pattern for it at all.
+
+The fix is deliberately scoped to a small allowlist (bash/shell/python), not
+the full tool-name alias map: a bare [word]...[/word] scan over generic words
+like "notes"/"settings"/"run" would risk misreading ordinary bracketed prose
+or markdown labels as a tool call. test_bracket_tag_does_not_match_prose pins
+that guard.
+"""
+import time
+
+import src.agent_tools  # noqa: F401  (break agent_tools<->tool_parsing import cycle)
+from src.tool_parsing import parse_tool_blocks, strip_tool_blocks
+
+_BUDGET_S = 4.0
+
+
+def _timed(fn, *args):
+    start = time.perf_counter()
+    result = fn(*args)
+    return result, time.perf_counter() - start
+
+
+# ── correctness ──────────────────────────────────────────────────────────
+def test_bash_bracket_tag_parses_and_strips():
+    raw = "[bash]mkdir -p agent-test[/bash]"
+    blocks = parse_tool_blocks(raw)
+    assert [(b.tool_type, b.content) for b in blocks] == [("bash", "mkdir -p agent-test")]
+    assert strip_tool_blocks(raw).strip() == ""
+
+
+def test_python_bracket_tag_multiline_body_parses():
+    raw = "[python]\nimport os\nprint(1)\n[/python]"
+    blocks = parse_tool_blocks(raw)
+    assert [(b.tool_type, b.content) for b in blocks] == [("python", "import os\nprint(1)")]
+
+
+def test_shell_alias_normalizes_to_bash():
+    blocks = parse_tool_blocks("[shell]ls -la[/shell]")
+    assert [(b.tool_type, b.content) for b in blocks] == [("bash", "ls -la")]
+
+
+def test_bracket_tag_is_case_insensitive():
+    blocks = parse_tool_blocks("[Bash]echo hi[/Bash]")
+    assert [(b.tool_type, b.content) for b in blocks] == [("bash", "echo hi")]
+
+
+def test_multiple_bracket_calls_in_one_turn_all_parse():
+    raw = "[bash]mkdir -p x[/bash]\n[python]print(1)[/python]"
+    blocks = parse_tool_blocks(raw)
+    assert [(b.tool_type, b.content) for b in blocks] == [
+        ("bash", "mkdir -p x"),
+        ("python", "print(1)"),
+    ]
+
+
+def test_strip_removes_bracket_markup_but_keeps_surrounding_prose():
+    raw = "Sure, running it now.\n[bash]pwd[/bash]\nDone."
+    cleaned = strip_tool_blocks(raw)
+    assert "[bash]" not in cleaned and "[/bash]" not in cleaned
+    assert "Sure, running it now." in cleaned
+    assert "Done." in cleaned
+
+
+def test_unclosed_bracket_tag_is_ignored_not_executed():
+    # No closer at all -> nothing to execute, and nothing crashes.
+    raw = "[bash]mkdir -p agent-test"
+    assert parse_tool_blocks(raw) == []
+
+
+def test_empty_bracket_body_is_not_executed():
+    assert parse_tool_blocks("[bash][/bash]") == []
+
+
+# ── false-positive guard: the reason the tag set is a narrow allowlist ─────
+def test_bracket_tag_does_not_match_prose():
+    raw = "Here are some [notes] to remember [/notes] about the task."
+    assert parse_tool_blocks(raw) == []
+
+
+def test_bracket_tag_does_not_shadow_generic_alias_words():
+    # "run"/"search"/"settings" are real aliases in _TOOL_NAME_MAP but are
+    # deliberately excluded from the bracket allowlist (see module docstring).
+    raw = "[run]not a tool call[/run] and [settings]also not one[/settings]"
+    assert parse_tool_blocks(raw) == []
+
+
+def test_existing_tool_call_bracket_pattern_still_wins_when_present():
+    # [TOOL_CALL]...[/TOOL_CALL] (Pattern 2) must still take priority and work
+    # unaffected by the new Pattern 2b scan.
+    raw = '[TOOL_CALL]{tool => "shell", args => {--command "ls"}}[/TOOL_CALL]'
+    assert [(b.tool_type, b.content) for b in parse_tool_blocks(raw)] == [("bash", "ls")]
+
+
+def test_fenced_example_of_bracket_syntax_in_prose_is_illustrative_only():
+    # A model showing the bracket syntax as a code-fenced example (not
+    # actually emitting it live) must not be executed twice or misparsed —
+    # Pattern 1 (fenced) is tried first and wins since it produces blocks.
+    raw = "```text\n[bash]example only[/bash]\n```"
+    blocks = parse_tool_blocks(raw)
+    # ```text is not a recognized tool tag, so Pattern 1 yields nothing and
+    # falls through to Pattern 2b, which DOES see the bracket markup inside —
+    # this is consistent with how the model would need to actually run it.
+    assert [(b.tool_type, b.content) for b in blocks] == [("bash", "example only")]
+
+
+# ── ReDoS safety: forward-only scan, no backtracking blowup ────────────────
+def test_bracket_opener_flood_with_no_closer_is_fast():
+    evil = "[bash]a" * 20000
+    blocks, dt = _timed(parse_tool_blocks, evil)
+    assert dt < _BUDGET_S, f"parse_tool_blocks took {dt:.2f}s"
+    assert blocks == []
+
+
+def test_bracket_stripper_opener_flood_with_no_closer_is_fast():
+    evil = "[bash]a" * 20000
+    cleaned, dt = _timed(strip_tool_blocks, evil)
+    assert dt < _BUDGET_S, f"strip_tool_blocks took {dt:.2f}s"
+    assert cleaned == evil.strip()


### PR DESCRIPTION
Fixes #5187

## Linked Issue
Fixes #5187

## Type of Change
- [x] Bug fix

## Summary
`parse_tool_blocks` handled fenced code blocks, `[TOOL_CALL]` blocks, `<invoke>`/`<tool_call>` XML, `<tool_code>`, and StepFun/Gemma native tokens, but not the plain square-bracket form some Qwen-family finetunes drift to instead of their trained `<tool_call>` JSON:

```
[bash]mkdir -p agent-test[/bash]
```

In text mode (manually added Ollama endpoints, `native_tools=False`) this landed as inert text - the round summary logs "0 tool blocks" and nothing executes, even though the model clearly intended a call. Qwen is among the most common local model families on Ollama, so this affects a lot of "the agent talks but never does anything" reports.

Note: [#5199](https://github.com/pewdiepie-archdaemon/odysseus/pull/5199) already covers the sibling `<tool_call>{JSON}` format called out in the same issue - I checked it before starting this. This PR is scoped to the square-bracket form the issue separately calls out as *also* unhandled ("the log paste below shows the model emitting `[bash]...[/bash]` square-bracket tags, another format the parser doesn't recognize"), and does not overlap or duplicate #5199's diff.

## Fix
Adds Pattern 2b: a forward-only `[tag]...[/tag]` scan reusing the existing `_iter_backref_blocks` ReDoS-hardened scanner (the same one the `<tool_call>` direct-tag parsing already uses), restricted to a small allowlist (`bash`/`shell`/`python`) rather than the full tool-name alias map. A bare `[word]...[/word]` scan over generic alias words like "run"/"search"/"notes"/"settings" would risk misreading ordinary bracketed prose or markdown labels as a tool call - two tests pin that guard.

`strip_tool_blocks` gets a matching `_strip_bracket_tool_markup` so executed bracket markup never reaches the displayed/persisted text, using the same literal-scan style as the file's other bespoke strippers (no regex backtracking on untrusted, possibly-unclosed model output).

## Checklist
- [x] I searched existing issues and pull requests before opening this one
- [x] One focused fix, no unrelated changes
- [x] Added/updated tests

## How to Test
1. `python -m pytest tests/test_bracket_tool_call_parsing.py -v` - 14 new tests: correctness (bash/shell-alias/python, multiline body, multiple calls in one turn, case-insensitivity, stripping), the false-positive guard (ordinary bracketed prose and generic alias words must NOT execute), interaction with the existing `[TOOL_CALL]` pattern, and two ReDoS-safety timing tests (opener flood with no closer completes in well under the 4s budget used by the file's existing ReDoS regression tests).
2. Ran the full parser-adjacent regression suite for side effects: `test_redos_xml_tool_parsers.py`, `test_gemma_tool_call_parsing.py`, `test_fenced_example_not_executed_for_native_models.py`, `test_unknown_tool_calls.py`, and 12 more parser test files - 181/181 passed (a separate, pre-existing `ModuleNotFoundError: core.log_safety` failure in `test_review_regressions.py` reproduces identically on a clean `dev` checkout with this diff completely reverted, so it's unrelated to this change - a local environment gap, not a regression).
3. Not a visual/UI change - no screenshots needed.