### PR TITLE
fix(chat): restore dropped _explicit_web_intent (fixes chat 500 NameError)

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -876,6 +876,12 @@ def setup_chat_routes(
         # by default without having to send allow_bash in every request.
         if allow_bash is not None and str(allow_bash).lower() != "true":
             disabled_tools.add("bash")
+        # Did the user's words explicitly ask for a web lookup/search? (vs. the
+        # web toggle). Used below to keep web_search/web_fetch available and to
+        # focus tools on the lookup. Derived from the deterministic intent
+        # classifier's "web" category. (Restores a definition dropped in a merge
+        # — 885/955/1413 consume it, so its absence NameError'd every chat.)
+        _explicit_web_intent = bool(_tool_intent and _tool_intent.category == "web")
         if (
             allow_web_search is not None
             and str(allow_web_search).lower() != "true"


### PR DESCRIPTION
## Problem
Every `POST /api/chat_stream` returns **500 Internal Server Error** with:
```
NameError: name '_explicit_web_intent' is not defined
```
in `routes/chat_routes.py` (`chat_stream`). Chat is fully broken for every model/provider.

## Root cause
A merge dropped the line that *defines* `_explicit_web_intent`, but three call sites still reference it:
- the disabled-tools focus block (`if _explicit_web_intent:`)
- the global-disabled-tools allowance (`explicit_web_allowed`)
- agent-mode forced tools (`_forced_tools`)

`_search_enabled` right above it is still defined — only `_explicit_web_intent` was lost.

## Fix
Restore the original one-line definition next to the other disabled-tools setup, derived from the deterministic intent classifier's `web` category (`src/action_intents.py`):
```python
_explicit_web_intent = bool(_tool_intent and _tool_intent.category == "web")
```
`_tool_intent` is already computed earlier in the same scope, so this is the minimal restoration; the existing consumers behave as intended again.

## Verification
- `python -m py_compile routes/chat_routes.py`
- Rebuilt + ran in Docker: `/api/chat_stream` streams normally instead of 500-ing.
