### PR TITLE
fix(embeddings): make the HTTP lane read timeout configurable

### DIFF
--- a/src/embeddings.py
+++ b/src/embeddings.py
@@ -54,7 +54,15 @@ class EmbeddingClient:
         # running on :11434) fast-fails to the local FastEmbed fallback instead
         # of stalling startup ~30s per probe. Read stays generous for a real
         # endpoint (embedding a short string returns in well under a second).
-        self._client = httpx.Client(timeout=httpx.Timeout(connect=3.0, read=10.0, write=5.0, pool=3.0))
+        # The read budget holds for a warm endpoint, but the FIRST call after a
+        # cold start also pays for loading the embedding model into memory — on
+        # a modest or busy machine that is well past 10s. The timeout then fires
+        # silently: the lane produces no vectors, its collection stays empty,
+        # and retrieval quietly degrades to whatever other lane is present, with
+        # nothing marking the endpoint as the cause. Overridable, default
+        # unchanged.
+        _read_timeout = max(1.0, float(os.getenv("EMBEDDING_TIMEOUT", "10")))
+        self._client = httpx.Client(timeout=httpx.Timeout(connect=3.0, read=_read_timeout, write=5.0, pool=3.0))
         self._batch_size = max(1, int(os.getenv("EMBEDDING_BATCH_SIZE", "8")))
         self._max_chars = max(200, int(os.getenv("EMBEDDING_MAX_CHARS", "900")))
 


### PR DESCRIPTION
﻿## Summary

The 10s read budget holds for a warm endpoint â€” embedding a short string does return in
well under a second, as the comment says. But the FIRST call after a cold start also
pays for loading the embedding model into memory, and on a modest or busy machine that
is comfortably past 10s.

The failure is silent, which is the part worth fixing. The timeout fires, the lane
produces no vectors, its collection stays empty, and retrieval degrades to whatever
other lane happens to be populated. Nothing marks the endpoint as the cause, so the
symptom shows up much later as poor retrieval quality rather than as an embedding error
â€” in our case French queries ranking badly because only the English-only fallback lane
had any content.

Adds `EMBEDDING_TIMEOUT` alongside the existing `EMBEDDING_BATCH_SIZE` and
`EMBEDDING_MAX_CHARS`, floored at 1s. The default is unchanged at 10s.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #5775

## Type of Change

- [x] Bug fix (non-breaking â€” fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs â€” this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above â€” no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up`) and verified the change works end-to-end.

## How to Test

1. Point the HTTP embedding lane at a local endpoint whose model is not resident, so the
   first call must load it.
2. **Before** â€” the lane's collection stays at 0 entries with no error logged, and
   retrieval silently uses the other lane.
3. Set `EMBEDDING_TIMEOUT=60` and reindex. The lane populates.
4. Confirm the default and the floor:

   ```python
   max(1.0, float(os.getenv("EMBEDDING_TIMEOUT", "10")))   # 10.0 unset, 1.0 when set to 0
   ```

## Visual / UI changes

None. `src/embeddings.py` only â€” an HTTP client timeout.
