### PR TITLE
fix(model-endpoints): add Settings switch to let local endpoints use tools

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -536,6 +536,7 @@ async function loadEndpoints() {
             </div>
           </div>
           <div class="admin-ep-detail">${esc(ep.base_url)}${category === 'local' ? `<button type="button" class="admin-ep-copy-btn" data-adm-copy-url="${esc(ep.base_url)}" title="Copy URL" aria-label="Copy URL" style="background:none;border:none;padding:0 2px;margin-left:6px;cursor:pointer;color:inherit;opacity:0.45;vertical-align:-2px;line-height:1;"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button>` : ''}${keyLabel}</div>
+          ${category === 'local' ? `<div class="admin-ep-detail" style="display:flex;align-items:center;gap:8px;margin-top:3px;"><span>Let this model use tools</span><label class="admin-switch" style="transform:scale(0.85);" title="Turn on so this model can actually use tools (read files, run commands) instead of just describing them."><input type="checkbox" aria-label="Let this model use tools" data-adm-tools-ep="${ep.id}" ${ep.supports_tools === true ? 'checked' : ''}><span class="admin-slider"></span></label></div>` : ''}
           ${hasModels ? `<div class="mcp-tools-panel hidden" data-adm-ep-models-panel="${ep.id}"></div>` : ''}
         </div>`;
     });
@@ -573,6 +574,13 @@ async function loadEndpoints() {
     };
     queryAll('[data-adm-toggle-ep]').forEach(btn => {
       btn.addEventListener('click', async (e) => { e.stopPropagation(); await fetch(`/api/model-endpoints/${btn.dataset.admToggleEp}`, { method: 'PATCH' }); loadEndpoints(); });
+    });
+    queryAll('[data-adm-tools-ep]').forEach(cb => {
+      cb.addEventListener('change', async (e) => {
+        e.stopPropagation();
+        await _setEndpointSupportsTools(cb.dataset.admToolsEp, cb.checked);
+        loadEndpoints();
+      });
     });
     queryAll('[data-adm-copy-url]').forEach(btn => {
       btn.addEventListener('click', (e) => {
@@ -774,6 +782,20 @@ async function _saveEpModelState(epId, panel) {
       settingsModule.refreshAiModelEndpoints();
     }
   } catch (e) { /* silent */ }
+}
+
+// Send true to force native tool schemas, null to fall back to auto-detect — never
+// false, so turning the switch off can't disable a cloud model the auto-detector
+// already handles.
+async function _setEndpointSupportsTools(epId, on) {
+  try {
+    await fetch(`/api/model-endpoints/${epId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
+      body: JSON.stringify({ supports_tools: on ? true : null }),
+    });
+  } catch (e) { /* caller re-syncs via loadEndpoints(); a failed write is safe to swallow */ }
 }
 
 function initEndpointForm() {

--- a/tests/test_endpoint_supports_tools_toggle_js.py
+++ b/tests/test_endpoint_supports_tools_toggle_js.py
@@ -1,0 +1,135 @@
+"""Behavioral test for issue #5048 — a Settings switch that lets local model
+endpoints use tools.
+
+Manually-added local endpoints store supports_tools=NULL, which the agent-loop
+heuristic treats as "no native tool schemas" for Ollama URLs — so Agent mode
+describes tool calls in prose instead of running them. The fix adds a
+per-local-endpoint switch in admin.js that PATCHes supports_tools; the backend
+route, DB column, and heuristic already honor the value (the True override is
+covered by tests/test_tool_support_heuristic.py).
+
+admin.js can't be imported standalone (browser-only deps), so — same approach as
+tests/test_local_endpoint_api_key_js.py — we extract the handler body from source
+and run it under node with a mocked fetch, asserting the outgoing request.
+"""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_ADMIN_JS = _REPO / "static" / "js" / "admin.js"
+_HAS_NODE = shutil.which("node") is not None
+
+_MARKER = "async function _setEndpointSupportsTools(epId, on)"
+
+
+def _extract_handler_body(src: str, marker: str) -> str:
+    """Return the body (without the outer braces) of the function that
+    immediately follows `marker` in `src`, using a quote-aware brace matcher."""
+    start = src.index(marker) + len(marker)
+    brace = src.index("{", start)
+    i = brace + 1
+    depth = 1
+    quote = None
+    escaped = False
+    while i < len(src):
+        c = src[i]
+        if quote:
+            if escaped:
+                escaped = False
+            elif c == "\\":
+                escaped = True
+            elif c == quote:
+                quote = None
+        elif c in "'\"`":
+            quote = c
+        elif c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return src[brace + 1:i]
+        i += 1
+    raise AssertionError(f"unbalanced braces after marker: {marker!r}")
+
+
+# On resolve the harness prints "OK:<calls-json>"; an unhandled rejection prints
+# "UNHANDLED:<msg>" and exits non-zero — which is exactly what the swallow guards
+# against, so the failure test asserts we never hit that path.
+_HARNESS = """
+let calls = [];
+async function fetch(url, opts) {{ {fetch_body} }}
+const epId = "ep-42";
+const on = {on};
+async function run() {{ {body} }}
+run().then(() => console.log("OK:" + JSON.stringify(calls)))
+     .catch((e) => {{ console.log("UNHANDLED:" + e.message); process.exit(3); }});
+"""
+
+_FETCH_OK = (
+    "calls.push({ url, method: opts.method, body: JSON.parse(opts.body) });"
+    " return { ok: true, async json() { return {}; } };"
+)
+_FETCH_THROWS = "throw new Error('network down');"
+
+
+def _run(on_literal: str, fetch_body: str) -> subprocess.CompletedProcess:
+    handler = _extract_handler_body(_ADMIN_JS.read_text(encoding="utf-8"), _MARKER)
+    js = _HARNESS.format(on=on_literal, body=handler, fetch_body=fetch_body)
+    return subprocess.run(
+        ["node", "--input-type=module"],
+        input=js, capture_output=True, text=True, cwd=str(_REPO), timeout=30,
+    )
+
+
+def _calls(on_literal: str) -> list:
+    proc = _run(on_literal, _FETCH_OK)
+    assert proc.returncode == 0, f"node failed: {proc.stderr}"
+    out = proc.stdout.strip()
+    assert out.startswith("OK:"), f"unexpected node output: {out}"
+    return json.loads(out[len("OK:"):])
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_switch_on_patches_supports_tools_true():
+    calls = _calls("true")
+    assert len(calls) == 1
+    assert calls[0]["method"] == "PATCH"
+    assert calls[0]["url"] == "/api/model-endpoints/ep-42"
+    assert calls[0]["body"] == {"supports_tools": True}
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_switch_off_patches_null_not_false():
+    # Off sends null (auto-detect), never false — so this local-only switch can
+    # never disable a cloud model the heuristic already treats as tool-capable.
+    calls = _calls("false")
+    assert calls[0]["body"] == {"supports_tools": None}
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_switch_patch_failure_is_swallowed():
+    # A failed PATCH must not surface as an unhandled rejection: the handler
+    # resolves so the caller's loadEndpoints() can re-sync the switch from the
+    # server (reverting the checkbox) instead of leaving a stale visual state.
+    proc = _run("true", _FETCH_THROWS)
+    assert proc.returncode == 0, f"unhandled rejection: {proc.stdout} {proc.stderr}"
+    assert proc.stdout.strip().startswith("OK:")
+
+
+def test_switch_rendered_and_gated_to_local_endpoints():
+    """Source-text check (the narrow TESTING_STANDARD.md exception): the row
+    template nests template literals and depends on many DOM/helper globals, so
+    it can't be practically rendered standalone. We assert the switch is wired to
+    the endpoint id, reflects persisted state, and sits inside the local guard."""
+    src = _ADMIN_JS.read_text(encoding="utf-8")
+    assert 'data-adm-tools-ep="${ep.id}"' in src
+    assert "ep.supports_tools === true ? 'checked' : ''" in src
+    tools_pos = src.index("data-adm-tools-ep")
+    guard = src[src.rindex("${", 0, tools_pos):tools_pos]
+    assert guard.startswith("${category === 'local' ?"), (
+        f"tool switch must be gated to local endpoints, got: {guard[:60]!r}"
+    )

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -1010,6 +1010,46 @@ def test_patch_models_pinned_does_not_clobber_hidden(monkeypatch):
     assert json.loads(ep.pinned_models) == ["deploy-1"]
 
 
+@pytest.mark.parametrize(
+    "initial, sent, expected",
+    [
+        (None, True, True),       # #5048: a NULL local endpoint can be forced tool-capable
+        (True, False, False),     # explicit force-off
+        (True, None, None),       # reset to auto-detect
+        (True, "unknown", None),  # unrecognized value falls back to auto-detect
+    ],
+)
+def test_patch_supports_tools_maps_tristate(monkeypatch, initial, sent, expected):
+    ep = _make_endpoint(supports_tools=initial)
+    db = _PinnedFakeDb([ep])
+    monkeypatch.setattr(model_routes, "SessionLocal", lambda: db)
+    monkeypatch.setattr(model_routes, "require_admin", lambda request: None)
+    endpoint = _get_route("/api/model-endpoints/{ep_id}", "PATCH")
+
+    # toggle_model_endpoint only reads the JSON body when content-length > 0.
+    request = _PinnedFakeRequest(body={"supports_tools": sent}, headers={"content-length": "40"})
+    result = asyncio.run(endpoint("ep1", request))
+
+    assert ep.supports_tools is expected
+    assert result["supports_tools"] is expected
+
+
+def test_patch_without_body_toggles_enabled_and_keeps_supports_tools(monkeypatch):
+    # A bodyless PATCH is the legacy enable/disable toggle; it must leave a
+    # previously-set supports_tools flag untouched.
+    ep = _make_endpoint(is_enabled=True, supports_tools=True)
+    db = _PinnedFakeDb([ep])
+    monkeypatch.setattr(model_routes, "SessionLocal", lambda: db)
+    monkeypatch.setattr(model_routes, "require_admin", lambda request: None)
+    endpoint = _get_route("/api/model-endpoints/{ep_id}", "PATCH")
+
+    result = asyncio.run(endpoint("ep1", _PinnedFakeRequest()))
+
+    assert ep.is_enabled is False
+    assert ep.supports_tools is True
+    assert result["supports_tools"] is True
+
+
 def test_get_models_returns_pinned_when_probe_empty(monkeypatch):
     ep = _make_endpoint(pinned_models=json.dumps(["deploy-1"]))
     db = _PinnedFakeDb([ep])


### PR DESCRIPTION
## What & why

Manually-added local model endpoints (e.g. Ollama at `http://localhost:11434/v1`) are stored with `supports_tools = NULL`. In Agent mode, the tool-support heuristic in `src/agent_loop.py` reads NULL as "no native tool schemas" for Ollama `/v1` URLs, so the model receives **zero** tool schemas and just *describes* tool calls ("you could run `bash pwd`") instead of executing them:

```
[agent-debug] round=1 model=qwen3.6:27b _is_api_model=False tools_sent=0 …
```

The heuristic already has an override — `supports_tools = True` forces native tools on, even for Ollama — but the only way to set it was a manual `sqlite3 UPDATE`. The DB column's own docstring says it is *"toggleable in the UI"*, but that control was never built.

## Change

Add a simple on/off switch — **"Let this model use tools"** — to each **local** endpoint row in Settings → Added Models. It PATCHes the existing `/api/model-endpoints/{id}` route:

- **On** → `supports_tools: true` (force native tool schemas)
- **Off** → `supports_tools: null` (auto-detect; never `false`, so it can't disable a cloud endpoint the heuristic already handles)

No backend, DB, or heuristic changes — the route, column, and heuristic already honor the value. Because the agent loop re-reads `supports_tools` from the DB per message, the switch takes effect **without a restart** (the sqlite workaround required one). The switch input carries an `aria-label`, and a failed PATCH is swallowed so the row's existing `loadEndpoints()` re-syncs the checkbox from the server rather than leaving a stale state.

## Why a toggle, and not just on-by-default for local endpoints?

Because "always on" would regress real setups. The conservative default is deliberate (`tests/test_tool_support_heuristic.py`): some local models **hard-break** when sent native tool schemas — e.g. `deepseek-r1` on Ollama returns HTTP 400, and others terminate after one token. The model *name* isn't a reliable signal (same name, different quant/version/runtime), so defaulting local endpoints to on would break those users with a worse failure than the graceful prose fallback. Cloud endpoints (`api.openai.com`, etc.) already default to on via the host allow-list; this only affects heterogeneous local endpoints.

This PR fixes the "no way to turn it on" gap for tool-capable local models (the reported bug) while keeping the safe default. A natural **follow-up** would be auto-detection (probe the endpoint's tool support on add and set `supports_tools` automatically); a manual override like this switch is still wanted alongside it, since auto-detection can be wrong in both directions.

## Tests

- `tests/test_endpoint_supports_tools_toggle_js.py` — behavioral test: extracts the switch handler from `admin.js` and runs it under `node`, asserting the PATCH body is `{supports_tools: true}` when on and `{supports_tools: null}` when off, that a failed PATCH is swallowed (no unhandled rejection), plus a gating check that the switch renders only for local endpoints.
- `tests/test_model_routes.py` — unit tests for the PATCH route's tri-state mapping (true/false/null/unrecognized) and that a bodyless PATCH still toggles enable/disable without disturbing `supports_tools`.
- `tests/test_tool_support_heuristic.py` already covers the `supports_tools=True` → native-tools path, so the full UI → API → DB → heuristic chain is covered.

```
./venv/bin/python -m pytest tests/test_endpoint_supports_tools_toggle_js.py tests/test_model_routes.py tests/test_tool_support_heuristic.py -q
node --check static/js/admin.js
```

## Manual test

Verified live against a local Ollama endpoint (`qwen3.6:35b` on `localhost:11434/v1`):

1. Settings → Added Models → the local endpoint now shows the **"Let this model use tools"** switch.
2. **On** → Agent-mode message runs a real `bash` tool; logs show `_is_api_model=True tools_sent=20 native_tools=True`, and the model executed native tool calls.
3. **Off** → the next message reverts to `_is_api_model=False tools_sent=0` (prose) — i.e. the original #5048 symptom, confirming the switch is the control. The off flip persisted `supports_tools=null` (not `false`), and no restart was needed for either direction.

Fixes #5048. Related: #5015 (same symptom, no separate root cause documented).
