### PR TITLE
fix(email): fetch by UID in sig-learner and daily brief

### DIFF
--- a/src/builtin_actions.py
+++ b/src/builtin_actions.py
@@ -1125,14 +1125,14 @@ async def action_learn_sender_signatures(owner: str, **kwargs) -> Tuple[str, boo
             conn = _imap_connect(None, owner=owner)
             try:
                 conn.select("INBOX", readonly=True)
-                status, data = conn.search(None, "ALL")
+                status, data = conn.uid("SEARCH", None, "ALL")
                 if status != "OK" or not data or not data[0]:
                     return results
                 uids = data[0].split()[-300:][::-1]  # newest 300
                 for uid in uids:
                     try:
-                        st, msg_data = conn.fetch(
-                            uid, "(BODY.PEEK[HEADER.FIELDS (FROM)])"
+                        st, msg_data = conn.uid(
+                            "FETCH", uid, "(BODY.PEEK[HEADER.FIELDS (FROM)])"
                         )
                         if st != "OK" or not msg_data or not msg_data[0]:
                             continue
@@ -1214,7 +1214,7 @@ async def action_learn_sender_signatures(owner: str, **kwargs) -> Tuple[str, boo
                     conn2.select("INBOX", readonly=True)
                     for mm in _msgs:
                         try:
-                            st, data = conn2.fetch(mm["uid"], "(BODY.PEEK[TEXT])")
+                            st, data = conn2.uid("FETCH", mm["uid"], "(BODY.PEEK[TEXT])")
                             if st != "OK" or not data or not data[0]:
                                 continue
                             raw = data[0][1] if isinstance(data[0], tuple) else None
@@ -1356,13 +1356,13 @@ async def action_daily_brief(owner: str, **kwargs) -> Tuple[str, bool]:
             conn = _imap_connect(None)
             try:
                 conn.select("INBOX", readonly=True)
-                status, data = conn.search(None, "UNSEEN")
+                status, data = conn.uid("SEARCH", None, "UNSEEN")
                 uids = (data[0].split() if status == "OK" and data and data[0] else [])
                 unread_count = len(uids)
                 # Grab headers for the most recent 5 unread (UIDs increase with arrival)
                 for uid in uids[-5:][::-1]:
                     try:
-                        _, msg_data = conn.fetch(uid, "(BODY.PEEK[HEADER.FIELDS (FROM SUBJECT)])")
+                        _, msg_data = conn.uid("FETCH", uid, "(BODY.PEEK[HEADER.FIELDS (FROM SUBJECT)])")
                         if not msg_data or not msg_data[0]:
                             continue
                         hdr = msg_data[0][1] if isinstance(msg_data[0], tuple) else msg_data[0]

--- a/tests/test_builtin_actions_imap_uid.py
+++ b/tests/test_builtin_actions_imap_uid.py
@@ -1,0 +1,138 @@
+"""Issue #5148 — scheduled email actions must fetch by UID, not sequence number.
+
+The Learn Sender Signatures and Daily Brief scheduled actions used
+``conn.search(...)`` / ``conn.fetch(...)`` which operate on IMAP *sequence
+numbers*. Sequence numbers are positional and shift when earlier messages are
+deleted/expunged, so after a mailbox deletion these actions fetched the *wrong*
+message (or hit NO). IMAP UIDs are stable across such changes, so the fix is to
+use ``conn.uid("SEARCH", ...)`` / ``conn.uid("FETCH", ...)`` — the same pattern
+the sibling urgency check (``action_check_email_urgency``) already uses.
+
+These tests inject a recording IMAP stub and assert the UID command path is
+taken (and the bare sequence-number ``search``/``fetch`` methods are never
+called) for both scheduled actions.
+"""
+
+import asyncio
+
+import pytest
+
+
+class _RecordingImap:
+    """Records command names so the test can assert UID vs sequence usage."""
+
+    def __init__(self):
+        self.calls = []  # ordered list of ("uid", subcommand, args...) / ("search", ...) / ("fetch", ...)
+
+    def select(self, *_args, **_kwargs):
+        return "OK", []
+
+    def search(self, *args):
+        self.calls.append(("search", *args))
+        return "OK", [b""]
+
+    def fetch(self, *args):
+        self.calls.append(("fetch", *args))
+        return "OK", []
+
+    def uid(self, command, *args):
+        self.calls.append(("uid", command, *args))
+        if command.upper() == "SEARCH":
+            return "OK", [b"1 2"]
+        # FETCH — return a minimal header tuple the callers can parse.
+        return "OK", [(b"1 (UID 1 BODY[HEADER.FIELDS (FROM SUBJECT)])",
+                       b"From: a@example.com\r\nSubject: Hi\r\n\r\n")]
+
+    def logout(self):
+        return "OK", []
+
+
+@pytest.fixture
+def _recording_imap(monkeypatch):
+    """Patch every IMAP entrypoint builtin_actions reaches through."""
+    import routes.email_helpers as email_helpers
+
+    imap = _RecordingImap()
+
+    def fake_connect(_account_id=None, owner="", timeout=None):
+        return imap
+
+    # action_daily_brief / action_learn_sender_signatures import _imap_connect
+    # from routes.email_helpers at call time, so patching the module attribute
+    # is enough.
+    monkeypatch.setattr(email_helpers, "_imap_connect", fake_connect)
+    return imap
+
+
+def _patch_empty_db(monkeypatch):
+    """Make SessionLocal().query(...) return empty lists for every model."""
+    import core.database as db_mod
+
+    class _Chain:
+        def join(self, *_a, **_k):
+            return self
+
+        def filter(self, *_a, **_k):
+            return self
+
+        def order_by(self, *_a, **_k):
+            return self
+
+        def all(self):
+            return []
+
+    class _FakeDb:
+        def query(self, _model):
+            return _Chain()
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(db_mod, "SessionLocal", lambda: _FakeDb())
+
+
+def test_daily_brief_fetches_unseen_by_uid(monkeypatch, _recording_imap):
+    import src.builtin_actions as builtin_actions
+
+    _patch_empty_db(monkeypatch)
+
+    asyncio.run(builtin_actions.action_daily_brief(owner="alice"))
+
+    subcommands = [c for c in _recording_imap.calls if c[0] == "uid"]
+    # Must issue a UID SEARCH (for UNSEEN) and UID FETCH (for headers).
+    assert any(c[1].upper() == "SEARCH" for c in subcommands), subcommands
+    assert any(c[1].upper() == "FETCH" for c in subcommands), subcommands
+    # And must never fall back to the sequence-number API.
+    assert not any(c[0] == "search" for c in _recording_imap.calls)
+    assert not any(c[0] == "fetch" for c in _recording_imap.calls)
+
+
+def test_learn_sender_signatures_searches_all_by_uid(monkeypatch, _recording_imap):
+    """Issue #5148 — sender-signature header pull must UID SEARCH ALL.
+
+    This action short-circuits when there are <3 messages or no LLM endpoint,
+    so we only assert the IMAP *search* contract (UID SEARCH ALL, never bare
+    sequence-number search) rather than the full LLM pipeline.
+    """
+    import src.builtin_actions as builtin_actions
+
+    _patch_empty_db(monkeypatch)
+    # No LLM endpoint → the action returns early, but only after the header
+    # pull (which is where the sequence-vs-UID bug lived) has run.
+    monkeypatch.setattr(
+        builtin_actions, "resolve_task_candidates",
+        lambda owner=None: [], raising=False,
+    )
+    # Ensure the early-skip branches (already-cached, <3 senders) don't fire
+    # before the header pull: the stub returns 2 messages from one sender,
+    # which is below the >=3 threshold, so the action exits after pulling
+    # headers — exactly the path we want to assert on.
+
+    asyncio.run(builtin_actions.action_learn_sender_signatures(owner="alice"))
+
+    # The header pull must use UID SEARCH ALL.
+    assert any(
+        c[0] == "uid" and c[1].upper() == "SEARCH" and "ALL" in c[2:]
+        for c in _recording_imap.calls
+    ), _recording_imap.calls
+    assert not any(c[0] == "search" for c in _recording_imap.calls)

--- a/tests/test_builtin_actions_owner_scope.py
+++ b/tests/test_builtin_actions_owner_scope.py
@@ -115,6 +115,13 @@ async def test_learn_sender_signatures_resolves_llm_for_task_owner(monkeypatch):
         def fetch(self, _uid, _query):
             return "OK", [(None, b"From: Writer <writer@example.com>\r\n\r\n")]
 
+        def uid(self, command, *args):
+            # The scheduled actions now operate on UIDs (#5148); route the
+            # stub back onto the same canned search/fetch results.
+            if command.upper() == "SEARCH":
+                return self.search(*args)
+            return self.fetch(*args)
+
         def logout(self):
             return None
 
@@ -189,6 +196,13 @@ async def test_learn_sender_signatures_writes_owner_scoped_cache(monkeypatch, tm
                     ),
                 )
             ]
+
+        def uid(self, command, *args):
+            # The scheduled actions now operate on UIDs (#5148); route the
+            # stub back onto the same canned search/fetch results.
+            if command.upper() == "SEARCH":
+                return self.search(*args)
+            return self.fetch(*args)
 
         def logout(self):
             return None


### PR DESCRIPTION
## Summary

The Learn Sender Signatures and Daily Brief scheduled actions fetched messages by IMAP **sequence number** instead of by **UID**. Sequence numbers are positional and shift when earlier messages are deleted or expunged, so after any mailbox deletion these actions fetched the *wrong* message (or hit a `NO`/error). Switching to UID-based `SEARCH`/`FETCH` addresses messages by a stable identifier that survives deletions.

Fixes #5148.

## Root cause

`action_learn_sender_signatures` (`_pull_headers`) and `action_daily_brief` used the sequence-number API:

```python
status, data = conn.search(None, "ALL")   # returns sequence numbers
...
conn.fetch(uid, "(BODY.PEEK[...])")        # fetches by sequence number
```

`imaplib`'s `search()`/`fetch()` operate on sequence numbers, which are renumbered after a `DELETE` + `EXPUNGE`. The code even named the result `uids`, but they were sequence numbers. After a deletion, sequence number *N* pointed at a different message than before, so the signature learner / daily brief pulled headers and bodies for the wrong messages.

The sibling `action_check_email_urgency` in the **same file** already does this correctly with `conn.uid("SEARCH", ...)` / `conn.uid("FETCH", ...)` — these two methods had diverged from it.

## Fix

Convert the five sequence-number calls across the two methods to the UID API:

- `conn.search(None, "ALL")` → `conn.uid("SEARCH", None, "ALL")`
- `conn.search(None, "UNSEEN")` → `conn.uid("SEARCH", None, "UNSEEN")`
- the three `conn.fetch(uid, ...)` → `conn.uid("FETCH", uid, ...)`

This matches the existing-correct pattern (`action_check_email_urgency`, and the `conn.uid(...)` helpers in `routes/email_routes.py`). No new coupling: UID commands are part of the base IMAP protocol the connection already speaks.

## Linked Issue

Fixes #5148

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor / cleanup (no behavior change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Test addition (regression coverage for the fix)

## How to Test

```
python -m py_compile src/builtin_actions.py
python -m pytest tests/test_builtin_actions_imap_uid.py tests/test_builtin_actions_owner_scope.py -q
```

- New `tests/test_builtin_actions_imap_uid.py` injects a recording IMAP stub and asserts both actions issue `uid("SEARCH", ...)` / `uid("FETCH", ...)` and **never** call the bare sequence-number `search`/`fetch`. I verified these tests **fail on the pre-fix code** and **pass after the fix**.
- Updated the two existing `FakeImap` stubs in `test_builtin_actions_owner_scope.py` to route `uid()` onto their canned `search`/`fetch` results; their owner-scoping and cache-write assertions are unchanged and still pass.

All 6 tests pass. Production change is Python-only and non-UI; no screenshot needed.

## Checklist

- [x] I searched existing issues and pull requests and this is not a duplicate.
- [x] I based this on the latest `dev` branch.
- [x] The change is Python-only and non-UI; no visual review or screenshot is needed.
- [x] I ran the relevant checks (`py_compile` + focused `pytest`) and reported the results above.
