### PR TITLE
docs: update stale pewdiepie-archdaemon URLs to odysseus-dev in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Odysseus is a self-hosted workspace with powerful local tools. Keep auth enabled
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=pewdiepie-archdaemon%2Fodysseus&type=date&legend=top-left">
+<a href="https://www.star-history.com/?repos=odysseus-dev%2Fodysseus&type=date&legend=top-left">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=odysseus-dev/odysseus&type=date&theme=dark&legend=top-left" />
    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=odysseus-dev/odysseus&type=date&legend=top-left" />

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@
 
 ## Quick Start
 
-> `dev` is the default branch and gets the newest changes first. Use [`main`](https://github.com/pewdiepie-archdaemon/odysseus/tree/main) if you want the more curated branch.
+> `dev` is the default branch and gets the newest changes first. Use [`main`](https://github.com/odysseus-dev/odysseus/tree/main) if you want the more curated branch.
 
 ```bash
-git clone https://github.com/pewdiepie-archdaemon/odysseus.git
+git clone https://github.com/odysseus-dev/odysseus.git
 cd odysseus
 cp .env.example .env
 docker compose up -d --build
@@ -65,9 +65,9 @@ Odysseus is a self-hosted workspace with powerful local tools. Keep auth enabled
 
 <a href="https://www.star-history.com/?repos=pewdiepie-archdaemon%2Fodysseus&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=pewdiepie-archdaemon/odysseus&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=pewdiepie-archdaemon/odysseus&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=pewdiepie-archdaemon/odysseus&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=odysseus-dev/odysseus&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=odysseus-dev/odysseus&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=odysseus-dev/odysseus&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
## Summary
  The repository moved from `pewdiepie-archdaemon/odysseus` to `odysseus-dev/odysseus`, but `README.md` still pointed at the old location. This updates the stale URLs: the `main` branch link, the `git clone` command, the three Star History chart image sources, and the link wrapping that chart. After this change no `pewdiepie-archdaemon` reference remains in the README.
  
  ## Target branch
  - [x] This PR targets **`dev`**, not `main`.

  ## Linked Issue
  Part of #5563
  
  ## Type of Change
  - [x] Documentation only

  ## Checklist
  - [x] I searched open issues and open PRs — not a duplicate.
  - [x] This PR targets `dev`
  - [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
  - [ ] I actually ran the app and verified end-to-end. (N/A: documentation-only change; verified by the rendered README preview and by confirming every updated link resolves to `odysseus-dev/odysseus`.)

  ## How to Test
  1. View the rendered `README.md` on this branch and search it for `pewdiepie-archdaemon`; confirm there are zero matches.
  2. Click the `main` branch link and the Star History chart (and its link); confirm they all resolve to `odysseus-dev/odysseus`.
  3. Run `git clone https://github.com/odysseus-dev/odysseus.git` and confirm it clones successfully.