### PR TITLE
fix(settings): preserve the OAuth connect payload

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -3031,12 +3031,14 @@ async function initEmailAccountsSettings() {
       const body = {
         name: el('eaf-name').value.trim() || el('eaf-from').value.trim(),
         from_address: el('eaf-from').value.trim(),
+        display_name: el('eaf-display-name').value.trim(),
         imap_host: el('eaf-imap-host').value.trim(),
         imap_port: parseInt(el('eaf-imap-port').value) || 993,
         imap_user: el('eaf-imap-user').value.trim(),
         imap_starttls: el('eaf-imap-starttls').checked,
         smtp_host: el('eaf-smtp-host').value.trim(),
         smtp_port: parseInt(el('eaf-smtp-port').value) || 587,
+        smtp_security: el('eaf-smtp-security').value,
         smtp_user: el('eaf-imap-user').value.trim(),
       };
       if (!body.name) { el('eaf-msg').textContent = 'Enter a Name or Email first'; el('eaf-msg').style.color = 'var(--red)'; return; }

--- a/tests/test_email_oauth_connect_smtp_security.py
+++ b/tests/test_email_oauth_connect_smtp_security.py
@@ -1,0 +1,15 @@
+"""Regression coverage for SMTP security saved before Google OAuth."""
+
+from pathlib import Path
+
+
+_REPO = Path(__file__).resolve().parents[1]
+
+
+def test_email_tab_oauth_connect_persists_selected_smtp_security():
+    source = (_REPO / "static" / "js" / "settings.js").read_text(encoding="utf-8")
+    start = source.index("el('eaf-oauth-btn').addEventListener")
+    handler_body = source[start:source.index("if (!body.name)", start)]
+
+    assert "smtp_security: el('eaf-smtp-security').value" in handler_body
+    assert "display_name: el('eaf-display-name').value.trim()" in handler_body


### PR DESCRIPTION
## Summary


This replaces #5652, which GitHub closed during the repository transfer and fork-network separation. The branch has been rebuilt on the current dev history; the implementation scope is unchanged.

Preserve the selected SMTP security mode and display name when the Email tab's Google Connect button first saves an account. This keeps the saved SMTP port and security mode consistent instead of relying on a server-side default that can disagree with the form.

The change only adds two existing form values to the account payload. It does not change rendering, account layout, or the OAuth redirect flow.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #5647

Part of #5637

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this Connect-payload bug is not already tracked.
- [x] This PR targets `dev`.
- [x] My changes are limited to two existing form fields and focused regression coverage.
- [ ] I ran the app end-to-end. Source-level regression tests and JavaScript syntax checks pass; a live Google callback was not available.

## How to Test

1. Run:

   ```bash
   python -m pytest -q tests/test_email_oauth_connect_smtp_security.py
   node --check static/js/settings.js
   ```

2. In the Email account form, select SMTP port 587 with STARTTLS and enter a display name.
3. Click Connect with Google and inspect the account-creation request.
4. Verify `smtp_security` and `display_name` match the form and persist on the saved account.

Current-`dev` isolated validation passes 37 focused/adjacent tests, JavaScript syntax, and diff checks.

## Visual / UI changes

N/A — the existing form renders identically; only its request payload changes.

### Screenshots / clips

N/A — no visual rendering change.
