### PR TITLE
chore(release): bump dev version to 1.0.2

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ import os
 
 from src.runtime_paths import get_app_root, get_default_data_dir
 
-APP_VERSION = "1.0.1"
+APP_VERSION = "1.0.2"
 
 # Base paths
 BASE_DIR = os.path.join(get_app_root(), "")


### PR DESCRIPTION
## Summary

Aligns `dev`'s application version with the `1.0.2` stable hotfix now that #5469 has landed on `main`. The chat regression fixes from #5290 and #5313 are already present on `dev`; this PR only updates `APP_VERSION` so the development branch no longer reports the older `1.0.1` version after the stable hotfix release.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Part of #5424

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

- `git diff --check`
- `python3 -m py_compile src/constants.py`
- Confirm `src.constants.APP_VERSION` is now `1.0.2`.

Not run: live app or Docker smoke test. This is a one-line version alignment after the chat fix already landed on `dev` and was backported to `main` in #5469.

## Visual / UI changes — REQUIRED if you touched anything that renders

N/A - backend/version metadata only; no UI rendering files changed.

### Screenshots / clips

N/A - no visual changes.
