### PR TITLE
fix(rewrite): surface provider auth errors instead of generic message

### DIFF
--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -5738,6 +5738,7 @@ import { wireArrowUpRecall, getUserMessagesFromChatHistory } from './composerArr
       const decoder = new TextDecoder();
       let buffer = '';
       let newText = '';
+      let _rwNextIsError = false;
 
       while (true) {
         const { done, value } = await reader.read();
@@ -5747,6 +5748,10 @@ import { wireArrowUpRecall, getUserMessagesFromChatHistory } from './composerArr
         buffer = lines.pop() || '';
 
         for (const line of lines) {
+          if (line.startsWith('event: ')) {
+            if (line.slice(7).trim() === 'error') _rwNextIsError = true;
+            continue;
+          }
           if (!line.startsWith('data: ')) continue;
           const payload = line.slice(6).trim();
           if (payload === '[DONE]') continue;
@@ -5754,9 +5759,14 @@ import { wireArrowUpRecall, getUserMessagesFromChatHistory } from './composerArr
             const data = JSON.parse(payload);
             // The endpoint streams `event: error\ndata: {error,status}` on
             // failure — surface it instead of silently hanging on "Rewriting…".
-            if (data.error) {
-              throw new Error(data.error || ('HTTP ' + (data.status || 500)));
+            // Provider HTTP errors (e.g. 401 auth failures) arrive with a "text"
+            // field rather than "error" -- check both, and also honour the SSE
+            // event type flag set above.
+            if (_rwNextIsError || data.error || data.text) {
+              _rwNextIsError = false;
+              throw new Error(data.error || data.text || ('HTTP ' + (data.status || 500)));
             }
+            _rwNextIsError = false;
             // Reasoning tokens (vLLM --reasoning-parser: Qwen3 / DeepSeek-R1)
             // arrive as separate {delta, thinking:true} chunks. They are NOT
             // the rewrite — fold them away so they don't pollute the result.

--- a/tests/test_rewrite_provider_auth_error_surfaced.py
+++ b/tests/test_rewrite_provider_auth_error_surfaced.py
@@ -1,0 +1,69 @@
+"""Regression guard for issue #5738.
+
+When a quick rewrite action (e.g. "Rewrite shorter") triggers a provider
+auth failure (HTTP 401), stream_llm emits an SSE error event whose data
+payload uses a "text" field rather than "error":
+
+    event: error
+    data: {"status": 401, "text": "...", "raw": "..."}
+
+The rewriteWith() function in chat.js previously only checked `data.error`,
+so the auth-failure payload was silently ignored, `newText` stayed empty,
+and the UI showed the generic "model returned no rewritten text" message
+instead of the actual provider error.
+
+The fix must:
+1. Track `event: error` SSE lines (not skip them entirely).
+2. Check `data.text` alongside `data.error` when deciding whether the
+   chunk represents a provider-side failure.
+"""
+import re
+from pathlib import Path
+
+CHAT_JS = Path(__file__).resolve().parent.parent / "static/js/chat.js"
+
+
+def _rewrite_with_body() -> str:
+    """Return the source of the rewriteWith export function."""
+    text = CHAT_JS.read_text(encoding="utf-8")
+    start = text.index("export async function rewriteWith(")
+    rest = text[start:]
+    # Stop at the next top-level export/function so we only look at rewriteWith.
+    m = re.search(r"\n(export |function )", rest[1:])
+    return rest[: m.start() + 1] if m else rest
+
+
+def test_rewrite_tracks_event_error_sse_type():
+    """rewriteWith must parse 'event: error' lines, not skip them."""
+    body = _rewrite_with_body()
+    assert re.search(
+        r"""line\.startsWith\s*\(\s*['"]event:\s*['"]\s*\)""", body
+    ), (
+        "rewriteWith must handle 'event: ' lines so the SSE error type can be "
+        "tracked; previously these were skipped entirely"
+    )
+
+
+def test_rewrite_error_check_includes_data_text():
+    """rewriteWith error detection must cover data.text, not only data.error.
+
+    Provider HTTP errors (e.g. 401 auth failures from ChatGPT Subscription)
+    arrive as {"status": N, "text": "...", "raw": "..."} -- no "error" key.
+    Without checking data.text the failure is silently swallowed.
+    """
+    body = _rewrite_with_body()
+    # The condition that throws must reference data.text.
+    assert "data.text" in body, (
+        "rewriteWith error condition must check data.text to catch provider "
+        "HTTP errors whose payload uses 'text' instead of 'error'"
+    )
+
+
+def test_rewrite_error_message_prefers_human_readable_text():
+    """The thrown Error must use data.error || data.text as the message."""
+    body = _rewrite_with_body()
+    # Allow either order; both are acceptable.
+    assert re.search(r"data\.error\s*\|\|\s*data\.text|data\.text\s*\|\|\s*data\.error", body), (
+        "rewriteWith must surface data.error || data.text as the error message "
+        "so the user sees the provider's explanation rather than a generic fallback"
+    )


### PR DESCRIPTION
## Summary

When a quick-rewrite action ("Rewrite shorter", "Explain simpler") hits a provider auth failure (e.g. HTTP 401 from ChatGPT Subscription), `stream_llm` correctly emits an SSE error event whose data payload uses `{"status": 401, "text": "...", "raw": "..."}` -- no `"error"` key. The `rewriteWith()` SSE parser in `chat.js` skipped all `event:` lines without setting a flag and only checked `data.error`, so auth-failure payloads were silently dropped and the UI showed the generic "model returned no rewritten text" instead of the actual provider error.

The fix tracks the `event: error` SSE type (mirroring the pattern the main chat stream handler already uses at lines ~2206-2313) and checks `data.text` alongside `data.error` when deciding whether to surface an error.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #5738

## Type of Change

- [x] Bug fix (non-breaking -- fixes a confirmed issue)
- [ ] New feature (non-breaking -- adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) -- this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above -- no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Configure a ChatGPT Subscription backend model with expired or invalid credentials.
2. Send a normal chat message and receive an assistant response.
3. Click a quick rewrite action ("Rewrite shorter" or "Explain simpler") on the response.
4. Before fix: UI shows "Rewrite failed: model returned no rewritten text".
5. After fix: UI shows the actual provider error, e.g. "Rewrite failed: ChatGPT Subscription credentials expired or were rejected. Reconnect the provider."

## Visual / UI changes -- REQUIRED if you touched anything that renders

This change modifies only the error-handling path in `rewriteWith()` -- no DOM structure, styles, or visual output changes. The only visible difference is that the error toast now shows the provider's actual message rather than a generic fallback.

- [x] **Style match**: no new colors, fonts, spacing, or component patterns introduced.
- [x] **No new component patterns.**

### Screenshots / clips

N/A -- no visual layout change; error message text content changes only.