### PR TITLE
refactor(routes): move cleanup domain into routes/cleanup/ subpackage

### DIFF
--- a/app.py
+++ b/app.py
@@ -704,7 +704,7 @@ from routes.diagnostics_routes import setup_diagnostics_routes
 app.include_router(setup_diagnostics_routes(rag_manager, rag_available, research_handler, memory_vector))
 
 # Cleanup
-from routes.cleanup_routes import setup_cleanup_routes
+from routes.cleanup.cleanup_routes import setup_cleanup_routes
 app.include_router(setup_cleanup_routes(session_manager))
 
 # Personal docs

--- a/routes/cleanup/__init__.py
+++ b/routes/cleanup/__init__.py
@@ -1,0 +1,5 @@
+"""Cleanup route domain package (slice 2g, #4082/#4071).
+
+Contains cleanup_routes.py, migrated from the flat routes/ directory.
+Backward-compat shim at routes/cleanup_routes.py re-exports from here.
+"""

--- a/routes/cleanup/cleanup_routes.py
+++ b/routes/cleanup/cleanup_routes.py
@@ -1,0 +1,60 @@
+# routes/cleanup_routes.py
+"""Routes for cleanup operations."""
+import logging
+from fastapi import APIRouter, HTTPException, Request
+from src.cleanup_service import get_cleanup_preview, cleanup_sessions
+from src.auth_helpers import get_current_user
+
+logger = logging.getLogger(__name__)
+
+def setup_cleanup_routes(session_manager):
+    """
+    Setup cleanup-related routes.
+
+    Args:
+        session_manager: SessionManager instance
+
+    Returns:
+        APIRouter instance with cleanup routes
+    """
+    router = APIRouter(prefix="/api/cleanup")
+
+    @router.get("/preview")
+    async def cleanup_preview(request: Request):
+        """
+        Preview what would be cleaned up without making any changes.
+
+        Returns:
+            JSON response with lists of sessions that would be archived/deleted and estimated space savings
+        """
+        user = get_current_user(request)
+        try:
+            preview = await get_cleanup_preview(owner=user)
+            return preview
+        except Exception as e:
+            logger.error(f"Cleanup preview failed: {e}")
+            raise HTTPException(500, "Cleanup preview generation failed")
+
+    @router.post("")
+    async def cleanup_endpoint(request: Request):
+        """
+        Perform cleanup operations:
+        1. Archive inactive sessions (not accessed for 7 days)
+        2. Delete old sessions (archived, not important, not accessed for 14+ days, with fewer than 10 messages)
+
+        Returns:
+            JSON response with counts of deleted and archived sessions, and space freed
+        """
+        user = get_current_user(request)
+        try:
+            archived_count, deleted_count, space_freed_mb = await cleanup_sessions(session_manager, owner=user)
+            return {
+                "archived_count": archived_count,
+                "deleted_count": deleted_count,
+                "space_freed_mb": round(space_freed_mb, 2)
+            }
+        except Exception as e:
+            logger.error(f"Cleanup failed: {e}")
+            raise HTTPException(500, "Cleanup operation failed")
+
+    return router

--- a/routes/cleanup_routes.py
+++ b/routes/cleanup_routes.py
@@ -1,60 +1,17 @@
-# routes/cleanup_routes.py
-"""Routes for cleanup operations."""
-import logging
-from fastapi import APIRouter, HTTPException, Request
-from src.cleanup_service import get_cleanup_preview, cleanup_sessions
-from src.auth_helpers import get_current_user
+"""Backward-compat shim — canonical location is routes/cleanup/cleanup_routes.py.
 
-logger = logging.getLogger(__name__)
+This module is replaced in ``sys.modules`` by the canonical module object so
+that ``import routes.cleanup_routes``, ``from routes.cleanup_routes import X``,
+``importlib.import_module("routes.cleanup_routes")``, and the string-targeted
+``monkeypatch.setattr("routes.cleanup_routes.get_cleanup_preview", ...)`` /
+``"routes.cleanup_routes.get_current_user"`` / ``"routes.cleanup_routes.
+cleanup_sessions"`` pattern used by test_cleanup_owner_scope.py all operate
+on the *same* object the application actually uses. Keeps existing import
+paths working after slice 2g (#4082/#4071).
+"""
 
-def setup_cleanup_routes(session_manager):
-    """
-    Setup cleanup-related routes.
+import sys as _sys
 
-    Args:
-        session_manager: SessionManager instance
+from routes.cleanup import cleanup_routes as _canonical  # noqa: F401
 
-    Returns:
-        APIRouter instance with cleanup routes
-    """
-    router = APIRouter(prefix="/api/cleanup")
-
-    @router.get("/preview")
-    async def cleanup_preview(request: Request):
-        """
-        Preview what would be cleaned up without making any changes.
-
-        Returns:
-            JSON response with lists of sessions that would be archived/deleted and estimated space savings
-        """
-        user = get_current_user(request)
-        try:
-            preview = await get_cleanup_preview(owner=user)
-            return preview
-        except Exception as e:
-            logger.error(f"Cleanup preview failed: {e}")
-            raise HTTPException(500, "Cleanup preview generation failed")
-
-    @router.post("")
-    async def cleanup_endpoint(request: Request):
-        """
-        Perform cleanup operations:
-        1. Archive inactive sessions (not accessed for 7 days)
-        2. Delete old sessions (archived, not important, not accessed for 14+ days, with fewer than 10 messages)
-
-        Returns:
-            JSON response with counts of deleted and archived sessions, and space freed
-        """
-        user = get_current_user(request)
-        try:
-            archived_count, deleted_count, space_freed_mb = await cleanup_sessions(session_manager, owner=user)
-            return {
-                "archived_count": archived_count,
-                "deleted_count": deleted_count,
-                "space_freed_mb": round(space_freed_mb, 2)
-            }
-        except Exception as e:
-            logger.error(f"Cleanup failed: {e}")
-            raise HTTPException(500, "Cleanup operation failed")
-
-    return router
+_sys.modules[__name__] = _canonical

--- a/tests/test_cleanup_routes_shim.py
+++ b/tests/test_cleanup_routes_shim.py
@@ -1,0 +1,25 @@
+"""Regression test for the cleanup route shim (slice 2g, #4082/#4071).
+
+The backward-compat shim at ``routes/cleanup_routes.py`` uses ``sys.modules``
+replacement so the legacy import path and the canonical ``routes.cleanup.*``
+path resolve to the *same* module object. This is required because
+``test_cleanup_owner_scope.py`` uses string-targeted
+``monkeypatch.setattr("routes.cleanup_routes.get_cleanup_preview", ...)`` and
+``monkeypatch.delitem(sys.modules, "routes.cleanup_routes")`` + re-import —
+for those patches to take effect at runtime, the legacy module object and
+the canonical one must be identical.
+"""
+
+import importlib
+
+import routes.cleanup_routes as _shim_cleanup  # noqa: F401
+
+
+def test_legacy_and_canonical_cleanup_module_are_same_object():
+    """``import routes.cleanup_routes`` must alias the canonical module."""
+    legacy = importlib.import_module("routes.cleanup_routes")
+    canonical = importlib.import_module("routes.cleanup.cleanup_routes")
+    assert legacy is canonical, (
+        "routes.cleanup_routes shim must resolve to the canonical "
+        "routes.cleanup.cleanup_routes module object"
+    )


### PR DESCRIPTION
## Summary

Slice 2g of the route-domain reorganization (Refs #4082 / #4071; inventory baseline in #4148). Moves the **cleanup** domain into `routes/cleanup/`, keeping a backward-compat `sys.modules` shim at the old path. Pure file reorganization, no behavior change.

Follows the same pattern as the merged gallery (#4903), research (#4975), memory (#5007), history (#5090), contacts (#5227), and note (#5236) slices.

## What moves
| From | To |
|------|----|
| `routes/cleanup_routes.py` (60 lines) | `routes/cleanup/cleanup_routes.py` |

New `routes/cleanup/__init__.py` marks the subpackage. Cleanup is a single-file, LOW-complexity domain with zero internal `routes/` coupling.

## Backward compatibility
A backward-compat shim remains at `routes/cleanup_routes.py`, using `sys.modules` replacement so string-targeted `monkeypatch.setattr("routes.cleanup_routes.*", ...)` in `test_cleanup_owner_scope.py` reaches the canonical module.

The canonical module imports only from `src/` and stdlib — no dependency on the legacy shim.

## Test repoints
**Zero source-introspection landmines.** No test reads this file by path.

## Shim regression test
Adds `tests/test_cleanup_routes_shim.py` to pin the `sys.modules` shim contract (same-object).

## How to test
```bash
python -m compileall routes/cleanup/ routes/cleanup_routes.py app.py
python -m pytest tests/ -q
```

## Target branch
- [x] This PR targets **`dev`**, not `main`.

## Linked Issue
Follows the Phase 0 architecture refactor (#4082 / #4071) and the merged runtime inventory (#4148). One domain per PR per maintainer guidance.

## Type of Change
- [x] Refactor / cleanup

## Checklist
- [x] I searched open issues and open PRs — this is not a duplicate
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors
- [x] No runtime behavior changes (pure file move + import shim)
- [x] Backward-compatible: old `from routes.cleanup_routes import ...` paths keep working via shim