### PR TITLE
fix(markdown): restore extracted blocks verbatim so $& and $$ survive

### DIFF
--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -758,30 +758,36 @@ export function mdToHtml(src, opts) {
   // Remove empty paragraphs
   s = s.replace(/<p><\/p>/g, '');
 
+  // Every restore below passes a function replacer rather than the block string
+  // itself. With a string replacement, `String.replace` reads `$&`, `` $` ``,
+  // `$'` and `$$` in the *replacement* as substitution patterns, so a restored
+  // block containing them is corrupted: `$&` re-inserts the placeholder, `` $` ``
+  // and `$'` splice in the surrounding document, and `$$` collapses to `$`. Those
+  // sequences are ordinary content in fenced code (`perl -pe 's/x/$& y/'`,
+  // `echo "$$USD"`). A function replacer inserts its return value verbatim.
+
   // CRITICAL: Restore allowed HTML blocks first
   allowedHtmlBlocks.forEach((block, index) => {
-    s = s.replace(`___ALLOWED_HTML_${index}___`, block);
+    s = s.replace(`___ALLOWED_HTML_${index}___`, () => block);
   });
 
   // Restore math blocks
   mathBlocks.forEach((block, index) => {
-    s = s.replace(`___MATH_BLOCK_${index}___`, block);
+    s = s.replace(`___MATH_BLOCK_${index}___`, () => block);
   });
 
   // Restore mermaid diagram blocks
   mermaidBlocks.forEach((block, index) => {
-    s = s.replace(`___MERMAID_BLOCK_${index}___`, block);
+    s = s.replace(`___MERMAID_BLOCK_${index}___`, () => block);
   });
 
   // CRITICAL: Restore code blocks at the end
   codeBlocks.forEach((block, index) => {
-    s = s.replace(`___CODE_BLOCK_${index}___`, block);
+    s = s.replace(`___CODE_BLOCK_${index}___`, () => block);
   });
 
   // Restore inline code spans last, so placeholders carried inside restored
-  // <a>/allowed-HTML blocks are resolved too. The function replacer keeps the
-  // escaped code literal — e.g. a shell snippet like `echo $1` is not treated
-  // as a regex back-reference.
+  // <a>/allowed-HTML blocks are resolved too.
   inlineCodeBlocks.forEach((block, index) => {
     s = s.replace(`___INLINE_CODE_${index}___`, () => block);
   });

--- a/tests/test_markdown_rendering_js.py
+++ b/tests/test_markdown_rendering_js.py
@@ -214,6 +214,50 @@ def test_inline_code_content_is_html_escaped(node_available):
     assert "<b>" not in html
 
 
+def test_fenced_code_keeps_dollar_ampersand(node_available):
+    # Issue #5663: the block-restore pass used a string replacement, so `$&` in a
+    # restored block was read as "the matched text" and re-inserted the
+    # placeholder. `perl -pe 's/world/$& again/'` rendered as
+    # "s/world/___CODE_BLOCK_0___amp; again/" — the trailing "amp;" is the orphan
+    # left behind after `$&` consumed the `$&` of the escaped `$&amp;`.
+    html = _run_markdown_case(
+        "```sh\necho \"hello world\" | perl -pe 's/world/$& again/'\n```"
+    )
+
+    assert "___CODE_BLOCK_" not in html
+    assert "s/world/$&amp; again/" in html
+    assert "amp; again" not in html.replace("$&amp; again", "")
+
+
+def test_fenced_code_keeps_dollar_backtick_and_quote(node_available):
+    # `` $` `` and `$'` splice the text before/after the placeholder into the
+    # block. Unlike `$&` these leave no placeholder behind — the characters just
+    # vanish — so assert the content survives verbatim.
+    html = _run_markdown_case("```sh\nsed \"s/$`/x/\" && sed \"s/$'/y/\"\n```")
+
+    assert "___CODE_BLOCK_" not in html
+    assert "s/$`/x/" in html
+    assert "s/$&#39;/y/" in html
+
+
+def test_fenced_code_keeps_double_dollar(node_available):
+    # `$$` collapsed to a single `$` in the restored block.
+    html = _run_markdown_case('```sh\necho "$$USD and $$"\n```')
+
+    assert "$$USD and $$" in html
+
+
+def test_mermaid_block_keeps_dollar_ampersand(node_available):
+    # The mermaid restore site had the same hazard: a node label containing `$&`
+    # re-inserted the ___MERMAID_BLOCK_n___ placeholder into the diagram source,
+    # which then fails to parse. The math and allowed-HTML sites are fixed the
+    # same way; they need KaTeX/sanitizer conditions this harness doesn't set up.
+    html = _run_markdown_case('```mermaid\ngraph TD; A["$&"] --> B;\n```')
+
+    assert "___MERMAID_BLOCK_" not in html
+    assert "$&amp;" in html
+
+
 def test_currency_dollar_amounts_are_not_rendered_as_math(node_available):
     # "$5 to $10" used to pair the two dollar signs as inline-math delimiters
     # and render "5 to" through KaTeX. Pandoc-style rules now reject it: the


### PR DESCRIPTION
## Summary

`mdToHtml` lifts fenced code, math, mermaid and allowed-HTML blocks out of the source and parks a placeholder (`___CODE_BLOCK_0___`) in their place so the markdown rules can't mangle them, then pastes each block back at the end. The paste used a **string** replacement:

```js
s = s.replace(`___CODE_BLOCK_${index}___`, block);
```

With a string replacement, `String.replace` reads `$&`, `` $` ``, `$'` and `$$` in the *replacement* as substitution patterns. So a restored block containing any of them is corrupted:

- `$&` re-inserts the matched text — i.e. the placeholder itself
- `` $` `` and `$'` splice in everything before / after the placeholder
- `$$` collapses to a single `$`

These are ordinary content in shell and perl snippets, so real code samples render wrong in chat, notes and documents. Reported in #5663.

This passes a function replacer at all four sites, matching the inline-code restore immediately below them which was already fixed this way. A function's return value is inserted verbatim, with no `$` interpretation.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #5663

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up -d --build`) and verified the change works end-to-end. Screenshots below.

## How to Test

1. Ask any model: *"Write a one-line bash script using `$&` and put it in a fenced sh code block."*
2. Before the fix, the rendered block shows the placeholder and an orphaned `amp;`:

   ```
   echo "hello world" | perl -pe 's/world/___CODE_BLOCK_0___amp; again/'
   ```

   (`$&` is HTML-escaped to `$&amp;` before the paste, so `$&` consumes the placeholder and leaves `amp;` behind.)

3. After the fix the same prompt renders the snippet verbatim, `$&` intact.

4. Deterministic check without a model — DevTools console on the app:

   ```js
   const { mdToHtml } = await import('/static/js/markdown.js');
   console.log(mdToHtml('```sh\necho "match: $&"\n```'));       // no ___CODE_BLOCK_
   console.log(mdToHtml('```sh\nsed \'s/$`/x/\'\n```'));        // $` no longer vanishes
   console.log(mdToHtml('```sh\necho "$$USD"\n```'));           // $$ no longer collapses
   ```

5. Tests:

   ```bash
   python -m pytest tests/test_markdown_rendering_js.py -q          # 17 passed
   python -m pytest tests/ -k "markdown or emoji or streaming_segmenter" -q   # 51 passed
   node --input-type=module --check < static/js/markdown.js
   node tests/markdown_codefence_placeholder_regression.mjs        # ok
   ```

   The four new tests were confirmed to **fail** against the unpatched `markdown.js` and pass with it.

## Note on the issue description

#5663 lists `$1` among the corrupting sequences, and an existing comment on the inline-code restore says `echo $1` would be treated as a back-reference. Neither is the case: with a *string* search value there are no capture groups, so JS leaves `$1`..`$99` literal. Verified both `$1` and `$10` pass through untouched. The four sequences that actually corrupt are `$&`, `` $` ``, `$'` and `$$`. The comment has been reworded accordingly; the fix itself is unchanged by this.

## Visual / UI changes

- [x] Screenshot of the change in the running app, attached below.
- [x] Style match: no CSS, markup, class or icon changes — this only affects the text content inside already-existing `<pre><code>` output.
- [x] No new component patterns.

### Screenshots

**Before** — `$&` replaced by the placeholder, with the orphaned `amp;`:

<img width="1123" height="736" alt="image" src="https://github.com/user-attachments/assets/9114fcab-4895-4b02-bd42-31ad5b240d1f" />

**After** — the snippet renders verbatim:

<img width="1227" height="448" alt="image" src="https://github.com/user-attachments/assets/59fc0234-ab5b-4234-8919-59a8767b73fb" />

## Files changed

- `static/js/markdown.js` — function replacer at the allowed-HTML, math, mermaid and code restore sites; the shared explanation moved above the group since it now covers all five.
- `tests/test_markdown_rendering_js.py` — four regression tests: `$&` (the reported perl case), `` $` `` / `$'` silent deletion, `$$` collapsing, and the mermaid restore path.

## Disclosure

The patch was drafted with Claude Code. I reproduced the bug in my own instance, reviewed the change, and verified before/after in the running app. Flagging it per CONTRIBUTING.md's note on agent-generated PRs — this is a single targeted fix against an existing issue, not a bulk submission.
