### PR TITLE
feat(odyssey): Phase 1 — life-data substrate (data/life + registry + auto-index)

### DIFF
--- a/docs/odyssey-plan.md
+++ b/docs/odyssey-plan.md
@@ -1,0 +1,127 @@
+# Odyssey — Home OS layer on Odysseus
+
+**What this is:** a personal life-management "home OS" for you and your wife, built as a
+thin layer on top of the Odysseus self-hosted AI workspace you already develop. Odysseus
+provides the primitives (agent, models, calendar, tasks, memory, documents, mobile PWA,
+auth); **Odyssey** is the data + skills + templates that turn those primitives into a tool
+that manages routines, recipes, the weekly plan, and a budget — digital *and* printed.
+
+Naming: **Odysseus** = the platform. **Odyssey** = the life-OS layer on top.
+
+---
+
+## Architecture decisions (settled)
+
+### 1. Layer on top — not a fork, not new core features
+Life-management lives as **data + skills + templates** riding on existing Odysseus
+primitives. Core Odysseus stays untouched until a rough edge proves something must go
+deeper. Cheapest, most reversible foundation; keeps us upstream-compatible.
+
+```
+data/life/
+  routines/night.md      recipes/tacos.md
+  weekly/2026-W30.md      registry.json   <- agent reads first: "what exists"
+templates/  recipe.html routine.html weekly.html daily.html
+styles/     design.css (@media screen)  print.css (@media print, B&W)
+skills/     log-expense/ update-recipe/ weekly-review/ daily-review/ print-artifact/
+```
+
+### 2. Data substrate — files canonical, indexed for retrieval
+Human-readable files under `data/life/` are the **one source of truth**. A `registry.json`
+manifest lists every domain + artifact so the agent always knows *what exists*. On save,
+each file is auto-indexed into the existing Chroma/RAG so vector + keyword search finds it
+months later. Structured/tabular data (expenses, metrics) lives in SQLite / Actual Budget.
+Files = truth; vectors = derived index. `[LAW:one-source-of-truth]`
+
+### 3. Two-tier agent — Operator vs Builder `[LAW:one-way-deps]`
+- **Operator** (ongoing, hot path): the routed cheap agent. *Operates* the life OS —
+  logs expenses, updates recipes, builds weekly reviews, prints. **No *unsupervised* code
+  changes.** It MAY make small, low-risk self-improvement hacks, but only after a
+  **verify-with-me gate**: it proposes the change and asks whether to (a) do it itself now,
+  or (b) delegate to a Builder. Anything non-trivial always goes to the Builder + review.
+  The invariant preserved is "no code changes the human didn't approve," not "the Operator
+  never touches code."
+- **Builder** (occasional, off hot path): Claude Code / OpenCode + **Grok 4.5** (existing
+  subscriptions). *Improves & hardens* the system's own code via the git worktree ->
+  draft PR -> review loop. Human-gated merge.
+- **Trigger model — both:** you can explicitly tell the Operator to dispatch a Builder now,
+  **or** gaps accumulate as a **system-improvement backlog** worked later in batches.
+  Either way it ships as a draft PR you approve. Half-wired already via
+  `integrations/claude` and `integrations/codex`.
+- **Operator self-improvement gate:** for small hacks the Operator itself can do, it always
+  asks first and offers do-it-now vs delegate-to-Builder; the backlog is the delegation sink.
+
+### 4. Model brain — privacy-aware router via LiteLLM
+Sensitivity is a **policy tag, not an ML classification**. The agent knows when it touches
+finance/private data because it loaded that context; it tags the request and LiteLLM pins
+routing by config. **Default-deny: unknown -> local**, so nothing leaks. `[LAW:single-enforcer]`
+- **Local (sensitive + everyday):** on-device model via Cookbook on the M4 Max / 48 GB
+  (Hermes-3 is a strong function-calling candidate; confirm fit + latency first).
+- **Cloud (hard, non-sensitive):** **Gemini Flash** primary (cheap, contractually doesn't
+  train on API data), GPT-mini fallback. Well under **$10/mo**.
+- **Avoid:** DeepSeek + OpenRouter free tiers (train/log data); RouteLLM / Not Diamond /
+  OpenRouter-Auto (route on *difficulty*, and by sending prompts to the cloud — wrong axis
+  for privacy). OpenHands & Open Interpreter both already use LiteLLM — well-worn path.
+
+### 5. Phone interface — PWA + Telegram + ntfy
+- **PWA** (installable, existing) over **Tailscale** for chat, dashboards, anything you want
+  fully local. **ntfy** for push reminders.
+- **Telegram** for frictionless quick capture from anywhere, incl. **receipt photos**.
+  Accepted tradeoff: a receipt is low-sensitivity (no card numbers) and transiting Telegram
+  is fine; parse it with cloud vision (Gemini Flash) for good OCR.
+- **Privacy boundary that stays honest:** individual receipts may transit cloud, but the
+  **aggregate financial picture** (totals, "how am I doing this month") is computed
+  **locally** against the Actual ledger — the whole-life view never leaves the Mac.
+
+### 6. Finance — integrate Actual Budget
+**Actual Budget** (open-source, local-first envelope budgeting, own dashboard + API) is the
+ledger. Odysseus is the **capture layer**: message / photo -> local (or cloud-vision for
+photos) parse + categorize -> write to Actual via API. Great dashboard for ~zero build;
+aggregate analysis stays local.
+
+### 7. Surfaces — template library + one design system
+A small set of canonical HTML templates (recipe, routine, weekly-plan, daily-review) the
+agent fills from a data model, plus **one shared stylesheet with screen AND print (B&W)
+styles**. Recurring artifacts reuse a liked template (cheap on tokens — fill a slot, don't
+redesign); novel one-offs are free-form HTML pulling the same stylesheet. Print-ready by
+construction.
+
+### 8. Printing — direct access, PDF-first until hardware is up
+Agent prints directly via macOS CUPS (`lp`) to the default printer — supports both
+**scheduled** (Sunday binder run: weekly plan + recipes + routines) and **on-demand**.
+Render path: template + `print.css` -> PDF (headless Chrome) -> `lp`.
+**Printer not connected yet** (post-move): build the pipeline to output **PDFs now**
+(fully verifiable), activate the final `lp` step once the printer is on the new network.
+
+### 9. Always-on — MacBook, keep-awake
+Run Odysseus as a launchd background service on this MacBook; disable sleep on power so it
+runs lid-closed while plugged in. $0, no extra hardware. Because it's service-ready + reached
+over Tailscale, a future move to a dedicated always-on box (Mac mini) would be a config move,
+not a rewrite.
+
+### 10. Calendar — Google Calendar (shared household)
+Chosen for zero-effort sharing with your wife and native phone access; Odysseus syncs via
+CalDAV/API and derives the weekly-review printout from it. Note: this is the one non-local
+piece — keep genuinely private notes out of event bodies; a dedicated "household" calendar
+keeps scheduling separate from anything sensitive.
+
+---
+
+## Suggested build order (phased)
+
+1. **Substrate:** `data/life/` + `registry.json` convention + auto-index-on-save into Chroma.
+2. **Design system:** `styles/design.css` + `print.css`; one template end-to-end (recipe)
+   rendered to PDF. Verifiable without a printer.
+3. **Operator skills:** `update-recipe`, `weekly-review` (from calendar), `daily-review`.
+4. **Router:** LiteLLM config — `local-sensitive`, `local-default`, `cloud-hard` groups +
+   tag routing + budget cap. Cookbook-serve the local model.
+5. **Finance:** stand up Actual Budget; `log-expense` capture skill (text + receipt photo via
+   Telegram -> cloud vision -> Actual API).
+6. **Interfaces:** Telegram bot listener; Tailscale; ntfy reminders; launchd keep-awake service.
+7. **Printing hardware:** wire `lp` once the printer is on the new network; scheduled binder run.
+8. **Builder loop:** system-improvement backlog + explicit-dispatch path -> draft PRs.
+
+## Open items to confirm later
+- Exact local model (Hermes-3 vs alternative) after Cookbook fit test on the M4 Max.
+- Whether the weekly-review printout format wants a first draft before templating it.
+- Backup strategy for `data/life/` + Actual (deferred by choice).

--- a/src/constants.py
+++ b/src/constants.py
@@ -53,6 +53,7 @@ SKILLS_DIR = os.path.join(DATA_DIR, "skills")
 GALLERY_DIR = os.path.join(DATA_DIR, "gallery")
 GALLERY_UPLOADS_DIR = os.path.join(DATA_DIR, "gallery_uploads")
 MEMORY_VECTORS_DIR = os.path.join(DATA_DIR, "memory_vectors")
+LIFE_DIR = os.path.join(DATA_DIR, "life")  # Odyssey life-data substrate (files = source of truth)
 
 # Paths with an intentional dedicated env override, defaulting under DATA_DIR.
 MAIL_ATTACHMENTS_DIR = os.getenv("ODYSSEUS_MAIL_ATTACHMENTS_DIR", os.path.join(DATA_DIR, "mail-attachments"))

--- a/src/life_store.py
+++ b/src/life_store.py
@@ -1,0 +1,330 @@
+"""Odyssey life-data substrate.
+
+The canonical file store for life artifacts (routines, recipes, weekly plans,
+…). Human-readable files under ``data/life/`` are the ONE source of truth
+[LAW:one-source-of-truth]. Two derived projections are kept in sync on every
+write, and never treated as authoritative:
+
+  - ``registry.json`` — a manifest enumerating every domain + artifact so the
+    agent always knows *what exists*. It is a pure scan of the tree; a rebuild
+    always reproduces it exactly, so it can never diverge from the files.
+  - the Chroma/RAG vector index — so a saved artifact is retrievable by
+    vector + keyword search months later. Indexing is delegated to a
+    ``LifeIndexer`` seam [LAW:effects-at-boundaries] so the store composes with
+    a fake in tests and with the real RAG in production.
+
+Files = truth; registry + vectors = derived index.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from dataclasses import asdict, dataclass
+from typing import Dict, List, Optional, Protocol
+
+from src.constants import LIFE_DIR
+
+logger = logging.getLogger(__name__)
+
+REGISTRY_VERSION = 1
+REGISTRY_FILENAME = "registry.json"
+
+# Seed domains from docs/odyssey-plan.md #1. The set is open — any slug-valid
+# domain is allowed — but these are created up front so the store is legible.
+SEED_DOMAINS = ("routines", "recipes", "weekly")
+
+ALLOWED_EXTENSIONS = (".md", ".html")
+
+_DOMAIN_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+_NAME_STEM_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_MD_TITLE_RE = re.compile(r"^\s{0,3}#\s+(.+?)\s*$", re.MULTILINE)
+_HTML_H1_RE = re.compile(r"<h1[^>]*>(.*?)</h1>", re.IGNORECASE | re.DOTALL)
+_HTML_TITLE_RE = re.compile(r"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+
+
+# ---------------------------------------------------------------------------
+# Types — a legal state is exactly a domain + artifact under the store root.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Artifact:
+    """One life file. ``path`` is relative to the store root so the manifest
+    is portable across machines; the store resolves it to an absolute path."""
+
+    domain: str
+    name: str          # filename incl. extension, e.g. "tacos.md"
+    path: str          # relative to store root, e.g. "recipes/tacos.md"
+    type: str          # extension, e.g. ".md"
+    title: str
+    size: int
+    modified: float    # mtime, epoch seconds
+
+
+@dataclass(frozen=True)
+class Registry:
+    version: int
+    domains: Dict[str, List[Artifact]]
+
+
+# ---------------------------------------------------------------------------
+# The indexing seam — the only coupling to Chroma/RAG lives behind this.
+# ---------------------------------------------------------------------------
+
+
+class LifeIndexer(Protocol):
+    def index(self, *, text: str, source: str, metadata: Dict[str, object]) -> int:
+        """Index ``text`` under ``source`` (a stable id). Re-indexing the same
+        source replaces prior content. Returns the number of chunks written."""
+
+    def remove(self, *, source: str) -> int:
+        """Remove all indexed content for ``source``. Returns chunks removed."""
+
+
+class RagLifeIndexer:
+    """Default ``LifeIndexer`` backed by the existing Odysseus VectorRAG.
+
+    When ChromaDB is unreachable the RAG manager is ``None``; indexing is a
+    derived best-effort projection, so we log loudly and return 0 rather than
+    failing the caller's save [LAW:no-silent-failure] — the file itself is the
+    source of truth and is already persisted."""
+
+    def index(self, *, text: str, source: str, metadata: Dict[str, object]) -> int:
+        from src.rag_singleton import get_rag_manager
+
+        rag = get_rag_manager()
+        if rag is None or not getattr(rag, "healthy", False):
+            logger.warning(
+                "life index skipped for %s: RAG unavailable (keyword-only until it recovers)",
+                source,
+            )
+            return 0
+
+        rag.delete_by_source(source)
+        chunks = rag._split_into_chunks(text)
+        written = 0
+        for chunk_id, chunk in enumerate(chunks):
+            if rag.add_document(chunk, {**metadata, "source": source, "chunk_id": chunk_id}):
+                written += 1
+        return written
+
+    def remove(self, *, source: str) -> int:
+        from src.rag_singleton import get_rag_manager
+
+        rag = get_rag_manager()
+        if rag is None or not getattr(rag, "healthy", False):
+            return 0
+        return rag.delete_by_source(source)
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers — validation, title derivation, (de)serialization.
+# ---------------------------------------------------------------------------
+
+
+def _validate(domain: str, name: str) -> str:
+    """Validate caller-supplied identifiers at the trust boundary and return
+    the file extension. Raises ValueError on anything unsafe."""
+
+    if not _DOMAIN_RE.match(domain):
+        raise ValueError(f"invalid domain {domain!r}: expected [a-z0-9_-]")
+    stem, ext = os.path.splitext(name)
+    if ext.lower() not in ALLOWED_EXTENSIONS:
+        raise ValueError(
+            f"invalid artifact name {name!r}: extension must be one of {ALLOWED_EXTENSIONS}"
+        )
+    if not _NAME_STEM_RE.match(stem) or ".." in name:
+        raise ValueError(f"invalid artifact name {name!r}: expected [A-Za-z0-9._-]")
+    return ext.lower()
+
+
+def _derive_title(name: str, ext: str, content: str) -> str:
+    """First heading in the content, else the filename stem."""
+
+    if ext == ".md":
+        m = _MD_TITLE_RE.search(content)
+        if m:
+            return m.group(1).strip()
+    elif ext == ".html":
+        for pattern in (_HTML_H1_RE, _HTML_TITLE_RE):
+            m = pattern.search(content)
+            if m:
+                text = _HTML_TAG_RE.sub("", m.group(1)).strip()
+                if text:
+                    return text
+    return os.path.splitext(name)[0]
+
+
+def _artifact_to_json(a: Artifact) -> Dict[str, object]:
+    return asdict(a)
+
+
+def _artifact_from_json(domain: str, raw: Dict[str, object]) -> Artifact:
+    return Artifact(
+        domain=domain,
+        name=str(raw["name"]),
+        path=str(raw["path"]),
+        type=str(raw["type"]),
+        title=str(raw.get("title", "")),
+        size=int(raw.get("size", 0)),
+        modified=float(raw.get("modified", 0.0)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# The store.
+# ---------------------------------------------------------------------------
+
+
+class LifeStore:
+    """Owns ``data/life/``. Single writer for the tree, its ``registry.json``
+    manifest, and the on-save vector index [LAW:no-shared-mutable-globals]."""
+
+    def __init__(self, root: Optional[str] = None, indexer: Optional[LifeIndexer] = None):
+        self.root = root or LIFE_DIR
+        self.indexer: LifeIndexer = indexer if indexer is not None else RagLifeIndexer()
+        os.makedirs(self.root, exist_ok=True)
+        for domain in SEED_DOMAINS:
+            os.makedirs(os.path.join(self.root, domain), exist_ok=True)
+
+    # -- paths -------------------------------------------------------------
+
+    @property
+    def registry_path(self) -> str:
+        return os.path.join(self.root, REGISTRY_FILENAME)
+
+    def _abs(self, domain: str, name: str) -> str:
+        return os.path.join(self.root, domain, name)
+
+    def _relpath(self, domain: str, name: str) -> str:
+        return f"{domain}/{name}"
+
+    # -- write path --------------------------------------------------------
+
+    def save(self, domain: str, name: str, content: str, *, owner: Optional[str] = None) -> Artifact:
+        """Persist a life artifact (creating the domain dir on demand), index
+        it into the RAG, and refresh the registry manifest. The file is the
+        source of truth; both projections are rebuilt from it."""
+
+        ext = _validate(domain, name)
+        abs_path = self._abs(domain, name)
+        os.makedirs(os.path.dirname(abs_path), exist_ok=True)
+        with open(abs_path, "w", encoding="utf-8") as f:
+            f.write(content)
+
+        source = self._relpath(domain, name)
+        metadata: Dict[str, object] = {
+            "kind": "life",
+            "life_domain": domain,
+            "life_artifact": name,
+            "filename": name,
+            "directory": domain,
+            "type": ext,
+        }
+        if owner:
+            metadata["owner"] = owner
+        self.indexer.index(text=content, source=source, metadata=metadata)
+
+        self.rebuild_registry()
+        return self._scan_artifact(domain, name)
+
+    def delete(self, domain: str, name: str) -> None:
+        """Remove an artifact and its derived index entries, then refresh the
+        manifest. Missing files are a no-op — the desired end state (absent) is
+        already true."""
+
+        _validate(domain, name)
+        abs_path = self._abs(domain, name)
+        if os.path.exists(abs_path):
+            os.remove(abs_path)
+        self.indexer.remove(source=self._relpath(domain, name))
+        self.rebuild_registry()
+
+    # -- read path ---------------------------------------------------------
+
+    def read(self, domain: str, name: str) -> str:
+        _validate(domain, name)
+        with open(self._abs(domain, name), "r", encoding="utf-8") as f:
+            return f.read()
+
+    def list_artifacts(self, domain: Optional[str] = None) -> List[Artifact]:
+        registry = self.load_registry()
+        if domain is None:
+            return [a for arts in registry.domains.values() for a in arts]
+        return list(registry.domains.get(domain, []))
+
+    # -- registry (derived manifest) --------------------------------------
+
+    def load_registry(self) -> Registry:
+        """Read ``registry.json``; rebuild it from the tree if absent or
+        unreadable so a caller always gets a truthful manifest."""
+
+        try:
+            with open(self.registry_path, "r", encoding="utf-8") as f:
+                raw = json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError):
+            return self.rebuild_registry()
+
+        domains = {
+            domain: [_artifact_from_json(domain, item) for item in items]
+            for domain, items in raw.get("domains", {}).items()
+        }
+        return Registry(version=int(raw.get("version", REGISTRY_VERSION)), domains=domains)
+
+    def rebuild_registry(self) -> Registry:
+        """Scan the tree and write ``registry.json``. This is the definition of
+        the manifest — every save/delete calls it, so the manifest is always a
+        faithful projection of the files [LAW:one-source-of-truth]."""
+
+        domains: Dict[str, List[Artifact]] = {}
+        for domain in sorted(self._existing_domains()):
+            artifacts = []
+            domain_dir = os.path.join(self.root, domain)
+            for name in sorted(os.listdir(domain_dir)):
+                if os.path.splitext(name)[1].lower() not in ALLOWED_EXTENSIONS:
+                    continue
+                if not os.path.isfile(os.path.join(domain_dir, name)):
+                    continue
+                artifacts.append(self._scan_artifact(domain, name))
+            domains[domain] = artifacts
+
+        registry = Registry(version=REGISTRY_VERSION, domains=domains)
+        payload = {
+            "version": registry.version,
+            "domains": {
+                domain: [_artifact_to_json(a) for a in arts]
+                for domain, arts in registry.domains.items()
+            },
+        }
+        with open(self.registry_path, "w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2, sort_keys=True)
+        return registry
+
+    # -- internal scan -----------------------------------------------------
+
+    def _existing_domains(self) -> List[str]:
+        return [
+            entry
+            for entry in os.listdir(self.root)
+            if _DOMAIN_RE.match(entry) and os.path.isdir(os.path.join(self.root, entry))
+        ]
+
+    def _scan_artifact(self, domain: str, name: str) -> Artifact:
+        abs_path = self._abs(domain, name)
+        ext = os.path.splitext(name)[1].lower()
+        stat = os.stat(abs_path)
+        with open(abs_path, "r", encoding="utf-8") as f:
+            content = f.read()
+        return Artifact(
+            domain=domain,
+            name=name,
+            path=self._relpath(domain, name),
+            type=ext,
+            title=_derive_title(name, ext, content),
+            size=stat.st_size,
+            modified=stat.st_mtime,
+        )

--- a/tests/test_life_store.py
+++ b/tests/test_life_store.py
@@ -1,0 +1,206 @@
+"""Tests for the Odyssey life-data substrate (src/life_store.py).
+
+The store's contract: files are the source of truth; registry.json and the
+vector index are derived projections kept in sync on every write. These tests
+assert that contract against a fake indexer (deterministic, no ChromaDB), plus
+one integration test that exercises real retrieval when a RAG backend is up.
+"""
+
+import json
+
+import pytest
+
+from src.life_store import (
+    ALLOWED_EXTENSIONS,
+    LifeStore,
+    RagLifeIndexer,
+    _derive_title,
+    _validate,
+)
+
+
+class FakeIndexer:
+    """In-memory stand-in for the RAG seam. Records what was indexed under each
+    source so tests can assert save/delete keep the index in sync."""
+
+    def __init__(self):
+        self.indexed = {}   # source -> (text, metadata)
+        self.calls = []
+
+    def index(self, *, text, source, metadata):
+        self.indexed[source] = (text, metadata)
+        self.calls.append(("index", source))
+        return 1
+
+    def remove(self, *, source):
+        existed = self.indexed.pop(source, None)
+        self.calls.append(("remove", source))
+        return 1 if existed else 0
+
+    def search(self, query):
+        """Faithful-enough keyword search over indexed text, so 'retrievable
+        via search' is checkable without ChromaDB."""
+        q = query.lower()
+        return [src for src, (text, _) in self.indexed.items() if q in text.lower()]
+
+
+@pytest.fixture
+def store(tmp_path):
+    return LifeStore(root=str(tmp_path / "life"), indexer=FakeIndexer())
+
+
+# -- save: file is written, registry updated, artifact indexed ---------------
+
+
+def test_save_writes_file_under_domain(store):
+    store.save("recipes", "tacos.md", "# Tacos\n\nCorn tortillas.")
+    assert store.read("recipes", "tacos.md") == "# Tacos\n\nCorn tortillas."
+
+
+def test_save_updates_registry_manifest(store):
+    store.save("recipes", "tacos.md", "# Tacos\n")
+
+    with open(store.registry_path, encoding="utf-8") as f:
+        raw = json.load(f)
+
+    assert raw["version"] == 1
+    entries = raw["domains"]["recipes"]
+    assert [e["name"] for e in entries] == ["tacos.md"]
+    entry = entries[0]
+    assert entry["path"] == "recipes/tacos.md"
+    assert entry["type"] == ".md"
+    assert entry["title"] == "Tacos"      # derived from the H1
+    assert entry["size"] > 0
+
+
+def test_save_indexes_content_with_life_metadata(store):
+    store.save("recipes", "tacos.md", "# Tacos\n\nCarne asada.", owner="alice")
+
+    text, meta = store.indexer.indexed["recipes/tacos.md"]
+    assert "Carne asada" in text
+    assert meta["kind"] == "life"
+    assert meta["life_domain"] == "recipes"
+    assert meta["life_artifact"] == "tacos.md"
+    assert meta["type"] == ".md"
+    assert meta["owner"] == "alice"
+
+
+def test_saved_artifact_is_retrievable_via_search(store):
+    """The acceptance criterion: an added file becomes findable."""
+    store.save("recipes", "tacos.md", "# Tacos\n\nSmoked brisket filling.")
+    assert "recipes/tacos.md" in store.indexer.search("brisket")
+
+
+def test_owner_omitted_when_not_provided(store):
+    store.save("routines", "night.md", "# Night\n")
+    _text, meta = store.indexer.indexed["routines/night.md"]
+    assert "owner" not in meta
+
+
+# -- resave and delete keep projections in sync ------------------------------
+
+
+def test_resave_replaces_index_content(store):
+    store.save("recipes", "tacos.md", "# Tacos\n\nold filling")
+    store.save("recipes", "tacos.md", "# Tacos\n\nnew filling")
+
+    text, _ = store.indexer.indexed["recipes/tacos.md"]
+    assert "new filling" in text and "old filling" not in text
+    assert store.indexer.search("old filling") == []
+
+
+def test_delete_removes_file_registry_entry_and_index(store):
+    store.save("recipes", "tacos.md", "# Tacos\n")
+    store.delete("recipes", "tacos.md")
+
+    assert store.list_artifacts("recipes") == []
+    assert "recipes/tacos.md" not in store.indexer.indexed
+    with open(store.registry_path, encoding="utf-8") as f:
+        assert json.load(f)["domains"].get("recipes", []) == []
+
+
+def test_delete_missing_artifact_is_noop(store):
+    store.delete("recipes", "ghost.md")  # must not raise
+    assert store.list_artifacts("recipes") == []
+
+
+# -- registry is a derived projection, never a second source of truth ---------
+
+
+def test_rebuild_registry_reflects_files_on_disk(store, tmp_path):
+    store.save("recipes", "tacos.md", "# Tacos\n")
+    # Write a file directly, bypassing the store, then rebuild.
+    (tmp_path / "life" / "recipes" / "salsa.md").write_text("# Salsa\n", encoding="utf-8")
+
+    registry = store.rebuild_registry()
+    names = {a.name for a in registry.domains["recipes"]}
+    assert names == {"tacos.md", "salsa.md"}
+
+
+def test_load_registry_rebuilds_when_missing(store, tmp_path):
+    store.save("recipes", "tacos.md", "# Tacos\n")
+    (tmp_path / "life" / "registry.json").unlink()
+
+    registry = store.load_registry()
+    assert [a.name for a in registry.domains["recipes"]] == ["tacos.md"]
+
+
+def test_seed_domains_exist_after_construction(tmp_path):
+    LifeStore(root=str(tmp_path / "life"), indexer=FakeIndexer())
+    for domain in ("routines", "recipes", "weekly"):
+        assert (tmp_path / "life" / domain).is_dir()
+
+
+def test_list_artifacts_across_all_domains(store):
+    store.save("recipes", "tacos.md", "# Tacos\n")
+    store.save("routines", "night.md", "# Night\n")
+    names = {a.name for a in store.list_artifacts()}
+    assert names == {"tacos.md", "night.md"}
+
+
+# -- validation at the trust boundary ----------------------------------------
+
+
+@pytest.mark.parametrize(
+    "domain,name",
+    [
+        ("recipes", "tacos.txt"),        # disallowed extension
+        ("recipes", "../escape.md"),     # path traversal
+        ("recipes", "sub/dir.md"),       # nested path
+        ("Bad Domain", "tacos.md"),      # invalid domain slug
+        ("recipes", ".hidden.md"),       # leading dot
+    ],
+)
+def test_save_rejects_unsafe_identifiers(store, domain, name):
+    with pytest.raises(ValueError):
+        store.save(domain, name, "# x\n")
+
+
+def test_html_title_derivation():
+    assert _derive_title("plan.html", ".html", "<h1>Weekly Plan</h1>") == "Weekly Plan"
+    assert _derive_title("plan.html", ".html", "<title>Fallback</title>") == "Fallback"
+    assert _derive_title("plan.html", ".html", "<p>no heading</p>") == "plan"
+
+
+def test_validate_returns_extension():
+    assert _validate("recipes", "tacos.md") == ".md"
+    assert _validate("weekly", "2026-W30.html") == ".html"
+    assert ".md" in ALLOWED_EXTENSIONS
+
+
+# -- integration: real retrieval through the RAG when a backend is available --
+
+
+def test_real_rag_indexes_and_retrieves(tmp_path):
+    from src.rag_singleton import get_rag_manager
+
+    rag = get_rag_manager()
+    if rag is None or not getattr(rag, "healthy", False):
+        pytest.skip("ChromaDB/RAG backend not reachable — integration path not exercised")
+
+    store = LifeStore(root=str(tmp_path / "life"), indexer=RagLifeIndexer())
+    store.save("recipes", "tacos.md", "# Tacos\n\nThe filling is smoked pineapple carnitas.")
+
+    hits = rag.search("smoked pineapple carnitas", k=5)
+    sources = {h.get("metadata", {}).get("source") for h in hits}
+    assert "recipes/tacos.md" in sources


### PR DESCRIPTION
## Ticket
`odysseus-odyssey-c7w.1` — Phase 1 of the Odyssey home-OS layer. See `docs/odyssey-plan.md` §2 (also added in this PR).

## What
Adds the canonical file store for life artifacts (routines, recipes, weekly plans).

- **`src/life_store.py`** — `LifeStore` owns `data/life/`. **Files are the one source of truth** `[LAW:one-source-of-truth]`; `registry.json` is a *derived* manifest (always a full scan of the tree, so it can never diverge), and the Chroma/RAG vector index is a second derived projection. Both are refreshed on every `save`/`delete`.
- Indexing is delegated behind a **`LifeIndexer` seam** `[LAW:effects-at-boundaries]`; the default `RagLifeIndexer` wraps the existing `VectorRAG` and degrades **loudly** (keyword-only, logged) when ChromaDB is down — it never fails a save, because the file is already persisted.
- Core Odysseus is untouched beyond an additive `LIFE_DIR` constant.

## Acceptance criterion — met
Adding a file writes it under its domain, lists it in `registry.json`, and makes it **retrievable via the existing `rag.search()`**.

- 20 tests in `tests/test_life_store.py` (save→file→registry→index→retrieve, resave/delete sync, derived-manifest rebuild, trust-boundary validation).
- Includes a **real-RAG integration test** verified end-to-end against a live ChromaDB — a saved life file is genuinely returned by `rag.search()`. It `pytest.skip`s explicitly (never a silent pass) when no backend is reachable.

## Notes
- `data/` is gitignored; the store creates domain dirs on demand at runtime.
- `docs/odyssey-plan.md` is committed here (the settled architecture every phase ticket references) since Phase 1 lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)