### PR TITLE
fix(chat): define missing _explicit_web_intent variable

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -596,6 +596,7 @@ def setup_chat_routes(
         # shell disabled).
         auto_escalated = False
         _tool_intent = _classify_tool_intent(message) if isinstance(message, str) else None
+        _explicit_web_intent = bool(_tool_intent and _tool_intent.category == "web")
         if chat_mode == "chat" and _tool_intent and _tool_intent.needs_tools:
             chat_mode = "agent"
             auto_escalated = True


### PR DESCRIPTION
## Summary
`_explicit_web_intent` is referenced at three points in `chat_routes.py` (lines 885, 955, 1413) to control tool availability during chat requests, but it is never assigned anywhere in the file. This causes every chat request to fail with `NameError: name '_explicit_web_intent' is not defined`, making the app completely unusable for chat. This PR defines the variable by deriving it from the existing `_tool_intent` classification (`category == "web"`), which is already computed a few lines earlier in the same function and used to derive the analogous `_search_enabled` flag.

## Target branch
- [x] This PR targets **`dev`**, not `main`.

## Linked Issue
Fixes #5291

## Type of Change
- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist
- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test
1. Pull this branch and run `docker compose up -d --build`.
2. Open the app, log in, and send any chat message (e.g. "hello").
3. Before this fix: the request fails with `NameError: name '_explicit_web_intent' is not defined` in the container logs and the chat hangs/errors in the UI.
4. After this fix: the message is processed normally and the assistant responds. Also verify a message with explicit web-search intent (e.g. "search the web for today's weather in São Paulo") still correctly enables `web_search`/`web_fetch` and disables the other tools as expected.

## Visual / UI changes
N/A — this is a backend-only fix in `routes/chat_routes.py`. No templates, CSS, or `static/js/` modules were touched.