### PR TITLE
fix(agent): expand regex auto-escalation to cover contacts, files, and sessions

### DIFF
--- a/src/action_intents.py
+++ b/src/action_intents.py
@@ -83,6 +83,30 @@ _ROUTING_PATTERNS: tuple[tuple[str, str, Pattern[str]], ...] = tuple(
         ("contacts", "contact lookup request", r"\b(?:look\s+up|find|search|get|pull\s+up|cerca|trova|busca)\b.{1,60}?\b(?:in|on|nel|nella|nell|nei|negli|en|su)\s+(?:my\s+)?(?:contacto?s?|contatt[io]s?|rubrica|address\s+book)\b"),
         ("contacts", "contact search request", r"\b(?:search|find|look\s+up|cerca|trova|busca)\b.{0,40}\b(?:my\s+)?(?:contacto?s?|contatt[io]s?|rubrica|address\s+book)\b"),
 
+        # Files / directory lookup. A question like "read the README" or
+        # "cosa c'è in config.yaml" needs the read_file / grep tools.
+        # The target must mention "file" or be a plausible filename: has an
+        # extension, starts with ./~/, or begins with a capital letter.
+        ("files", "read or show a file", r"\b(?:read|display|open|view)\s+(?:the\s+)?(?:file\s+|contents?\s+of\s+|(?:[.~/]\S+|\S+\.\w{1,6}|(?-i:[A-Z][A-Za-z0-9_]{1,})))\b"),
+        ("files", "show me file contents", r"\bshow(?:\s+me)?\s+(?:the\s+)?(?:file\s+|contents?\s+of\s+|(?:[.~/]\S+|\S+\.\w{1,6}|(?-i:[A-Z][A-Za-z0-9_]{1,})))\b"),
+        ("files", "look at a file", r"\blook\s+at\s+(?:the\s+)?(?:file\s+|(?:[.~/]\S+|\S+\.\w{1,6}|(?-i:[A-Z][A-Za-z0-9_]{1,})))\b"),
+        ("files", "what's in a file", r"\bwhat(?:'s|\s+is)\s+(?:in|inside)\s+(?:the\s+)?(?:file\s+|(?:[.~/]\S+|\S+\.\w{1,6}|(?-i:[A-Z][A-Za-z0-9_]{1,})))\b"),
+        ("files", "what does file contain", r"\bwhat\s+does\s+(?:the\s+)?(?:file\s+)?(?:[.~/]\S+|\S+\.\w{1,6}|(?-i:[A-Z][A-Za-z0-9_]{1,}))\s+contain\b"),
+        # Italian: "leggi X", "mostrami X", "apri X", "visualizza X", "guarda X", "cosa c'è in X"
+        ("files", "leggi/apri/visualizza/guarda file", r"\b(?:leggi|apri|visualizza|guarda|vedi)\s+(?:il\s+)?(?:file\s+|contenuto\s+(?:di|del)\s+|(?:[.~/]\S+|\S+\.\w{1,6}|(?-i:[A-Z][A-Za-z0-9_]{1,})))\b"),
+        ("files", "mostrami file", r"\bmostra(?:mi)?\s+(?:il\s+)?(?:file\s+|contenuto\s+(?:di|del)\s+|(?:[.~/]\S+|\S+\.\w{1,6}|(?-i:[A-Z][A-Za-z0-9_]{1,})))\b"),
+        ("files", "cosa c'è nel file", r"\b(?:cosa|che(?:\s+cosa)?)\s+(?:c['’`]?è|c['’`]?e)\s+(?:in|dentro|nel)\s+(?:il\s+)?(?:file\s+|(?:[.~/]\S+|\S+\.\w{1,6}|(?-i:[A-Z][A-Za-z0-9_]{1,})))\b"),
+
+        # Sessions / chat-history search.
+        ("sessions", "search chats", r"\bsearch\s+(?:my\s+)?(?:chat|conversation|message)s?\b"),
+        ("sessions", "find in chats", r"\bfind\s+(?:(?:in|through)\s+)?(?:my\s+|the\s+)?(?:chats?|conversations?|messages?|history)\b"),
+        ("sessions", "look through chats", r"\b(?:look|go)\s+through\s+(?:my\s+)?(?:chats?|conversations?|history)\b"),
+        ("sessions", "what did we say", r"\bwhat\s+did\s+(?:we|i)\s+(?:say|discuss|talk)\s+about\b"),
+        # Italian: "cerca nelle chat", "trova la conversazione", "cosa abbiamo detto su X"
+        ("sessions", "cerca nelle chat", r"\bcerca\s+(?:nel(?:la|le|l['’`]?)?|nei|negli|tra\s+(?:le|i)|in)\s+(?:chat|conversazion[ei]|messaggi[o]?)\b"),
+        ("sessions", "trova conversazione", r"\btrova\s+(?:la\s+)?(?:conversazione|chat|discussione)\b"),
+        ("sessions", "cosa abbiamo detto", r"\bcosa\s+(?:abbiamo|ho)\s+(?:detto|parlato|discusso)\s+(?:di|su(?:l(?:la|le|gli)?)?|a\s+riguardo\s+(?:di|del))\b"),
+
         # Email actions.
         ("email", "assistant email action request", rf"{_ACTION_QUESTION}(?:send|write|reply|email|message|archive|delete|mark)\b.{{0,120}}\b(?:emails?|mail|messages?|inbox|unread|read)\b"),
         ("email", "send/write/reply email request", rf"{_PLEASE}(?:send|write|reply)\b.{{0,120}}\b(?:emails?|mail|messages?)\b"),

--- a/src/action_intents.py
+++ b/src/action_intents.py
@@ -77,6 +77,12 @@ _ROUTING_PATTERNS: tuple[tuple[str, str, Pattern[str]], ...] = tuple(
         ("notes", "set reminder request", rf"{_PLEASE}set\s+(?:a\s+)?reminder\b"),
         ("notes", "assistant reminder request", rf"{_ACTION_QUESTION}set\s+(?:a\s+)?reminder\b"),
 
+        # Contacts / address-book lookup. A question like "what is Mario's
+        # number?" or "look up Anna in contacts" needs the contacts tool.
+        ("contacts", "phone/number lookup request", r"\b(?:what(?:'s| is)|tell\s+me|give\s+me|do\s+you\s+have|mi\s+dici|dime|decime|qual(?:'è|e| è)|cerca|busca)\b.{1,80}?\b(?:phone|telephone|number|numero|número|tel[eé]fono|email|address|indirizzo|direcci[oó]n|contact|contatto|contacto)\b"),
+        ("contacts", "contact lookup request", r"\b(?:look\s+up|find|search|get|pull\s+up|cerca|trova|busca)\b.{1,60}?\b(?:in|on|nel|nella|nell|nei|negli|en|su)\s+(?:my\s+)?(?:contacto?s?|contatt[io]s?|rubrica|address\s+book)\b"),
+        ("contacts", "contact search request", r"\b(?:search|find|look\s+up|cerca|trova|busca)\b.{0,40}\b(?:my\s+)?(?:contacto?s?|contatt[io]s?|rubrica|address\s+book)\b"),
+
         # Email actions.
         ("email", "assistant email action request", rf"{_ACTION_QUESTION}(?:send|write|reply|email|message|archive|delete|mark)\b.{{0,120}}\b(?:emails?|mail|messages?|inbox|unread|read)\b"),
         ("email", "send/write/reply email request", rf"{_PLEASE}(?:send|write|reply)\b.{{0,120}}\b(?:emails?|mail|messages?)\b"),

--- a/tests/test_action_intents.py
+++ b/tests/test_action_intents.py
@@ -79,6 +79,43 @@ def test_explanatory_calendar_questions_stay_plain_chat():
     assert intent.reason == "explanatory feature question"
 
 
+def test_contacts_lookup_promotes_to_agent():
+    assert message_needs_tools("mi dici il numero di Paolo?")
+    assert message_needs_tools("what is the phone number of Mario?")
+    assert message_needs_tools("tell me Anna address")
+    assert message_needs_tools("cerca Francesca nei contatti")
+    assert message_needs_tools("do you have Giorgio phone?")
+    assert classify_tool_intent("mi dici il numero di Paolo?").category == "contacts"
+    assert classify_tool_intent("look up Marco in contacts").category == "contacts"
+
+
+def test_files_lookup_promotes_to_agent():
+    assert message_needs_tools("leggi il file README")
+    assert message_needs_tools("read the CHANGELOG")
+    assert message_needs_tools("what's in config.yaml")
+    assert message_needs_tools("open Makefile")
+    assert message_needs_tools("cosa c'è in server.log")
+    assert classify_tool_intent("show me package.json").category == "files"
+    assert classify_tool_intent("what does app.py contain").category == "files"
+    # UI panel names must NOT be classified as files
+    assert classify_tool_intent("open settings").category == "ui"
+    assert classify_tool_intent("open my calendar").category == "ui"
+    # Explanatory questions must NOT promote
+    assert not message_needs_tools("how do I read files?")
+    assert not message_needs_tools("what is a file system?")
+
+
+def test_sessions_lookup_promotes_to_agent():
+    assert message_needs_tools("search my chats for the bitcoin discussion")
+    assert message_needs_tools("find the conversation about the project")
+    assert message_needs_tools("cerca nelle chat il progetto")
+    assert message_needs_tools("trova la conversazione sul viaggio")
+    assert message_needs_tools("cosa abbiamo detto sul budget")
+    assert classify_tool_intent("look through my conversations").category == "sessions"
+    # Ambiguous "find" must NOT trigger sessions
+    assert not message_needs_tools("find me a restaurant")
+
+
 def test_router_reports_non_calendar_categories():
     assert classify_tool_intent("reply to that email").category == "email"
     assert classify_tool_intent("open my calendar").category == "ui"


### PR DESCRIPTION
> **Note:** Re-opening of #5089, auto-closed 2026-07-23 during the `odysseus-dev` org transfer (the `dev` history rewrite force-closed all open PRs). Same change, cleanly rebased onto the current `dev`. Original review thread: #5089.

## Summary

The chat→agent auto-escalation (`_classify_tool_intent`) only covered calendar, notes, email, UI, web, research, and shell intents. Three domains reachable from plain chat were missing: contacts, files, and sessions.

This adds 15 regex patterns (IT/EN) covering:
- **Contacts:** phone/number/email/address lookup ("mi dici il numero di [Name]?", "what is Mario's email?")
- **Files:** read/show/open/look-at file requests ("leggi il README", "what's in config.yaml")
- **Sessions:** search/find/filter chat history ("cerca nelle chat", "find the conversation about X")

File patterns guard against UI collisions by requiring a filename-like target (extension, path, or capital letter).

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #5030

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. **Contacts:** send `mi dici il numero di [Name]?` in chat mode → auto-escalates to agent with `category=contacts`
2. **Files:** send `leggi il README` → auto-escalates to agent with `category=files`
3. **Files UI guard:** send `open settings` → stays `ui` (not files)
4. **Sessions:** send `cerca nelle chat il progetto` → auto-escalates to agent with `category=sessions`
5. **False positive check:** `how do I read files?` / `what is a file system?` → stay in chat mode

## Visual / UI changes

None — backend-only change.
