### PR TITLE
fix(docker): detect snap+WSL2 GPU passthrough incompatibility

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -151,6 +151,21 @@ scripts/check-docker-gpu.sh --enable-nvidia-overlay
 scripts/check-docker-gpu.sh --install-nvidia-toolkit --enable-nvidia-overlay
 ```
 
+> **WSL2 + snap Docker.** If `docker run --gpus all ...` fails with
+> `failed to fulfil mount request: open /usr/lib/wsl/lib/libdxcore.so: no
+> such file or directory`, check whether Docker was installed via `snap`
+> (`snap list docker`, or `docker info --format '{{.DockerRootDir}}'` reports
+> a path under `/var/snap/docker/`). Snap's confinement prevents Docker from
+> seeing the GPU library WSL2 injects at `/usr/lib/wsl/lib`, even though the
+> file exists on the host — installing or reconfiguring
+> `nvidia-container-toolkit` will not fix this, since the toolkit isn't the
+> problem. `scripts/check-docker-gpu.sh` detects this combination and calls
+> it out directly. The fix is to remove snap Docker and install the official
+> apt-based Docker Engine instead
+> ([docs.docker.com/engine/install](https://docs.docker.com/engine/install/)),
+> then re-run `nvidia-ctk runtime configure --runtime=docker` and restart
+> Docker.
+
 Safety notes:
 - The app never installs host GPU runtime automatically.
 - The app never edits `.env` automatically.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -151,20 +151,33 @@ scripts/check-docker-gpu.sh --enable-nvidia-overlay
 scripts/check-docker-gpu.sh --install-nvidia-toolkit --enable-nvidia-overlay
 ```
 
-> **WSL2 + snap Docker.** If `docker run --gpus all ...` fails with
-> `failed to fulfil mount request: open /usr/lib/wsl/lib/libdxcore.so: no
-> such file or directory`, check whether Docker was installed via `snap`
-> (`snap list docker`, or `docker info --format '{{.DockerRootDir}}'` reports
-> a path under `/var/snap/docker/`). Snap's confinement prevents Docker from
-> seeing the GPU library WSL2 injects at `/usr/lib/wsl/lib`, even though the
-> file exists on the host — installing or reconfiguring
-> `nvidia-container-toolkit` will not fix this, since the toolkit isn't the
-> problem. `scripts/check-docker-gpu.sh` detects this combination and calls
-> it out directly. The fix is to remove snap Docker and install the official
-> apt-based Docker Engine instead
-> ([docs.docker.com/engine/install](https://docs.docker.com/engine/install/)),
-> then re-run `nvidia-ctk runtime configure --runtime=docker` and restart
-> Docker.
+**WSL2 + snap Docker.** If the NVIDIA check fails with this error, Docker may be
+installed via snap:
+
+```text
+failed to fulfil mount request: open /usr/lib/wsl/lib/libdxcore.so: no such file or directory
+```
+
+Check with `snap list docker` or:
+
+```bash
+docker info --format '{{.DockerRootDir}}'
+```
+
+A Docker root under `/var/snap/docker/` means snap confinement can prevent
+Docker from seeing WSL2's `/usr/lib/wsl/lib` GPU libraries even when the files
+exist on the host. Reinstalling or reconfiguring `nvidia-container-toolkit` will
+not fix that. Remove snap Docker, install the official apt-based Docker Engine
+([Docker docs](https://docs.docker.com/engine/install/ubuntu/)), then configure
+the NVIDIA runtime again:
+
+```bash
+sudo snap remove docker
+sudo nvidia-ctk runtime configure --runtime=docker
+sudo systemctl restart docker
+```
+
+Then re-run `scripts/check-docker-gpu.sh`.
 
 Safety notes:
 - The app never installs host GPU runtime automatically.

--- a/scripts/check-docker-gpu.sh
+++ b/scripts/check-docker-gpu.sh
@@ -214,16 +214,9 @@ _check_nvidia_smi() {
     echo
 }
 
-# Returns 1 if Docker is unavailable (callers should stop further GPU checks).
-# WSL2 only: Docker installed via snap confines the container runtime's mount
-# namespace, so it cannot see the GPU library WSL2 injects at
-# /usr/lib/wsl/lib/libdxcore.so even though the file exists on the host.
-# Symptom: `docker run --gpus all ...` fails with
-# "failed to fulfil mount request: open /usr/lib/wsl/lib/libdxcore.so: no
-# such file or directory". No nvidia-container-toolkit install or
-# `nvidia-ctk runtime configure` fixes this — the fix is to stop using the
-# snap package. DockerRootDir is the reliable way to tell: snap installs
-# report a path under /var/snap/docker/ instead of the normal /var/lib/docker.
+# WSL2 snap Docker cannot see /usr/lib/wsl/lib/libdxcore.so from its confined
+# namespace, so NVIDIA passthrough fails until the user switches to non-snap
+# Docker. DockerRootDir identifies snap installs more reliably than snap(8).
 _is_wsl() {
     grep -qi microsoft /proc/version 2>/dev/null && return 0
     [ -d /usr/lib/wsl ] && return 0
@@ -237,6 +230,7 @@ _is_docker_snap() {
     return 1
 }
 
+# Returns 1 if Docker is unavailable (callers should stop further GPU checks).
 _check_docker() {
     _info "Checking Docker..."
     if ! command -v docker >/dev/null 2>&1; then

--- a/scripts/check-docker-gpu.sh
+++ b/scripts/check-docker-gpu.sh
@@ -215,6 +215,28 @@ _check_nvidia_smi() {
 }
 
 # Returns 1 if Docker is unavailable (callers should stop further GPU checks).
+# WSL2 only: Docker installed via snap confines the container runtime's mount
+# namespace, so it cannot see the GPU library WSL2 injects at
+# /usr/lib/wsl/lib/libdxcore.so even though the file exists on the host.
+# Symptom: `docker run --gpus all ...` fails with
+# "failed to fulfil mount request: open /usr/lib/wsl/lib/libdxcore.so: no
+# such file or directory". No nvidia-container-toolkit install or
+# `nvidia-ctk runtime configure` fixes this — the fix is to stop using the
+# snap package. DockerRootDir is the reliable way to tell: snap installs
+# report a path under /var/snap/docker/ instead of the normal /var/lib/docker.
+_is_wsl() {
+    grep -qi microsoft /proc/version 2>/dev/null && return 0
+    [ -d /usr/lib/wsl ] && return 0
+    return 1
+}
+
+_is_docker_snap() {
+    case "$(docker info --format '{{.DockerRootDir}}' 2>/dev/null)" in
+        */snap/docker/*|*/snap.docker/*) return 0 ;;
+    esac
+    return 1
+}
+
 _check_docker() {
     _info "Checking Docker..."
     if ! command -v docker >/dev/null 2>&1; then
@@ -258,6 +280,26 @@ _check_gpu_passthrough() {
         echo
         _fail "GPU passthrough failed. Check these steps in order:"
         echo
+        if _is_wsl && _is_docker_snap; then
+            _warn "Detected: Docker installed via snap, running on WSL2."
+            _warn "This is a known incompatibility, not a toolkit/config problem:"
+            _warn "  snap confines Docker's mount namespace, so it cannot see the"
+            _warn "  WSL2-injected GPU library at /usr/lib/wsl/lib/libdxcore.so even"
+            _warn "  though the file exists on the host. Installing/reconfiguring"
+            _warn "  nvidia-container-toolkit will NOT fix this — the numbered"
+            _warn "  steps below will not help until Docker itself is replaced."
+            echo
+            _info "Fix: remove snap Docker and install the official apt-based Docker"
+            _info "Engine instead (unsandboxed, can see /usr/lib/wsl/lib):"
+            echo
+            echo "  sudo snap remove docker"
+            echo "  # then follow: https://docs.docker.com/engine/install/ubuntu/"
+            echo "  sudo nvidia-ctk runtime configure --runtime=docker"
+            echo "  sudo systemctl restart docker"
+            echo
+            _info "Re-run this script afterward to confirm passthrough works."
+            echo
+        fi
         echo "  1. Install NVIDIA Container Toolkit (if not already installed):"
         echo "     Arch:    sudo pacman -S nvidia-container-toolkit"
         echo "     Debian:  sudo apt install nvidia-container-toolkit"


### PR DESCRIPTION
## Summary

On WSL2, Docker installed via `snap` runs in a confined mount namespace that can't see `/usr/lib/wsl/lib/libdxcore.so` — the GPU library WSL2 injects for passthrough — even though the file exists on the host. `docker run --gpus all ...` fails with `failed to fulfil mount request: open /usr/lib/wsl/lib/libdxcore.so: no such file or directory`, and none of the usual fixes (reinstalling/reconfiguring `nvidia-container-toolkit`) resolve it, since the toolkit was never the problem. `scripts/check-docker-gpu.sh` now detects this specific combination (snap-installed Docker + WSL2) and surfaces the real diagnosis and fix instead of the generic toolkit-reinstall steps. `docs/setup.md` documents the failure signature and fix for anyone who hits this searching the error text.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #5259

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate. (Closest existing issue, #2659, is a different root cause — missing the `deploy.resources.reservations` device block, already solved by the existing `docker/gpu.nvidia.yml` overlay — not this snap-confinement issue.)
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. On a WSL2 machine with Docker installed via `snap install docker` and an NVIDIA GPU, run `scripts/check-docker-gpu.sh`. Before this change, the failure branch only prints the generic "install/reconfigure nvidia-container-toolkit, restart Docker" steps. After this change, it additionally detects the snap+WSL2 combination and prints the specific diagnosis (snap confinement blocking `/usr/lib/wsl/lib`) plus the fix (`sudo snap remove docker`, install `docker-ce` via apt, `nvidia-ctk runtime configure --runtime=docker`, restart Docker).
2. Confirmed on a real snap-Docker-on-WSL2 host: `docker run --rm --gpus all nvidia/cuda:12.4.1-base-ubuntu22.04 nvidia-smi` fails with the `libdxcore.so` error before the fix, and succeeds after replacing snap Docker with apt-installed `docker-ce` and re-running `scripts/check-docker-gpu.sh`.
3. `bash -n scripts/check-docker-gpu.sh` — syntax check passes.