### PR TITLE
Fix: define _explicit_web_intent using classify_tool_intent (NameError on chat)

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -20,6 +20,7 @@ from src.agent_loop import stream_agent_loop
 from src import agent_runs
 from src.model_context import estimate_tokens
 from src.chat_helpers import coerce_message_and_session
+from src.action_intents import classify_tool_intent
 from src.endpoint_resolver import normalize_base as _normalize_base, build_chat_url
 from src.session_search import search_session_messages
 from src.prompt_security import untrusted_context_message
@@ -868,6 +869,7 @@ def setup_chat_routes(
         finally:
             _doc_db.close()
 
+        _explicit_web_intent = classify_tool_intent(message).category == "web"
         # Build disabled-tools set from frontend toggles + user privileges
         disabled_tools = set()
         # Only disable bash/web_search when the caller *explicitly* set them


### PR DESCRIPTION
## Summary
`_explicit_web_intent` was used in `chat_routes.py` (lines 885, 955, 1413) but never defined, causing a NameError on every chat message (500 Internal Server Error). This fix imports `classify_tool_intent` from `src.action_intents` and computes the variable from the incoming message before it's used, matching the existing "web" category check.

Fixes #5305

## Type of Change
- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist
- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test
1. Clone the repo, run `docker compose up -d --build`, and open `localhost:7000`.
2. Configure any chat model (e.g. an OpenRouter free model) and send any message (e.g. "Hola").
3. Before this fix: request fails with `NameError: name '_explicit_web_intent' is not defined` (500 Internal Server Error). After this fix: the message is answered normally.

## Visual / UI changes — REQUIRED if you touched anything that renders
N/A — this is a backend-only fix in `routes/chat_routes.py`. No UI, CSS, HTML, or rendering code was touched.

- [x] I am not an LLM agent submitting a bulk PR.