### PR TITLE
fix(skills): use utility model for skill tests instead of chat default

### DIFF
--- a/routes/skills_routes.py
+++ b/routes/skills_routes.py
@@ -1409,7 +1409,7 @@ def setup_skills_routes(skills_manager: SkillsManager) -> APIRouter:
 
         # Prefer the configured DEFAULT (→ Utility) model — not the current chat
         # session's model. Fall back to the caller's session model only if unset.
-        url, model, headers = resolve_endpoint("default", owner=user)
+        url, model, headers = resolve_endpoint("utility", owner=user)
         if not url or not model:
             url = url or ((body.get("endpoint_url") or "").strip() or None)
             model = model or ((body.get("model") or "").strip() or None)


### PR DESCRIPTION
## Summary

Skill tests were using `resolve_endpoint("default", ...)` which returns the chat model. They should use the utility model, like auto-naming and memory audit already do (fixed in PR #4027). One-word change: `"default"` → `"utility"`.

> **Note:** Re-opening of #5026, which was auto-closed on 2026-07-23 when the repository was transferred to the `odysseus-dev` org (the `dev` history rewrite orphaned the old base and forced all open PRs closed). This branch is the same one-line fix cleanly rebased onto the current `dev`. Original review thread: #5026.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #5025

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I verified the change by running a skill test and confirming the logs show the utility model instead of the chat model.

## How to Test

1. Configure different models for Default Chat and Utility in Settings
2. Go to Skills, pick a skill, click Test
3. Check logs: the skill test agent round should show the utility model, not the chat model

## Visual / UI changes

None — backend-only change.
