### PR TITLE
fix(agent): add missing 'Any' import in agent_loop.py

### DIFF
--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -12,7 +12,7 @@ import json
 import re
 import time
 import logging
-from typing import AsyncGenerator, List, Dict, Optional, Set
+from typing import Any, AsyncGenerator, List, Dict, Optional, Set
 from urllib.parse import urlparse
 
 from src.llm_core import (


### PR DESCRIPTION
## Summary

Commit `cf4e240a` ("Merge verified Odysseus fixes") added two functions to `src/agent_loop.py` that use `dict[str, Any]` in their type annotations, but did not add `Any` to the typing import on line 15. This causes an immediate `NameError` on startup — Odysseus fails to start entirely on both `main` and `dev` branches.

The fix is a one-line change: add `Any` to the existing `from typing import ...` statement.

## Target branch

- [x] This PR targets **`dev`* and `main`.

## Linked Issue

Fixes #5723

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. `git checkout main` (or `dev` — same bug on both)
2. `python3 -c "from src.agent_loop import stream_agent_loop"` — raises `NameError: name 'Any' is not defined`
3. Apply this PR, repeat step 2 — import succeeds, no error
