### PR TITLE
fix(email): hide OAuth storage fields from config responses

### DIFF
--- a/routes/email_routes.py
+++ b/routes/email_routes.py
@@ -4699,6 +4699,13 @@ def setup_email_routes():
         cfg = _get_email_config(owner=owner)
         cfg["smtp_password"] = "***" if cfg["smtp_password"] else ""
         cfg["imap_password"] = "***" if cfg["imap_password"] else ""
+        # `_get_email_config` includes encrypted OAuth fields for the server's
+        # IMAP/SMTP helpers.  They are implementation secrets, not client
+        # configuration, so keep them out of this browser-facing response just
+        # as the account-list endpoint does.
+        cfg.pop("oauth_access_token", None)
+        cfg.pop("oauth_refresh_token", None)
+        cfg.pop("oauth_token_expiry", None)
         # Include preferences from settings.json
         settings = _load_settings()
         cfg["email_auto_summarize"] = bool(settings.get("email_auto_summarize", False))

--- a/tests/test_email_oauth.py
+++ b/tests/test_email_oauth.py
@@ -578,3 +578,53 @@ async def test_account_list_response_does_not_expose_token_values():
     assert acct["oauth_provider"] == "google"   # status is exposed
     assert "oauth_access_token" not in acct      # token value is not
     assert "oauth_refresh_token" not in acct
+
+
+@pytest.mark.asyncio
+async def test_config_response_does_not_expose_oauth_storage_fields():
+    """The client-facing config route must not serialize the encrypted token
+    fields returned by the internal transport helper."""
+    from routes.email_routes import setup_email_routes
+    from src.secret_storage import encrypt as _enc
+
+    encrypted_access = _enc("ya29.internal_access_token")
+    encrypted_refresh = _enc("1//internal_refresh_token")
+    internal_cfg = {
+        "account_id": "acct-config",
+        "account_name": "Google Workspace",
+        "smtp_host": "smtp.gmail.com",
+        "smtp_port": 587,
+        "smtp_security": "starttls",
+        "smtp_user": "alice@example.edu",
+        "smtp_password": "",
+        "imap_host": "imap.gmail.com",
+        "imap_port": 993,
+        "imap_user": "alice@example.edu",
+        "imap_password": "",
+        "imap_starttls": False,
+        "from_address": "alice@example.edu",
+        "oauth_provider": "google",
+        "oauth_access_token": encrypted_access,
+        "oauth_refresh_token": encrypted_refresh,
+        "oauth_token_expiry": "4102444800",
+        "display_name": "Alice",
+    }
+
+    router = setup_email_routes()
+    get_config = None
+    for route in router.routes:
+        if route.path == "/api/email/config" and "GET" in getattr(route, "methods", set()):
+            get_config = route.endpoint
+            break
+    assert get_config is not None, "email config route not found"
+
+    with mock.patch("routes.email_routes._get_email_config", return_value=internal_cfg.copy()), \
+         mock.patch("routes.email_routes._load_settings", return_value={}):
+        result = await get_config(owner="alice")
+
+    assert result["oauth_provider"] == "google"
+    assert "oauth_access_token" not in result
+    assert "oauth_refresh_token" not in result
+    assert "oauth_token_expiry" not in result
+    assert encrypted_access not in json.dumps(result)
+    assert encrypted_refresh not in json.dumps(result)


### PR DESCRIPTION
## Summary

Remove encrypted Google OAuth access-token, refresh-token, and expiry storage fields from the browser-facing legacy email configuration response. The route still returns the provider status and ordinary account settings needed by the UI, matching the existing account-list response boundary.

The internal transport helper remains unchanged and can continue supplying OAuth fields to server-side IMAP/SMTP callers.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #5639

Part of #5637

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this response-serialization bug is not already tracked.
- [x] This PR targets `dev`.
- [x] My changes are limited to the client response boundary and focused regression coverage.
- [ ] I ran the app end-to-end. This backend serialization fix was validated with the live route function and adjacent email tests in an isolated environment with mocked provider/network I/O.

## How to Test

1. Run:

   ```bash
   python -m pytest -q tests/test_email_oauth.py tests/test_email_owner_scope.py
   ```

2. Configure a Google email account and request `GET /api/email/config`.
3. Verify the response still contains `oauth_provider: "google"` but does not contain `oauth_access_token`, `oauth_refresh_token`, or `oauth_token_expiry`.
4. Verify password masking and ordinary email preferences are unchanged.

Current-`dev` isolated validation passes 146 adjacent tests. Python compilation and diff checks pass.

## Visual / UI changes

N/A — backend response serialization and tests only; no UI rendering changed.

### Screenshots / clips

N/A — no visual changes.