### PR TITLE
Fixed missing use of CA Bundles in several locations

### DIFF
--- a/routes/chat_helpers.py
+++ b/routes/chat_helpers.py
@@ -253,7 +253,7 @@ def try_fallback_endpoint(sess, session_id: str) -> dict | None:
 
     Returns {"model": ..., "endpoint_url": ..., "endpoint_name": ...} or None.
     """
-    import requests as _req
+    import httpx as _req
     from src.endpoint_resolver import (
         build_chat_url,
         build_headers,
@@ -262,6 +262,7 @@ def try_fallback_endpoint(sess, session_id: str) -> dict | None:
         resolve_endpoint_runtime,
     )
     from src.chatgpt_subscription import is_chatgpt_subscription_base
+    from src.tls_overrides import llm_verify
 
     current_url = sess.endpoint_url or ""
     owner = getattr(sess, "owner", None)
@@ -290,7 +291,7 @@ def try_fallback_endpoint(sess, session_id: str) -> dict | None:
         headers = build_headers(api_key, base)
         try:
             if ping_url:
-                r = _req.get(ping_url, headers=headers, timeout=5)
+                r = _req.get(ping_url, headers=headers, timeout=5, verify=llm_verify())
                 r.raise_for_status()
                 data = r.json()
                 models = [m.get("id") for m in (data.get("data") or []) if m.get("id")]

--- a/routes/email_routes.py
+++ b/routes/email_routes.py
@@ -4120,9 +4120,12 @@ def setup_email_routes():
     async def summarize_email(data: dict, owner: str = Depends(require_owner)):
         """Generate a quick AI summary of an email body."""
         try:
-            from src.endpoint_resolver import resolve_endpoint
-            from src.llm_core import _uses_max_completion_tokens, _restricts_temperature
-            import requests as _req
+            from src.endpoint_resolver import (
+                resolve_endpoint,
+                resolve_utility_fallback_candidates,
+                resolve_chat_fallback_candidates,
+            )
+            from src.llm_core import llm_call_async_with_fallback
 
             body = data.get("body", "")
             subject = data.get("subject", "")
@@ -4158,54 +4161,43 @@ def setup_email_routes():
             if att_text:
                 body_for_llm = body + "\n\n--- ATTACHMENTS ---\n\n" + att_text
 
-            url, model, headers = resolve_endpoint("utility", owner=owner)
-            if not url:
-                url, model, headers = resolve_endpoint("default", owner=owner)
-            if not url or not model:
+            candidates = []
+            seen = set()
+
+            def _add(url, model, headers):
+                key = (url or "", model or "")
+                if not url or not model or key in seen:
+                    return
+                seen.add(key)
+                candidates.append((url, model, headers))
+
+            try:
+                _add(*resolve_endpoint("utility", owner=owner))
+            except Exception:
+                pass
+            try:
+                _add(*resolve_endpoint("default", owner=owner))
+            except Exception:
+                pass
+            for cand in resolve_utility_fallback_candidates(owner=owner) or []:
+                _add(*cand)
+            for cand in resolve_chat_fallback_candidates(owner=owner) or []:
+                _add(*cand)
+            if not candidates:
                 return {"success": False, "error": "No LLM endpoint configured"}
 
-            req_headers = {"Content-Type": "application/json"}
-            if headers:
-                req_headers.update(headers)
-            tok_key = "max_completion_tokens" if _uses_max_completion_tokens(model) else "max_tokens"
-            payload = {
-                "model": model,
-                "messages": [
+            content = await llm_call_async_with_fallback(
+                candidates,
+                messages=[
                     {"role": "system", "content": "You are an email summarizer. Format: 1-3 short bullet points (use '- '). Cover: main point, action items, deadlines. If the email has attachments (marked '--- ATTACHMENTS ---'), USE THEIR CONTENTS — pull invoice totals, deadlines, key clauses, concrete numbers/dates from PDFs/docs into the bullets. Be terse.\n\nOUTPUT FORMAT: Put ONLY the bullet points between these exact markers, each on its own line:\n<<<SUMMARY>>>\n- ...\n<<<END>>>\nAny reasoning must come BEFORE <<<SUMMARY>>> (ideally inside <think>...</think>). Only the text between the markers is kept."},
                     {"role": "user", "content": f"From: {sender}\nSubject: {subject}\n\n{body_for_llm[:12000]}\n\n---\n\nSummarize the email. Output the bullets between <<<SUMMARY>>> and <<<END>>>."},
                 ],
-                tok_key: 8192,
-                "temperature": 0.3,
-                "stream": False,
-            }
-            # Reasoning models (o1/o3/o4/gpt-5) reject an explicit temperature.
-            if _restricts_temperature(model):
-                payload.pop("temperature", None)
-            resp = await asyncio.to_thread(
-                _req.post, url, json=payload, headers=req_headers, timeout=180
+                temperature=0.3,
+                max_tokens=8192,
+                timeout=180,
             )
-            if not resp.ok:
-                return {"success": False, "error": f"LLM HTTP {resp.status_code}"}
-            rdata = resp.json()
-            msg = (rdata.get("choices") or [{}])[0].get("message", {})
-            content = (msg.get("content") or "").strip()
-            content = _extract_reply(content)
-
-            if not content:
-                # Model put everything in reasoning_content — extract bullet points
-                rc = (msg.get("reasoning_content") or "").strip()
-                # Find bullet-point style output (lines starting with -, •, *, or numbered)
-                bullet_lines = []
-                for line in rc.split("\n"):
-                    stripped = line.strip()
-                    if re.match(r"^[-•*]\s+|^\d+[.)]\s+", stripped):
-                        bullet_lines.append(stripped)
-                if bullet_lines:
-                    content = "\n".join(bullet_lines)
-                else:
-                    # Last resort: take the last paragraph
-                    paragraphs = [p.strip() for p in rc.split("\n\n") if p.strip()]
-                    content = paragraphs[-1] if paragraphs else rc[:500]
+            model = candidates[0][1] if candidates else ""
+            content = _extract_reply((content or "").strip())
 
             if not content:
                 return {"success": False, "error": "Empty response from model"}

--- a/src/ai_interaction.py
+++ b/src/ai_interaction.py
@@ -935,6 +935,7 @@ async def do_generate_image(content: str, session_id: Optional[str] = None, owne
             try:
                 from src.database import SessionLocal, ModelEndpoint
                 from src.auth_helpers import owner_filter
+                from src.tls_overrides import llm_verify
                 import httpx as _req
                 _idb = SessionLocal()
                 try:
@@ -950,7 +951,7 @@ async def do_generate_image(content: str, session_id: Optional[str] = None, owne
                         if not _ibase.endswith("/v1"):
                             _ibase += "/v1"
                         try:
-                            _r = _req.get(_ibase + "/models", timeout=3)
+                            _r = _req.get(_ibase + "/models", timeout=3, verify=llm_verify())
                             _r.raise_for_status()
                             _data = _r.json()
                             _ditems = _data if isinstance(_data, list) else (_data.get("data") or [])

--- a/tests/test_tls_overrides_scope.py
+++ b/tests/test_tls_overrides_scope.py
@@ -39,6 +39,8 @@ REPO = Path(__file__).resolve().parents[1]
 ALLOWED_CALLERS = frozenset({
     "src/llm_core.py",          # shared AsyncClient used by stream_llm
     "routes/model_routes.py",   # _probe_endpoint + _ping_endpoint
+    "routes/chat_helpers.py",   # try_fallback_endpoint pings candidate LLM endpoints' /models
+    "src/ai_interaction.py",    # image-model auto-detect pings local LLM endpoints' /models
 })
 
 


### PR DESCRIPTION
## Summary

This fixes bug #5438 - this bug causes email summarization to fail if a custom LLM_CA_BUNDLE is set and the used endpoint uses a self-signed certificate that is trusted only via the supplied bundle. It also fixes the same issue in two other places.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #5438 

## Type of Change

- [X] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [X] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [X] This PR targets `dev`
- [X] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [X] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

<!-- Step-by-step instructions a reviewer can follow to verify this works.
     Do not leave this empty — a PR without test steps will be sent back. -->

1. Set up an LLM endpoint with a self signed certificate on another machine.
2. Install the root CA via LLM_CA_BUNDLE
3. Set up the endpoint in odysseus and verify it works in chat
4. Connect an email account in Integrations
5. Summarize an email. This now works.

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable, no UI change.

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [X] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

Not applicable, no UI change.
