### PR TITLE
fix: stop status polling from cancelling running scheduled tasks

### DIFF
--- a/app.py
+++ b/app.py
@@ -630,15 +630,25 @@ app.include_router(auth_router)
 
 @app.post("/api/activity/heartbeat")
 async def activity_heartbeat():
-    from src.interactive_gate import mark_browser_activity, _enabled as _gate_enabled
+    from src.interactive_gate import (
+        mark_browser_activity,
+        maybe_stop_background_tasks_for_heartbeat,
+    )
+
     await mark_browser_activity()
-    if _gate_enabled():
-        async def _stop_background():
-            try:
-                await task_scheduler.stop_background_tasks_for_foreground(reason="browser heartbeat")
-            except Exception:
-                logging.getLogger("app.foreground_gate").debug("heartbeat task stop failed", exc_info=True)
-        asyncio.create_task(_stop_background())
+
+    async def _stop_background():
+        try:
+            await maybe_stop_background_tasks_for_heartbeat(
+                task_scheduler.stop_background_tasks_for_foreground
+            )
+        except Exception:
+            logging.getLogger("app.foreground_gate").debug(
+                "heartbeat task stop failed",
+                exc_info=True,
+            )
+
+    asyncio.create_task(_stop_background())
     return {"ok": True}
 
 

--- a/app.py
+++ b/app.py
@@ -630,14 +630,15 @@ app.include_router(auth_router)
 
 @app.post("/api/activity/heartbeat")
 async def activity_heartbeat():
-    from src.interactive_gate import mark_browser_activity
+    from src.interactive_gate import mark_browser_activity, _enabled as _gate_enabled
     await mark_browser_activity()
-    async def _stop_background():
-        try:
-            await task_scheduler.stop_background_tasks_for_foreground(reason="browser heartbeat")
-        except Exception:
-            logging.getLogger("app.foreground_gate").debug("heartbeat task stop failed", exc_info=True)
-    asyncio.create_task(_stop_background())
+    if _gate_enabled():
+        async def _stop_background():
+            try:
+                await task_scheduler.stop_background_tasks_for_foreground(reason="browser heartbeat")
+            except Exception:
+                logging.getLogger("app.foreground_gate").debug("heartbeat task stop failed", exc_info=True)
+        asyncio.create_task(_stop_background())
     return {"ok": True}
 
 

--- a/src/interactive_gate.py
+++ b/src/interactive_gate.py
@@ -77,6 +77,19 @@ _PASSIVE_PREFIXES = (
 )
 
 
+async def maybe_stop_background_tasks_for_heartbeat(stop_background) -> bool:
+    """Stop background work for browser activity only when the gate is enabled.
+
+    ``stop_background`` is injected by the application boundary so this policy
+    remains independently testable without importing the full FastAPI app.
+    """
+    if not _enabled():
+        return False
+
+    await stop_background(reason="browser heartbeat")
+    return True
+
+
 def should_track_interactive_request(path: str, method: str = "GET") -> bool:
     if not _enabled():
         return False

--- a/src/interactive_gate.py
+++ b/src/interactive_gate.py
@@ -63,6 +63,7 @@ _PASSIVE_EXACT_PATHS = {
     "/api/activity/heartbeat",
     "/api/client-perf",
     "/api/tasks/notifications",
+    "/api/tasks/runs/recent",
     "/api/research/active",
     "/api/email/urgency-state",
     # UI idle poll sibling of urgency-state; must not pre-empt background tasks.

--- a/tests/test_poll_endpoint_no_task_interrupt.py
+++ b/tests/test_poll_endpoint_no_task_interrupt.py
@@ -1,54 +1,66 @@
-"""Regression: read-only task-status polling must not interrupt running background tasks.
+"""Regression tests for polling endpoints and foreground task interruption."""
 
-GET /api/tasks/runs/recent is called by the Activity view while a scheduled
-task is executing. Before this fix, the _InteractiveActivityMiddleware treated
-it as a foreground request and called stop_background_tasks_for_foreground,
-which immediately cancelled the running task. The fix adds the endpoint to
-_PASSIVE_EXACT_PATHS so it is excluded from interactive tracking.
-
-Additionally, /api/activity/heartbeat called stop_background_tasks_for_foreground
-unconditionally, ignoring BACKGROUND_TASK_FOREGROUND_GATE=false. The fix wraps
-that call in a _gate_enabled() check so the env var fully disables interrupts.
-"""
-
+import asyncio
 import importlib
-import os
 
 
 def _reload_gate():
     import src.interactive_gate as ig
+
     importlib.reload(ig)
     return ig
 
 
 def test_tasks_runs_recent_is_passive():
     ig = _reload_gate()
-    assert not ig.should_track_interactive_request("/api/tasks/runs/recent", "GET"), (
-        "GET /api/tasks/runs/recent must be treated as a passive endpoint so that "
-        "the Activity-view polling does not trigger stop_background_tasks_for_foreground "
-        "and cancel running scheduled tasks"
+
+    assert not ig.should_track_interactive_request(
+        "/api/tasks/runs/recent", "GET"
     )
 
 
 def test_tasks_runs_recent_does_not_affect_other_task_paths():
     ig = _reload_gate()
-    # Non-polling mutating task routes should still be interactive.
-    assert ig.should_track_interactive_request("/api/tasks/runs/recent/something", "POST")
+
+    # A neighboring mutating path must remain interactive.
+    assert ig.should_track_interactive_request(
+        "/api/tasks/runs/recent/something", "POST"
+    )
 
 
-def test_heartbeat_respects_foreground_gate_disabled(monkeypatch):
-    """stop_background_tasks_for_foreground must NOT be called from the heartbeat
-    handler when BACKGROUND_TASK_FOREGROUND_GATE=false."""
+def test_heartbeat_does_not_stop_background_tasks_when_gate_disabled(monkeypatch):
+    ig = _reload_gate()
     monkeypatch.setenv("BACKGROUND_TASK_FOREGROUND_GATE", "false")
-    ig = _reload_gate()
-    assert not ig._enabled(), (
-        "_enabled() should return False when BACKGROUND_TASK_FOREGROUND_GATE=false"
+
+    stop_calls = []
+
+    async def fake_stop_background_tasks_for_foreground(*, reason):
+        stop_calls.append(reason)
+
+    result = asyncio.run(
+        ig.maybe_stop_background_tasks_for_heartbeat(
+            fake_stop_background_tasks_for_foreground
+        )
     )
 
+    assert result is False
+    assert stop_calls == []
 
-def test_heartbeat_gate_enabled_by_default(monkeypatch):
+
+def test_heartbeat_stops_background_tasks_when_gate_enabled(monkeypatch):
+    ig = _reload_gate()
     monkeypatch.delenv("BACKGROUND_TASK_FOREGROUND_GATE", raising=False)
-    ig = _reload_gate()
-    assert ig._enabled(), (
-        "_enabled() should return True by default (foreground gate on)"
+
+    stop_calls = []
+
+    async def fake_stop_background_tasks_for_foreground(*, reason):
+        stop_calls.append(reason)
+
+    result = asyncio.run(
+        ig.maybe_stop_background_tasks_for_heartbeat(
+            fake_stop_background_tasks_for_foreground
+        )
     )
+
+    assert result is True
+    assert stop_calls == ["browser heartbeat"]

--- a/tests/test_poll_endpoint_no_task_interrupt.py
+++ b/tests/test_poll_endpoint_no_task_interrupt.py
@@ -1,0 +1,54 @@
+"""Regression: read-only task-status polling must not interrupt running background tasks.
+
+GET /api/tasks/runs/recent is called by the Activity view while a scheduled
+task is executing. Before this fix, the _InteractiveActivityMiddleware treated
+it as a foreground request and called stop_background_tasks_for_foreground,
+which immediately cancelled the running task. The fix adds the endpoint to
+_PASSIVE_EXACT_PATHS so it is excluded from interactive tracking.
+
+Additionally, /api/activity/heartbeat called stop_background_tasks_for_foreground
+unconditionally, ignoring BACKGROUND_TASK_FOREGROUND_GATE=false. The fix wraps
+that call in a _gate_enabled() check so the env var fully disables interrupts.
+"""
+
+import importlib
+import os
+
+
+def _reload_gate():
+    import src.interactive_gate as ig
+    importlib.reload(ig)
+    return ig
+
+
+def test_tasks_runs_recent_is_passive():
+    ig = _reload_gate()
+    assert not ig.should_track_interactive_request("/api/tasks/runs/recent", "GET"), (
+        "GET /api/tasks/runs/recent must be treated as a passive endpoint so that "
+        "the Activity-view polling does not trigger stop_background_tasks_for_foreground "
+        "and cancel running scheduled tasks"
+    )
+
+
+def test_tasks_runs_recent_does_not_affect_other_task_paths():
+    ig = _reload_gate()
+    # Non-polling mutating task routes should still be interactive.
+    assert ig.should_track_interactive_request("/api/tasks/runs/recent/something", "POST")
+
+
+def test_heartbeat_respects_foreground_gate_disabled(monkeypatch):
+    """stop_background_tasks_for_foreground must NOT be called from the heartbeat
+    handler when BACKGROUND_TASK_FOREGROUND_GATE=false."""
+    monkeypatch.setenv("BACKGROUND_TASK_FOREGROUND_GATE", "false")
+    ig = _reload_gate()
+    assert not ig._enabled(), (
+        "_enabled() should return False when BACKGROUND_TASK_FOREGROUND_GATE=false"
+    )
+
+
+def test_heartbeat_gate_enabled_by_default(monkeypatch):
+    monkeypatch.delenv("BACKGROUND_TASK_FOREGROUND_GATE", raising=False)
+    ig = _reload_gate()
+    assert ig._enabled(), (
+        "_enabled() should return True by default (foreground gate on)"
+    )


### PR DESCRIPTION
## Linked Issue

Fixes #5782

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Summary

Two paths caused the scheduler to cancel a running background task the moment the frontend Activity view polled for status.

Bug 1: GET /api/tasks/runs/recent was not in _PASSIVE_EXACT_PATHS in src/interactive_gate.py. The _InteractiveActivityMiddleware treated it as a foreground request and called stop_background_tasks_for_foreground, cancelling any in-flight task immediately. Added it to _PASSIVE_EXACT_PATHS alongside the other read-only polling endpoints.

Bug 2: The /api/activity/heartbeat handler called stop_background_tasks_for_foreground unconditionally, ignoring BACKGROUND_TASK_FOREGROUND_GATE=false. The call is now guarded by _gate_enabled().

Both issues combined to produce the log pattern from the issue:

    [agent-timing] round_start round=1 ...
    Stopped 2 background scheduler task(s): foreground request GET /api/tasks/runs/recent

## Checklist

- [x] I searched existing open issues and PRs and did not find a duplicate.

## How to Test

1. Start a scheduled LLM task (e.g. an email-reading task with Ollama).
2. While the task is running (after Starting... appears in the Activity view), open or refresh the Activity view so it polls GET /api/tasks/runs/recent.
3. Before this fix, the task would be immediately cancelled with "Stopped 2 background scheduler task(s): foreground request GET /api/tasks/runs/recent" in the logs. After the fix, the task continues to run.

Unit-level: python -c "import src.interactive_gate as ig; assert not ig.should_track_interactive_request('/api/tasks/runs/recent', 'GET'); print('OK')"