### PR TITLE
fix(cookbook): activate local Windows venv in bash runner

### DIFF
--- a/routes/cookbook_helpers.py
+++ b/routes/cookbook_helpers.py
@@ -1204,6 +1204,41 @@ def _safe_env_prefix(ep: str | None) -> str | None:
     return f'[ -f "{path}" ] && source "{path}" || true'
 
 
+def _local_windows_bash_env_prefix(ep: str | None) -> str | None:
+    """Convert a frontend PowerShell venv prefix for the local Git Bash runner."""
+    if not ep:
+        return ep
+
+    prefix = ep.strip()
+    if not prefix.startswith("&"):
+        return ep
+
+    raw_path = prefix[1:].lstrip()
+    if not raw_path:
+        return ep
+    if raw_path.startswith("'"):
+        if len(raw_path) < 2 or not raw_path.endswith("'"):
+            return ep
+        quoted_path = raw_path[1:-1]
+        if "'" in quoted_path.replace("''", ""):
+            return ep
+        path = quoted_path.replace("''", "'")
+    else:
+        path = raw_path.rstrip()
+        if "'" in path or '"' in path:
+            return ep
+    if any(c in path for c in "\r\n;&|`$<>"):
+        return ep
+    if not path.replace("\\", "/").casefold().endswith("/scripts/activate.ps1"):
+        return ep
+
+    bash_path = _git_bash_path(path)
+    if "\\" in bash_path:
+        return ep
+    bash_path = bash_path[: -len("Activate.ps1")] + "activate"
+    return "source " + shlex.quote(bash_path)
+
+
 def _ssh_ps(host, script_path, port=None):
     """Build SSH command to run a PowerShell script on a Windows remote."""
     pf = f"-p {port} " if port and port != "22" else ""

--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -50,7 +50,7 @@ from routes.cookbook_helpers import (
     _SESSION_ID_RE, _validate_repo_id, _validate_serve_model_id, _validate_include, _validate_token,
     _validate_local_dir, _validate_gpus, _shell_path,
     _ps_squote, _bash_squote, _validate_serve_cmd, _parse_serve_phase, OLLAMA_MISSING_HINT,
-    _safe_env_prefix, _local_tooling_path_export, _append_serve_preflight_exit_lines,
+    _safe_env_prefix, _local_windows_bash_env_prefix, _local_tooling_path_export, _append_serve_preflight_exit_lines,
     _append_serve_exit_code_lines, _append_llama_cpp_linux_accel_build_lines, _cached_model_scan_script,
     load_stored_hf_token,
     _append_vllm_linux_preflight_lines, _ollama_bind_from_cmd, _pip_install_fallback_chain,
@@ -1336,7 +1336,7 @@ def setup_cookbook_routes() -> APIRouter:
             # Local: run hf download in the background (tmux on POSIX, a detached
             # process + logfile on Windows where tmux doesn't exist).
             if req.env_prefix:
-                lines.append(_safe_env_prefix(req.env_prefix))
+                lines.append(_safe_env_prefix(_local_windows_bash_env_prefix(req.env_prefix) if local_windows else req.env_prefix))
             else:
                 lines.append("deactivate 2>/dev/null; hash -r")
             # Show whether the HF token reached this run (masked) — tells a gated
@@ -2166,7 +2166,7 @@ def setup_cookbook_routes() -> APIRouter:
             if req.gpus:
                 runner_lines.append(f"export CUDA_VISIBLE_DEVICES='{req.gpus}'")
             if req.env_prefix:
-                runner_lines.append(_safe_env_prefix(req.env_prefix))
+                runner_lines.append(_safe_env_prefix(_local_windows_bash_env_prefix(req.env_prefix) if local_windows else req.env_prefix))
             else:
                 runner_lines.append("deactivate 2>/dev/null; hash -r")
             _append_venv_nvidia_library_path_lines(runner_lines, cmd=req.cmd)

--- a/static/js/cookbookDownload.js
+++ b/static/js/cookbookDownload.js
@@ -15,6 +15,7 @@ let _getPlatform;
 let _serverByVal;
 let _isWindows;
 let _buildEnvPrefix;
+let _psQuote;
 let _buildServeCmd;
 let _detectBackend;
 let _detectToolParser;
@@ -538,7 +539,7 @@ export async function _runModelDownload(panel, model, backend, hostOverride) {
   if (srv.downloadDir) payload.local_dir = srv.downloadDir;
   if (isWin) {
     if (env === 'venv' && envPath) {
-      payload.env_prefix = '& ' + (envPath.endsWith('\\Scripts\\Activate.ps1') ? envPath : envPath + '\\Scripts\\Activate.ps1');
+      payload.env_prefix = '& ' + _psQuote(envPath.endsWith('\\Scripts\\Activate.ps1') ? envPath : envPath + '\\Scripts\\Activate.ps1');
     } else if (env === 'conda' && envPath) {
       payload.env_prefix = 'conda activate ' + envPath;
     }
@@ -652,6 +653,7 @@ export function initDownload(shared) {
   _serverByVal = shared._serverByVal;
   _isWindows = shared._isWindows;
   _buildEnvPrefix = shared._buildEnvPrefix;
+  _psQuote = shared._psQuote;
   _buildServeCmd = shared._buildServeCmd;
   _detectBackend = shared._detectBackend;
   _detectToolParser = shared._detectToolParser;

--- a/static/js/cookbookRunning.js
+++ b/static/js/cookbookRunning.js
@@ -338,6 +338,7 @@ let _sshPrefix;
 let _getPlatform;
 let _isWindows;
 let _buildEnvPrefix;
+let _psQuote;
 let _loadPresets;
 let _savePresets;
 let _copyText;
@@ -1971,7 +1972,7 @@ export async function _launchServeTask(shortName, repo, cmd, fields, hostOverrid
   let envPrefix = '';
   if (_isWindows()) {
     if (_envState.env === 'venv' && _envState.envPath) {
-      envPrefix = '& ' + (_envState.envPath.endsWith('\\Scripts\\Activate.ps1') ? _envState.envPath : _envState.envPath + '\\Scripts\\Activate.ps1');
+      envPrefix = '& ' + _psQuote(_envState.envPath.endsWith('\\Scripts\\Activate.ps1') ? _envState.envPath : _envState.envPath + '\\Scripts\\Activate.ps1');
     } else if (_envState.env === 'conda' && _envState.envPath) {
       envPrefix = 'conda activate ' + _envState.envPath;
     }
@@ -4402,6 +4403,7 @@ export function initRunning(shared) {
   _getPlatform = shared._getPlatform;
   _isWindows = shared._isWindows;
   _buildEnvPrefix = shared._buildEnvPrefix;
+  _psQuote = shared._psQuote;
   _loadPresets = shared._loadPresets;
   _savePresets = shared._savePresets;
   _copyText = shared._copyText;

--- a/tests/test_cookbook_helpers.py
+++ b/tests/test_cookbook_helpers.py
@@ -16,6 +16,7 @@ from routes.cookbook_helpers import (
     _llama_cpp_rebuild_cmd,
     _append_vllm_linux_preflight_lines,
     _local_tooling_path_export,
+    _local_windows_bash_env_prefix,
     _pip_install_attempt,
     _pip_install_fallback_chain,
     _ollama_bind_from_cmd,
@@ -105,6 +106,70 @@ def test_safe_env_prefix_accepts_powershell_activation_path():
         _safe_env_prefix("& 'C:\\Users\\me\\venv\\Scripts\\Activate.ps1'")
         == "& 'C:\\Users\\me\\venv\\Scripts\\Activate.ps1'"
     )
+
+
+@pytest.mark.parametrize(
+    ("prefix", "expected"),
+    [
+        ("& 'C:\\Users\\me\\venv\\Scripts\\Activate.ps1'", "source /c/Users/me/venv/Scripts/activate"),
+        (r"& C:\Users\me\venv\Scripts\Activate.ps1", "source /c/Users/me/venv/Scripts/activate"),
+        (
+            r"& C:\Users\me\My Envs\venv\Scripts\Activate.ps1",
+            "source '/c/Users/me/My Envs/venv/Scripts/activate'",
+        ),
+        (
+            "& 'C:\\Users\\me\\My Envs\\venv\\Scripts\\Activate.ps1'",
+            "source '/c/Users/me/My Envs/venv/Scripts/activate'",
+        ),
+        (r"& D:/Envs/venv/Scripts/Activate.ps1", "source /d/Envs/venv/Scripts/activate"),
+    ],
+)
+def test_local_windows_bash_env_prefix_converts_powershell_venv_activation(prefix, expected):
+    converted = _local_windows_bash_env_prefix(prefix)
+
+    assert converted == expected
+    assert _safe_env_prefix(converted).startswith('[ -f "')
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        None,
+        "",
+        "source /home/me/venv/bin/activate",
+        "conda activate qwen35",
+        'eval "$(conda shell.bash hook)" && conda activate qwen35',
+        r"& \\server\share\venv\Scripts\Activate.ps1",
+    ],
+)
+def test_local_windows_bash_env_prefix_leaves_other_prefixes_unchanged(prefix):
+    assert _local_windows_bash_env_prefix(prefix) == prefix
+
+
+def test_local_windows_bash_env_prefix_handles_long_whitespace_input():
+    prefix = "\t" * 100_000
+
+    assert _local_windows_bash_env_prefix(prefix) == prefix
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    ["static/js/cookbookRunning.js", "static/js/cookbookDownload.js"],
+)
+def test_primary_windows_venv_emitters_quote_activation_path(relative_path):
+    source = (Path(__file__).resolve().parents[1] / relative_path).read_text(encoding="utf-8")
+
+    assert "'& ' + _psQuote(" in source
+    assert "_psQuote = shared._psQuote;" in source
+
+
+def test_windows_venv_conversion_stays_scoped_to_local_git_bash_runners():
+    source = (Path(__file__).resolve().parents[1] / "routes/cookbook_routes.py").read_text(encoding="utf-8")
+    guarded_conversion = (
+        "_local_windows_bash_env_prefix(req.env_prefix) if local_windows else req.env_prefix"
+    )
+
+    assert source.count(guarded_conversion) == 2
 
 
 def test_validate_local_dir_accepts_external_drive_paths_with_spaces():


### PR DESCRIPTION
## Summary

Local Windows Cookbook serve/download tasks run through detached Git Bash, while the frontend builds PowerShell venv activation prefixes such as `& C:\path\Scripts\Activate.ps1`. The primary Serve and Download emitters previously left those paths unquoted. POSIX parsing then stripped backslashes or split paths containing spaces, so the selected venv never activated.

This PR:

- Quotes venv activation paths in the primary Serve and Download emitters.
- Converts quoted and unquoted local-Windows PowerShell venv prefixes to Git Bash `source /c/.../Scripts/activate` commands before the existing env-prefix validator runs.
- Reuses the existing `_git_bash_path` converter and rejects unsupported or unsafe input shapes.
- Uses a linear parser instead of a user-controlled regular expression.
- Adds regression coverage for quoted and unquoted paths, spaces, forward slashes, pass-through behavior, frontend emitters, route scoping, and long whitespace input.

Remote Windows, POSIX, and conda prefixes remain unchanged. Supersedes #4894, which was closed after `dev` was force-updated without absorbing this fix.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release.

## Linked Issue

Part of #2710; supersedes #4894

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behavior)
- [ ] Breaking change (changes or removes existing behavior)
- [ ] Refactor / cleanup (behavior unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) - this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the primary native Windows Download and Serve paths.
- [ ] I did not run the app/runtime validation and stated that gap in **How to Test**. Leave this unchecked when the app-run box above is checked.

## How to Test

Native Windows runtime validation was performed on rebased local head `254f0aff`. Its change patch has the same Git patch ID as PR head `85ad875c`.

1. Booted an isolated native Windows app instance with `uvicorn app:app` on `127.0.0.1:7099`.
2. Configured Local for the Windows venv at `G:\AI\odysseus\venv`.
3. Ran a model download through the primary Download path; `hf-internal-testing/tiny-random-gpt2` completed and the API returned 200.
4. Ran a primary Serve task using `python -m pip --version`; pip resolved from `G:\AI\odysseus\venv\Lib\site-packages` and the process exited 0.
5. Stopped the isolated validation app. The daily-driver app and existing model processes were not touched.

Automated validation performed:

- Focused Windows env-prefix regression selection: 15 passed, 69 deselected, 2 warnings.
- Related Cookbook suites: 25 passed, 2 warnings.
- Python compilation and `node --check` for both changed JavaScript modules passed.
- GitHub Actions full pytest suite: 5696 passed, 4 skipped, 8 warnings.
- CodeQL, Trivy, dependency review, secret scan, and workflow security checks passed.

Residual gap: `G:\AI\odysseus\.runtime-validation\Venv With Space` was configured in the native Windows UI, but that second path was not executed end-to-end. Quoted and unquoted paths containing spaces remain covered by the focused regression suite.

## Visual / UI changes - REQUIRED if you touched anything that renders

No rendered layout, CSS, icon, typography, or component behavior changed. `static/js/cookbookRunning.js` and `static/js/cookbookDownload.js` only quote command payload values before requests are sent.

- [x] **Screenshot or short clip** of the change in the running app, attached below.
- [x] **Style match**: no styles, colors, fonts, spacing, layout, or rendered components changed.
- [x] **No new component patterns.** The change only reuses the existing shared PowerShell quoting helper.
- [x] **I am not an LLM agent submitting a bulk PR.** This is a focused single-bug fix with targeted regression coverage.

### Screenshots / clips

![Native Windows Cookbook runtime validation](https://raw.githubusercontent.com/gist/zoomdbz/4ef7e06334fc1f6b5448c6139e43251a/raw/7ebb0061d9912c26f17d1d468ec0d50286b9465e/odysseus-pr-5734-runtime-evidence.svg)

The capture shows the primary Download task completed and the primary Serve task resolving pip from the configured local Windows venv before exiting 0. [GitHub-hosted evidence source](https://gist.github.com/zoomdbz/4ef7e06334fc1f6b5448c6139e43251a).

<!-- validation-evidence: native-windows-2026-08-17-pushed-r4 -->
