### PR TITLE
fix(agent-loop): import Any so app can start

### DIFF
--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -12,7 +12,7 @@ import json
 import re
 import time
 import logging
-from typing import AsyncGenerator, List, Dict, Optional, Set
+from typing import Any, AsyncGenerator, List, Dict, Optional, Set
 from urllib.parse import urlparse
 
 from src.llm_core import (


### PR DESCRIPTION
## Summary

`src/agent_loop.py` annotates two module-scope functions with `dict[str, Any]` (lines 1503 and 1877) but never imports `Any` from `typing` — line 15 imports only `AsyncGenerator, List, Dict, Optional, Set`. Because these annotations are evaluated at import time, importing the module raises `NameError: name 'Any' is not defined`. That crashes the whole app on startup through the import chain `app.py` → `routes/chat_routes.py` → `src/agent_loop.py`, failing uvicorn's `config.load_app()`. This adds `Any` to the existing `typing` import so the module loads and the app starts.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #5732

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app` via `./start-macos.sh`) and verified the change works end-to-end.

## How to Test

1. On a fresh `dev` checkout, run `./start-macos.sh` (or `python -m uvicorn app:app`) — startup crashes with `NameError: name 'Any' is not defined` at `src/agent_loop.py:1503`.
2. Apply this change (add `Any` to the `typing` import on line 15).
3. Run `python -c "import src.agent_loop"` — imports cleanly, no `NameError`.
4. Run `./start-macos.sh` again — the app boots fully; uvicorn serves and `GET /` returns `302` (redirect to login, auth enabled).

Environment: macOS (Apple Silicon), Python 3.11.

## Visual / UI changes

N/A — this change touches no rendering code (one-line import in `src/agent_loop.py`).

## Disclosure

This fix was prepared with an LLM coding assistant. Per CONTRIBUTING.md, issue #5732 was opened first describing the problem; this PR is a single-line, focused fix linked to it, not a bulk auto-generated change. Happy to have it handled via the issue instead if the maintainers prefer.
