### PR TITLE
fix(login): render the profile's active theme on the login page

### DIFF
--- a/src/app_helpers.py
+++ b/src/app_helpers.py
@@ -1,5 +1,6 @@
 # src/app_helpers.py
 import base64
+import json
 import logging
 import os
 
@@ -8,6 +9,37 @@ from fastapi.responses import HTMLResponse
 from starlette.requests import Request
 
 logger = logging.getLogger(__name__)
+
+
+def _login_theme_json() -> str:
+    """Active profile theme as a script-safe JSON literal for the login page.
+
+    The pre-auth login page can't fetch /api/prefs/theme (401) and a fresh
+    device has nothing in localStorage, so without this it always renders the
+    built-in default. We inject the profile's active theme so login matches
+    the theme set in-app. Only a single-user instance is handled — with more
+    than one user there's no way to know whose theme to show before sign-in,
+    so we return "null" and let the client fall back to localStorage/default.
+    Returns the string "null" (a valid JS literal) on any miss or error.
+    """
+    try:
+        from src.constants import USER_PREFS_FILE
+        with open(USER_PREFS_FILE, "r", encoding="utf-8") as f:
+            users = (json.load(f) or {}).get("_users", {})
+        if len(users) != 1:
+            return "null"
+        theme = next(iter(users.values())).get("theme")
+        if not isinstance(theme, dict) or not theme.get("colors"):
+            return "null"
+        # Escape so the JSON can't break out of the surrounding <script>.
+        return (
+            json.dumps(theme)
+            .replace("<", "\\u003c")
+            .replace(">", "\\u003e")
+            .replace("&", "\\u0026")
+        )
+    except Exception:
+        return "null"
 
 def read_if_exists(path: str) -> str:
     """Read file if it exists, return empty string otherwise."""
@@ -46,6 +78,10 @@ def serve_html_with_nonce(request: Request, file_path: str) -> HTMLResponse:
         raise HTTPException(500, "Internal server error")
     nonce = getattr(request.state, "csp_nonce", "")
     html = html.replace("{{CSP_NONCE}}", nonce)
+    # Only the login page carries this placeholder; skip the prefs read for
+    # every other template (index, backgrounds) that doesn't need it.
+    if "{{LOGIN_THEME}}" in html:
+        html = html.replace("{{LOGIN_THEME}}", _login_theme_json())
     return HTMLResponse(html)
 
 

--- a/static/login.html
+++ b/static/login.html
@@ -23,7 +23,12 @@
   };
   var THEME_DEFAULT_INTENSITY = { midnight:0.5, terminal:0.8, organs:0.65 };
   try {
-    var t = JSON.parse(localStorage.getItem('odysseus-theme'));
+    // Prefer the profile's active theme injected by the server (so the login
+    // page matches the in-app theme on ANY device, even a first visit with an
+    // empty localStorage). Falls back to this device's localStorage, then to
+    // the default :root palette below. The server substitutes a theme object
+    // or the literal null in the parenthesized slot on the next line.
+    var t = ({{LOGIN_THEME}}) || JSON.parse(localStorage.getItem('odysseus-theme'));
     var s = document.documentElement.style;
     if (t && t.colors) {
       var c = t.colors;


### PR DESCRIPTION
## Summary

The login page always rendered the built-in default palette instead of the user's configured theme, because it is served pre-authentication: it cannot call `/api/prefs/theme` (401) and a fresh browser has nothing in `localStorage`, so the localStorage-only theme lookup in `static/login.html` always fell through to the default `:root` colors on a first visit. This PR injects the profile's active theme into the login page at render time — `serve_html_with_nonce` in `src/app_helpers.py` substitutes a `{{LOGIN_THEME}}` placeholder with the active theme read from `USER_PREFS_FILE` (per the constants rule in CONTRIBUTING.md), and `static/login.html` prefers that injected theme, then `localStorage`, then the existing default. Scoped to single-user instances: with more than one user there is no way to know whose theme to show before sign-in, so the helper returns `null` and behavior is unchanged. The injected JSON is escaped (`<`, `>`, `&`) so it cannot break out of the surrounding `<script>`.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #5730

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate (closest is #3679, which is an animated-login feature request, not this bug).
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in (+42/−1 across 2 files).
- [x] I actually ran the app (`docker compose up`) and verified the change works end-to-end.

## How to Test

1. `docker compose up -d --build`, sign in, and set a non-default theme in Settings → Themes (e.g. Terminal).
2. Simulate a fresh device: in DevTools run `localStorage.removeItem('odysseus-theme')`, then load `/login` (or open the login page in a private window / another browser that has never visited the app).
3. Before this change the login page renders the default palette; with it, the login page renders the configured theme (verified `--bg`/`--fg`/`--red` computed styles match the profile theme with `localStorage` empty).
4. Fallbacks: with more than one user in `user_prefs.json`, with no theme set, or with a malformed prefs file, `curl -s localhost:7000/login | grep 'var t ='` shows `(null) ||` and the page renders exactly as before.

## Visual / UI changes — REQUIRED if you touched anything that renders

- [ ] **Screenshot or short clip** — the default rendering is unchanged (no theme set → `null` → existing behavior); when a theme is set, the login simply picks up the palette the app already renders. Screenshots of default vs. themed login can be attached on request.
- [x] **Style match**: no new colors, fonts, spacing, classes, or CSS are introduced — the change only feeds the existing `--bg`/`--fg`/`--panel`/`--border`/`--red` variables and advanced-key pipeline already used by `static/login.html`.
- [x] **No new component patterns.**
- [ ] **I am not an LLM agent submitting a bulk PR.** — Left unchecked in honesty: this is a single, human-directed, agent-assisted fix. Per this template's request, the problem was first reported as issue #5730, which describes the bug and this exact patch; this PR follows that issue rather than replacing it.

### Screenshots / clips

Default (no saved theme) is byte-identical to current behavior. Happy to attach before/after screenshots of the themed login if useful.
