### PR TITLE
fix(teacher): import _TEACHER_SYSTEM_PROMPT from its current module

### DIFF
--- a/src/teacher_escalation.py
+++ b/src/teacher_escalation.py
@@ -233,7 +233,8 @@ async def _call_teacher(teacher_model_spec: str, prompt: str,
                         owner: Optional[str] = None) -> Optional[str]:
     """Call the configured teacher endpoint with the escalation prompt."""
     from src.llm_core import llm_call_async
-    from src.ai_interaction import _resolve_model, _TEACHER_SYSTEM_PROMPT
+    from src.ai_interaction import _resolve_model
+    from src.agent_tools.model_interaction_tools import _TEACHER_SYSTEM_PROMPT
     try:
         url, model, headers = await asyncio.to_thread(_resolve_model, teacher_model_spec, owner=owner)
     except Exception as e:

--- a/tests/test_teacher_audit_owner_scope.py
+++ b/tests/test_teacher_audit_owner_scope.py
@@ -21,10 +21,14 @@ def test_call_teacher_scopes_model_resolution_to_owner(monkeypatch):
         return ("http://endpoint.local/v1", "teacher-model", {})
 
     async def fake_llm_call_async(url, model, messages, **kwargs):
+        seen["messages"] = messages
         return "teacher reply"
 
     monkeypatch.setattr("src.ai_interaction._resolve_model", fake_resolve_model)
-    monkeypatch.setattr("src.ai_interaction._TEACHER_SYSTEM_PROMPT", "sys", raising=False)
+    monkeypatch.setattr(
+        "src.agent_tools.model_interaction_tools._TEACHER_SYSTEM_PROMPT",
+        "sys",
+    )
     monkeypatch.setattr("src.llm_core.llm_call_async", fake_llm_call_async)
 
     result = asyncio.run(
@@ -34,6 +38,7 @@ def test_call_teacher_scopes_model_resolution_to_owner(monkeypatch):
     assert result == "teacher reply"
     assert seen["owner"] == "alice"
     assert seen["spec"] == "teacher-model"
+    assert seen["messages"][0] == {"role": "system", "content": "sys"}
 
 
 def test_audit_teacher_resolution_scoped_to_owner(monkeypatch):

--- a/tests/test_teacher_audit_owner_scope.py
+++ b/tests/test_teacher_audit_owner_scope.py
@@ -24,9 +24,12 @@ def test_call_teacher_scopes_model_resolution_to_owner(monkeypatch):
         seen["messages"] = messages
         return "teacher reply"
 
+    from src.agent_tools import model_interaction_tools
+
     monkeypatch.setattr("src.ai_interaction._resolve_model", fake_resolve_model)
     monkeypatch.setattr(
-        "src.agent_tools.model_interaction_tools._TEACHER_SYSTEM_PROMPT",
+        model_interaction_tools,
+        "_TEACHER_SYSTEM_PROMPT",
         "sys",
     )
     monkeypatch.setattr("src.llm_core.llm_call_async", fake_llm_call_async)


### PR DESCRIPTION
## Summary

Teacher escalation currently imports `_TEACHER_SYSTEM_PROMPT` from
`src.ai_interaction`, but that symbol moved to
`src/agent_tools/model_interaction_tools.py` during the tool-registry migration.

As a result, any runtime path reaching `_call_teacher()` raises `ImportError`
before the configured teacher can run.

This PR imports the prompt from its current module and repairs the existing
owner-scope regression, which previously monkeypatched a non-existent
`src.ai_interaction._TEACHER_SYSTEM_PROMPT` attribute and therefore masked the bug.

The contributor branch was also rebuilt directly on current `dev` after the
original branch, which was based on old `main` history, produced an unrelated
247-file diff when retargeted.

## Target branch

- [x] This PR targets `dev`.

## Linked Issue

Fixes #4962

Related historical PR: #4967

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched existing issues and pull requests and confirmed the active bug is #4962 and the previous fix #4967 did not land.
- [x] This PR targets `dev`.
- [x] Changes are limited to the broken teacher import and its focused regression.
- [x] The rebuilt branch contains only the intended production fix and regression update.
- [ ] Full application end-to-end testing was not run because this is an isolated import-path regression with direct behavioral coverage.

## How to Test

1. Run `python -m pytest -q tests/test_teacher_audit_owner_scope.py tests/test_teacher_eval_tier2.py`.
2. Run `python -m compileall -q src/teacher_escalation.py tests/test_teacher_audit_owner_scope.py`.
3. Run `git diff --check`.
4. Verify `_call_teacher()` resolves the teacher model for the requesting owner.
5. Verify the system message passed to the LLM comes from `src.agent_tools.model_interaction_tools._TEACHER_SYSTEM_PROMPT`.

Focused validation on the rebuilt exact head completed successfully: 10 tests passed.

## Visual / UI changes

None. Backend import-path fix and regression coverage only.