### PR TITLE
fix(settings): show Google email OAuth callback results

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -5788,29 +5788,30 @@ export function close() {
   window.history.replaceState(null, '', clean);
   const success = sp.has('email_oauth_success');
   const errMsg = sp.get('email_oauth_error') || '';
-  // Open settings → integrations after the app has initialised.
-  function _tryOpen() {
-    if (window.settingsModule && typeof window.settingsModule.open === 'function') {
-      window.settingsModule.open('integrations');
-      // Brief toast-style banner.
-      const banner = document.createElement('div');
-      banner.textContent = success
-        ? '✓ Google account connected — email is ready'
-        : `Google OAuth failed: ${errMsg || 'unknown error'}`;
-      Object.assign(banner.style, {
-        position: 'fixed', bottom: '24px', left: '50%', transform: 'translateX(-50%)',
-        background: success ? 'var(--accent, #50fa7b)' : 'var(--red, #ff5555)',
-        color: '#000', padding: '8px 18px', borderRadius: '6px', fontSize: '12px',
-        fontWeight: '600', zIndex: '99999', pointerEvents: 'none',
-        boxShadow: '0 2px 12px rgba(0,0,0,0.3)',
-      });
-      document.body.appendChild(banner);
-      setTimeout(() => banner.remove(), 4000);
-    } else {
-      setTimeout(_tryOpen, 100);
-    }
+  // Open settings → integrations once the document is ready. This module owns
+  // the open() API, so it does not need to wait for a window-level alias.
+  function _showResult() {
+    open('integrations');
+    // Brief toast-style banner.
+    const banner = document.createElement('div');
+    banner.textContent = success
+      ? 'Google account connected — email is ready'
+      : `Google OAuth failed: ${errMsg || 'unknown error'}`;
+    Object.assign(banner.style, {
+      position: 'fixed', bottom: '24px', left: '50%', transform: 'translateX(-50%)',
+      background: success ? 'var(--accent, #50fa7b)' : 'var(--red, #ff5555)',
+      color: '#000', padding: '8px 18px', borderRadius: '6px', fontSize: '12px',
+      fontWeight: '600', zIndex: '99999', pointerEvents: 'none',
+      boxShadow: '0 2px 12px rgba(0,0,0,0.3)',
+    });
+    document.body.appendChild(banner);
+    setTimeout(() => banner.remove(), 4000);
   }
-  _tryOpen();
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', _showResult, { once: true });
+  } else {
+    _showResult();
+  }
 })();
 
 const settingsModule = { open, close, initIntegrations, initUnifiedIntegrations, syncAdminVisibility, refreshAiModelEndpoints };

--- a/tests/test_email_oauth_settings_redirect.py
+++ b/tests/test_email_oauth_settings_redirect.py
@@ -1,0 +1,19 @@
+"""Regression coverage for the settings UI after Google OAuth redirects."""
+
+from pathlib import Path
+
+
+_REPO = Path(__file__).resolve().parents[1]
+
+
+def test_oauth_redirect_uses_the_module_local_settings_api():
+    source = (_REPO / "static" / "js" / "settings.js").read_text(encoding="utf-8")
+    handler = source[
+        source.index("(function _handleOauthRedirect"):
+        source.index("const settingsModule =")
+    ]
+
+    assert "open('integrations');" in handler
+    assert "window.settingsModule" not in handler
+    assert "window.__odysseusAppStarted" not in handler
+    assert "document.addEventListener('DOMContentLoaded', _showResult, { once: true })" in handler


### PR DESCRIPTION
## Summary


This replaces #5654, which GitHub closed during the repository transfer and fork-network separation. The branch has been rebuilt on the current dev history; the implementation scope is unchanged.

Open Settings directly to Integrations after a Google OAuth callback and show the existing success/error banner once the document is ready. The redirect handler now calls this module's own `open()` API instead of polling forever for a window-level alias that is never assigned.

The callback query parameters are still removed from browser history before the result is displayed. No new component or style system is introduced.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #5643

Part of #5637

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this callback UI dead-wait is not already tracked.
- [x] This PR targets `dev`.
- [x] My changes are limited to the OAuth redirect handler and focused regression coverage.
- [ ] I ran the app end-to-end. The callback-result UI was exercised in the running app with a synthetic success query, and browser assertions verified URL cleanup, panel state, and banner visibility. A live Google authorization was not performed.

## How to Test

1. Run:

   ```bash
   python -m pytest -q tests/test_email_oauth_settings_redirect.py
   node --check static/js/settings.js
   ```

2. Complete or simulate a callback redirect containing `email_oauth_success=1`.
3. Verify Settings opens to Integrations once and shows the success banner.
4. Repeat with `email_oauth_error=...` and verify the error banner appears.
5. Reload and verify the cleaned URL does not replay either banner.

Current-`dev` isolated validation passes 17 focused/adjacent tests, JavaScript syntax, and diff checks. A running-app browser pass also verifies that Integrations opens, the success banner appears, and the callback query is removed.

## Visual / UI changes — REQUIRED if you touched anything that renders

The existing Settings panel and callback result banner now appear after redirect. Their current visual styling is retained.

- [x] **Screenshot or short clip** — running-app capture attached below.
- [x] **Style match** — existing Settings and banner styles are retained.
- [x] **No new component patterns.**
- [ ] **I am not an LLM agent submitting a bulk PR.** Contributor attestation remains for the human author.

### Screenshots / clips

Running-app capture using a synthetic success query; no credentials or live provider traffic:

![Settings open to Integrations with the Google email OAuth success banner](https://raw.githubusercontent.com/RaresKeY/odysseus/b23ea889f5fb3adf66c686b59d81225b475ff0c0/docs/visual-evidence/oauth-callback-success.png)
