### PR TITLE
fix(mcp): preserve inherited PYTHONPATH for built-in Python MCP servers

### DIFF
--- a/src/builtin_mcp.py
+++ b/src/builtin_mcp.py
@@ -104,6 +104,28 @@ def _spawn_bg(coro) -> asyncio.Task:
     return task
 
 
+def _builtin_python_env(base_dir: str) -> dict:
+    """Build the env passed to a built-in Python MCP subprocess.
+
+    The app root must be importable so the server can `from src... import ...`,
+    but it must not clobber an inherited ``PYTHONPATH``. Source checkouts, Nix
+    builds, and containers often rely on environment-provided import paths; the
+    previous ``{"PYTHONPATH": base_dir}`` replaced that value wholesale, which
+    broke built-in MCP tools in those launches (e.g. "MCP server not connected:
+    email"). Prepend the app root to the inherited entries and de-duplicate
+    while preserving order.
+    """
+    inherited = os.environ.get("PYTHONPATH", "")
+    seen: set[str] = set()
+    entries: list[str] = []
+    for part in [base_dir, *inherited.split(os.pathsep)]:
+        part = part.strip()
+        if part and part not in seen:
+            seen.add(part)
+            entries.append(part)
+    return {"PYTHONPATH": os.pathsep.join(entries)}
+
+
 async def register_builtin_servers(mcp_manager):
     """Connect all built-in MCP servers to the manager."""
     if MCP_DISABLED:
@@ -121,7 +143,7 @@ async def register_builtin_servers(mcp_manager):
                 transport="stdio",
                 command=python,
                 args=[script_path],
-                env={"PYTHONPATH": base_dir},
+                env=_builtin_python_env(base_dir),
             )
             if ok:
                 logger.info(f"Built-in MCP server registered: {name}")

--- a/src/mcp_manager.py
+++ b/src/mcp_manager.py
@@ -504,7 +504,7 @@ class McpManager:
     async def _reconnect_builtin(self, server_id: str) -> bool:
         """Tear down and reconnect a crashed builtin MCP server."""
         import sys
-        from src.builtin_mcp import _BUILTIN_SERVERS
+        from src.builtin_mcp import _BUILTIN_SERVERS, _builtin_python_env
 
         if server_id not in _BUILTIN_SERVERS:
             return False
@@ -523,7 +523,7 @@ class McpManager:
                 transport="stdio",
                 command=sys.executable,
                 args=[script_path],
-                env={"PYTHONPATH": base_dir},
+                env=_builtin_python_env(base_dir),
             )
             if ok:
                 logger.info(f"Reconnected builtin MCP server: {name}")

--- a/tests/test_builtin_mcp_pythonpath.py
+++ b/tests/test_builtin_mcp_pythonpath.py
@@ -1,0 +1,91 @@
+"""Issue #5116 — built-in Python MCP servers must not drop an inherited PYTHONPATH.
+
+``src/builtin_mcp.py`` and ``src/mcp_manager.py`` previously built the subprocess
+environment as ``{"PYTHONPATH": base_dir}``. Because ``McpManager._connect_stdio``
+merges that as ``{**os.environ, **env}``, the single ``PYTHONPATH`` key replaced
+the inherited value wholesale — so source/Nix/container launches that rely on
+environment-provided import paths lost them and the built-in server failed to
+import (surfacing as e.g. "MCP server not connected: email").
+
+``_builtin_python_env`` now prepends the app root to the inherited ``PYTHONPATH``
+and de-duplicates while preserving order. The helper is exercised here in
+isolation (same loader the bg-task tests use), so no real servers are spawned.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_builtin_mcp(monkeypatch):
+    core = types.ModuleType("core")
+    core.__path__ = []
+    platform_compat = types.ModuleType("core.platform_compat")
+    platform_compat.IS_WINDOWS = False
+    platform_compat.which_tool = lambda name: None
+    monkeypatch.setitem(sys.modules, "core", core)
+    monkeypatch.setitem(sys.modules, "core.platform_compat", platform_compat)
+
+    spec = importlib.util.spec_from_file_location(
+        "builtin_mcp_pythonpath_under_test",
+        ROOT / "src" / "builtin_mcp.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_prepends_app_root_to_empty_inherited_pythonpath(monkeypatch):
+    """With no inherited PYTHONPATH the app root is the sole entry."""
+    builtin_mcp = _load_builtin_mcp(monkeypatch)
+    monkeypatch.delenv("PYTHONPATH", raising=False)
+
+    env = builtin_mcp._builtin_python_env("/opt/odysseus")
+
+    assert env == {"PYTHONPATH": "/opt/odysseus"}
+
+
+def test_preserves_inherited_pythonpath_entries(monkeypatch):
+    """Inherited entries must survive — they carry env-provided import paths."""
+    builtin_mcp = _load_builtin_mcp(monkeypatch)
+    inherited = os.pathsep.join(["/nix/store/extra/lib", "/opt/venv/site-packages"])
+    monkeypatch.setenv("PYTHONPATH", inherited)
+
+    env = builtin_mcp._builtin_python_env("/opt/odysseus")
+
+    parts = env["PYTHONPATH"].split(os.pathsep)
+    # App root first so it wins on import conflicts ...
+    assert parts[0] == "/opt/odysseus"
+    # ... but every inherited entry is still present.
+    assert "/nix/store/extra/lib" in parts
+    assert "/opt/venv/site-packages" in parts
+    assert len(parts) == 3
+
+
+def test_dedupes_app_root_already_present(monkeypatch):
+    """If the app root is already on PYTHONPATH, it is not duplicated."""
+    builtin_mcp = _load_builtin_mcp(monkeypatch)
+    monkeypatch.setenv("PYTHONPATH", os.pathsep.join(["/opt/odysseus", "/other"]))
+
+    env = builtin_mcp._builtin_python_env("/opt/odysseus")
+
+    parts = env["PYTHONPATH"].split(os.pathsep)
+    assert parts.count("/opt/odysseus") == 1
+    assert parts[0] == "/opt/odysseus"
+    assert "/other" in parts
+
+
+def test_drops_empty_and_duplicate_segments(monkeypatch):
+    """Empty segments from a trailing/leading separator are ignored."""
+    builtin_mcp = _load_builtin_mcp(monkeypatch)
+    monkeypatch.setenv("PYTHONPATH", os.pathsep.join(["/a", "", "/b", "/a"]))
+
+    env = builtin_mcp._builtin_python_env("/root")
+
+    assert env["PYTHONPATH"].split(os.pathsep) == ["/root", "/a", "/b"]


### PR DESCRIPTION
## Summary

Built-in Python MCP servers (image_gen, memory, rag, email) dropped any inherited `PYTHONPATH` when spawning their subprocess. Source, Nix, and container launches that rely on environment-provided import paths therefore lost them, and the server failed to import — surfacing in the UI as a tool failure such as `MCP server not connected: email` even though the integration was configured.

## Root cause

`register_builtin_servers()` (startup) and `McpManager._reconnect_builtin()` (reconnect) both built the subprocess environment as `env={"PYTHONPATH": base_dir}`. `McpManager._connect_stdio` overlays that dict on `os.environ` via `{**os.environ, **env}` (`src/mcp_manager.py:191`), so the single `PYTHONPATH` key **replaced** the inherited value instead of extending it. Where the launch environment depends on an inherited `PYTHONPATH`, the built-in server lost required import paths and couldn't connect.

## Fix

Add one helper, `_builtin_python_env(base_dir)` in `src/builtin_mcp.py`, that prepends the app root to the inherited `PYTHONPATH` and de-duplicates while preserving order (empty segments from a trailing/leading separator are dropped). The helper is used for **both** initial startup and reconnect so the two paths construct the environment consistently. `mcp_manager.py` already imports from `src.builtin_mcp` inside `_reconnect_builtin`, so the new import adds no new coupling.

## Linked Issue

Fixes #5116

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor / cleanup (no behavior change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Test addition (no production code changed beyond what the test exercises)

## How to Test

1. `python -m py_compile src/builtin_mcp.py src/mcp_manager.py`
2. `python -m pytest tests/test_builtin_mcp_pythonpath.py tests/test_builtin_mcp_bg_tasks.py tests/test_mcp_reconnect_args.py`

The new tests assert the four behaviors: empty inherited value yields `{PYTHONPATH: <app root>}`; inherited `/a:/b` is preserved as `<app root>:/a:/b`; the app root is not duplicated if already present; and empty path segments are dropped. All 7 tests pass. The two pre-existing failures in `tests/test_builtin_mcp_npx_cache.py` reproduce on pristine `dev` (a Windows-subprocess-fallback interaction unrelated to this change).

## Checklist

- [x] I searched existing issues and pull requests and this is not a duplicate.
- [x] I based this on the latest `dev` branch.
- [x] The change is Python-only and non-UI; no visual review or screenshot is needed.
- [x] I ran the relevant checks (`py_compile` + focused `pytest`) and reported the results above.
