### PR TITLE
fix(chat): restore missing _explicit_web_intent definition to prevent…

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -876,6 +876,7 @@ def setup_chat_routes(
         # by default without having to send allow_bash in every request.
         if allow_bash is not None and str(allow_bash).lower() != "true":
             disabled_tools.add("bash")
+        _explicit_web_intent = bool(_tool_intent and _tool_intent.category == "web")
         if (
             allow_web_search is not None
             and str(allow_web_search).lower() != "true"


### PR DESCRIPTION
# fix: restore missing _explicit_web_intent definition to prevent NameError                                                                                                                  
                                                                                                                                                                                                 
    ## Summary                                                                                                                                                                                   
    Restores the missing definition of the local variable `_explicit_web_intent` in the `chat_stream` endpoint. A previous refactoring commit (`fix(chat): honor explicit web search denial`)    
  removed the definition of `_explicit_web_intent` because its primary check was removed, but missed three other active references to it in the same file. This led to a `NameError` crash and   
  returned a `500 Internal Server Error` whenever users tried to stream messages (such as when using `deepseek-r1:1.5b` or other models).
  
    ## Target branch
  
    - [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and    
  change the base.
  
 ## Linked Issue
    Fixes #5310
 
  
    ## Type of Change
  
    - [x] Bug fix (non-breaking — fixes a confirmed issue)
    - [ ] New feature (non-breaking — adds new behaviour)
    - [ ] Breaking change (changes or removes existing behaviour)
    - [ ] Refactor / cleanup (behaviour unchanged)
    - [ ] Documentation only
    - [ ] CI / tooling / configuration
  
    ## Checklist
  
    - [x] I searched open issues and open PRs — this is not a duplicate.
    - [x] This PR targets `dev`
    - [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
    - [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.
  
    ## How to Test
    1. Set up a local model (e.g., `deepseek-r1:1.5b` or `llama3.2`) in Ollama/vLLM.
    2. Configure this model endpoint in Odysseus.
    3. Open a session using this model and send a chat message.
    4. Verify that the server successfully streams the response without crashing on a `NameError` or returning `500 Internal Server Error`.
    5. Run the existing tests: `./venv/bin/pytest tests/test_chat_helpers.py` and ensure they pass.
  
    ## Visual / UI changes — REQUIRED if you touched anything that renders
    *N/A (No rendering/UI files were touched).*
