### PR TITLE
fix(mcp): merge PYTHONPATH for built-in stdio servers (#5116)

### DIFF
--- a/src/builtin_mcp.py
+++ b/src/builtin_mcp.py
@@ -113,6 +113,13 @@ async def register_builtin_servers(mcp_manager):
     base_dir = get_app_root()
     python = sys.executable
 
+    def _python_mcp_env() -> dict:
+        env = dict(os.environ)
+        existing = env.get("PYTHONPATH", "")
+        parts = [p for p in (base_dir, existing) if p]
+        env["PYTHONPATH"] = os.pathsep.join(parts)
+        return env
+
     async def _connect_python_server(server_id: str, script_path: str, name: str):
         try:
             ok = await mcp_manager.connect_server(
@@ -121,7 +128,7 @@ async def register_builtin_servers(mcp_manager):
                 transport="stdio",
                 command=python,
                 args=[script_path],
-                env={"PYTHONPATH": base_dir},
+                env=_python_mcp_env(),
             )
             if ok:
                 logger.info(f"Built-in MCP server registered: {name}")


### PR DESCRIPTION
## Summary

Prepend the app root to the existing PYTHONPATH instead of replacing it so built-in MCP scripts can import odysseus modules when launched from packaged installs.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #5116

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] Verified with targeted pytest / syntax checks.

## How to Test

1. Start Odysseus with built-in MCP enabled. 2. Confirm servers connect without ModuleNotFoundError in logs. 3. Run a tool from a built-in MCP server.
