### PR TITLE
fix(tools): stop web_search from swallowing requests that name a URL

### DIFF
--- a/src/tool_schemas.py
+++ b/src/tool_schemas.py
@@ -64,7 +64,7 @@ FUNCTION_TOOL_SCHEMAS = [
         "type": "function",
         "function": {
             "name": "web_search",
-            "description": "Quick single web lookup for a fact or current event mid-task. NOT for 'research X' / 'do research on X' — those are deep-research jobs; use trigger_research instead.",
+            "description": "Quick single web lookup for a fact or current event mid-task, when you do NOT already know which page to read. NOT when the user hands you a URL — fetch that page with web_fetch instead of searching for it. NOT for 'research X' / 'do research on X' — those are deep-research jobs; use trigger_research instead.",
             "parameters": {
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
﻿## Summary

Asked to open a specific page and summarise it, the model called `web_search` with the
URL as the query â€” and added a freshness filter of its own, so the search returned
nothing useful. It never fetched the page it had just been handed.

The two descriptions are asymmetric. `web_fetch` already says "Use when you already
have a concrete URL/domain. NOT for open-ended searches (use web_search)", so the model
has a reason not to reach for it when searching. `web_search` says nothing about URLs,
so nothing argues against using it for one. The gap shows up with smaller models, which
lean on the descriptions rather than on judgement.

Adds the reciprocal guidance. Measured with the real toolset on a local model: the same
request went from `web_search` to `web_fetch`.

Worth recording that tool count matters as much as wording here. The same prompt
resolved correctly with 3 tools in a clean context, chose `web_search` with the 20 the
agent loop offers, and chose `web_fetch` again once the toolset was trimmed and this
description fixed. The wording is necessary but not sufficient â€” it is the cheap half.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #5773

## Type of Change

- [x] Bug fix (non-breaking â€” fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs â€” this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above â€” no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up`) and verified the change works end-to-end.

## How to Test

1. In agent mode with a small local model, send:
   `Open https://example.com and summarise the page`.
2. **Before** â€” the logs show `Tool executed: web_search`, with results unrelated to the
   site named in the request.
3. **After** â€” the logs show `Tool executed: web_fetch -> exit_code=0` and the answer is
   drawn from the page.

## Visual / UI changes

None. `src/tool_schemas.py` only â€” a single description string.
