### PR TITLE
fix(companion): preserve models with auth disabled

### DIFF
--- a/companion/routes.py
+++ b/companion/routes.py
@@ -23,7 +23,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse
 
 from core.middleware import require_admin
-from src.auth_helpers import get_current_user
+from src.auth_helpers import _auth_disabled, get_current_user
 
 from companion import pairing as _pairing
 
@@ -113,8 +113,9 @@ def setup_companion_routes() -> APIRouter:
         The stock /api/models route scopes to get_current_user, which for a
         bearer token is the sandboxed pseudo-user "api" (owns nothing). Here we
         scope to the token's real owner instead, plus legacy null-owner shared
-        rows -- the same rule as owner_filter. Read-only; never returns api_key
-        material.
+        rows -- the same rule as owner_filter. Explicit auth-disabled mode keeps
+        the stock route's single-user all-endpoints view. Read-only; never
+        returns api_key material.
         """
         require_models_scope(request)
         import json as _json
@@ -123,6 +124,11 @@ def setup_companion_routes() -> APIRouter:
         from src.endpoint_resolver import build_chat_url
 
         owner = token_owner(request)
+        single_user_mode = (
+            owner is None
+            and not getattr(request.state, "api_token", False)
+            and _auth_disabled()
+        )
         out = []
         db = SessionLocal()
         try:
@@ -133,7 +139,7 @@ def setup_companion_routes() -> APIRouter:
             if owner:
                 q = q.filter((ModelEndpoint.owner == owner) | (ModelEndpoint.owner == None))  # noqa: E711
             for ep in q.all():
-                if not owner_can_see(ep.owner, owner):
+                if not single_user_mode and not owner_can_see(ep.owner, owner):
                     continue
                 try:
                     model_ids = _json.loads(ep.cached_models) if ep.cached_models else []

--- a/tests/test_companion_readonly.py
+++ b/tests/test_companion_readonly.py
@@ -279,6 +279,47 @@ def test_models_route_unresolved_owner_returns_only_shared_rows(monkeypatch):
     assert _endpoint_names(endpoints) == ["shared-endpoint"]
 
 
+def test_models_route_auth_disabled_does_not_widen_ownerless_api_token(monkeypatch):
+    monkeypatch.setenv("AUTH_ENABLED", "false")
+    rows = [
+        _ep(1, "alice-endpoint", "alice"),
+        _ep(2, "shared-endpoint", None),
+        _ep(3, "bob-endpoint", "bob"),
+    ]
+    monkeypatch.setattr(companion_routes, "get_current_user", lambda request: None)
+
+    endpoints = _call_models_route(
+        monkeypatch,
+        rows,
+        _request(
+            api_token=True,
+            api_token_owner=None,
+            api_token_scopes=["chat"],
+            current_user="api",
+        ),
+    )
+
+    assert _endpoint_names(endpoints) == ["shared-endpoint"]
+
+
+def test_models_route_auth_disabled_keeps_cookie_owner_scoped(monkeypatch):
+    monkeypatch.setenv("AUTH_ENABLED", "false")
+    rows = [
+        _ep(1, "alice-endpoint", "alice"),
+        _ep(2, "shared-endpoint", None),
+        _ep(3, "bob-endpoint", "bob"),
+    ]
+    monkeypatch.setattr(companion_routes, "get_current_user", lambda request: "alice")
+
+    endpoints = _call_models_route(
+        monkeypatch,
+        rows,
+        _request(api_token=False, current_user="alice"),
+    )
+
+    assert _endpoint_names(endpoints) == ["alice-endpoint", "shared-endpoint"]
+
+
 def test_models_route_auth_enabled_anonymous_returns_only_shared_rows(monkeypatch):
     monkeypatch.setenv("AUTH_ENABLED", "true")
     rows = [

--- a/tests/test_companion_readonly.py
+++ b/tests/test_companion_readonly.py
@@ -257,6 +257,7 @@ def test_models_route_rejects_api_token_without_chat_scope(monkeypatch):
 
 
 def test_models_route_unresolved_owner_returns_only_shared_rows(monkeypatch):
+    monkeypatch.setenv("AUTH_ENABLED", "true")
     rows = [
         _ep(1, "alice-endpoint", "alice"),
         _ep(2, "shared-endpoint", None),
@@ -276,6 +277,46 @@ def test_models_route_unresolved_owner_returns_only_shared_rows(monkeypatch):
     )
 
     assert _endpoint_names(endpoints) == ["shared-endpoint"]
+
+
+def test_models_route_auth_enabled_anonymous_returns_only_shared_rows(monkeypatch):
+    monkeypatch.setenv("AUTH_ENABLED", "true")
+    rows = [
+        _ep(1, "alice-endpoint", "alice"),
+        _ep(2, "shared-endpoint", None),
+        _ep(3, "bob-endpoint", "bob"),
+    ]
+    monkeypatch.setattr(companion_routes, "get_current_user", lambda request: None)
+
+    endpoints = _call_models_route(
+        monkeypatch,
+        rows,
+        _request(api_token=False, current_user=None),
+    )
+
+    assert _endpoint_names(endpoints) == ["shared-endpoint"]
+
+
+def test_models_route_auth_disabled_returns_all_enabled_rows(monkeypatch):
+    monkeypatch.setenv("AUTH_ENABLED", "false")
+    rows = [
+        _ep(1, "alice-endpoint", "alice"),
+        _ep(2, "shared-endpoint", None),
+        _ep(3, "bob-endpoint", "bob"),
+    ]
+    monkeypatch.setattr(companion_routes, "get_current_user", lambda request: None)
+
+    endpoints = _call_models_route(
+        monkeypatch,
+        rows,
+        _request(api_token=False, current_user=None),
+    )
+
+    assert _endpoint_names(endpoints) == [
+        "alice-endpoint",
+        "shared-endpoint",
+        "bob-endpoint",
+    ]
 
 
 def test_models_route_filters_hidden_models_and_secret_fields(monkeypatch):


### PR DESCRIPTION
## Summary


This replaces #5619, which GitHub closed during the repository transfer and fork-network separation. The branch has been rebuilt on the current dev history; the implementation scope is unchanged.

Preserves companion model inventory in the supported auth-disabled single-user mode. The route now returns every enabled LLM endpoint when authentication is explicitly disabled and no bearer token or owner is resolved, matching `/api/models`, while authenticated browser and token callers keep the existing owner/scope filtering.

The regression coverage pins all three relevant modes: authenticated owner scoping, unresolved authenticated/token callers seeing shared rows only, and explicit auth-disabled mode seeing owner-stamped plus shared rows.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #5617

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

Not run: live app. This is a focused backend compatibility change covered by route-level regressions and adjacent model/owner-scope tests; no UI rendering changed.

## How to Test

1. Run the companion and adjacent model-owner regressions:

   ```bash
   python -m pytest -q tests/test_companion_readonly.py tests/test_gallery_owner_filter_single_user.py tests/test_model_routes.py
   ```

2. Run the companion pairing/read-only group:

   ```bash
   python -m pytest -q tests/test_companion_readonly.py tests/test_companion_pairing.py
   ```

3. Compile the changed Python files and check the diff:

   ```bash
   python -m py_compile companion/routes.py tests/test_companion_readonly.py
   git diff --check origin/dev...HEAD
   ```

Expected results: auth-disabled requests return owner-stamped and shared enabled LLM endpoints; authenticated owners remain limited to their own plus shared endpoints; an unresolved bearer owner still sees shared rows only; secret endpoint fields remain absent.

## Visual / UI changes — REQUIRED if you touched anything that renders

N/A — backend only; no UI rendering changed.

### Screenshots / clips

N/A — backend only; no UI rendering changed.

