### PR TITLE
feat(docker): add opt-in CUDA toolkit build arg for GPU-accelerated Cookbook builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,35 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libmagic1 \
     && rm -rf /var/lib/apt/lists/*
 
+# CUDA Toolkit (opt-in, off by default — several GB, NVIDIA/x86_64 only).
+# Cookbook's llama.cpp bootstrap already builds with -DGGML_CUDA=ON whenever
+# it finds `nvcc` + `libcudart` on the system (see _append_llama_cpp_linux_accel_build_lines
+# in routes/cookbook_helpers.py) — it just has nothing to find in the default
+# slim image, since GPU passthrough (nvidia-smi working in the container)
+# only proves the driver is visible, not that the CUDA compiler/runtime is
+# installed. Without this, llama.cpp silently falls back to a CPU-only build
+# (no hard error) whenever the upstream prebuilt-binary release doesn't ship
+# a matching Ubuntu+CUDA asset. Build with:
+#   docker compose build --build-arg INSTALL_CUDA_TOOLKIT=true
+ARG INSTALL_CUDA_TOOLKIT=false
+RUN if [ "$INSTALL_CUDA_TOOLKIT" = "true" ]; then \
+      curl -fsSL -o /tmp/cuda-keyring.deb \
+        https://developer.download.nvidia.com/compute/cuda/repos/debian13/x86_64/cuda-keyring_1.1-1_all.deb \
+      && dpkg -i /tmp/cuda-keyring.deb \
+      && rm -f /tmp/cuda-keyring.deb \
+      && apt-get update \
+      && apt-get install -y --no-install-recommends cuda-toolkit-13-1 \
+      && rm -rf /var/lib/apt/lists/* \
+      && ln -sfn /usr/local/cuda-13.1 /usr/local/cuda \
+      && echo "/usr/local/cuda-13.1/lib64" > /etc/ld.so.conf.d/cuda-13-1.conf \
+      && ldconfig ; \
+    fi
+# Harmless no-ops when INSTALL_CUDA_TOOLKIT=false — the dynamic linker and
+# shell just skip a PATH/LD_LIBRARY_PATH entry that doesn't exist.
+ENV CUDA_HOME=/usr/local/cuda-13.1 \
+    PATH="/usr/local/cuda-13.1/bin:${PATH}" \
+    LD_LIBRARY_PATH="/usr/local/cuda-13.1/lib64:${LD_LIBRARY_PATH}"
+
 # libgl1/libglib2.0-0t64/libxcb1 are runtime shared libs (libGL.so.1,
 # libglib-2.0/libgthread, libxcb.so.1) that opencv-python (cv2) loads. The
 # slim base omits them, so the Cookbook "install realesrgan" path imports cv2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,13 @@
 services:
   odysseus:
-    build: .
+    build:
+      context: .
+      args:
+        # Read from .env so a plain `docker compose up -d --build` (no
+        # --build-arg on the command line) still gets the CUDA toolkit,
+        # instead of silently rebuilding CPU-only the next time the
+        # container is recreated.
+        INSTALL_CUDA_TOOLKIT: ${INSTALL_CUDA_TOOLKIT:-false}
     ports:
       - "${APP_BIND:-127.0.0.1}:${APP_PORT:-7000}:7000"
     volumes:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -208,8 +208,18 @@ docker compose exec odysseus sh -lc 'test -e /dev/kfd && test -d /dev/dri && ls 
 > the CUDA Toolkit at runtime. If Cookbook logs show `Unable to find cudart
 > library`, `Could NOT find CUDAToolkit`, `CUDA Toolkit not found`, or
 > tensors/layers assigned to CPU, that is a Cookbook/llama.cpp build issue —
-> not a Docker passthrough failure. Reinstall the serve engine via
-> **Cookbook → Dependencies** to get a CUDA-enabled build.
+> not a Docker passthrough failure. The default image doesn't include the
+> CUDA Toolkit at all (it's several GB and NVIDIA-only), so Cookbook's
+> from-source llama.cpp build silently falls back to CPU — reinstalling via
+> **Cookbook → Dependencies** alone won't fix this, since there's still no
+> `nvcc`/`libcudart` for it to build against. Rebuild the image with the
+> toolkit included instead:
+> ```bash
+> docker compose build --build-arg INSTALL_CUDA_TOOLKIT=true
+> docker compose up -d
+> ```
+> Then trigger a rebuild of the serve engine (Cookbook → Dependencies, or
+> Stop/Run the model again) so it picks up `nvcc` and links CUDA.
 >
 > The same split applies to AMD/ROCm: seeing `/dev/kfd` and `/dev/dri` inside
 > the container confirms device passthrough, not ROCm userspace or a


### PR DESCRIPTION
## Summary

Adds an opt-in `INSTALL_CUDA_TOOLKIT` Docker build arg (default `false`) that installs the NVIDIA CUDA Toolkit via NVIDIA's official apt repo when enabled, and wires it through `docker-compose.yml`'s `build.args` (reading from `.env`) so it's usable via a plain `docker compose build`/`up -d --build`. Without the toolkit, Cookbook's from-source `llama.cpp` build in `routes/cookbook_helpers.py` (`_append_llama_cpp_linux_accel_build_lines`) can never find `nvcc`/`libcudart` in the stock image and silently falls back to a CPU-only `llama-server`, even on hosts where GPU passthrough is fully working — this affects any Docker install (not WSL2-specific), since the gap is in the image itself. This makes the CUDA toolchain available system-wide (`CUDA_HOME`/`PATH`/`LD_LIBRARY_PATH` set via Dockerfile `ENV`) without touching the default image's size or behavior.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #5287

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [x] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Default path (regression check): `docker compose config` to confirm the new `build.args` mapping is valid, then `docker compose up -d --build` with no `.env` override — confirm the image builds as before, `nvcc` and `libcudart` are still absent (`docker compose exec odysseus sh -lc 'command -v nvcc; ldconfig -p | grep libcudart'` prints nothing), and Cookbook still builds `llama-server` CPU-only exactly as it did before this PR.
2. Opt-in path: set `INSTALL_CUDA_TOOLKIT=true` in `.env` (or pass `--build-arg INSTALL_CUDA_TOOLKIT=true`), run `docker compose build && docker compose up -d`, then confirm inside the container: `nvcc --version` succeeds and `ldconfig -p | grep libcudart` shows the runtime lib.
3. In Cookbook, trigger a dependency rebuild (or download/serve a fresh GGUF model) and confirm the build log now shows `[odysseus] CUDA nvcc + cudart found — building llama-server with CUDA (GPU) support...` instead of the CPU-fallback warning, and that `--gpu-layers` is actually honored at serve time (e.g. via `nvidia-smi` showing VRAM usage, or the server log reporting offloaded layers).
4. `docker compose logs --tail=120 odysseus` on both paths above to confirm no unrelated errors were introduced.