### PR TITLE
fix(skills): replace deprecated utcnow in skill timestamp helper

### DIFF
--- a/services/memory/skill_format.py
+++ b/services/memory/skill_format.py
@@ -50,7 +50,7 @@ import json
 import logging
 import re
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
@@ -441,4 +441,4 @@ class Skill:
 
 
 def _now_iso() -> str:
-    return datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/tests/test_skill_format_timestamp.py
+++ b/tests/test_skill_format_timestamp.py
@@ -1,0 +1,52 @@
+"""Regression for issue #5697 — skill timestamps must not use ``datetime.utcnow()``.
+
+``_now_iso()`` builds the ``created`` value in skill frontmatter. ``utcnow()``
+returns a *naive* datetime and has been deprecated since Python 3.12, scheduled
+for removal. The replacement must stay timezone-aware while keeping the
+serialized ``YYYY-MM-DDTHH:MM:SSZ`` shape, so skill files written by older
+versions keep parsing.
+
+The UTC check matters on its own: a bare ``datetime.now()`` also produces the
+right shape, but emits local wall time, which would silently backdate or
+postdate skills for every user outside UTC.
+"""
+
+import os
+import re
+import time
+import warnings
+from datetime import datetime, timezone
+
+from services.memory.skill_format import _now_iso
+
+_ISO_Z = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+
+def test_now_iso_keeps_serialized_shape():
+    assert _ISO_Z.match(_now_iso())
+
+
+def test_now_iso_emits_no_deprecation_warning():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _now_iso()
+    assert not [w for w in caught if issubclass(w.category, DeprecationWarning)]
+
+
+def test_now_iso_is_utc_not_local_time():
+    """Pin UTC under a non-UTC local timezone, where the two visibly diverge."""
+    original_tz = os.environ.get("TZ")
+    os.environ["TZ"] = "Asia/Amman"  # UTC+3, never UTC
+    time.tzset()
+    try:
+        emitted = datetime.strptime(_now_iso(), "%Y-%m-%dT%H:%M:%SZ").replace(
+            tzinfo=timezone.utc
+        )
+        drift = abs((emitted - datetime.now(timezone.utc)).total_seconds())
+        assert drift < 60, f"timestamp is {drift}s off UTC — local time leaked in"
+    finally:
+        if original_tz is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = original_tz
+        time.tzset()

--- a/tests/test_skill_format_timestamp.py
+++ b/tests/test_skill_format_timestamp.py
@@ -17,6 +17,8 @@ import time
 import warnings
 from datetime import datetime, timezone
 
+import pytest
+
 from services.memory.skill_format import _now_iso
 
 _ISO_Z = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
@@ -33,6 +35,10 @@ def test_now_iso_emits_no_deprecation_warning():
     assert not [w for w in caught if issubclass(w.category, DeprecationWarning)]
 
 
+@pytest.mark.skipif(
+    not hasattr(time, "tzset"),
+    reason="time.tzset is unavailable on this platform",
+)
 def test_now_iso_is_utc_not_local_time():
     """Pin UTC under a non-UTC local timezone, where the two visibly diverge."""
     original_tz = os.environ.get("TZ")


### PR DESCRIPTION
## Summary

`_now_iso()` in `services/memory/skill_format.py` builds the `created` timestamp written into every skill's frontmatter. It used `datetime.utcnow()`, which returns a **naive** datetime and has been deprecated since Python 3.12 and scheduled for removal:

```
DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for
removal in a future version. Use timezone-aware objects to represent datetimes
in UTC: datetime.datetime.now(datetime.UTC).
```

This switches the helper to the timezone-aware `datetime.now(timezone.utc)` while keeping the serialized `YYYY-MM-DDTHH:MM:SSZ` shape byte-for-byte, so skill files written by earlier versions keep parsing unchanged.

`timezone.utc` is used rather than the `datetime.UTC` alias from the warning text, since the alias is only available on Python 3.11+ and `timezone.utc` works everywhere with no behavioural difference. This also matches the fix suggested in the issue.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #5697

## Type of Change

- [x] Chore / cleanup (non-breaking — removes a deprecated API call)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I exercised the changed code path and verified the output is unchanged.

## Scope

`utcnow()` appears 177 times across 39 files in the tree. This PR deliberately changes only the helper named in the issue, which asks for a small scoped cleanup. Converting the rest would be a large mechanical diff better handled separately, and several of the other call sites feed comparisons against naive datetimes that need checking individually rather than blanket-replacing.

## How to Test

1. Confirm the deprecation on current `dev`:

   ```python
   import warnings
   from services.memory.skill_format import _now_iso
   with warnings.catch_warnings(record=True) as w:
       warnings.simplefilter("always")
       _now_iso()
   print([str(x.message) for x in w])
   # -> ["datetime.datetime.utcnow() is deprecated ..."]
   ```

2. With this patch the same snippet reports no warnings, and `_now_iso()` still returns e.g. `2026-07-26T20:19:34Z`.

3. Round-trip through the code path that actually writes frontmatter:

   ```python
   from services.memory.skill_format import Skill
   md = Skill(name="demo-skill", description="round-trip check").to_markdown()
   print([l for l in md.splitlines() if l.startswith("created")])
   # -> ['created: "2026-07-26T20:19:34Z"']   (matches real UTC, no warning raised)
   ```

4. Tests:

   ```bash
   python -m pytest tests/test_skill_format_timestamp.py -q   # 3 passed
   python -m pytest tests/ -k skill -q                        # 77 passed
   ```

## Tests added

`tests/test_skill_format_timestamp.py` pins three properties:

| Test | Guards against |
|---|---|
| `test_now_iso_emits_no_deprecation_warning` | the reported regression — **verified failing** against unpatched `dev` |
| `test_now_iso_keeps_serialized_shape` | a future change altering the on-disk format |
| `test_now_iso_is_utc_not_local_time` | a plausible wrong fix — bare `datetime.now()` produces the identical shape but emits local wall time |

The third is not decorative: patched to `datetime.now()`, it fails by exactly the local UTC offset. It forces a non-UTC timezone (`Asia/Amman`) so the two visibly diverge, since under a UTC-configured test runner a naive `now()` would otherwise pass unnoticed.

## Visual / UI changes

- [x] None — this is a backend-only cleanup with no rendered output. The serialized timestamp is unchanged.

## Files changed

- `services/memory/skill_format.py` — import `timezone`; `_now_iso()` uses `datetime.now(timezone.utc)`.
- `tests/test_skill_format_timestamp.py` — new regression tests (see table above).

## Disclosure

The patch was drafted with Claude Code. I reproduced the deprecation warning in my own instance, reviewed the change, and confirmed the new tests fail against unpatched `dev` before they pass with it. Flagging it per CONTRIBUTING.md's note on agent-generated PRs — this is a single targeted change against an existing issue, not a bulk submission.
