### PR TITLE
fix(url-safety): reject RFC 6598 shared address space in strict mode

### DIFF
--- a/src/url_safety.py
+++ b/src/url_safety.py
@@ -25,6 +25,14 @@ from urllib.parse import urlparse
 
 ALLOWED_SCHEMES = ("http", "https")
 
+# RFC 6598 shared address space (carrier-grade NAT). It is not globally
+# routable, but CPython does not report it as ``is_private`` (it is "shared",
+# not "private"), so strict mode must reject it explicitly. ``not is_global``
+# would also catch it, but only on CPython 3.11.10+/3.12.4+/3.13+ — the CI
+# matrix runs 3.11/3.12, so an explicit reject stays correct across patch
+# levels and the 3.14 runtime image.
+_SHARED_ADDRESS_SPACE_V4 = ipaddress.ip_network("100.64.0.0/10")
+
 
 def _default_resolver(host: str) -> List[str]:
     """Resolve a hostname to the list of IP strings it maps to (A + AAAA)."""
@@ -40,8 +48,12 @@ def _classify(ip: ipaddress._BaseAddress, *, block_private: bool) -> Optional[st
         return f"link-local address blocked (SSRF metadata risk): {ip}"
     if ip.is_multicast or ip.is_reserved or ip.is_unspecified:
         return f"disallowed address: {ip}"
-    if block_private and (ip.is_private or ip.is_loopback):
-        return f"private/loopback address blocked: {ip}"
+    if block_private and (
+        ip.is_private
+        or ip.is_loopback
+        or (isinstance(ip, ipaddress.IPv4Address) and ip in _SHARED_ADDRESS_SPACE_V4)
+    ):
+        return f"private/shared/loopback address blocked: {ip}"
     return None
 
 

--- a/src/url_safety.py
+++ b/src/url_safety.py
@@ -26,11 +26,11 @@ from urllib.parse import urlparse
 ALLOWED_SCHEMES = ("http", "https")
 
 # RFC 6598 shared address space (carrier-grade NAT). It is not globally
-# routable, but CPython does not report it as ``is_private`` (it is "shared",
-# not "private"), so strict mode must reject it explicitly. ``not is_global``
-# would also catch it, but only on CPython 3.11.10+/3.12.4+/3.13+ — the CI
-# matrix runs 3.11/3.12, so an explicit reject stays correct across patch
-# levels and the 3.14 runtime image.
+# routable, but CPython does not classify it as ``is_private`` (it is "shared",
+# not "private"), so the is_private/is_loopback checks miss it. Reject the range
+# explicitly. This closes exactly the shared-space gap without coupling strict
+# mode to ``is_global``'s broader definition, which has shifted across CPython
+# versions for other special ranges.
 _SHARED_ADDRESS_SPACE_V4 = ipaddress.ip_network("100.64.0.0/10")
 
 

--- a/tests/test_url_safety.py
+++ b/tests/test_url_safety.py
@@ -64,6 +64,33 @@ def test_strict_mode_blocks_private_and_loopback():
     assert ok is False and "private" in reason
 
 
+def test_strict_mode_blocks_cgnat_shared_space():
+    # RFC 6598 shared/CGNAT space (100.64.0.0/10) is not globally routable.
+    # A public redirect into it must be rejected under full SSRF lockdown,
+    # even though ipaddress reports is_private=False for this range.
+    CGNAT = _resolver({"svc.example": ["100.64.0.1"]})
+    ok, reason = check_outbound_url("http://svc.example:8080", block_private=True, resolver=CGNAT)
+    assert ok is False
+    assert "blocked" in reason
+
+
+def test_strict_mode_blocks_non_global_ranges():
+    # Strict mode is a full SSRF lockdown: only globally-routable public
+    # addresses may be reached. Benchmarking (198.18.0.0/15) and TEST-NET
+    # documentation space (192.0.2.0/24) are not globally routable.
+    for ip in ("198.18.0.1", "192.0.2.10"):
+        res = _resolver({"svc.example": [ip]})
+        ok, reason = check_outbound_url("http://svc.example", block_private=True, resolver=res)
+        assert ok is False, ip
+        assert "blocked" in reason
+
+
+def test_strict_mode_still_allows_public_ip():
+    # The lockdown must not reject a legitimate globally-routable target.
+    ok, reason = check_outbound_url("https://example.com/v1", block_private=True, resolver=PUBLIC)
+    assert ok is True, reason
+
+
 def test_unresolvable_host_blocked():
     ok, reason = check_outbound_url("http://does-not-resolve.invalid", resolver=PUBLIC)
     assert ok is False


### PR DESCRIPTION
## Summary

strict-mode SSRF hardening for the shared URL validator. `check_outbound_url(..., block_private=True)` is the full SSRF lockdown used for exposed multi-tenant deployments. it rejected `is_private` and `is_loopback` targets, but RFC 6598 shared / CGNAT space (`100.64.0.0/10`) fell through, because CPython does not classify that range as `is_private` (it is "shared", not "private"). so a public `skills.sh`-style redirect into `100.64.0.1` passed the per-hop guard and still issued the request to a potentially internal CGNAT service. this change rejects `100.64.0.0/10` explicitly in strict mode.

an explicit range reject (a pure integer-arithmetic membership test) closes exactly the shared-space gap and avoids coupling strict mode to `is_global`'s broader definition, which has shifted across CPython versions for other special ranges. default local-first mode (`block_private=False`) is unchanged: loopback, LAN, and CGNAT stay reachable for local embedding servers. link-local metadata (`169.254.0.0/16`) was already covered, so CGNAT was the residual.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

no separate issue was filed. the shared-space gap was raised by @RaresKeY in the strict-mode SSRF review on #5261; this splits the validator-level fix out from that importer PR so it can land on its own.

Part of #5261

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough. (left unchecked on purpose: this is a pure validator function with no runtime surface a full app-run exercises beyond the injected-resolver tests, and the resolver injection is exactly how the DNS path is driven deterministically. verified at that level plus a revert-to-RED proof, see How to Test.)

## How to Test

the validator is DNS-dependent, so the tests inject a resolver and never touch real network. `conftest.py` pulls the full app stack, so run this stdlib-only module directly with `--noconftest`:

1. `python3 -m pytest tests/test_url_safety.py -q --noconftest` -> 13 passed
2. the fix is load-bearing (revert-to-RED): `git checkout dev -- src/url_safety.py && python3 -m pytest tests/test_url_safety.py::test_strict_mode_blocks_cgnat_shared_space -q --noconftest` -> fails on `assert ok is False`. restore the file -> passes again.
3. manual check:

```
python3 -c "from src.url_safety import check_outbound_url as c; \
print('strict CGNAT :', c('http://x', block_private=True,  resolver=lambda h: ['100.64.0.1'])); \
print('strict public:', c('http://x', block_private=True,  resolver=lambda h: ['8.8.8.8'])); \
print('default CGNAT:', c('http://x', block_private=False, resolver=lambda h: ['100.64.0.1']))"
# strict CGNAT : (False, 'private/shared/loopback address blocked: 100.64.0.1')
# strict public: (True, 'ok')
# default CGNAT: (True, 'ok')   # local-first mode unchanged
```

## Visual / UI changes

N/A. no UI or rendering changes. touches only `src/url_safety.py` (validator logic) and `tests/test_url_safety.py`.
