### PR TITLE
fix(login): render the profile's active theme on the login page

### DIFF
--- a/src/app_helpers.py
+++ b/src/app_helpers.py
@@ -1,5 +1,6 @@
 # src/app_helpers.py
 import base64
+import json
 import logging
 import os
 
@@ -8,6 +9,37 @@ from fastapi.responses import HTMLResponse
 from starlette.requests import Request
 
 logger = logging.getLogger(__name__)
+
+
+def _login_theme_json() -> str:
+    """Active profile theme as a script-safe JSON literal for the login page.
+
+    The pre-auth login page can't fetch /api/prefs/theme (401) and a fresh
+    device has nothing in localStorage, so without this it always renders the
+    built-in default. We inject the profile's active theme so login matches
+    the theme set in-app. Only a single-user instance is handled — with more
+    than one user there's no way to know whose theme to show before sign-in,
+    so we return "null" and let the client fall back to localStorage/default.
+    Returns the string "null" (a valid JS literal) on any miss or error.
+    """
+    try:
+        from src.constants import USER_PREFS_FILE
+        with open(USER_PREFS_FILE, "r", encoding="utf-8") as f:
+            users = (json.load(f) or {}).get("_users", {})
+        if len(users) != 1:
+            return "null"
+        theme = next(iter(users.values())).get("theme")
+        if not isinstance(theme, dict) or not theme.get("colors"):
+            return "null"
+        # Escape so the JSON can't break out of the surrounding <script>.
+        return (
+            json.dumps(theme)
+            .replace("<", "\\u003c")
+            .replace(">", "\\u003e")
+            .replace("&", "\\u0026")
+        )
+    except Exception:
+        return "null"
 
 def read_if_exists(path: str) -> str:
     """Read file if it exists, return empty string otherwise."""
@@ -46,6 +78,10 @@ def serve_html_with_nonce(request: Request, file_path: str) -> HTMLResponse:
         raise HTTPException(500, "Internal server error")
     nonce = getattr(request.state, "csp_nonce", "")
     html = html.replace("{{CSP_NONCE}}", nonce)
+    # Only the login page carries this placeholder; skip the prefs read for
+    # every other template (index, backgrounds) that doesn't need it.
+    if "{{LOGIN_THEME}}" in html:
+        html = html.replace("{{LOGIN_THEME}}", _login_theme_json())
     return HTMLResponse(html)
 
 

--- a/static/login.html
+++ b/static/login.html
@@ -23,7 +23,12 @@
   };
   var THEME_DEFAULT_INTENSITY = { midnight:0.5, terminal:0.8, organs:0.65 };
   try {
-    var t = JSON.parse(localStorage.getItem('odysseus-theme'));
+    // Prefer the profile's active theme injected by the server (so the login
+    // page matches the in-app theme on ANY device, even a first visit with an
+    // empty localStorage). Falls back to this device's localStorage, then to
+    // the default :root palette below. The server substitutes a theme object
+    // or the literal null in the parenthesized slot on the next line.
+    var t = ({{LOGIN_THEME}}) || JSON.parse(localStorage.getItem('odysseus-theme'));
     var s = document.documentElement.style;
     if (t && t.colors) {
       var c = t.colors;


### PR DESCRIPTION
## Problem
The login page always renders the built-in default palette, even when the user has selected a custom theme in-app. On a fresh device (new browser or phone) it never matches the chosen theme.

## Root cause
The login page is served pre-authentication, so it can't call `/api/prefs/theme` (401), and a fresh browser has nothing in `localStorage`. `static/login.html` only reads the theme from `localStorage`, so it falls back to the default `:root` palette whenever that's empty — which is always, on a first visit.

## Fix
- **`src/app_helpers.py`** — `serve_html_with_nonce` substitutes a new `{{LOGIN_THEME}}` placeholder with the active profile theme, read from `USER_PREFS_FILE`. The prefs read only happens for templates that contain the placeholder (login), so other pages are unaffected. The injected JSON is escaped (`<`, `>`, `&`) so it can't break out of the surrounding `<script>`.
- **`static/login.html`** — prefers the injected theme, then `localStorage`, then the existing default `:root`.

Scoped to single-user instances: with more than one user there's no way to know whose theme to show before sign-in, so it returns `null` and the client falls back to `localStorage`/default (unchanged behavior).

## Testing
- With an empty `localStorage` (fresh-device simulation), the login page renders the active profile theme from the server.
- Multi-user, missing theme, and malformed prefs all fall back cleanly to the prior behavior.
- Uses the `USER_PREFS_FILE` constant from `src/constants.py` per the contributing guidelines; no hardcoded paths.

Reproduced on the current `dev` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
