### PR TITLE
fix(agent): do not switch models mid agent loop (#4561)

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -1423,7 +1423,7 @@ def setup_chat_routes(
                         disabled_tools=disabled_tools if disabled_tools else None,
                         tool_policy=tool_policy,
                         owner=_user,
-                        fallbacks=_fallback_candidates,
+                        fallbacks=[],
                         plan_mode=plan_mode,
                         approved_plan=approved_plan or None,
                         workspace=workspace or None,


### PR DESCRIPTION
## Summary

Pass an empty fallback list into stream_agent_loop so tool-call rounds stay on the session-selected model instead of silently failing over to a different endpoint.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click \"Edit\" on this PR and change the base.

## Linked Issue

Fixes #4561

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] Verified with targeted pytest / syntax checks.

## How to Test

1. Configure a fallback chain unlike the session model. 2. Enable agent mode and trigger multi-round tool use. 3. Confirm every round uses the same model shown in the UI.
