### PR TITLE
fix(katex): prevent currency amounts ($10, $50) from rendering as KaTeX math

### DIFF
--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -662,7 +662,7 @@ export function mdToHtml(src, opts) {
       } catch (e) { return match; }
     });
     // Inline math: $...$  (not preceded/followed by $ or digit, not spanning multiple lines)
-    s = s.replace(/(?<!\$)\$(?!\$)([^\$\n]+?)\$(?!\$)/g, (match, math) => {
+    s = s.replace(/(?<!\$)\$(?![\$\d])([^\$\n]+?)\$(?!\$)/g, (match, math) => {
       try {
         const raw = math.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>');
         const placeholder = `___MATH_BLOCK_${mathBlocks.length}___`;


### PR DESCRIPTION
## Summary

The inline-math regex at `static/js/markdown.js:664` matched `$10 to $50` as a KaTeX expression because the opening `$` was only guarded against a following `$` (`(?!\$)`), not against a following digit. That caused `$10 to $` to be consumed as a math expression with content `10 to `, leaving the `50` orphaned below the rendered KaTeX block.

The fix extends the negative lookahead from `(?!\$`) to `(?![\$\d])`. Opening `$` followed immediately by a digit — `$10`, `$50`, `$100` — is now treated as plain text. Valid math expressions (`$x^2$`, `$\alpha$`, `${foo}$`) are unaffected because they start with a letter, backslash, or brace.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #5130

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Start Odysseus and open a chat.
2. Send: "Repeat after me: $10 to $50"
3. Before the fix: `$10 to $` renders as broken KaTeX, `50` is orphaned.
4. After the fix: `$10 to $50` stays as plain text.
5. Verify that real math still renders: send `Write inline math: $x^2 + y^2 = z^2$` — KaTeX should render the expression.

```bash
node --check static/js/markdown.js
```