### PR TITLE
fix(agent): make the tool-selection timeout configurable

### DIFF
--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -9,6 +9,7 @@ The LLM decides when to use tools by writing fenced code blocks.
 import asyncio
 import collections
 import json
+import os
 import re
 import time
 import logging
@@ -894,7 +895,20 @@ _ADMIN_SCHEMA_NAMES = frozenset([
     "create_session", "list_sessions", "send_to_session", "pipeline",
     "ask_teacher", "list_models", "search_chats",
 ])
-_TOOL_SELECTION_TIMEOUT_SECONDS = 1.5
+# Budget for the three tool-selection steps (index init, MCP indexing, retrieval).
+#
+# 1.5s suits a warm index on quick hardware. It is tight anywhere else: the steps
+# run during a request, while the app may also be loading FastEmbed, reaching
+# ChromaDB and spawning MCP servers. When it expires, selection falls back to
+# ALWAYS_AVAILABLE — which contains no MCP tool at all, so every MCP server
+# silently disappears for that turn. The agent then reports it lacks tools it is
+# in fact connected to, and nothing in the logs ties the two together.
+#
+# Overridable so slower or busier deployments can buy headroom without a patch.
+# The default is unchanged.
+_TOOL_SELECTION_TIMEOUT_SECONDS = float(
+    os.environ.get("ODYSSEUS_TOOL_SELECTION_TIMEOUT", "1.5")
+)
 
 
 def _is_ollama_openai_compat_url(endpoint_url: str) -> bool:


### PR DESCRIPTION
﻿## Summary

Tool selection has a 1.5s budget covering three steps: index init, MCP indexing, and
retrieval. That suits a warm index on quick hardware. It is tight anywhere else,
because the steps run inside a request while the app may also be loading FastEmbed,
reaching ChromaDB and spawning MCP servers.

The failure mode is what makes this worth fixing rather than the number itself. On
expiry, selection falls back to `ALWAYS_AVAILABLE` â€” which contains no MCP tool at all.
Every MCP server therefore disappears for that turn, and the agent reports it does not
have tools it is connected to and could call directly. The warning line says the
timeout expired; nothing says the consequence was dropping the entire MCP surface.

Makes the value overridable via `ODYSSEUS_TOOL_SELECTION_TIMEOUT`. The default is
unchanged at 1.5s, so nothing moves for existing installs.

Also adds the missing `import os` â€” the module did not import it and made no use of
`os.` anywhere, so the new call would have raised `NameError` at import time. Worth
flagging because `py_compile` does not catch it: it checks syntax, not name resolution.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #5771

## Type of Change

- [x] Bug fix (non-breaking â€” fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs â€” this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above â€” no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up`) and verified the change works end-to-end.

## How to Test

1. With an MCP server connected, send an agent request while the app is still warming
   up. **Before** â€” the `[tool-rag]` warning fires and the following `[agent-debug]`
   line contains no `mcp__*` tool; the agent reports it has no such tool.
2. Set `ODYSSEUS_TOOL_SELECTION_TIMEOUT=15` and repeat. Retrieval completes and the
   `mcp__*` tools appear in `tool_names`.
3. Unset it and confirm the default is still 1.5s:

   ```python
   float(os.environ.get("ODYSSEUS_TOOL_SELECTION_TIMEOUT", "1.5"))  # 1.5
   ```

4. Confirm the module imports cleanly (`python -c "import src.agent_loop"`), which is
   what catches the missing `import os`.

## Visual / UI changes

None. `src/agent_loop.py` only â€” a module-level constant and an import.
