### PR TITLE
fix(macos): adopt a running Apfel instead of racing for its port

### DIFF
--- a/start-macos.sh
+++ b/start-macos.sh
@@ -170,7 +170,13 @@ ODYSSEUS_SKIP_RUN_HINT=1 ./venv/bin/python setup.py
 MACHINE_ARCH="$(uname -m)"
 APFEL_PID=""
 if [ "$MACHINE_ARCH" = "arm64" ]; then
-    if command -v apfel >/dev/null 2>&1; then
+    if (exec 3<>"/dev/tcp/127.0.0.1/11435") 2>/dev/null; then
+        # An Apfel from a previous run can outlive it (nohup'd child + a trap
+        # that never fires on force-quit). Adopt it instead of blindly racing
+        # for the port — same policy as ChromaDB below. APFEL_PID stays empty,
+        # so the EXIT trap won't kill a server this run didn't start.
+        echo "▶ Apfel already running on 127.0.0.1:11435 — using it."
+    elif command -v apfel >/dev/null 2>&1; then
         APFEL_LOG="${TMPDIR:-/tmp}/odysseus-apfel.log"
         echo "▶ Starting Apfel server in the background on port 11435…"
         echo "  logging to $APFEL_LOG"


### PR DESCRIPTION
## Problem

`start-macos.sh` starts Apfel with a blind background launch:

```bash
nohup apfel --serve --port 11435 >"$APFEL_LOG" 2>&1 &
```

The ChromaDB block ~25 lines below does the opposite — it probes its port first and reuses a live server:

```bash
if (exec 3<>"/dev/tcp/127.0.0.1/$CHROMA_PORT") 2>/dev/null; then
    echo "▶ ChromaDB already running on 127.0.0.1:$CHROMA_PORT - using it."
```

Apfel is a `nohup`'d child, and the `trap ... EXIT INT TERM` that would kill it never fires when the terminal is force-closed or the script is SIGKILLed. So an Apfel routinely outlives its run, and every later run logs:

```
error: Port 11435 is already in use.
Another process (e.g. Ollama) may be listening on this port.
```

The run still succeeds — the incumbent keeps serving — but the error is misleading twice over: nothing is actually broken, and it fingers Ollama when the listener is almost always Apfel itself from a previous session.

## Fix

Give Apfel the same probe ChromaDB already uses:

```bash
if (exec 3<>"/dev/tcp/127.0.0.1/11435") 2>/dev/null; then
    echo "▶ Apfel already running on 127.0.0.1:11435 — using it."
elif command -v apfel >/dev/null 2>&1; then
    ...
```

`APFEL_PID` stays empty in the adopt branch, so the EXIT trap won't kill a server this run didn't start — matching ChromaDB's semantics of never reaping a process it merely adopted. Without that, `Ctrl+C` on a second run would tear down an Apfel another session is still using.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Fresh boot, no Apfel | starts it | starts it (unchanged) |
| Apfel already listening | `error: Port 11435 is already in use` | `▶ Apfel already running — using it.` |
| Ctrl+C after adopting | n/a | leaves the incumbent alone |

## Testing

- `bash -n start-macos.sh` — parses clean
- Verified against a real stale Apfel (`PPID=1`, survived a force-closed terminal): before the patch the run logged the port error; after, it prints the adopt message and proceeds.
- Non-arm64 and Apfel-not-installed paths are untouched.