### PR TITLE
fix(rewrite): auth refresh for rewrite requests

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -1970,11 +1970,14 @@ def setup_chat_routes(
             raise HTTPException(400, "session_id, original_text, and instruction are required")
 
         _verify_session_owner(request, session_id)
+        owner = effective_user(request)
 
         try:
             sess = session_manager.get_session(session_id)
         except (KeyError, SessionNotFoundError):
             raise HTTPException(404, "Session not found")
+
+        resolve_session_auth(sess, session_id, owner=owner)
 
         messages = [
             {"role": "system", "content": (

--- a/tests/test_rewrite_auth_refresh.py
+++ b/tests/test_rewrite_auth_refresh.py
@@ -1,0 +1,80 @@
+"""ChatGPT Subscription rewrites must resolve fresh request-local auth."""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from starlette.requests import Request
+
+import routes.chat_routes as chat_routes
+
+
+def _json_request(payload):
+    body = json.dumps(payload).encode("utf-8")
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/rewrite",
+            "headers": [],
+            "query_string": b"",
+        },
+        receive,
+    )
+
+
+@pytest.mark.asyncio
+async def test_chatgpt_rewrite_resolves_auth_before_starting_model_stream(monkeypatch):
+    session = SimpleNamespace(
+        endpoint_url="https://chatgpt.com/backend-api/codex/responses",
+        model="gpt-5.4",
+        headers={"Authorization": "Bearer expired"},
+        history=[],
+    )
+    session_manager = SimpleNamespace(
+        get_session=lambda session_id: session,
+    )
+    calls = []
+
+    def refresh_auth(sess, session_id, owner=None):
+        calls.append(("refresh_auth", session_id, owner))
+        sess.headers = {"Authorization": "Bearer refreshed"}
+
+    async def fake_stream(endpoint_url, model, messages, headers=None, **kwargs):
+        calls.append(("stream_llm", headers))
+        yield 'data: {"delta": "Shortened response"}\n\n'
+
+    monkeypatch.setattr(chat_routes, "_verify_session_owner", lambda request, session_id: None)
+    monkeypatch.setattr(chat_routes, "effective_user", lambda request: "alice")
+    monkeypatch.setattr(chat_routes, "resolve_session_auth", refresh_auth)
+    monkeypatch.setattr(chat_routes, "stream_llm", fake_stream)
+
+    router = chat_routes.setup_chat_routes(
+        session_manager,
+        chat_handler=None,
+        chat_processor=None,
+        memory_manager=None,
+        research_handler=None,
+        upload_handler=None,
+    )
+    endpoint = next(
+        route.endpoint for route in router.routes if route.path == "/api/rewrite"
+    )
+    response = await endpoint(
+        _json_request({
+            "session_id": "session-1",
+            "original_text": "A response that should be shorter.",
+            "instruction": "Make it shorter.",
+        })
+    )
+    chunks = [chunk async for chunk in response.body_iterator]
+
+    assert calls == [
+        ("refresh_auth", "session-1", "alice"),
+        ("stream_llm", {"Authorization": "Bearer refreshed"}),
+    ]
+    assert "Shortened response" in "".join(chunks)


### PR DESCRIPTION
## Summary

<!-- One paragraph: what changed and why. "Fixed bug" and "Added feature" are not summaries. -->

Fixes ChatGPT Subscription chat rewrite requests failing with 401 Unauthorized. The /api/rewrite endpoint now resolves the session’s owner scoped authentication before starting the model stream. Adds a regression test which verifies that the resolved authorization header is used by the rewrite request.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

<!-- Every PR should be linked to an issue.
     Use one of:  Fixes #NNN  |  Part of #NNN  |  Closes #NNN  -->

Fixes #5738

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

<!-- Step-by-step instructions a reviewer can follow to verify this works.
     Do not leave this empty — a PR without test steps will be sent back. -->

1. Configure and connect a ChatGPT Subscription provider.
2. Start a chat and receive an assistant response.
3. Use Rewrite shorter or Explain simpler on that response.
4. Confirm the rewritten response streams successfully without errors.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

No UI changes

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

<!-- Drag and drop images or a screen recording here. Required for any UI/visual change. -->
