### PR TITLE
fix(chat): only leave agent mode when the model really has no tool support

### DIFF
--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -24,6 +24,16 @@ import createResearchSynapse from './researchSynapse.js';
 import { createStreamRenderer } from './streamingRenderer.js';
 import { wireArrowUpRecall, getUserMessagesFromChatHistory } from './composerArrowUpRecall.js?v=20260714promptrecall';
 
+  // Does this error actually mean "the model cannot do tool calls"?
+  //
+  // Matching a bare "tool" or "auto" anywhere in the message catches far too
+  // much — a tool timing out, an MCP server dropping, anything mentioning
+  // "automatic" — and the consequences are not cosmetic: the real error is
+  // replaced, the UI leaves agent mode, and the choice is persisted. Match the
+  // provider's actual wording instead (Ollama: "<model> does not support
+  // tools").
+  const TOOLS_UNSUPPORTED_RE = /does\s*n[o']?t\s+support\s+tools?|tools?\s+(?:are\s+)?not\s+supported/i;
+
   const RESEARCH_TIMEOUT_MS = 360000;
   const DEFAULT_TIMEOUT_MS = 120000;
   const RESEARCH_SVG = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>';
@@ -1861,8 +1871,9 @@ import { wireArrowUpRecall, getUserMessagesFromChatHistory } from './composerArr
           if (m) errText = m[1].replace(/\\"/g, '"');
           else if (errBody.length < 200) errText = errBody;
         } catch {}
-        // Auto-switch to chat mode for tool-related errors
-        if (errText.includes('tool') || errText.includes('auto')) {
+        // Auto-switch to chat mode when the model genuinely cannot do tools.
+        // Anything else keeps its own error text and stays in agent mode.
+        if (TOOLS_UNSUPPORTED_RE.test(errText)) {
           errText = 'This model doesn\'t support agent tools — switched to Chat mode. Try again.';
           const _ab = document.getElementById('mode-agent-btn');
           const _cb = document.getElementById('mode-chat-btn');
@@ -3911,8 +3922,10 @@ import { wireArrowUpRecall, getUserMessagesFromChatHistory } from './composerArr
             const errorHolder = document.querySelector('.msg-ai:last-of-type .body');
             if (errorHolder) {
               let errMsg = `Error: ${err.message}`;
-              // Add hint for tool-call errors
-              if (err.message && (err.message.includes('tool') || err.message.includes('auto'))) {
+              // Add hint only when the error really is "no tool support" —
+              // appending it to an unrelated failure sends the user off
+              // switching modes instead of reading the actual error.
+              if (err.message && TOOLS_UNSUPPORTED_RE.test(err.message)) {
                 errMsg += '\n\nThis model may not support tools — try switching to Chat mode.';
               }
               typewriterInto(errorHolder, errMsg);


### PR DESCRIPTION
## Summary

Both checks in `static/js/chat.js` match a bare `tool` or `auto` anywhere in the error
text, which catches a great deal that has nothing to do with tool support: a tool
timing out, an MCP server dropping, any message containing "automatic".

At the first site the consequences are not cosmetic. The real error is replaced with
*"This model doesn't support agent tools"*, so the actual cause is lost. The UI leaves
agent mode. And the choice is written to `localStorage`, so every later message in
that conversation also runs without tools, with nothing on screen explaining why. It
presents as *"agent mode works in a new chat but not in this one"*, which sends you
looking at the model, the session or the endpoint rather than at a substring match in
the error path.

The second site is milder — it appends a hint rather than switching — but appending
*"this model may not support tools"* to an unrelated failure still points the user at
the wrong fix.

This matches the provider's actual wording instead. Ollama returns `<model> does not
support tools`; the pattern also covers "doesn't support tools" and "tools are not
supported". The original error text is kept in both branches so a genuine failure
stays diagnosable.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #5766

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up`) and verified the change works end-to-end.

## How to Test

1. In agent mode with a model that does support tools, trigger a failure whose message
   contains `tool` or `auto` — killing an MCP server mid-turn, or letting a tool time
   out, both work.
2. **Before the change** — the message shown is "This model doesn't support agent
   tools", the mode toggle flips to Chat, and `localStorage` keeps it there. Sending a
   second message in the same conversation runs without tools.
3. **After the change** — the real error text is displayed and agent mode stays on.
4. Regression check on the strings that used to misfire — none of these demote any
   more, while the three real phrasings still do:

   ```js
   const re = /does\s*n[o']?t\s+support\s+tools?|tools?\s+(?:are\s+)?not\s+supported/i;

   re.test('registry.ollama.ai/library/llama3.2 does not support tools'); // true
   re.test("this model doesn't support tools");                           // true
   re.test('Tools are not supported by this endpoint');                   // true

   re.test('Error 500: tool execution timed out');        // false
   re.test('MCP server not connected: builtin_browser');  // false
   re.test('automatic retry failed');                     // false
   re.test('tool_choice auto is invalid');                // false
   re.test('Error 502: peer closed connection');          // false
   ```

## Visual / UI changes — REQUIRED if you touched anything that renders

This touches `static/js/chat.js`, so I want to be explicit rather than tick "none".

What changes on screen: an **error message string**, and the **state of the mode
toggle** in the cases where it previously flipped by mistake. No styling, layout,
spacing, colour, font, icon, HTML structure or CSS is touched — the diff is a regular
expression and the two conditions that use it.

I have not attached a screenshot because producing one means provoking an artificial
backend failure, and the resulting image would show one arbitrary error string in a
message bubble — it would not illustrate the defect, which is *which* errors are
matched. The regression table above is a more faithful account of the change.

Happy to attach a before/after capture if you would rather have one — say the word and
I will provoke the failure and record it.
