### PR TITLE
fix(email): clear bulk selection on library context change (#5228)

### DIFF
--- a/static/js/emailLibrary.js
+++ b/static/js/emailLibrary.js
@@ -1409,10 +1409,12 @@ export function openEmailLibrary(opts = {}) {
 
   document.getElementById('email-lib-folder').addEventListener('change', (e) => {
     state._libFolder = e.target.value;
+    _resetEmailBulkSelection();
     _loadEmailsFresh();
   });
   document.getElementById('email-lib-filter').addEventListener('change', (e) => {
     state._libFilter = e.target.value;
+    _resetEmailBulkSelection();
     _syncUnreadWindowGlow();
     _syncReminderClearButton();
     _loadEmailsFresh();
@@ -1427,6 +1429,7 @@ export function openEmailLibrary(opts = {}) {
     const btn = document.getElementById('email-attach-btn');
     state._libHasAttachments = !state._libHasAttachments;
     btn?.classList.toggle('active', state._libHasAttachments);
+    _resetEmailBulkSelection();
     _syncReminderClearButton();
     _loadEmailsFresh();
   });
@@ -1652,6 +1655,14 @@ export function openEmailLibrary(opts = {}) {
     if (!btn) return;
     if (on) { btn.classList.add('active'); btn.innerHTML = _SELECT_BTN_X_SVG + 'Cancel'; }
     else { btn.classList.remove('active'); btn.innerHTML = _SELECT_BTN_DOT_SVG + 'Select'; }
+  };
+  const _resetEmailBulkSelection = () => {
+    if (!state._selectMode && (!state._selectedUids || state._selectedUids.size === 0)) return;
+    state._selectMode = false;
+    state._selectedUids?.clear();
+    _setSelectBtnState(false);
+    _updateBulkBar();
+    _renderGrid();
   };
   document.getElementById('email-lib-select-btn').addEventListener('click', () => {
     state._selectMode = !state._selectMode;
@@ -2795,6 +2806,7 @@ async function _initEmailSearchChipBar() {
         // search so state._libEmails is replaced with the actual hits,
         // then the pill filter narrows to matches.
         state._libSearch = v;
+        _resetEmailBulkSelection();
         _doSearch();
       }
       return;


### PR DESCRIPTION
## Summary

Reset select-mode and selected UIDs when folder, filter, attachment filter, or search context changes.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #5228

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] Verified with targeted pytest / syntax checks.

## How to Test

1. Open Email library, enable Select, select messages. 2. Change folder or filter or search. 3. Confirm selection clears and bulk bar shows zero selected.
