### PR TITLE
fix: assign _explicit_web_intent in chat_stream (NameError, chat 500s)

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -596,6 +596,7 @@ def setup_chat_routes(
         # shell disabled).
         auto_escalated = False
         _tool_intent = _classify_tool_intent(message) if isinstance(message, str) else None
+        _explicit_web_intent = bool(_tool_intent and _tool_intent.category == "web")
         if chat_mode == "chat" and _tool_intent and _tool_intent.needs_tools:
             chat_mode = "agent"
             auto_escalated = True


### PR DESCRIPTION
## Summary

`chat_stream` in `routes/chat_routes.py` reads `_explicit_web_intent` at three sites (lines 885, 955, 1413) but a refactor removed the assignment, so every `/api/chat_stream` request died with `NameError: name '_explicit_web_intent' is not defined` before reaching the LLM; chat was fully broken on fresh installs of both `main` and `dev`. This PR adds the missing assignment right where `_tool_intent` is computed: the flag is true when the message classifies into the `web` intent category, which is what the disabled-tools tests and the comment at line 885 expect.

Re the scope concern raised in the issue comments (local-model paths bypassing the assignment): the assignment is straight-line code in the main body of `chat_stream`, immediately after form parsing and before any provider- or mode-dependent branching, so it executes on every request regardless of backend. A separate top-of-function `= False` initialization would be redundant.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click Edit on this PR and change the base.

## Linked Issue

Fixes #5289

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Fresh clone without this patch, `cp .env.example .env && docker compose up -d --build`, log in, add any provider (I used OpenRouter, the connection test passes), pick a model, send a chat message → Internal Server Error, and `docker compose logs odysseus` shows the `NameError` traceback at `routes/chat_routes.py:885`.
2. Apply this PR (one line), rebuild with `docker compose up -d --build`.
3. Send the same chat message, normal streamed reply. Also confirmed by a second user in the issue thread against their own setup.

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable — single-line backend fix, nothing that renders was touched.