### PR TITLE
fix(agent): tell the model that navigating a page is not reading it

### DIFF
--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -2412,6 +2412,29 @@ def _build_system_prompt(
             'that open draft is the target: use update_document/edit_document on it instead of creating another document.'
         )
 
+    # Browsing is a two-step tool and models routinely stop after step one.
+    # browser_navigate returns the page TITLE and a snapshot reference — never
+    # the page text. Observed: asked to open a URL and summarise it, the agent
+    # called browser_navigate, saw exit_code=0, reported "the page loaded
+    # successfully", and stopped, having read nothing. browser_snapshot has the
+    # same trap one level down: its optional `filename` argument saves the
+    # snapshot to a file INSTEAD of returning it, and models volunteer one.
+    if relevant_tools and not suppress_local_context and any(
+        "browser_" in str(_t) for _t in relevant_tools
+    ):
+        agent_prompt += (
+            "\n\n🌐 READING A WEB PAGE: browser_navigate only OPENS the page — it returns the "
+            "title and a snapshot reference, never the page text. It is never the last step. "
+            "To read the content you must then call browser_snapshot (or browser_find to look "
+            "for specific text). Reporting that a page 'loaded successfully' is not an answer: "
+            "the user asked what is ON the page. "
+            "Call browser_snapshot with NO arguments. Do NOT pass 'filename' — that writes the "
+            "snapshot to a file INSTEAD of returning it, so you get a path you cannot read and "
+            "the page content is lost. "
+            "When you only need to read a page and not interact with it, web_fetch does it in a "
+            "single call and is preferred."
+        )
+
     # Inject relevant skills based on the user's last message. The
     # SkillsManager does a Jaccard token-match over published skills'
     # name + description + when_to_use + procedure, returning the top


### PR DESCRIPTION
## Summary

`browser_navigate` returns the page title and a snapshot reference. It never returns
the page text. Asked to open a URL and summarise it, the agent called
`browser_navigate`, saw `exit_code=0`, answered "the page loaded successfully" and
stopped — having read nothing. The turn looks successful and the tool log agrees, so
nothing flags it.

`browser_snapshot` has the same trap one level down: its optional `filename` argument
is documented as *"Save snapshot to markdown file instead of returning it in the
response"*, and the model volunteers one. It then receives a path it cannot open —
175 characters of reference where omitting the argument returns 1634 of content.

This adds a note covering both. Navigation is never the last step, follow it with
`browser_snapshot` or `browser_find`; call snapshot with no arguments; and prefer
`web_fetch` when the task is only to read a page, since it does the whole thing in
one call rather than three round trips — which matters on local hardware where each
round trip is a full generation.

The note is injected only when browser tools are in that turn's selection, and is
suppressed alongside the other local-context blocks, so it costs nothing on unrelated
requests.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #5764

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up`) and verified the change works end-to-end.

## How to Test

1. Run with the built-in browser MCP server connected, in agent mode.
2. Send: `Open https://example.com and summarise what this page is about`.
3. **Before the change** — the agent calls `browser_navigate`, then ends the turn with
   a message along the lines of "the page loaded successfully", without answering the
   question. The round summary reads `0 native calls, 0 tool blocks`.
4. **After the change** — the agent follows `browser_navigate` with `browser_snapshot`
   and answers from the page content. Confirmed in the logs:

   ```
   Tool executed: mcp__builtin_browser__browser_navigate -> exit_code=0
   Tool executed: mcp__builtin_browser__browser_snapshot -> exit_code=0
   ```

5. To check the conditional injection, build the system prompt with and without a
   browser tool in `relevant_tools`. The `READING A WEB PAGE` block is present in the
   first case and absent in the second.

## Visual / UI changes

None. This PR only touches `src/agent_loop.py` — prompt text assembled server-side.
No HTML, CSS, SVG or `static/js/` module is modified.
