### PR TITLE
fix(chat): restore missing _explicit_web_intent definition

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -876,6 +876,7 @@ def setup_chat_routes(
         # by default without having to send allow_bash in every request.
         if allow_bash is not None and str(allow_bash).lower() != "true":
             disabled_tools.add("bash")
+        _explicit_web_intent = bool(_tool_intent and _tool_intent.category == "web")
         if (
             allow_web_search is not None
             and str(allow_web_search).lower() != "true"


### PR DESCRIPTION
## Summary

`chat_stream()` in `routes/chat_routes.py` reads a local variable `_explicit_web_intent` in three places — the disabled-tools gate (line ~885), the global-disabled web allowance (line ~955), and the per-turn tool filter (line ~1413) — but the variable is never assigned on current `dev`/`main`. As a result **every chat message raises `NameError: name '_explicit_web_intent' is not defined`** and the request 500s with a bare `Internal Server Error` before any LLM call is made, so nothing ever reaches the provider. The assignment was originally added in `a07fe35` ("fix(agent): honor explicit web search requests") but was dropped during a later branch merge (`Stabilize local dev merge`); the three read sites survived, the definition did not. This PR restores the one-line definition, computed from the already-derived `_tool_intent`, immediately before its first use:

```python
_explicit_web_intent = bool(_tool_intent and _tool_intent.category == "web")
```

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #5289

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate. (Matches issue #5289; no other open PR addresses it.)
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in. (Single added line.)
- [x] I actually ran the app (`uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

Reproduce the crash on unpatched `dev`, then confirm this branch fixes it. Tested locally on macOS with a native `uvicorn app:app` install against Ollama (`llama3.1:8b`).

**Before (on `dev` without this patch):**
1. Start the app: `uvicorn app:app --host 127.0.0.1 --port 7860` (or `./start-macos.sh`).
2. Point it at any provider (e.g. Ollama at `http://localhost:11434/v1`) and select a model.
3. Send any chat message.
4. The UI shows **`Internal Server Error`**. Server stderr shows:
   ```
   File "routes/chat_routes.py", line 885, in chat_stream
       if _explicit_web_intent:
   NameError: name '_explicit_web_intent' is not defined
   ```
   No `POST /v1/chat/completions` is ever logged — the request dies before the provider call.

**After (this branch):**
1. Same steps 1–3.
2. The message streams a normal reply. Server log shows the call reaching the provider and succeeding:
   ```
   POST http://localhost:11434/v1/chat/completions "HTTP/1.1 200 OK"
   src.llm_core - INFO - LLM async call ... succeeded in 0.81s (attempt 1)
   ```
3. Optional sanity check that the restored variable still gates web tools: send a plain lookup like "what is the capital of Romania" (chat mode) and confirm it answers without error; `_explicit_web_intent` is derived from `_tool_intent.category == "web"` exactly as before.

## Visual / UI changes

Not applicable — this is a backend-only change (one line in `routes/chat_routes.py`). No rendering, CSS, HTML, SVG, or `static/js/` code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)