### PR TITLE
fix(auth): default-deny API-token route capabilities

### DIFF
--- a/app.py
+++ b/app.py
@@ -392,9 +392,15 @@ if AUTH_ENABLED:
             # Allow DIRECT localhost requests (internal service calls from
             # heartbeats etc.). Tunnel/proxy-forwarded requests are excluded by
             # _is_trusted_loopback so LOCALHOST_BYPASS can't be abused over a
-            # Cloudflare tunnel / reverse proxy. Keep LOCALHOST_BYPASS=false for
-            # network-exposed deployments regardless.
-            if LOCALHOST_BYPASS and _is_trusted_loopback(request):
+            # Cloudflare tunnel / reverse proxy. An explicitly presented ody_
+            # bearer token still follows its token capability boundary; local
+            # requests without one keep the documented bypass behavior.
+            auth_header = request.headers.get("authorization", "")
+            if (
+                LOCALHOST_BYPASS
+                and _is_trusted_loopback(request)
+                and not auth_header.startswith("Bearer ody_")
+            ):
                 return await call_next(request)
             if not auth_manager.is_configured:
                 # No users yet — redirect to login for first-time setup
@@ -403,7 +409,6 @@ if AUTH_ENABLED:
                 return JSONResponse(status_code=401, content={"error": "Setup required"})
 
             # --- Bearer token auth (API tokens for external integrations) ---
-            auth_header = request.headers.get("authorization", "")
             if auth_header.startswith("Bearer ody_"):
                 raw_token = auth_header[7:]
                 # Sanity check: tokens are "ody_" + 43 chars of base64
@@ -426,11 +431,11 @@ if AUTH_ENABLED:
                             matched_scopes = scopes or []
                             break
                     if matched_id:
-                        from src.api_token_capabilities import authorize_api_token_route
+                        from src.api_token_capabilities import authorize_api_token_request
 
-                        route_decision = authorize_api_token_route(
+                        route_decision = authorize_api_token_request(
                             request.method,
-                            path,
+                            request.scope,
                             matched_scopes,
                         )
                         if not route_decision.allowed:

--- a/app.py
+++ b/app.py
@@ -396,10 +396,18 @@ if AUTH_ENABLED:
             # bearer token still follows its token capability boundary; local
             # requests without one keep the documented bypass behavior.
             auth_header = request.headers.get("authorization", "")
+            auth_scheme, auth_separator, auth_credentials = auth_header.partition(" ")
+            raw_api_token = (
+                auth_credentials.lstrip(" ")
+                if auth_separator and auth_scheme.casefold() == "bearer"
+                else ""
+            )
+            if not raw_api_token.startswith("ody_"):
+                raw_api_token = ""
             if (
                 LOCALHOST_BYPASS
                 and _is_trusted_loopback(request)
-                and not auth_header.startswith("Bearer ody_")
+                and not raw_api_token
             ):
                 return await call_next(request)
             if not auth_manager.is_configured:
@@ -409,8 +417,8 @@ if AUTH_ENABLED:
                 return JSONResponse(status_code=401, content={"error": "Setup required"})
 
             # --- Bearer token auth (API tokens for external integrations) ---
-            if auth_header.startswith("Bearer ody_"):
-                raw_token = auth_header[7:]
+            if raw_api_token:
+                raw_token = raw_api_token
                 # Sanity check: tokens are "ody_" + 43 chars of base64
                 if len(raw_token) < 12 or len(raw_token) > 100:
                     return JSONResponse(status_code=401, content={"error": "Invalid API token"})

--- a/app.py
+++ b/app.py
@@ -426,6 +426,19 @@ if AUTH_ENABLED:
                             matched_scopes = scopes or []
                             break
                     if matched_id:
+                        from src.api_token_capabilities import authorize_api_token_route
+
+                        route_decision = authorize_api_token_route(
+                            request.method,
+                            path,
+                            matched_scopes,
+                        )
+                        if not route_decision.allowed:
+                            return JSONResponse(
+                                status_code=403,
+                                content={"error": route_decision.error},
+                            )
+
                         # Update last_used_at off the hot path. Doing it
                         # inline used to keep the request open across an
                         # extra commit; do it fire-and-forget instead.

--- a/companion/README.md
+++ b/companion/README.md
@@ -5,14 +5,15 @@ Odysseus server offers and pair to it, without duplicating any LLM logic.
 
 | Method | Path | Auth | Purpose |
 |---|---|---|---|
-| GET | `/api/companion/ping` | session or token | cheap, auth-validated health check |
-| GET | `/api/companion/info` | session or token | server identity + capability flags |
-| GET | `/api/companion/models` | session or token | the **caller's own** model endpoints |
+| GET | `/api/companion/ping` | session or chat-scoped token | cheap, auth-validated health check |
+| GET | `/api/companion/info` | session or chat-scoped token | server identity + capability flags |
+| GET | `/api/companion/models` | session or chat-scoped token | the **caller's own** model endpoints |
 | GET | `/api/companion/pair` | **admin cookie** | pairing page (a form; never mints) |
 | POST | `/api/companion/pair` | **admin cookie** | mint a one-time pairing token (`?format=json` for an in-app screen) |
 
-`/models` scopes to the caller's real owner plus legacy null-owner shared rows
-(same rule as `owner_filter`) and never returns API-key material.
+Bearer reads use the existing chat scope. `/models` scopes to the caller's real
+owner plus legacy null-owner shared rows (same rule as `owner_filter`) and never
+returns API-key material.
 
 ## Pairing CSRF posture
 

--- a/companion/routes.py
+++ b/companion/routes.py
@@ -5,9 +5,8 @@ offers and pair to it, without duplicating any LLM logic.
 
 Auth is enforced globally by AuthMiddleware (app.py), so reaching a handler here
 means the caller is authenticated by either a cookie session or a Bearer `ody_`
-API token. Ping/info accept either credential type, models requires a chat-
-scoped API token for bearer callers, and the pairing endpoints are admin-cookie
-only.
+API token. Read endpoints accept cookie sessions or chat-scoped bearer tokens;
+the pairing endpoints remain admin-cookie only.
 
 Pairing CSRF posture: minting happens ONLY on POST. The session cookie is
 SameSite=Lax (routes/auth_routes.py), which a browser does not send on a
@@ -53,8 +52,8 @@ def owner_can_see(row_owner, owner) -> bool:
     return row_owner is None or row_owner == owner
 
 
-def require_models_scope(request: Request) -> None:
-    """Require the companion chat scope for bearer-token model inventory."""
+def require_companion_scope(request: Request) -> None:
+    """Require the existing chat scope for companion bearer reads."""
     if not getattr(request.state, "api_token", False):
         return
     scopes = getattr(request.state, "api_token_scopes", None) or []
@@ -86,6 +85,7 @@ def setup_companion_routes() -> APIRouter:
     def ping(request: Request):
         """Cheap, auth-validated health check. A 200 with ok=true confirms the
         host/port and credential are valid; middleware returns 401 otherwise."""
+        require_companion_scope(request)
         from core.constants import APP_VERSION
         return {
             "ok": True,
@@ -98,6 +98,7 @@ def setup_companion_routes() -> APIRouter:
     def info(request: Request):
         """Server identity + coarse capability flags. `owner` is the caller's own
         identity (the token's owner for bearer callers)."""
+        require_companion_scope(request)
         from core.constants import APP_VERSION
         return {
             "name": "odysseus",
@@ -116,7 +117,7 @@ def setup_companion_routes() -> APIRouter:
         rows -- the same rule as owner_filter. Read-only; never returns api_key
         material.
         """
-        require_models_scope(request)
+        require_companion_scope(request)
         import json as _json
 
         from core.database import SessionLocal, ModelEndpoint

--- a/integrations/claude/skills/odysseus/SKILL.md
+++ b/integrations/claude/skills/odysseus/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: odysseus
-description: Use when the user asks Claude Code to read or write Odysseus data (todos, email, calendar, memory, documents) or to launch/monitor/stop a Cookbook model-serve task through the scoped Claude Agent API. Requires ODYSSEUS_URL and ODYSSEUS_API_TOKEN.
+description: Use when the user asks Claude Code to read or write Odysseus data (todos, email, calendar, memory, documents) through the scoped Claude Agent API. Requires ODYSSEUS_URL and ODYSSEUS_API_TOKEN.
 ---
 
 # Odysseus
@@ -105,49 +105,6 @@ python3 ~/.claude/skills/odysseus/scripts/odysseus_api.py POST /api/codex/memory
 - Prefer `POST /api/codex/emails/draft-document` for agent-written email replies. It creates an editable Odysseus Document with `language: "email"` and does not touch IMAP/send.
 - `POST /api/codex/emails/draft` — body matches `SendEmailRequest` (`to`, `cc`, `bcc`, `subject`, `body`, `body_html`, `attachments`, `account_id`, `in_reply_to`, `references`). Requires `email:draft` (or `email:send`).
 - `POST /api/codex/emails/send` — same body. Requires `email:send`. Never send without explicit user instruction.
-
-## Cookbook serve (debug a failing model launch)
-
-The Cookbook surface lets you reproduce what a human would do in Odysseus → Cookbook: read which serves are running, tail their tmux output to see why they crashed, edit the launch command, relaunch, kill a stuck one. Use this when the user is debugging a model server that won't come up (compute-capability errors, OOM, missing kernels, wrong attention backend, etc.).
-
-- `GET /api/codex/cookbook/tasks` — list active serve/download/install tasks (sessionId, type, status, repo_id, remoteHost, payload._cmd). Requires `cookbook:read`.
-- `GET /api/codex/cookbook/servers` — list configured servers (name, host, port, env type + path, model dirs). Requires `cookbook:read`.
-- `GET /api/codex/cookbook/cached?host=<NAME>` — list models already cached on the named server (HF cache + Ollama + extra modelDirs). Call BEFORE `serve` to see what's already on disk. Requires `cookbook:read`.
-- `GET /api/codex/cookbook/presets` — list saved serve presets (model + host + port + cmd). The user's saved preset usually has a working cmd — try `preset NAME` before composing your own. Requires `cookbook:read`.
-- `GET /api/codex/cookbook/output/{session_id}?tail=400` — read the last N lines of the task's persistent log file (preferred) or tmux pane (fallback). The log file persists across vllm crashes, so this returns the actual Python traceback even after the bash prompt + neofetch banner overwrites the pane. Default tail=400. Requires `cookbook:read`.
-- `POST /api/codex/cookbook/serve` — launch a serve task. Body matches `ServeRequest`: `{ repo_id, cmd, remote_host?, ssh_port?, env_prefix?, gpus?, platform? }`. The `cmd` is validated: leading binary must be `vllm`/`python3`/`sglang`/`llama-server`/`ollama`/`node`/`npx`. NEVER prefix with `cd …`, `source …`, or chain with `&&`/`||`/`;`/`$(...)` — the validator rejects shell metacharacters. The venv activation (`env_prefix`) is added automatically from the host's saved settings, so pass the bare binary + args. Requires `cookbook:launch`.
-- `POST /api/codex/cookbook/preset/{name}` — launch a saved preset by name. Reuses the working cmd + host the user already saved. Requires `cookbook:launch`.
-- `POST /api/codex/cookbook/adopt` — register an externally-launched tmux session into cookbook tracking. Body: `{ tmux_session, model, host?, port? }`. Use this when serve_model rejected a cmd and you fell back to direct ssh+tmux — without adoption, the session is invisible to the UI. Requires `cookbook:launch`.
-- `POST /api/codex/cookbook/stop/{session_id}` — kill the tmux session for that task. Requires `cookbook:launch`.
-
-```bash
-# Survey what's running
-python3 ~/.claude/skills/odysseus/scripts/odysseus_api.py cookbook tasks
-
-# Tail the failing one (sessionId from `cookbook tasks`)
-python3 ~/.claude/skills/odysseus/scripts/odysseus_api.py cookbook output serve-abc12345 400
-
-# Stop the previous attempt before you try a new flag set
-python3 ~/.claude/skills/odysseus/scripts/odysseus_api.py cookbook stop serve-abc12345
-
-# Relaunch with new flags. cmd MUST begin with one of the allowlisted binaries.
-python3 ~/.claude/skills/odysseus/scripts/odysseus_api.py cookbook serve \
-  /mnt/HADES/models/Qwen3.5-397B-A17B-AWQ \
-  "vllm serve /mnt/HADES/models/Qwen3.5-397B-A17B-AWQ --host 0.0.0.0 --port 8001 --tensor-parallel-size 8 --max-model-len 262144 --gpu-memory-utilization 0.90 --dtype auto --max-num-seqs 8 --trust-remote-code --enable-expert-parallel --enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser qwen3" \
-  pewds@192.168.1.12
-```
-
-**Debug loop pattern:** when a serve is failing, the productive sequence is
-
-1. `cookbook tasks` → find the failing sessionId.
-2. `cookbook output SID 600` → read the last 600 lines, find the actual root-cause line (often above the visible tail because tmux scrollback rolled — request a larger `tail` if the error references "above").
-3. `cookbook stop SID` — kill the previous attempt before relaunching; two serves on the same `--port` collide.
-4. `cookbook serve repo "new cmd"` — try the next variation. Wait ~20s, then `cookbook output` on the new sessionId.
-
-**Hard limits this surface enforces:**
-- `cookbook serve` cmd allowlist + shell-metacharacter rejection — you cannot run arbitrary shell, only model-server binaries.
-- `cookbook stop` only targets task sessionIds matching `[a-zA-Z0-9_-]+`.
-- The agent CAN spawn GPU-pinning long-lived processes — always `cookbook stop` your previous attempt before relaunching, and check `cookbook tasks` for collisions on the same `--port` before launching.
 
 ## Forbidden Bypass Pattern
 

--- a/integrations/claude/skills/odysseus/scripts/odysseus_api.py
+++ b/integrations/claude/skills/odysseus/scripts/odysseus_api.py
@@ -22,15 +22,6 @@ def _usage() -> int:
     print("  odysseus_api.py documents read DOC_ID", file=sys.stderr)
     print("  odysseus_api.py documents create JSON_PAYLOAD", file=sys.stderr)
     print("  odysseus_api.py documents delete DOC_ID", file=sys.stderr)
-    print("  odysseus_api.py cookbook tasks", file=sys.stderr)
-    print("  odysseus_api.py cookbook servers", file=sys.stderr)
-    print("  odysseus_api.py cookbook cached [HOST]", file=sys.stderr)
-    print("  odysseus_api.py cookbook presets", file=sys.stderr)
-    print("  odysseus_api.py cookbook output SESSION_ID [tail]", file=sys.stderr)
-    print("  odysseus_api.py cookbook serve REPO_ID 'CMD' [REMOTE_HOST]", file=sys.stderr)
-    print("  odysseus_api.py cookbook preset NAME", file=sys.stderr)
-    print("  odysseus_api.py cookbook adopt SESSION_ID MODEL [HOST] [PORT]", file=sys.stderr)
-    print("  odysseus_api.py cookbook stop SESSION_ID", file=sys.stderr)
     print("  odysseus_api.py METHOD /api/codex/path [json-body]", file=sys.stderr)
     return 2
 
@@ -110,61 +101,6 @@ def main() -> int:
         elif action == "delete" and len(sys.argv) >= 4:
             method = "DELETE"
             path = f"/api/codex/documents/{sys.argv[3]}"
-            body = None
-        else:
-            return _usage()
-    elif command == "cookbook":
-        if len(sys.argv) < 3:
-            return _usage()
-        action = sys.argv[2].lower()
-        if action == "tasks":
-            method = "GET"
-            path = "/api/codex/cookbook/tasks"
-            body = None
-        elif action == "servers":
-            method = "GET"
-            path = "/api/codex/cookbook/servers"
-            body = None
-        elif action == "output" and len(sys.argv) >= 4:
-            method = "GET"
-            sid = sys.argv[3]
-            tail = sys.argv[4] if len(sys.argv) >= 5 else "400"
-            path = f"/api/codex/cookbook/output/{sid}?tail={tail}"
-            body = None
-        elif action == "cached":
-            method = "GET"
-            if len(sys.argv) >= 4:
-                from urllib.parse import quote
-                path = f"/api/codex/cookbook/cached?host={quote(sys.argv[3])}"
-            else:
-                path = "/api/codex/cookbook/cached"
-            body = None
-        elif action == "presets":
-            method = "GET"
-            path = "/api/codex/cookbook/presets"
-            body = None
-        elif action == "preset" and len(sys.argv) >= 4:
-            from urllib.parse import quote
-            method = "POST"
-            path = f"/api/codex/cookbook/preset/{quote(sys.argv[3])}"
-            body = None
-        elif action == "adopt" and len(sys.argv) >= 5:
-            method = "POST"
-            path = "/api/codex/cookbook/adopt"
-            payload = {"tmux_session": sys.argv[3], "model": sys.argv[4]}
-            if len(sys.argv) >= 6: payload["host"] = sys.argv[5]
-            if len(sys.argv) >= 7: payload["port"] = int(sys.argv[6])
-            body = json.dumps(payload)
-        elif action == "serve" and len(sys.argv) >= 5:
-            method = "POST"
-            path = "/api/codex/cookbook/serve"
-            payload = {"repo_id": sys.argv[3], "cmd": sys.argv[4]}
-            if len(sys.argv) >= 6:
-                payload["remote_host"] = sys.argv[5]
-            body = json.dumps(payload)
-        elif action == "stop" and len(sys.argv) >= 4:
-            method = "POST"
-            path = f"/api/codex/cookbook/stop/{sys.argv[3]}"
             body = None
         else:
             return _usage()

--- a/integrations/codex/scripts/odysseus_api.py
+++ b/integrations/codex/scripts/odysseus_api.py
@@ -22,15 +22,6 @@ def _usage() -> int:
     print("  odysseus_api.py documents read DOC_ID", file=sys.stderr)
     print("  odysseus_api.py documents create JSON_PAYLOAD", file=sys.stderr)
     print("  odysseus_api.py documents delete DOC_ID", file=sys.stderr)
-    print("  odysseus_api.py cookbook tasks", file=sys.stderr)
-    print("  odysseus_api.py cookbook servers", file=sys.stderr)
-    print("  odysseus_api.py cookbook cached [HOST]", file=sys.stderr)
-    print("  odysseus_api.py cookbook presets", file=sys.stderr)
-    print("  odysseus_api.py cookbook output SESSION_ID [tail]", file=sys.stderr)
-    print("  odysseus_api.py cookbook serve REPO_ID 'CMD' [REMOTE_HOST]", file=sys.stderr)
-    print("  odysseus_api.py cookbook preset NAME", file=sys.stderr)
-    print("  odysseus_api.py cookbook adopt SESSION_ID MODEL [HOST] [PORT]", file=sys.stderr)
-    print("  odysseus_api.py cookbook stop SESSION_ID", file=sys.stderr)
     print("  odysseus_api.py METHOD /api/codex/path [json-body]", file=sys.stderr)
     return 2
 
@@ -110,61 +101,6 @@ def main() -> int:
         elif action == "delete" and len(sys.argv) >= 4:
             method = "DELETE"
             path = f"/api/codex/documents/{sys.argv[3]}"
-            body = None
-        else:
-            return _usage()
-    elif command == "cookbook":
-        if len(sys.argv) < 3:
-            return _usage()
-        action = sys.argv[2].lower()
-        if action == "tasks":
-            method = "GET"
-            path = "/api/codex/cookbook/tasks"
-            body = None
-        elif action == "servers":
-            method = "GET"
-            path = "/api/codex/cookbook/servers"
-            body = None
-        elif action == "output" and len(sys.argv) >= 4:
-            method = "GET"
-            sid = sys.argv[3]
-            tail = sys.argv[4] if len(sys.argv) >= 5 else "400"
-            path = f"/api/codex/cookbook/output/{sid}?tail={tail}"
-            body = None
-        elif action == "cached":
-            method = "GET"
-            if len(sys.argv) >= 4:
-                from urllib.parse import quote
-                path = f"/api/codex/cookbook/cached?host={quote(sys.argv[3])}"
-            else:
-                path = "/api/codex/cookbook/cached"
-            body = None
-        elif action == "presets":
-            method = "GET"
-            path = "/api/codex/cookbook/presets"
-            body = None
-        elif action == "preset" and len(sys.argv) >= 4:
-            from urllib.parse import quote
-            method = "POST"
-            path = f"/api/codex/cookbook/preset/{quote(sys.argv[3])}"
-            body = None
-        elif action == "adopt" and len(sys.argv) >= 5:
-            method = "POST"
-            path = "/api/codex/cookbook/adopt"
-            payload = {"tmux_session": sys.argv[3], "model": sys.argv[4]}
-            if len(sys.argv) >= 6: payload["host"] = sys.argv[5]
-            if len(sys.argv) >= 7: payload["port"] = int(sys.argv[6])
-            body = json.dumps(payload)
-        elif action == "serve" and len(sys.argv) >= 5:
-            method = "POST"
-            path = "/api/codex/cookbook/serve"
-            payload = {"repo_id": sys.argv[3], "cmd": sys.argv[4]}
-            if len(sys.argv) >= 6:
-                payload["remote_host"] = sys.argv[5]
-            body = json.dumps(payload)
-        elif action == "stop" and len(sys.argv) >= 4:
-            method = "POST"
-            path = f"/api/codex/cookbook/stop/{sys.argv[3]}"
             body = None
         else:
             return _usage()

--- a/integrations/codex/skills/odysseus/SKILL.md
+++ b/integrations/codex/skills/odysseus/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: odysseus
-description: Use when the user asks Codex to read or write Odysseus data (todos, email, calendar, memory, documents) or to launch/monitor/stop a Cookbook model-serve task through the scoped Codex Agent API. Requires ODYSSEUS_URL and ODYSSEUS_API_TOKEN.
+description: Use when the user asks Codex to read or write Odysseus data (todos, email, calendar, memory, documents) through the scoped Codex Agent API. Requires ODYSSEUS_URL and ODYSSEUS_API_TOKEN.
 ---
 
 # Odysseus
@@ -105,37 +105,6 @@ python3 integrations/codex/scripts/odysseus_api.py POST /api/codex/memory '{"tex
 - Prefer `POST /api/codex/emails/draft-document` for Codex-written email replies. It creates an editable Odysseus Document with `language: "email"` and does not touch IMAP/send.
 - `POST /api/codex/emails/draft` — body matches `SendEmailRequest` (`to`, `cc`, `bcc`, `subject`, `body`, `body_html`, `attachments`, `account_id`, `in_reply_to`, `references`). Requires `email:draft` (or `email:send`).
 - `POST /api/codex/emails/send` — same body. Requires `email:send`. Never send without explicit user instruction.
-
-## Cookbook serve (debug a failing model launch)
-
-The Cookbook surface lets you reproduce what a human would do in Odysseus → Cookbook: read which serves are running, tail their tmux output to see why they crashed, edit the launch command, relaunch, kill a stuck one. Use this when the user is debugging a model server that won't come up (compute-capability errors, OOM, missing kernels, wrong attention backend, etc.).
-
-- `GET /api/codex/cookbook/tasks` — list active serve/download/install tasks (sessionId, type, status, repo_id, remoteHost, payload._cmd). Requires `cookbook:read`.
-- `GET /api/codex/cookbook/servers` — list configured servers (name, host, port, env type + path, model dirs). Requires `cookbook:read`.
-- `GET /api/codex/cookbook/cached?host=<NAME>` — list models already cached on the named server (HF cache + Ollama + extra modelDirs). Call BEFORE `serve` to see what's already on disk. Requires `cookbook:read`.
-- `GET /api/codex/cookbook/presets` — list saved serve presets (model + host + port + cmd). The user's saved preset usually has a working cmd — try `preset NAME` before composing your own. Requires `cookbook:read`.
-- `GET /api/codex/cookbook/output/{session_id}?tail=400` — read the last N lines of the task's persistent log file (preferred) or tmux pane (fallback). The log file persists across vllm crashes, so this returns the actual Python traceback even after the bash prompt + neofetch banner overwrites the pane. Default tail=400. Requires `cookbook:read`.
-- `POST /api/codex/cookbook/serve` — launch a serve task. Body matches `ServeRequest`: `{ repo_id, cmd, remote_host?, ssh_port?, env_prefix?, gpus?, platform? }`. The `cmd` is validated: leading binary must be `vllm`/`python3`/`sglang`/`llama-server`/`ollama`/`node`/`npx`. NEVER prefix with `cd …`, `source …`, or chain with `&&`/`||`/`;`/`$(...)` — the validator rejects shell metacharacters. The venv activation (`env_prefix`) is added automatically from the host's saved settings, so pass the bare binary + args. Requires `cookbook:launch`.
-- `POST /api/codex/cookbook/preset/{name}` — launch a saved preset by name. Reuses the working cmd + host the user already saved. Requires `cookbook:launch`.
-- `POST /api/codex/cookbook/adopt` — register an externally-launched tmux session into cookbook tracking. Body: `{ tmux_session, model, host?, port? }`. Use this when serve_model rejected a cmd and you fell back to direct ssh+tmux — without adoption, the session is invisible to the UI. Requires `cookbook:launch`.
-- `POST /api/codex/cookbook/stop/{session_id}` — kill the tmux session. Requires `cookbook:launch`.
-
-```bash
-python3 ~/plugins/odysseus/scripts/odysseus_api.py cookbook tasks
-python3 ~/plugins/odysseus/scripts/odysseus_api.py cookbook output serve-abc12345 400
-python3 ~/plugins/odysseus/scripts/odysseus_api.py cookbook stop serve-abc12345
-python3 ~/plugins/odysseus/scripts/odysseus_api.py cookbook serve \
-  /mnt/HADES/models/Qwen3.5-397B-A17B-AWQ \
-  "vllm serve /mnt/HADES/models/Qwen3.5-397B-A17B-AWQ --host 0.0.0.0 --port 8001 --tensor-parallel-size 8 --max-model-len 262144 --gpu-memory-utilization 0.90 --dtype auto --max-num-seqs 8 --trust-remote-code --enable-expert-parallel --enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser qwen3" \
-  pewds@192.168.1.12
-```
-
-**Debug loop pattern:** `tasks` → `output SID 600` (find root cause; request larger `tail` if it references "above") → `stop SID` → `serve repo "new cmd"` → wait ~20s → `output` on the new sessionId.
-
-**Hard limits this surface enforces:**
-- `cookbook serve` cmd allowlist + shell-metacharacter rejection.
-- `cookbook stop` requires sessionIds matching `[a-zA-Z0-9_-]+`.
-- Agent CAN spawn GPU-pinning long-lived processes — always `cookbook stop` your previous attempt before relaunching.
 
 ## Forbidden Bypass Pattern
 

--- a/routes/api_token_routes.py
+++ b/routes/api_token_routes.py
@@ -54,7 +54,6 @@ def _normalize_scopes(scopes: str | list[str] | None = None, profile: str | None
     ensure_before("calendar:write", "calendar:read")
     ensure_before("memory:write", "memory:read")
     ensure_before("email:draft", "email:read")
-    ensure_before("cookbook:launch", "cookbook:read")
 
     return normalized or [DEFAULT_SCOPES]
 

--- a/routes/api_token_routes.py
+++ b/routes/api_token_routes.py
@@ -8,26 +8,12 @@ from fastapi import APIRouter, HTTPException, Request, Form
 
 from core.database import get_db_session, ApiToken
 from core.middleware import require_admin
+from src.api_token_capabilities import ALL_API_TOKEN_SCOPES
 from src.auth_helpers import get_current_user
 
 MAX_NAME_LEN = 100
 DEFAULT_SCOPES = "chat"
-ALLOWED_SCOPES = {
-    "chat",
-    "todos:read",
-    "todos:write",
-    "documents:read",
-    "documents:write",
-    "email:read",
-    "email:draft",
-    "email:send",
-    "calendar:read",
-    "calendar:write",
-    "memory:read",
-    "memory:write",
-    "cookbook:read",
-    "cookbook:launch",
-}
+ALLOWED_SCOPES = ALL_API_TOKEN_SCOPES
 TOKEN_PROFILES = {
     "chat": ["chat"],
     "codex_todos": ["todos:read", "todos:write"],

--- a/routes/api_token_routes.py
+++ b/routes/api_token_routes.py
@@ -14,6 +14,7 @@ from src.auth_helpers import get_current_user
 MAX_NAME_LEN = 100
 DEFAULT_SCOPES = "chat"
 ALLOWED_SCOPES = ALL_API_TOKEN_SCOPES
+RETIRED_API_TOKEN_SCOPES = frozenset({"cookbook:read", "cookbook:launch"})
 TOKEN_PROFILES = {
     "chat": ["chat"],
     "codex_todos": ["todos:read", "todos:write"],
@@ -22,7 +23,13 @@ TOKEN_PROFILES = {
 }
 
 
-def _normalize_scopes(scopes: str | list[str] | None = None, profile: str | None = None) -> list[str]:
+def _normalize_scopes(
+    scopes: str | list[str] | None = None,
+    profile: str | None = None,
+    *,
+    drop_retired: bool = False,
+    require_active: bool = False,
+) -> list[str]:
     profile = profile if isinstance(profile, str) else None
     profile_key = (profile or "").strip()
     if profile_key:
@@ -34,10 +41,12 @@ def _normalize_scopes(scopes: str | list[str] | None = None, profile: str | None
     elif isinstance(scopes, str) and scopes:
         requested = [s.strip() for s in scopes.replace(" ", ",").split(",") if s.strip()]
     else:
-        requested = [DEFAULT_SCOPES]
+        requested = [] if require_active else [DEFAULT_SCOPES]
 
     normalized = []
     for scope in requested:
+        if drop_retired and scope in RETIRED_API_TOKEN_SCOPES:
+            continue
         if scope not in ALLOWED_SCOPES:
             raise HTTPException(400, f"Unknown token scope: {scope}")
         if scope not in normalized:
@@ -55,7 +64,26 @@ def _normalize_scopes(scopes: str | list[str] | None = None, profile: str | None
     ensure_before("memory:write", "memory:read")
     ensure_before("email:draft", "email:read")
 
-    return normalized or [DEFAULT_SCOPES]
+    if normalized:
+        return normalized
+    if require_active:
+        raise HTTPException(400, "At least one active token scope is required")
+    return [DEFAULT_SCOPES]
+
+
+def _display_scopes(stored_scopes: str | None) -> tuple[list[str], list[str]]:
+    values = [
+        scope.strip()
+        for scope in (stored_scopes or DEFAULT_SCOPES).split(",")
+        if scope.strip()
+    ]
+    active: list[str] = []
+    retired: list[str] = []
+    for scope in values:
+        target = retired if scope in RETIRED_API_TOKEN_SCOPES else active
+        if scope not in target:
+            target.append(scope)
+    return active, retired
 
 
 def setup_api_token_routes() -> APIRouter:
@@ -66,19 +94,21 @@ def setup_api_token_routes() -> APIRouter:
         require_admin(request)
         with get_db_session() as db:
             tokens = db.query(ApiToken).all()
-            return [
-                {
-                    "id": t.id,
-                    "name": t.name,
-                    "owner": getattr(t, "owner", None),
-                    "token_prefix": t.token_prefix,
-                    "scopes": [s.strip() for s in (getattr(t, "scopes", "") or DEFAULT_SCOPES).split(",") if s.strip()],
-                    "is_active": t.is_active,
-                    "last_used_at": t.last_used_at.isoformat() if t.last_used_at else None,
-                    "created_at": t.created_at.isoformat() if t.created_at else None,
-                }
-                for t in tokens
-            ]
+            result = []
+            for token in tokens:
+                active_scopes, retired_scopes = _display_scopes(getattr(token, "scopes", ""))
+                result.append({
+                    "id": token.id,
+                    "name": token.name,
+                    "owner": getattr(token, "owner", None),
+                    "token_prefix": token.token_prefix,
+                    "scopes": active_scopes,
+                    "retired_scopes": retired_scopes,
+                    "is_active": token.is_active,
+                    "last_used_at": token.last_used_at.isoformat() if token.last_used_at else None,
+                    "created_at": token.created_at.isoformat() if token.created_at else None,
+                })
+            return result
 
     def _invalidate_cache(request: Request):
         """Tell the auth middleware its cached token map is stale."""
@@ -160,19 +190,20 @@ def setup_api_token_routes() -> APIRouter:
             # not silently reset the token to the default scope — that dropped
             # every previously granted scope.
             if "scopes" in payload:
-                token.scopes = ",".join(_normalize_scopes(payload.get("scopes")))
+                token.scopes = ",".join(_normalize_scopes(
+                    payload.get("scopes"),
+                    drop_retired=True,
+                    require_active=True,
+                ))
             db.add(token)
-            current_scopes = [
-                s.strip()
-                for s in (getattr(token, "scopes", "") or DEFAULT_SCOPES).split(",")
-                if s.strip()
-            ]
+            current_scopes, retired_scopes = _display_scopes(getattr(token, "scopes", ""))
             response = {
                 "id": token_id,
                 "name": getattr(token, "name", ""),
                 "owner": getattr(token, "owner", None),
                 "token_prefix": getattr(token, "token_prefix", ""),
                 "scopes": current_scopes,
+                "retired_scopes": retired_scopes,
             }
         _invalidate_cache(request)
         return response

--- a/routes/codex_routes.py
+++ b/routes/codex_routes.py
@@ -17,10 +17,10 @@ from fastapi.responses import StreamingResponse
 
 from core.middleware import require_admin
 from src.api_token_capabilities import (
+    ALL_API_TOKEN_SCOPES,
+    API_TOKEN_FORBIDDEN_ERROR,
     CALENDAR_READ_SCOPES,
     CALENDAR_WRITE_SCOPES,
-    COOKBOOK_LAUNCH_SCOPES,
-    COOKBOOK_READ_SCOPES,
     DOCS_READ_SCOPES,
     DOCS_WRITE_SCOPES,
     EMAIL_DRAFT_SCOPES,
@@ -112,17 +112,12 @@ def _scope_owner_all(request: Request, required: set[str]) -> str:
     return require_user(request)
 
 
-def _require_cookbook_scope(request: Request, allowed: set[str]) -> str:
-    """Authorize a Codex cookbook route.
-
-    For API-token callers, enforce the given scope set.
-    For cookie-session callers, additionally require admin privileges
-    because cookbook surfaces expose host topology, task logs, tmux
-    commands, and model-serving controls.
-    """
-    owner = _scope_owner(request, allowed)
-    if not getattr(request.state, "api_token", False):
-        require_admin(request)
+def _require_cookbook_admin(request: Request) -> str:
+    """Keep Cookbook controls on the intentional cookie/admin path only."""
+    if getattr(request.state, "api_token", False):
+        raise HTTPException(403, API_TOKEN_FORBIDDEN_ERROR)
+    owner = require_user(request)
+    require_admin(request)
     return owner
 
 
@@ -168,7 +163,7 @@ def setup_codex_routes(
 
     @router.get("/capabilities")
     def capabilities(request: Request):
-        token_scopes = set(getattr(request.state, "api_token_scopes", []) or [])
+        token_scopes = set(getattr(request.state, "api_token_scopes", []) or []).intersection(ALL_API_TOKEN_SCOPES)
         has_token = bool(getattr(request.state, "api_token", False))
         def scoped(allowed):
             return bool(token_scopes.intersection(allowed)) if has_token else True
@@ -204,11 +199,6 @@ def setup_codex_routes(
                     "write": scoped(DOCS_WRITE_SCOPES),
                     "actions": ["library", "read", "create", "delete"],
                     "available": documents_library_endpoint is not None,
-                },
-                "cookbook": {
-                    "read": scoped(COOKBOOK_READ_SCOPES),
-                    "launch": scoped(COOKBOOK_LAUNCH_SCOPES),
-                    "actions": ["tasks", "servers", "output", "serve", "stop"],
                 },
             },
             "safety": {
@@ -515,15 +505,8 @@ def setup_codex_routes(
         return await _as_owner(request, owner, documents_create_endpoint, request, req)
 
     # ── Cookbook surface ──
-    # Lets the agent run the same launch / monitor / kill loop the user
-    # would do by hand in the Cookbook UI: read the current task list +
-    # tmux output, launch a serve task, stop one.  Two scopes:
-    #   cookbook:read   — list tasks + tail output + list servers
-    #   cookbook:launch — also start/stop serves (host shell exec)
-    # `cookbook:launch` is genuinely powerful: /api/model/serve runs SSH'd
-    # commands on the user's hosts. The existing _validate_serve_cmd
-    # allowlist (vllm/python3/sglang/llama-server/etc., no shell metachars)
-    # keeps the agent inside the same sandbox the UI uses.
+    # Cookbook remains available to cookie-session admins for UI compatibility,
+    # but it is not part of the API-token capability surface.
 
     async def _run_shell(cmd: str, timeout: float = 15.0) -> dict:
         """Run a shell command, return {exit_code, stdout, stderr}."""
@@ -569,14 +552,14 @@ def setup_codex_routes(
 
     @router.get("/cookbook/tasks")
     async def codex_cookbook_tasks(request: Request):
-        _require_cookbook_scope(request, COOKBOOK_READ_SCOPES)
+        _require_cookbook_admin(request)
         state = _read_cookbook_state()
         tasks = state.get("tasks") or []
         return {"tasks": [_redact_task(t) for t in tasks]}
 
     @router.get("/cookbook/servers")
     async def codex_cookbook_servers(request: Request):
-        _require_cookbook_scope(request, COOKBOOK_READ_SCOPES)
+        _require_cookbook_admin(request)
         state = _read_cookbook_state()
         servers = state.get("env", {}).get("servers") or []
         # Strip ssh creds / passwords; keep only what's needed to pick a host.
@@ -595,7 +578,7 @@ def setup_codex_routes(
 
     @router.get("/cookbook/output/{session_id}")
     async def codex_cookbook_output(request: Request, session_id: str, tail: int = 400):
-        _require_cookbook_scope(request, COOKBOOK_READ_SCOPES)
+        _require_cookbook_admin(request)
         # Defensive: session_id must be the tmux-style id we issue
         # (`serve-XXXX` / `cookbook-XXXX` / `queue-XXXX`); anything else
         # would let the agent run arbitrary `tmux capture-pane` targets.
@@ -637,7 +620,7 @@ def setup_codex_routes(
 
     @router.post("/cookbook/serve")
     async def codex_cookbook_serve(request: Request, body: dict[str, Any] = Body(default_factory=dict)):
-        _require_cookbook_scope(request, COOKBOOK_LAUNCH_SCOPES)
+        _require_cookbook_admin(request)
         # Wraps /api/model/serve with the SAME validation the UI uses.
         # _validate_serve_cmd (called inside model_serve) rejects shell
         # metachars and requires the leading binary to be in the
@@ -676,7 +659,7 @@ def setup_codex_routes(
 
     @router.post("/cookbook/stop/{session_id}")
     async def codex_cookbook_stop(request: Request, session_id: str):
-        _require_cookbook_scope(request, COOKBOOK_LAUNCH_SCOPES)
+        _require_cookbook_admin(request)
         import re as _re
         if not _re.fullmatch(r"[a-zA-Z0-9_-]+", session_id):
             raise HTTPException(400, "Invalid session id")
@@ -696,7 +679,7 @@ def setup_codex_routes(
         """List cached models on a configured server (or local if host is omitted).
         Mirrors `list_cached_models` from the chat agent so external agents have
         the same inventory view before deciding what to serve/download."""
-        _require_cookbook_scope(request, COOKBOOK_READ_SCOPES)
+        _require_cookbook_admin(request)
         # Hit /api/model/cached internally, with the same modelDirs the chat
         # agent's list_cached_models would resolve from cookbook state.
         state = _read_cookbook_state()
@@ -758,7 +741,7 @@ def setup_codex_routes(
         """List saved serve presets (model + host + port + launch cmd).
         Counterpart to `list_serve_presets`. Use BEFORE composing a `serve`
         body — the user's saved preset usually has the working cmd already."""
-        _require_cookbook_scope(request, COOKBOOK_READ_SCOPES)
+        _require_cookbook_admin(request)
         state = _read_cookbook_state()
         presets = state.get("presets") or []
         out = []
@@ -778,7 +761,7 @@ def setup_codex_routes(
     async def codex_cookbook_serve_preset(request: Request, name: str):
         """Launch a saved preset by name. Reuses the working cmd + host the
         user already saved, avoiding the cmd-allowlist trial-and-error loop."""
-        _require_cookbook_scope(request, COOKBOOK_LAUNCH_SCOPES)
+        _require_cookbook_admin(request)
         import re as _re
         if not _re.fullmatch(r"[A-Za-z0-9 _.:@\-]+", name):
             raise HTTPException(400, "Invalid preset name")
@@ -830,7 +813,7 @@ def setup_codex_routes(
         cookbook tracking. Needed when serve_model rejects a cmd and the
         agent falls back to direct ssh — without adoption the session is
         invisible to the UI. Body: {tmux_session, model, host?, port?}."""
-        _require_cookbook_scope(request, COOKBOOK_LAUNCH_SCOPES)
+        _require_cookbook_admin(request)
         norm = dict(body or {})
         sess = (norm.get("tmux_session") or norm.get("session_id") or "").strip()
         model = (norm.get("model") or norm.get("repo_id") or "").strip()

--- a/routes/codex_routes.py
+++ b/routes/codex_routes.py
@@ -16,25 +16,27 @@ from fastapi import APIRouter, BackgroundTasks, Body, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
 from core.middleware import require_admin
+from src.api_token_capabilities import (
+    CALENDAR_READ_SCOPES,
+    CALENDAR_WRITE_SCOPES,
+    COOKBOOK_LAUNCH_SCOPES,
+    COOKBOOK_READ_SCOPES,
+    DOCS_READ_SCOPES,
+    DOCS_WRITE_SCOPES,
+    EMAIL_DRAFT_SCOPES,
+    EMAIL_READ_SCOPES,
+    EMAIL_SEND_SCOPES,
+    MEMORY_READ_SCOPES,
+    MEMORY_WRITE_SCOPES,
+    TODO_READ_SCOPES,
+    TODO_WRITE_SCOPES,
+)
 from src.auth_helpers import require_authenticated_request, require_user
 from src.tool_implementations import do_manage_notes
 from src.constants import COOKBOOK_STATE_FILE
 from routes._validators import validate_remote_host, validate_ssh_port
 
 
-COOKBOOK_READ_SCOPES = {"cookbook:read", "cookbook:launch"}
-COOKBOOK_LAUNCH_SCOPES = {"cookbook:launch"}
-TODO_READ_SCOPES = {"todos:read", "todos:write"}
-TODO_WRITE_SCOPES = {"todos:write"}
-EMAIL_READ_SCOPES = {"email:read", "email:draft", "email:send"}
-EMAIL_DRAFT_SCOPES = {"email:draft", "email:send"}
-EMAIL_SEND_SCOPES = {"email:send"}
-MEMORY_READ_SCOPES = {"memory:read", "memory:write"}
-MEMORY_WRITE_SCOPES = {"memory:write"}
-CALENDAR_READ_SCOPES = {"calendar:read", "calendar:write"}
-CALENDAR_WRITE_SCOPES = {"calendar:write"}
-DOCS_READ_SCOPES = {"documents:read", "documents:write"}
-DOCS_WRITE_SCOPES = {"documents:write"}
 WRITE_ACTIONS = {"add", "create", "new", "save", "remind", "update", "delete", "toggle_item", "remove", "remove_item"}
 
 

--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -1614,8 +1614,10 @@ def setup_model_routes(model_discovery):
         legacy/shared null-owner rows). Cached per-user for 30s."""
         # Require auth; "" is the unconfigured single-user mode, treated as
         # "see everything" by _fetch_models.
+        is_api_token = False
         try:
-            if getattr(request.state, "api_token", False):
+            is_api_token = bool(getattr(request.state, "api_token", False))
+            if is_api_token:
                 scopes = set(getattr(request.state, "api_token_scopes", []) or [])
                 if "chat" not in scopes:
                     raise HTTPException(403, "API token is not scoped for chat")
@@ -1633,15 +1635,17 @@ def setup_model_routes(model_discovery):
         except Exception as e:
             logger.error("Auth gate error in GET /api/models, failing closed: %s", e)
             raise HTTPException(status_code=500, detail="Internal error")
-        # Admins see every endpoint (they manage the global pool); regular
-        # users get the owner-scoped view.
+        # Browser admins see every endpoint because they manage the global
+        # pool. Bearer tokens are integrations, not browser-admin sessions:
+        # even an admin-owned token stays limited to owner + shared endpoints.
         _is_admin = False
-        try:
-            auth_mgr = getattr(request.app.state, "auth_manager", None)
-            if owner and auth_mgr is not None and getattr(auth_mgr, "is_admin", None):
-                _is_admin = bool(auth_mgr.is_admin(owner))
-        except Exception:
-            _is_admin = False
+        if not is_api_token:
+            try:
+                auth_mgr = getattr(request.app.state, "auth_manager", None)
+                if owner and auth_mgr is not None and getattr(auth_mgr, "is_admin", None):
+                    _is_admin = bool(auth_mgr.is_admin(owner))
+            except Exception:
+                _is_admin = False
         now = _time.time()
         # Cache key includes the admin flag so a demotion / promotion doesn't
         # serve the wrong scoped view from cache.
@@ -1654,7 +1658,7 @@ def setup_model_routes(model_discovery):
         # Kick off background refresh to update caches from live endpoints.
         # Page boot can opt out with background=false so opening Odysseus does
         # not start endpoint probes against slow/offline model servers.
-        if background or refresh:
+        if not is_api_token and (background or refresh):
             _refresh_caches_bg(force=refresh)
         return result
 

--- a/src/api_token_capabilities.py
+++ b/src/api_token_capabilities.py
@@ -1,0 +1,209 @@
+"""Default-deny route capabilities for ``ody_`` API tokens."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class ApiTokenRouteCapability:
+    methods: frozenset[str]
+    path: str
+    scopes: frozenset[str] = field(default_factory=frozenset)
+
+    def matches(self, method: str, path: str) -> bool:
+        return (
+            method.upper() in self.methods
+            and _path_template_matches(self.path, path)
+        )
+
+
+@dataclass(frozen=True)
+class ApiTokenRouteDecision:
+    allowed: bool
+    error: str | None = None
+    required_scopes: tuple[str, ...] = ()
+
+
+def _methods(*methods: str) -> frozenset[str]:
+    return frozenset(m.upper() for m in methods)
+
+
+def _scopes(*scopes: str) -> frozenset[str]:
+    return frozenset(scopes)
+
+
+def _path_template_matches(template: str, path: str) -> bool:
+    template_parts = template.strip("/").split("/")
+    path_parts = path.strip("/").split("/")
+    if len(template_parts) != len(path_parts):
+        return False
+    for expected, actual in zip(template_parts, path_parts):
+        if expected.startswith("{") and expected.endswith("}"):
+            if not actual:
+                return False
+            continue
+        if expected != actual:
+            return False
+    return True
+
+
+TODO_READ = _scopes("todos:read", "todos:write")
+TODO_WRITE = _scopes("todos:write")
+EMAIL_READ = _scopes("email:read", "email:draft", "email:send")
+EMAIL_DRAFT = _scopes("email:draft", "email:send")
+EMAIL_SEND = _scopes("email:send")
+MEMORY_READ = _scopes("memory:read", "memory:write")
+MEMORY_WRITE = _scopes("memory:write")
+CALENDAR_READ = _scopes("calendar:read", "calendar:write")
+CALENDAR_WRITE = _scopes("calendar:write")
+DOCUMENTS_READ = _scopes("documents:read", "documents:write")
+DOCUMENTS_WRITE = _scopes("documents:write")
+COOKBOOK_READ = _scopes("cookbook:read", "cookbook:launch")
+COOKBOOK_LAUNCH = _scopes("cookbook:launch")
+
+
+API_TOKEN_ROUTE_CAPABILITIES: tuple[ApiTokenRouteCapability, ...] = (
+    ApiTokenRouteCapability(_methods("POST"), "/api/v1/chat", _scopes("chat")),
+    ApiTokenRouteCapability(_methods("GET"), "/api/companion/ping"),
+    ApiTokenRouteCapability(_methods("GET"), "/api/companion/info"),
+    ApiTokenRouteCapability(_methods("GET"), "/api/companion/models"),
+    ApiTokenRouteCapability(_methods("GET"), "/api/codex/capabilities"),
+    ApiTokenRouteCapability(_methods("GET"), "/api/codex/plugin.zip"),
+    ApiTokenRouteCapability(_methods("GET"), "/api/claude/plugin.zip"),
+    ApiTokenRouteCapability(_methods("GET"), "/api/codex/todos", TODO_READ),
+    ApiTokenRouteCapability(
+        _methods("POST"),
+        "/api/codex/todos",
+        TODO_READ | TODO_WRITE,
+    ),
+    ApiTokenRouteCapability(_methods("GET"), "/api/codex/emails", EMAIL_READ),
+    ApiTokenRouteCapability(_methods("GET"), "/api/codex/emails/{uid}", EMAIL_READ),
+    ApiTokenRouteCapability(_methods("POST"), "/api/codex/emails/draft", EMAIL_DRAFT),
+    ApiTokenRouteCapability(_methods("POST"), "/api/codex/emails/send", EMAIL_SEND),
+    ApiTokenRouteCapability(_methods("GET"), "/api/codex/memory", MEMORY_READ),
+    ApiTokenRouteCapability(_methods("POST"), "/api/codex/memory", MEMORY_WRITE),
+    ApiTokenRouteCapability(
+        _methods("DELETE"),
+        "/api/codex/memory/{memory_id}",
+        MEMORY_WRITE,
+    ),
+    ApiTokenRouteCapability(
+        _methods("GET"),
+        "/api/codex/calendar/events",
+        CALENDAR_READ,
+    ),
+    ApiTokenRouteCapability(
+        _methods("POST"),
+        "/api/codex/calendar/events",
+        CALENDAR_WRITE,
+    ),
+    ApiTokenRouteCapability(
+        _methods("DELETE"),
+        "/api/codex/calendar/events/{uid}",
+        CALENDAR_WRITE,
+    ),
+    ApiTokenRouteCapability(_methods("GET"), "/api/codex/documents", DOCUMENTS_READ),
+    ApiTokenRouteCapability(
+        _methods("GET"),
+        "/api/codex/documents/{doc_id}",
+        DOCUMENTS_READ,
+    ),
+    ApiTokenRouteCapability(
+        _methods("POST"),
+        "/api/codex/documents",
+        DOCUMENTS_WRITE,
+    ),
+    ApiTokenRouteCapability(
+        _methods("DELETE"),
+        "/api/codex/documents/{doc_id}",
+        DOCUMENTS_WRITE,
+    ),
+    ApiTokenRouteCapability(
+        _methods("GET"),
+        "/api/codex/cookbook/tasks",
+        COOKBOOK_READ,
+    ),
+    ApiTokenRouteCapability(
+        _methods("GET"),
+        "/api/codex/cookbook/servers",
+        COOKBOOK_READ,
+    ),
+    ApiTokenRouteCapability(
+        _methods("GET"),
+        "/api/codex/cookbook/output/{session_id}",
+        COOKBOOK_READ,
+    ),
+    ApiTokenRouteCapability(
+        _methods("GET"),
+        "/api/codex/cookbook/cached",
+        COOKBOOK_READ,
+    ),
+    ApiTokenRouteCapability(
+        _methods("GET"),
+        "/api/codex/cookbook/presets",
+        COOKBOOK_READ,
+    ),
+    ApiTokenRouteCapability(
+        _methods("POST"),
+        "/api/codex/cookbook/serve",
+        COOKBOOK_LAUNCH,
+    ),
+    ApiTokenRouteCapability(
+        _methods("POST"),
+        "/api/codex/cookbook/stop/{session_id}",
+        COOKBOOK_LAUNCH,
+    ),
+    ApiTokenRouteCapability(
+        _methods("POST"),
+        "/api/codex/cookbook/preset/{name}",
+        COOKBOOK_LAUNCH,
+    ),
+    ApiTokenRouteCapability(
+        _methods("POST"),
+        "/api/codex/cookbook/adopt",
+        COOKBOOK_LAUNCH,
+    ),
+)
+
+
+def find_api_token_route_capability(
+    method: str,
+    path: str,
+) -> ApiTokenRouteCapability | None:
+    for capability in API_TOKEN_ROUTE_CAPABILITIES:
+        if capability.matches(method, path):
+            return capability
+    return None
+
+
+def authorize_api_token_route(
+    method: str,
+    path: str,
+    token_scopes: Iterable[str] | None,
+) -> ApiTokenRouteDecision:
+    capability = find_api_token_route_capability(method, path)
+    if capability is None:
+        return ApiTokenRouteDecision(
+            allowed=False,
+            error="API token is not allowed for this endpoint",
+        )
+
+    if not capability.scopes:
+        return ApiTokenRouteDecision(allowed=True)
+
+    scopes = {
+        str(scope).strip()
+        for scope in (token_scopes or [])
+        if str(scope).strip()
+    }
+    if scopes.intersection(capability.scopes):
+        return ApiTokenRouteDecision(allowed=True)
+
+    required = tuple(sorted(capability.scopes))
+    return ApiTokenRouteDecision(
+        allowed=False,
+        error=f"API token missing required scope: {' or '.join(required)}",
+        required_scopes=required,
+    )

--- a/src/api_token_capabilities.py
+++ b/src/api_token_capabilities.py
@@ -26,8 +26,6 @@ CALENDAR_READ_SCOPES = frozenset({"calendar:read", "calendar:write"})
 CALENDAR_WRITE_SCOPES = frozenset({"calendar:write"})
 DOCS_READ_SCOPES = frozenset({"documents:read", "documents:write"})
 DOCS_WRITE_SCOPES = frozenset({"documents:write"})
-COOKBOOK_READ_SCOPES = frozenset({"cookbook:read", "cookbook:launch"})
-COOKBOOK_LAUNCH_SCOPES = frozenset({"cookbook:launch"})
 
 ALL_API_TOKEN_SCOPES = frozenset().union(
     CHAT_SCOPES,

--- a/src/api_token_capabilities.py
+++ b/src/api_token_capabilities.py
@@ -1,42 +1,124 @@
-"""Default-deny route capabilities for ``ody_`` API tokens."""
+"""Default-deny route capabilities for ``ody_`` API tokens.
+
+The auth middleware consults this manifest only after it has validated a bearer
+token. Browser sessions, internal-tool requests, auth exemptions, preflight
+requests, and auth-disabled deployments stay on their existing auth paths.
+"""
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Iterable
+from dataclasses import dataclass
+from itertools import product
+from typing import Iterable, Mapping, Sequence
+
+
+API_TOKEN_FORBIDDEN_ERROR = "API token is not authorized for this endpoint"
+
+CHAT_SCOPES = frozenset({"chat"})
+TODO_READ_SCOPES = frozenset({"todos:read", "todos:write"})
+TODO_WRITE_SCOPES = frozenset({"todos:write"})
+EMAIL_READ_SCOPES = frozenset({"email:read", "email:draft", "email:send"})
+EMAIL_DRAFT_SCOPES = frozenset({"email:draft", "email:send"})
+EMAIL_SEND_SCOPES = frozenset({"email:send"})
+MEMORY_READ_SCOPES = frozenset({"memory:read", "memory:write"})
+MEMORY_WRITE_SCOPES = frozenset({"memory:write"})
+CALENDAR_READ_SCOPES = frozenset({"calendar:read", "calendar:write"})
+CALENDAR_WRITE_SCOPES = frozenset({"calendar:write"})
+DOCS_READ_SCOPES = frozenset({"documents:read", "documents:write"})
+DOCS_WRITE_SCOPES = frozenset({"documents:write"})
+COOKBOOK_READ_SCOPES = frozenset({"cookbook:read", "cookbook:launch"})
+COOKBOOK_LAUNCH_SCOPES = frozenset({"cookbook:launch"})
+
+ALL_API_TOKEN_SCOPES = frozenset().union(
+    CHAT_SCOPES,
+    TODO_READ_SCOPES,
+    EMAIL_READ_SCOPES,
+    MEMORY_READ_SCOPES,
+    CALENDAR_READ_SCOPES,
+    DOCS_READ_SCOPES,
+    COOKBOOK_READ_SCOPES,
+)
+
+
+ScopeSet = frozenset[str]
+ScopeOptions = tuple[ScopeSet, ...]
+
+
+def _one_of(scopes: Iterable[str]) -> ScopeOptions:
+    """Return alternatives where any one accepted scope authorizes a route."""
+    return tuple(frozenset({scope}) for scope in sorted(scopes))
+
+
+def _one_from_each(*groups: Iterable[str]) -> ScopeOptions:
+    """Return alternatives requiring one accepted scope from every group."""
+    normalized = [tuple(sorted(group)) for group in groups]
+    return tuple(frozenset(option) for option in product(*normalized))
 
 
 @dataclass(frozen=True)
 class ApiTokenRouteCapability:
     methods: frozenset[str]
     path: str
-    scopes: frozenset[str] = field(default_factory=frozenset)
+    scope_options: ScopeOptions
 
     def matches(self, method: str, path: str) -> bool:
+        normalized_path = _normalize_route_path(path)
         return (
-            method.upper() in self.methods
-            and _path_template_matches(self.path, path)
+            normalized_path is not None
+            and method.upper() in self.methods
+            and _path_template_matches(self.path, normalized_path)
         )
+
+    def accepts(self, token_scopes: Iterable[str] | str | None) -> bool:
+        scopes = normalize_api_token_scopes(token_scopes)
+        return any(required.issubset(scopes) for required in self.scope_options)
 
 
 @dataclass(frozen=True)
 class ApiTokenRouteDecision:
     allowed: bool
     error: str | None = None
-    required_scopes: tuple[str, ...] = ()
 
 
 def _methods(*methods: str) -> frozenset[str]:
-    return frozenset(m.upper() for m in methods)
+    return frozenset(method.upper() for method in methods)
 
 
-def _scopes(*scopes: str) -> frozenset[str]:
-    return frozenset(scopes)
+def _capability(
+    method: str,
+    path: str,
+    scopes: Iterable[str],
+) -> ApiTokenRouteCapability:
+    return ApiTokenRouteCapability(_methods(method), path, _one_of(scopes))
+
+
+def _normalize_route_path(path: str) -> str | None:
+    """Normalize the single trailing slash FastAPI redirects by default.
+
+    Everything else stays strict. Query strings and fragments do not belong in
+    ASGI ``scope['path']``; repeated separators, dot segments, backslashes, and
+    control characters are treated as malformed instead of being normalized
+    into a capability match.
+    """
+    if not isinstance(path, str) or not path.startswith("/"):
+        return None
+    if any(ord(char) < 32 or ord(char) == 127 for char in path):
+        return None
+    if "?" in path or "#" in path or "\\" in path:
+        return None
+    if path != "/" and path.endswith("/"):
+        path = path[:-1]
+    if path != "/" and (path.endswith("/") or "//" in path):
+        return None
+    parts = path.split("/")[1:]
+    if any(part in {"", ".", ".."} for part in parts):
+        return None
+    return path
 
 
 def _path_template_matches(template: str, path: str) -> bool:
-    template_parts = template.strip("/").split("/")
-    path_parts = path.strip("/").split("/")
+    template_parts = template.split("/")[1:]
+    path_parts = path.split("/")[1:]
     if len(template_parts) != len(path_parts):
         return False
     for expected, actual in zip(template_parts, path_parts):
@@ -49,123 +131,142 @@ def _path_template_matches(template: str, path: str) -> bool:
     return True
 
 
-TODO_READ = _scopes("todos:read", "todos:write")
-TODO_WRITE = _scopes("todos:write")
-EMAIL_READ = _scopes("email:read", "email:draft", "email:send")
-EMAIL_DRAFT = _scopes("email:draft", "email:send")
-EMAIL_SEND = _scopes("email:send")
-MEMORY_READ = _scopes("memory:read", "memory:write")
-MEMORY_WRITE = _scopes("memory:write")
-CALENDAR_READ = _scopes("calendar:read", "calendar:write")
-CALENDAR_WRITE = _scopes("calendar:write")
-DOCUMENTS_READ = _scopes("documents:read", "documents:write")
-DOCUMENTS_WRITE = _scopes("documents:write")
-COOKBOOK_READ = _scopes("cookbook:read", "cookbook:launch")
-COOKBOOK_LAUNCH = _scopes("cookbook:launch")
+def _route_path_from_scope(scope: Mapping[str, object]) -> str:
+    """Return the same application-relative path the ASGI router receives."""
+    path = scope.get("path", "")
+    root_path = scope.get("root_path", "")
+    if not isinstance(path, str):
+        return ""
+    if not isinstance(root_path, str):
+        root_path = ""
+    root_path = root_path.rstrip("/")
+    if root_path and (path == root_path or path.startswith(root_path + "/")):
+        path = path[len(root_path):] or "/"
+    return path
+
+
+def _has_encoded_path_separator(scope: Mapping[str, object]) -> bool:
+    """Reject encoded delimiters whose decoding can differ across HTTP layers."""
+    raw_path = scope.get("raw_path")
+    if not isinstance(raw_path, (bytes, bytearray)):
+        return False
+    lowered = bytes(raw_path).split(b"?", 1)[0].lower()
+    return any(encoded in lowered for encoded in (b"%2f", b"%5c", b"%00"))
+
+
+def normalize_api_token_scopes(
+    token_scopes: Iterable[str] | str | None,
+) -> frozenset[str]:
+    if isinstance(token_scopes, str):
+        values: Iterable[object] = token_scopes.split(",")
+    else:
+        values = token_scopes or ()
+    return frozenset(
+        normalized
+        for scope in values
+        if (normalized := str(scope).strip())
+    )
+
+
+_BOOTSTRAP_SCOPES = _one_of(ALL_API_TOKEN_SCOPES)
+_EMAIL_DOCUMENT_DRAFT_SCOPES = _one_from_each(
+    EMAIL_DRAFT_SCOPES,
+    DOCS_WRITE_SCOPES,
+)
 
 
 API_TOKEN_ROUTE_CAPABILITIES: tuple[ApiTokenRouteCapability, ...] = (
-    ApiTokenRouteCapability(_methods("POST"), "/api/v1/chat", _scopes("chat")),
-    ApiTokenRouteCapability(_methods("GET"), "/api/companion/ping"),
-    ApiTokenRouteCapability(_methods("GET"), "/api/companion/info"),
-    ApiTokenRouteCapability(_methods("GET"), "/api/companion/models"),
-    ApiTokenRouteCapability(_methods("GET"), "/api/codex/capabilities"),
-    ApiTokenRouteCapability(_methods("GET"), "/api/codex/plugin.zip"),
-    ApiTokenRouteCapability(_methods("GET"), "/api/claude/plugin.zip"),
-    ApiTokenRouteCapability(_methods("GET"), "/api/codex/todos", TODO_READ),
+    _capability("POST", "/api/v1/chat", CHAT_SCOPES),
+    _capability("GET", "/api/models", CHAT_SCOPES),
+    _capability("GET", "/api/companion/ping", CHAT_SCOPES),
+    _capability("GET", "/api/companion/info", CHAT_SCOPES),
+    _capability("GET", "/api/companion/models", CHAT_SCOPES),
     ApiTokenRouteCapability(
-        _methods("POST"),
-        "/api/codex/todos",
-        TODO_READ | TODO_WRITE,
-    ),
-    ApiTokenRouteCapability(_methods("GET"), "/api/codex/emails", EMAIL_READ),
-    ApiTokenRouteCapability(_methods("GET"), "/api/codex/emails/{uid}", EMAIL_READ),
-    ApiTokenRouteCapability(_methods("POST"), "/api/codex/emails/draft", EMAIL_DRAFT),
-    ApiTokenRouteCapability(_methods("POST"), "/api/codex/emails/send", EMAIL_SEND),
-    ApiTokenRouteCapability(_methods("GET"), "/api/codex/memory", MEMORY_READ),
-    ApiTokenRouteCapability(_methods("POST"), "/api/codex/memory", MEMORY_WRITE),
-    ApiTokenRouteCapability(
-        _methods("DELETE"),
-        "/api/codex/memory/{memory_id}",
-        MEMORY_WRITE,
+        _methods("GET"),
+        "/api/codex/capabilities",
+        _BOOTSTRAP_SCOPES,
     ),
     ApiTokenRouteCapability(
         _methods("GET"),
-        "/api/codex/calendar/events",
-        CALENDAR_READ,
+        "/api/codex/plugin.zip",
+        _BOOTSTRAP_SCOPES,
     ),
+    ApiTokenRouteCapability(
+        _methods("GET"),
+        "/api/claude/plugin.zip",
+        _BOOTSTRAP_SCOPES,
+    ),
+    _capability("GET", "/api/codex/todos", TODO_READ_SCOPES),
+    _capability("POST", "/api/codex/todos", TODO_READ_SCOPES),
+    _capability("GET", "/api/codex/emails", EMAIL_READ_SCOPES),
+    _capability("GET", "/api/codex/emails/{uid}", EMAIL_READ_SCOPES),
     ApiTokenRouteCapability(
         _methods("POST"),
-        "/api/codex/calendar/events",
-        CALENDAR_WRITE,
+        "/api/codex/emails/draft-document",
+        _EMAIL_DOCUMENT_DRAFT_SCOPES,
     ),
-    ApiTokenRouteCapability(
-        _methods("DELETE"),
+    _capability("POST", "/api/codex/emails/draft", EMAIL_DRAFT_SCOPES),
+    _capability("POST", "/api/codex/emails/send", EMAIL_SEND_SCOPES),
+    _capability("GET", "/api/codex/memory", MEMORY_READ_SCOPES),
+    _capability("POST", "/api/codex/memory", MEMORY_WRITE_SCOPES),
+    _capability("DELETE", "/api/codex/memory/{memory_id}", MEMORY_WRITE_SCOPES),
+    _capability("GET", "/api/codex/calendar/events", CALENDAR_READ_SCOPES),
+    _capability("POST", "/api/codex/calendar/events", CALENDAR_WRITE_SCOPES),
+    _capability(
+        "DELETE",
         "/api/codex/calendar/events/{uid}",
-        CALENDAR_WRITE,
+        CALENDAR_WRITE_SCOPES,
     ),
-    ApiTokenRouteCapability(_methods("GET"), "/api/codex/documents", DOCUMENTS_READ),
-    ApiTokenRouteCapability(
-        _methods("GET"),
-        "/api/codex/documents/{doc_id}",
-        DOCUMENTS_READ,
-    ),
-    ApiTokenRouteCapability(
-        _methods("POST"),
-        "/api/codex/documents",
-        DOCUMENTS_WRITE,
-    ),
-    ApiTokenRouteCapability(
-        _methods("DELETE"),
-        "/api/codex/documents/{doc_id}",
-        DOCUMENTS_WRITE,
-    ),
-    ApiTokenRouteCapability(
-        _methods("GET"),
-        "/api/codex/cookbook/tasks",
-        COOKBOOK_READ,
-    ),
-    ApiTokenRouteCapability(
-        _methods("GET"),
-        "/api/codex/cookbook/servers",
-        COOKBOOK_READ,
-    ),
-    ApiTokenRouteCapability(
-        _methods("GET"),
+    _capability("GET", "/api/codex/documents", DOCS_READ_SCOPES),
+    _capability("GET", "/api/codex/documents/{doc_id}", DOCS_READ_SCOPES),
+    _capability("POST", "/api/codex/documents", DOCS_WRITE_SCOPES),
+    _capability("DELETE", "/api/codex/documents/{doc_id}", DOCS_WRITE_SCOPES),
+    _capability("GET", "/api/codex/cookbook/tasks", COOKBOOK_READ_SCOPES),
+    _capability("GET", "/api/codex/cookbook/servers", COOKBOOK_READ_SCOPES),
+    _capability(
+        "GET",
         "/api/codex/cookbook/output/{session_id}",
-        COOKBOOK_READ,
+        COOKBOOK_READ_SCOPES,
     ),
-    ApiTokenRouteCapability(
-        _methods("GET"),
-        "/api/codex/cookbook/cached",
-        COOKBOOK_READ,
-    ),
-    ApiTokenRouteCapability(
-        _methods("GET"),
-        "/api/codex/cookbook/presets",
-        COOKBOOK_READ,
-    ),
-    ApiTokenRouteCapability(
-        _methods("POST"),
-        "/api/codex/cookbook/serve",
-        COOKBOOK_LAUNCH,
-    ),
-    ApiTokenRouteCapability(
-        _methods("POST"),
+    _capability("GET", "/api/codex/cookbook/cached", COOKBOOK_READ_SCOPES),
+    _capability("GET", "/api/codex/cookbook/presets", COOKBOOK_READ_SCOPES),
+    _capability("POST", "/api/codex/cookbook/serve", COOKBOOK_LAUNCH_SCOPES),
+    _capability(
+        "POST",
         "/api/codex/cookbook/stop/{session_id}",
-        COOKBOOK_LAUNCH,
+        COOKBOOK_LAUNCH_SCOPES,
     ),
-    ApiTokenRouteCapability(
-        _methods("POST"),
+    _capability(
+        "POST",
         "/api/codex/cookbook/preset/{name}",
-        COOKBOOK_LAUNCH,
+        COOKBOOK_LAUNCH_SCOPES,
     ),
-    ApiTokenRouteCapability(
-        _methods("POST"),
-        "/api/codex/cookbook/adopt",
-        COOKBOOK_LAUNCH,
-    ),
+    _capability("POST", "/api/codex/cookbook/adopt", COOKBOOK_LAUNCH_SCOPES),
 )
+
+
+def _validate_manifest(capabilities: Sequence[ApiTokenRouteCapability]) -> None:
+    seen: set[tuple[str, str]] = set()
+    for capability in capabilities:
+        if _normalize_route_path(capability.path) != capability.path:
+            raise RuntimeError(
+                f"Malformed API-token capability path: {capability.path!r}"
+            )
+        if not capability.methods or not capability.scope_options:
+            raise RuntimeError("API-token capabilities must declare methods and scopes")
+        for required in capability.scope_options:
+            if not required or not required.issubset(ALL_API_TOKEN_SCOPES):
+                raise RuntimeError("API-token capability contains an unknown scope")
+        for method in capability.methods:
+            key = (method, capability.path)
+            if key in seen:
+                raise RuntimeError(
+                    f"Duplicate API-token capability: {method} {capability.path}"
+                )
+            seen.add(key)
+
+
+_validate_manifest(API_TOKEN_ROUTE_CAPABILITIES)
 
 
 def find_api_token_route_capability(
@@ -181,29 +282,23 @@ def find_api_token_route_capability(
 def authorize_api_token_route(
     method: str,
     path: str,
-    token_scopes: Iterable[str] | None,
+    token_scopes: Iterable[str] | str | None,
 ) -> ApiTokenRouteDecision:
     capability = find_api_token_route_capability(method, path)
-    if capability is None:
-        return ApiTokenRouteDecision(
-            allowed=False,
-            error="API token is not allowed for this endpoint",
-        )
-
-    if not capability.scopes:
+    if capability is not None and capability.accepts(token_scopes):
         return ApiTokenRouteDecision(allowed=True)
+    return ApiTokenRouteDecision(allowed=False, error=API_TOKEN_FORBIDDEN_ERROR)
 
-    scopes = {
-        str(scope).strip()
-        for scope in (token_scopes or [])
-        if str(scope).strip()
-    }
-    if scopes.intersection(capability.scopes):
-        return ApiTokenRouteDecision(allowed=True)
 
-    required = tuple(sorted(capability.scopes))
-    return ApiTokenRouteDecision(
-        allowed=False,
-        error=f"API token missing required scope: {' or '.join(required)}",
-        required_scopes=required,
+def authorize_api_token_request(
+    method: str,
+    scope: Mapping[str, object],
+    token_scopes: Iterable[str] | str | None,
+) -> ApiTokenRouteDecision:
+    if _has_encoded_path_separator(scope):
+        return ApiTokenRouteDecision(allowed=False, error=API_TOKEN_FORBIDDEN_ERROR)
+    return authorize_api_token_route(
+        method,
+        _route_path_from_scope(scope),
+        token_scopes,
     )

--- a/src/api_token_capabilities.py
+++ b/src/api_token_capabilities.py
@@ -36,7 +36,6 @@ ALL_API_TOKEN_SCOPES = frozenset().union(
     MEMORY_READ_SCOPES,
     CALENDAR_READ_SCOPES,
     DOCS_READ_SCOPES,
-    COOKBOOK_READ_SCOPES,
 )
 
 
@@ -95,16 +94,17 @@ def _capability(
 def _normalize_route_path(path: str) -> str | None:
     """Normalize the single trailing slash FastAPI redirects by default.
 
-    Everything else stays strict. Query strings and fragments do not belong in
-    ASGI ``scope['path']``; repeated separators, dot segments, backslashes, and
-    control characters are treated as malformed instead of being normalized
-    into a capability match.
+    Everything else stays strict. ASGI ``scope['path']`` is already decoded, so
+    question marks and hashes can be legitimate path-segment data rather than
+    query or fragment delimiters. Repeated separators, dot segments,
+    backslashes, and control characters are treated as malformed instead of
+    being normalized into a capability match.
     """
     if not isinstance(path, str) or not path.startswith("/"):
         return None
     if any(ord(char) < 32 or ord(char) == 127 for char in path):
         return None
-    if "?" in path or "#" in path or "\\" in path:
+    if "\\" in path:
         return None
     if path != "/" and path.endswith("/"):
         path = path[:-1]
@@ -139,9 +139,15 @@ def _route_path_from_scope(scope: Mapping[str, object]) -> str:
         return ""
     if not isinstance(root_path, str):
         root_path = ""
-    root_path = root_path.rstrip("/")
-    if root_path and (path == root_path or path.startswith(root_path + "/")):
-        path = path[len(root_path):] or "/"
+    if root_path:
+        if path == root_path:
+            path = "/"
+        elif (
+            path.startswith(root_path)
+            and len(path) > len(root_path)
+            and path[len(root_path)] == "/"
+        ):
+            path = path[len(root_path):]
     return path
 
 
@@ -221,27 +227,6 @@ API_TOKEN_ROUTE_CAPABILITIES: tuple[ApiTokenRouteCapability, ...] = (
     _capability("GET", "/api/codex/documents/{doc_id}", DOCS_READ_SCOPES),
     _capability("POST", "/api/codex/documents", DOCS_WRITE_SCOPES),
     _capability("DELETE", "/api/codex/documents/{doc_id}", DOCS_WRITE_SCOPES),
-    _capability("GET", "/api/codex/cookbook/tasks", COOKBOOK_READ_SCOPES),
-    _capability("GET", "/api/codex/cookbook/servers", COOKBOOK_READ_SCOPES),
-    _capability(
-        "GET",
-        "/api/codex/cookbook/output/{session_id}",
-        COOKBOOK_READ_SCOPES,
-    ),
-    _capability("GET", "/api/codex/cookbook/cached", COOKBOOK_READ_SCOPES),
-    _capability("GET", "/api/codex/cookbook/presets", COOKBOOK_READ_SCOPES),
-    _capability("POST", "/api/codex/cookbook/serve", COOKBOOK_LAUNCH_SCOPES),
-    _capability(
-        "POST",
-        "/api/codex/cookbook/stop/{session_id}",
-        COOKBOOK_LAUNCH_SCOPES,
-    ),
-    _capability(
-        "POST",
-        "/api/codex/cookbook/preset/{name}",
-        COOKBOOK_LAUNCH_SCOPES,
-    ),
-    _capability("POST", "/api/codex/cookbook/adopt", COOKBOOK_LAUNCH_SCOPES),
 )
 
 

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -2477,8 +2477,6 @@ const _TOKEN_SCOPES = [
   { key: 'calendar:write',    label: 'Calendar write',    detail: 'Create and update calendar events' },
   { key: 'memory:read',       label: 'Memory read',       detail: 'Read memory when enabled' },
   { key: 'memory:write',      label: 'Memory write',      detail: 'Write memory when enabled' },
-  { key: 'cookbook:read',     label: 'Cookbook read',     detail: 'List cookbook tasks + tail their tmux output' },
-  { key: 'cookbook:launch',   label: 'Cookbook launch',   detail: 'Launch and stop cookbook serve tasks' },
 ];
 
 function _renderTokenScopeRows(t) {
@@ -2497,6 +2495,12 @@ function _renderTokenScopeRows(t) {
         <label class="admin-switch" style="margin-left:auto;flex-shrink:0;"><input type="checkbox" class="adm-tok-scope" data-token-id="${esc(t.id)}" data-scope="${esc(s.key)}" ${have.has(s.key) ? 'checked' : ''}><span class="admin-slider"></span></label>
       </label>`;
   }).join('');
+}
+
+function _renderRetiredTokenScopes(t) {
+  const retired = Array.isArray(t.retired_scopes) ? t.retired_scopes : [];
+  if (!retired.length) return '';
+  return `<div data-adm-tok-retired="${esc(t.id)}" style="font-size:11px;line-height:1.4;margin-bottom:7px;padding:6px 8px;border-radius:4px;background:rgba(255,184,0,0.08);color:var(--fg-muted,#888);">Retired permissions (${retired.map(esc).join(', ')}) are inactive and will be removed the next time permissions are changed.</div>`;
 }
 
 async function loadTokens() {
@@ -2519,6 +2523,7 @@ async function loadTokens() {
           <button class="admin-btn-delete" data-adm-del-token="${esc(t.id)}">Revoke</button>
         </div>
         <div data-adm-tok-perm="${esc(t.id)}" style="display:none;margin-top:8px;padding:8px 4px 0;border-top:1px solid var(--border);">
+          ${_renderRetiredTokenScopes(t)}
           ${_renderTokenScopeRows(t)}
           <div class="adm-tok-scope-msg" data-token-id="${esc(t.id)}" style="font-size:11px;min-height:14px;margin-top:4px;"></div>
         </div>
@@ -2578,6 +2583,9 @@ async function loadTokens() {
           });
           const d = await r.json().catch(() => ({}));
           if (!r.ok) throw new Error(d.detail || 'Failed');
+          if (Array.isArray(d.retired_scopes) && d.retired_scopes.length === 0) {
+            list.querySelector(`[data-adm-tok-retired="${tokenId}"]`)?.remove();
+          }
           if (msg) { msg.textContent = 'Saved'; msg.style.color = 'var(--green, #50fa7b)'; setTimeout(() => { msg.textContent = ''; }, 1200); }
         } catch (err) {
           cb.checked = !cb.checked;

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -3669,6 +3669,7 @@ async function initUnifiedIntegrations() {
     }
     for (const tok of (Array.isArray(tokenRes) ? tokenRes : [])) {
       const scopes = tok.scopes || [];
+      const retiredScopes = tok.retired_scopes || [];
       const lowerName = (tok.name || '').toLowerCase();
       let agentType = null;
       if (lowerName.startsWith('claude agent')) agentType = 'claude';
@@ -3678,7 +3679,10 @@ async function initUnifiedIntegrations() {
         agentType = 'codex';
       }
       if (!agentType) continue;
-      const detail = `${tok.token_prefix || 'token'}... - ${scopes.join(', ') || 'chat'}`;
+      const scopeDetail = scopes.length
+        ? scopes.join(', ')
+        : (retiredScopes.length ? `no active scopes; retired: ${retiredScopes.join(', ')}` : 'chat');
+      const detail = `${tok.token_prefix || 'token'}... - ${scopeDetail}`;
       items.push({ type: agentType, id: tok.id, name: tok.name || (agentType === 'claude' ? 'Claude Agent' : 'Codex Agent'), detail, enabled: true, data: tok });
     }
     // Vaultwarden removed as an integration option.
@@ -5242,8 +5246,6 @@ async function initUnifiedIntegrations() {
       { key: 'calendar:write', label: 'Calendar write', detail: 'Create and update calendar events' },
       { key: 'memory:read', label: 'Memory', detail: 'Read memory when enabled' },
       { key: 'memory:write', label: 'Memory write', detail: 'Write memory when enabled' },
-      { key: 'cookbook:read', label: 'Cookbook', detail: 'List cookbook tasks + tail their tmux output (debug a model serve from outside the UI)' },
-      { key: 'cookbook:launch', label: 'Cookbook launch', detail: 'Launch and stop cookbook serve tasks. Powerful: runs SSH commands on your configured servers, bounded by the same allowlist the UI uses (vllm/python3/sglang/llama-server/...)' },
     ];
     // Strict name-prefix match keeps Codex and Claude tokens in their own forms.
     const agentTokens = (Array.isArray(tokens) ? tokens : []).filter(tok =>
@@ -5256,7 +5258,6 @@ async function initUnifiedIntegrations() {
       email: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><polyline points="2 6 12 13 22 6"/></svg>',
       calendar: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>',
       memory: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M9.5 2a2.5 2.5 0 0 0-2.5 2.5 2.5 2.5 0 0 0-2.5 2.5A2.5 2.5 0 0 0 2 9.5v3A2.5 2.5 0 0 0 4.5 15a2.5 2.5 0 0 0 2.5 2.5A2.5 2.5 0 0 0 9.5 20H10V2z"/><path d="M14.5 2a2.5 2.5 0 0 1 2.5 2.5 2.5 2.5 0 0 1 2.5 2.5A2.5 2.5 0 0 1 22 9.5v3A2.5 2.5 0 0 1 19.5 15a2.5 2.5 0 0 1-2.5 2.5A2.5 2.5 0 0 1 14.5 20H14V2z"/></svg>',
-      cookbook: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>',
     };
     const _scopeNiceLabel = (label) => label.replace(/\s+(write|drafts?|send)$/i, '');
     const _scopeAction = (key) => (key.split(':')[1] || '').toLowerCase();
@@ -5283,6 +5284,11 @@ async function initUnifiedIntegrations() {
     };
     const origin = window.location.origin || '';
     const setupForToken = (token) => cfg.buildSetup(origin, token);
+    const retiredScopeNotice = (token) => {
+      const retired = Array.isArray(token.retired_scopes) ? token.retired_scopes : [];
+      if (!retired.length) return '';
+      return `<div id="uf-codex-retired-scopes" style="font-size:11px;line-height:1.4;margin-bottom:7px;padding:6px 8px;border-radius:4px;background:rgba(255,184,0,0.08);color:var(--fg-muted,#888);">Retired permissions (${retired.map(esc).join(', ')}) are inactive and will be removed the next time permissions are changed.</div>`;
+    };
 
     // Inline editor for the existing token the user clicked into (current).
     // Shows the rename input, the prefix/last-used, and scope toggles that
@@ -5295,6 +5301,7 @@ async function initUnifiedIntegrations() {
           <span style="font-size:10px;opacity:0.55;">${esc(current.token_prefix || 'token')}...${current.last_used_at ? ` · Last used ${new Date(current.last_used_at).toLocaleDateString()}` : ' · Never used'}</span>
         </div>
         <div style="font-size:11px;font-weight:600;opacity:0.62;margin-bottom:4px;">Permissions</div>
+        ${retiredScopeNotice(current)}
         ${scopeToggles(current)}
         <div id="uf-codex-existing-msg" style="font-size:11px;min-height:14px;margin-top:4px;"></div>
       </div>` : '';
@@ -5402,6 +5409,7 @@ async function initUnifiedIntegrations() {
             });
             const d = await r.json().catch(() => ({}));
             if (!r.ok) throw new Error(d.detail || 'Failed');
+            if (Array.isArray(d.retired_scopes) && d.retired_scopes.length === 0) el('uf-codex-retired-scopes')?.remove();
             if (msg) { msg.textContent = 'Saved'; msg.style.color = 'var(--green, #50fa7b)'; setTimeout(() => { msg.textContent = ''; }, 1200); }
             notifyIntegrationsChanged();
           } catch (err) {

--- a/tests/test_api_token_capabilities.py
+++ b/tests/test_api_token_capabilities.py
@@ -1,0 +1,106 @@
+from src.api_token_capabilities import (
+    authorize_api_token_route,
+    find_api_token_route_capability,
+)
+
+
+def test_api_token_route_capability_allows_declared_scope():
+    decision = authorize_api_token_route("POST", "/api/v1/chat", ["chat"])
+
+    assert decision.allowed is True
+    assert decision.error is None
+
+
+def test_api_token_route_capability_rejects_missing_scope():
+    decision = authorize_api_token_route("POST", "/api/v1/chat", ["documents:read"])
+
+    assert decision.allowed is False
+    assert decision.error == "API token missing required scope: chat"
+    assert decision.required_scopes == ("chat",)
+
+
+def test_api_token_route_capability_rejects_unregistered_routes():
+    for method, path in [
+        ("GET", "/api/tokens"),
+        ("POST", "/api/tokens"),
+        ("GET", "/api/companion/pair"),
+        ("POST", "/api/companion/pair"),
+        ("GET", "/api/codex/todos/export"),
+    ]:
+        decision = authorize_api_token_route(method, path, ["chat", "todos:write"])
+        assert decision.allowed is False
+        assert decision.error == "API token is not allowed for this endpoint"
+
+
+def test_api_token_route_capability_allows_valid_token_only_bootstrap_routes():
+    for method, path in [
+        ("GET", "/api/companion/ping"),
+        ("GET", "/api/companion/info"),
+        ("GET", "/api/companion/models"),
+        ("GET", "/api/codex/capabilities"),
+        ("GET", "/api/codex/plugin.zip"),
+        ("GET", "/api/claude/plugin.zip"),
+    ]:
+        decision = authorize_api_token_route(method, path, [])
+        assert decision.allowed is True
+
+
+def test_api_token_route_capability_matches_path_templates():
+    assert (
+        find_api_token_route_capability("GET", "/api/codex/emails/abc123")
+        is not None
+    )
+    assert (
+        find_api_token_route_capability(
+            "DELETE",
+            "/api/codex/calendar/events/event-1",
+        )
+        is not None
+    )
+    assert (
+        find_api_token_route_capability("GET", "/api/codex/emails/abc123/extra")
+        is None
+    )
+
+
+def test_api_token_route_capability_preserves_codex_fine_grained_checks():
+    assert (
+        authorize_api_token_route("GET", "/api/codex/todos", ["todos:write"]).allowed
+        is True
+    )
+    assert (
+        authorize_api_token_route("POST", "/api/codex/todos", ["todos:read"]).allowed
+        is True
+    )
+    assert (
+        authorize_api_token_route(
+            "POST",
+            "/api/codex/emails/send",
+            ["email:draft"],
+        ).allowed
+        is False
+    )
+    assert (
+        authorize_api_token_route(
+            "POST",
+            "/api/codex/emails/send",
+            ["email:send"],
+        ).allowed
+        is True
+    )
+    assert (
+        authorize_api_token_route(
+            "DELETE",
+            "/api/codex/documents/doc-1",
+            ["documents:read"],
+        ).allowed
+        is False
+    )
+    assert (
+        authorize_api_token_route(
+            "DELETE",
+            "/api/codex/documents/doc-1",
+            ["documents:write"],
+        ).allowed
+        is True
+    )

--- a/tests/test_api_token_capabilities.py
+++ b/tests/test_api_token_capabilities.py
@@ -1,106 +1,379 @@
+from pathlib import Path
+
+import pytest
+
 from src.api_token_capabilities import (
+    ALL_API_TOKEN_SCOPES,
+    API_TOKEN_FORBIDDEN_ERROR,
+    API_TOKEN_ROUTE_CAPABILITIES,
+    authorize_api_token_request,
     authorize_api_token_route,
     find_api_token_route_capability,
 )
 
 
-def test_api_token_route_capability_allows_declared_scope():
-    decision = authorize_api_token_route("POST", "/api/v1/chat", ["chat"])
-
-    assert decision.allowed is True
-    assert decision.error is None
+def _allowed(method, path, scopes):
+    return authorize_api_token_route(method, path, scopes).allowed
 
 
-def test_api_token_route_capability_rejects_missing_scope():
-    decision = authorize_api_token_route("POST", "/api/v1/chat", ["documents:read"])
-
-    assert decision.allowed is False
-    assert decision.error == "API token missing required scope: chat"
-    assert decision.required_scopes == ("chat",)
-
-
-def test_api_token_route_capability_rejects_unregistered_routes():
+def test_retained_public_chat_and_model_inventory_require_chat_scope():
     for method, path in [
+        ("POST", "/api/v1/chat"),
+        ("GET", "/api/models"),
+    ]:
+        assert _allowed(method, path, ["chat"]) is True
+        assert _allowed(method, path, ["documents:read"]) is False
+        assert _allowed(method, path, []) is False
+
+
+def test_companion_bearer_reads_all_require_chat_scope():
+    for path in [
+        "/api/companion/ping",
+        "/api/companion/info",
+        "/api/companion/models",
+    ]:
+        assert _allowed("GET", path, ["chat"]) is True
+        assert _allowed("GET", path, ["todos:read"]) is False
+        assert _allowed("GET", path, []) is False
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "accepted_scope", "rejected_scope"),
+    [
+        ("GET", "/api/codex/todos", "todos:read", "email:read"),
+        ("POST", "/api/codex/todos", "todos:write", "email:read"),
+        ("GET", "/api/codex/emails", "email:read", "todos:read"),
+        ("GET", "/api/codex/emails/abc123", "email:send", "chat"),
+        ("POST", "/api/codex/emails/draft", "email:draft", "email:read"),
+        ("POST", "/api/codex/emails/send", "email:send", "email:draft"),
+        ("GET", "/api/codex/memory", "memory:read", "calendar:read"),
+        ("POST", "/api/codex/memory", "memory:write", "memory:read"),
+        ("DELETE", "/api/codex/memory/mem-1", "memory:write", "memory:read"),
+        ("GET", "/api/codex/calendar/events", "calendar:read", "memory:read"),
+        ("POST", "/api/codex/calendar/events", "calendar:write", "calendar:read"),
+        (
+            "DELETE",
+            "/api/codex/calendar/events/event-1",
+            "calendar:write",
+            "calendar:read",
+        ),
+        ("GET", "/api/codex/documents", "documents:read", "todos:read"),
+        ("GET", "/api/codex/documents/doc-1", "documents:write", "chat"),
+        ("POST", "/api/codex/documents", "documents:write", "documents:read"),
+        (
+            "DELETE",
+            "/api/codex/documents/doc-1",
+            "documents:write",
+            "documents:read",
+        ),
+        ("GET", "/api/codex/cookbook/tasks", "cookbook:read", "chat"),
+        ("GET", "/api/codex/cookbook/servers", "cookbook:launch", "chat"),
+        (
+            "GET",
+            "/api/codex/cookbook/output/serve-1",
+            "cookbook:read",
+            "chat",
+        ),
+        ("GET", "/api/codex/cookbook/cached", "cookbook:read", "chat"),
+        ("GET", "/api/codex/cookbook/presets", "cookbook:read", "chat"),
+        ("POST", "/api/codex/cookbook/serve", "cookbook:launch", "chat"),
+        (
+            "POST",
+            "/api/codex/cookbook/stop/serve-1",
+            "cookbook:launch",
+            "cookbook:read",
+        ),
+        (
+            "POST",
+            "/api/codex/cookbook/preset/default",
+            "cookbook:launch",
+            "cookbook:read",
+        ),
+        ("POST", "/api/codex/cookbook/adopt", "cookbook:launch", "chat"),
+    ],
+)
+def test_codex_route_families_require_their_existing_scopes(
+    method,
+    path,
+    accepted_scope,
+    rejected_scope,
+):
+    assert _allowed(method, path, [accepted_scope]) is True
+    assert _allowed(method, path, [rejected_scope]) is False
+
+
+def test_email_draft_document_requires_email_draft_and_document_write():
+    path = "/api/codex/emails/draft-document"
+
+    assert _allowed("POST", path, ["email:draft", "documents:write"]) is True
+    assert _allowed("POST", path, ["email:send", "documents:write"]) is True
+    assert _allowed("POST", path, ["email:draft"]) is False
+    assert _allowed("POST", path, ["documents:write"]) is False
+    assert _allowed("POST", path, ["email:read", "documents:write"]) is False
+
+
+def test_bootstrap_downloads_require_at_least_one_accepted_scope():
+    for path in [
+        "/api/codex/capabilities",
+        "/api/codex/plugin.zip",
+        "/api/claude/plugin.zip",
+    ]:
+        for scope in ALL_API_TOKEN_SCOPES:
+            assert _allowed("GET", path, [scope]) is True
+        assert _allowed("GET", path, []) is False
+        assert _allowed("GET", path, ["unknown:scope"]) is False
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
         ("GET", "/api/tokens"),
         ("POST", "/api/tokens"),
+        ("GET", "/api/tokens/profiles"),
+        ("PATCH", "/api/tokens/token-1"),
         ("GET", "/api/companion/pair"),
         ("POST", "/api/companion/pair"),
+        ("POST", "/api/shell/exec"),
+        ("POST", "/api/shell/stream"),
+        ("GET", "/api/workspace/browse"),
+        ("GET", "/api/tools"),
+        ("POST", "/api/tools"),
+        ("GET", "/api/users"),
+        ("GET", "/api/sessions"),
+        ("GET", "/api/history/session-1"),
+        ("POST", "/api/upload"),
+        ("POST", "/api/chat_stream"),
+        ("GET", "/api/calendar/events"),
         ("GET", "/api/codex/todos/export"),
+    ],
+)
+def test_privileged_and_owner_attributing_ui_routes_remain_blocked(method, path):
+    decision = authorize_api_token_route(method, path, ALL_API_TOKEN_SCOPES)
+
+    assert decision.allowed is False
+    assert decision.error == API_TOKEN_FORBIDDEN_ERROR
+
+
+def test_method_matching_is_exact_and_case_insensitive():
+    assert _allowed("post", "/api/v1/chat", ["chat"]) is True
+    assert _allowed("GET", "/api/v1/chat", ["chat"]) is False
+    assert _allowed("POST", "/api/models", ["chat"]) is False
+    assert _allowed("OPTIONS", "/api/models", ["chat"]) is False
+
+
+def test_single_trailing_slash_matches_but_malformed_paths_fail_closed():
+    assert _allowed("GET", "/api/models/", ["chat"]) is True
+    for path in [
+        "/api/models//",
+        "//api/models",
+        "/api//models",
+        "/api/./models",
+        "/api/../models",
+        "/api/models?refresh=true",
+        "/api/models#fragment",
+        "/api/models\\extra",
+        "/api/models\x00",
+        "api/models",
+        "",
     ]:
-        decision = authorize_api_token_route(method, path, ["chat", "todos:write"])
-        assert decision.allowed is False
-        assert decision.error == "API token is not allowed for this endpoint"
+        assert _allowed("GET", path, ["chat"]) is False
 
 
-def test_api_token_route_capability_allows_valid_token_only_bootstrap_routes():
-    for method, path in [
+def test_path_templates_match_one_nonempty_segment_only():
+    assert find_api_token_route_capability(
+        "GET",
+        "/api/codex/emails/abc123",
+    ) is not None
+    assert find_api_token_route_capability(
+        "DELETE",
+        "/api/codex/calendar/events/event-1",
+    ) is not None
+    assert find_api_token_route_capability(
+        "GET",
+        "/api/codex/emails/abc123/extra",
+    ) is None
+    assert find_api_token_route_capability("GET", "/api/codex/emails//") is None
+
+
+def test_asgi_root_path_is_removed_before_matching():
+    decision = authorize_api_token_request(
+        "GET",
+        {
+            "root_path": "/odysseus",
+            "path": "/odysseus/api/models",
+            "raw_path": b"/odysseus/api/models",
+        },
+        ["chat"],
+    )
+
+    assert decision.allowed is True
+
+    wrong_prefix = authorize_api_token_request(
+        "GET",
+        {
+            "root_path": "/odysseus",
+            "path": "/odyssey/api/models",
+            "raw_path": b"/odyssey/api/models",
+        },
+        ["chat"],
+    )
+    assert wrong_prefix.allowed is False
+
+
+@pytest.mark.parametrize("encoded", [b"%2f", b"%2F", b"%5c", b"%5C", b"%00"])
+def test_encoded_path_delimiters_fail_closed(encoded):
+    decision = authorize_api_token_request(
+        "GET",
+        {
+            "path": "/api/models",
+            "raw_path": b"/api" + encoded + b"models",
+        },
+        ["chat"],
+    )
+
+    assert decision.allowed is False
+
+
+def test_encoded_static_letters_follow_the_decoded_router_path():
+    decision = authorize_api_token_request(
+        "GET",
+        {
+            "path": "/api/models",
+            "raw_path": b"/api/%6dodels",
+        },
+        ["chat"],
+    )
+
+    assert decision.allowed is True
+
+
+def test_missing_scope_and_unknown_route_share_one_public_error():
+    wrong_scope = authorize_api_token_route("GET", "/api/models", ["todos:read"])
+    unknown_route = authorize_api_token_route(
+        "GET",
+        "/api/private-owner-data",
+        ["chat"],
+    )
+
+    assert wrong_scope == unknown_route
+    assert wrong_scope.error == API_TOKEN_FORBIDDEN_ERROR
+
+
+def test_scope_string_normalization_is_not_character_based():
+    assert _allowed("GET", "/api/models", "todos:read, chat") is True
+    assert _allowed("GET", "/api/models", "c,h,a,t") is False
+
+
+def test_every_manifest_entry_has_known_nonempty_scopes_and_unique_methods():
+    seen = set()
+    for capability in API_TOKEN_ROUTE_CAPABILITIES:
+        assert capability.scope_options
+        for option in capability.scope_options:
+            assert option
+            assert option <= ALL_API_TOKEN_SCOPES
+        for method in capability.methods:
+            key = (method, capability.path)
+            assert key not in seen
+            seen.add(key)
+
+
+def test_manifest_contains_only_the_current_audited_bearer_routes():
+    expected = {
+        ("POST", "/api/v1/chat"),
+        ("GET", "/api/models"),
         ("GET", "/api/companion/ping"),
         ("GET", "/api/companion/info"),
         ("GET", "/api/companion/models"),
         ("GET", "/api/codex/capabilities"),
         ("GET", "/api/codex/plugin.zip"),
         ("GET", "/api/claude/plugin.zip"),
-    ]:
-        decision = authorize_api_token_route(method, path, [])
-        assert decision.allowed is True
+        ("GET", "/api/codex/todos"),
+        ("POST", "/api/codex/todos"),
+        ("GET", "/api/codex/emails"),
+        ("GET", "/api/codex/emails/{uid}"),
+        ("POST", "/api/codex/emails/draft-document"),
+        ("POST", "/api/codex/emails/draft"),
+        ("POST", "/api/codex/emails/send"),
+        ("GET", "/api/codex/memory"),
+        ("POST", "/api/codex/memory"),
+        ("DELETE", "/api/codex/memory/{memory_id}"),
+        ("GET", "/api/codex/calendar/events"),
+        ("POST", "/api/codex/calendar/events"),
+        ("DELETE", "/api/codex/calendar/events/{uid}"),
+        ("GET", "/api/codex/documents"),
+        ("GET", "/api/codex/documents/{doc_id}"),
+        ("POST", "/api/codex/documents"),
+        ("DELETE", "/api/codex/documents/{doc_id}"),
+        ("GET", "/api/codex/cookbook/tasks"),
+        ("GET", "/api/codex/cookbook/servers"),
+        ("GET", "/api/codex/cookbook/output/{session_id}"),
+        ("GET", "/api/codex/cookbook/cached"),
+        ("GET", "/api/codex/cookbook/presets"),
+        ("POST", "/api/codex/cookbook/serve"),
+        ("POST", "/api/codex/cookbook/stop/{session_id}"),
+        ("POST", "/api/codex/cookbook/preset/{name}"),
+        ("POST", "/api/codex/cookbook/adopt"),
+    }
+    actual = {
+        (method, capability.path)
+        for capability in API_TOKEN_ROUTE_CAPABILITIES
+        for method in capability.methods
+    }
+
+    assert actual == expected
 
 
-def test_api_token_route_capability_matches_path_templates():
-    assert (
-        find_api_token_route_capability("GET", "/api/codex/emails/abc123")
-        is not None
-    )
-    assert (
-        find_api_token_route_capability(
-            "DELETE",
-            "/api/codex/calendar/events/event-1",
-        )
-        is not None
-    )
-    assert (
-        find_api_token_route_capability("GET", "/api/codex/emails/abc123/extra")
-        is None
-    )
+def test_accepted_scope_catalog_is_explicit_and_has_no_admin_scope():
+    assert ALL_API_TOKEN_SCOPES == {
+        "chat",
+        "todos:read",
+        "todos:write",
+        "documents:read",
+        "documents:write",
+        "email:read",
+        "email:draft",
+        "email:send",
+        "calendar:read",
+        "calendar:write",
+        "memory:read",
+        "memory:write",
+        "cookbook:read",
+        "cookbook:launch",
+    }
 
 
-def test_api_token_route_capability_preserves_codex_fine_grained_checks():
+def test_token_minting_and_route_checks_share_the_scope_catalog():
+    from routes.api_token_routes import ALLOWED_SCOPES
+    import routes.codex_routes as codex_routes
+
+    assert ALLOWED_SCOPES is ALL_API_TOKEN_SCOPES
+    assert codex_routes.TODO_READ_SCOPES <= ALL_API_TOKEN_SCOPES
+    assert codex_routes.EMAIL_READ_SCOPES <= ALL_API_TOKEN_SCOPES
+    assert codex_routes.COOKBOOK_READ_SCOPES <= ALL_API_TOKEN_SCOPES
+
+
+def test_capability_gate_runs_only_after_a_valid_bearer_match():
+    source = Path("app.py").read_text(encoding="utf-8")
+    cors_gate = source.index("if is_cors_preflight(")
+    exempt_gate = source.index("if _is_auth_exempt(path):")
+    internal_gate = source.index("# In-process internal-tool token bypass")
+    local_gate = source.index("# Allow DIRECT localhost requests")
+    bearer_gate = source.index('if auth_header.startswith("Bearer ody_"):')
+    token_match = source.index("if matched_id:", bearer_gate)
+    capability_gate = source.index("authorize_api_token_request(", token_match)
+    token_state = source.index("request.state.api_token = True", capability_gate)
+    cookie_gate = source.index("# --- Cookie-based session auth ---", token_state)
+
     assert (
-        authorize_api_token_route("GET", "/api/codex/todos", ["todos:write"]).allowed
-        is True
+        cors_gate
+        < exempt_gate
+        < internal_gate
+        < local_gate
+        < bearer_gate
+        < token_match
+        < capability_gate
+        < token_state
+        < cookie_gate
     )
-    assert (
-        authorize_api_token_route("POST", "/api/codex/todos", ["todos:read"]).allowed
-        is True
-    )
-    assert (
-        authorize_api_token_route(
-            "POST",
-            "/api/codex/emails/send",
-            ["email:draft"],
-        ).allowed
-        is False
-    )
-    assert (
-        authorize_api_token_route(
-            "POST",
-            "/api/codex/emails/send",
-            ["email:send"],
-        ).allowed
-        is True
-    )
-    assert (
-        authorize_api_token_route(
-            "DELETE",
-            "/api/codex/documents/doc-1",
-            ["documents:read"],
-        ).allowed
-        is False
-    )
-    assert (
-        authorize_api_token_route(
-            "DELETE",
-            "/api/codex/documents/doc-1",
-            ["documents:write"],
-        ).allowed
-        is True
-    )
+    local_block = source[local_gate:bearer_gate]
+    assert 'not auth_header.startswith("Bearer ody_")' in local_block

--- a/tests/test_api_token_capabilities.py
+++ b/tests/test_api_token_capabilities.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import pytest
 
 from src.api_token_capabilities import (
@@ -277,43 +275,36 @@ def test_every_manifest_entry_has_known_nonempty_scopes_and_unique_methods():
             seen.add(key)
 
 
-def test_manifest_contains_only_the_current_audited_bearer_routes():
+def _router_inventory(router):
+    return {
+        (method, route.path)
+        for route in router.routes
+        for method in getattr(route, "methods", set())
+    }
+
+
+def test_manifest_matches_runtime_scoped_router_inventory():
+    from companion.routes import setup_companion_routes
+    from routes.codex_routes import setup_claude_routes, setup_codex_routes
+
+    companion_inventory = _router_inventory(setup_companion_routes())
+    companion_pairing = {
+        route
+        for route in companion_inventory
+        if route[1] == "/api/companion/pair"
+    }
+    assert companion_pairing == {
+        ("GET", "/api/companion/pair"),
+        ("POST", "/api/companion/pair"),
+    }
+
     expected = {
         ("POST", "/api/v1/chat"),
         ("GET", "/api/models"),
-        ("GET", "/api/companion/ping"),
-        ("GET", "/api/companion/info"),
-        ("GET", "/api/companion/models"),
-        ("GET", "/api/codex/capabilities"),
-        ("GET", "/api/codex/plugin.zip"),
-        ("GET", "/api/claude/plugin.zip"),
-        ("GET", "/api/codex/todos"),
-        ("POST", "/api/codex/todos"),
-        ("GET", "/api/codex/emails"),
-        ("GET", "/api/codex/emails/{uid}"),
-        ("POST", "/api/codex/emails/draft-document"),
-        ("POST", "/api/codex/emails/draft"),
-        ("POST", "/api/codex/emails/send"),
-        ("GET", "/api/codex/memory"),
-        ("POST", "/api/codex/memory"),
-        ("DELETE", "/api/codex/memory/{memory_id}"),
-        ("GET", "/api/codex/calendar/events"),
-        ("POST", "/api/codex/calendar/events"),
-        ("DELETE", "/api/codex/calendar/events/{uid}"),
-        ("GET", "/api/codex/documents"),
-        ("GET", "/api/codex/documents/{doc_id}"),
-        ("POST", "/api/codex/documents"),
-        ("DELETE", "/api/codex/documents/{doc_id}"),
-        ("GET", "/api/codex/cookbook/tasks"),
-        ("GET", "/api/codex/cookbook/servers"),
-        ("GET", "/api/codex/cookbook/output/{session_id}"),
-        ("GET", "/api/codex/cookbook/cached"),
-        ("GET", "/api/codex/cookbook/presets"),
-        ("POST", "/api/codex/cookbook/serve"),
-        ("POST", "/api/codex/cookbook/stop/{session_id}"),
-        ("POST", "/api/codex/cookbook/preset/{name}"),
-        ("POST", "/api/codex/cookbook/adopt"),
     }
+    expected.update(_router_inventory(setup_codex_routes()))
+    expected.update(_router_inventory(setup_claude_routes()))
+    expected.update(companion_inventory - companion_pairing)
     actual = {
         (method, capability.path)
         for capability in API_TOKEN_ROUTE_CAPABILITIES
@@ -350,30 +341,3 @@ def test_token_minting_and_route_checks_share_the_scope_catalog():
     assert codex_routes.TODO_READ_SCOPES <= ALL_API_TOKEN_SCOPES
     assert codex_routes.EMAIL_READ_SCOPES <= ALL_API_TOKEN_SCOPES
     assert codex_routes.COOKBOOK_READ_SCOPES <= ALL_API_TOKEN_SCOPES
-
-
-def test_capability_gate_runs_only_after_a_valid_bearer_match():
-    source = Path("app.py").read_text(encoding="utf-8")
-    cors_gate = source.index("if is_cors_preflight(")
-    exempt_gate = source.index("if _is_auth_exempt(path):")
-    internal_gate = source.index("# In-process internal-tool token bypass")
-    local_gate = source.index("# Allow DIRECT localhost requests")
-    bearer_gate = source.index('if auth_header.startswith("Bearer ody_"):')
-    token_match = source.index("if matched_id:", bearer_gate)
-    capability_gate = source.index("authorize_api_token_request(", token_match)
-    token_state = source.index("request.state.api_token = True", capability_gate)
-    cookie_gate = source.index("# --- Cookie-based session auth ---", token_state)
-
-    assert (
-        cors_gate
-        < exempt_gate
-        < internal_gate
-        < local_gate
-        < bearer_gate
-        < token_match
-        < capability_gate
-        < token_state
-        < cookie_gate
-    )
-    local_block = source[local_gate:bearer_gate]
-    assert 'not auth_header.startswith("Bearer ody_")' in local_block

--- a/tests/test_api_token_capabilities.py
+++ b/tests/test_api_token_capabilities.py
@@ -401,5 +401,34 @@ def test_token_minting_and_route_checks_share_the_scope_catalog():
     assert ALLOWED_SCOPES is ALL_API_TOKEN_SCOPES
     assert codex_routes.TODO_READ_SCOPES <= ALL_API_TOKEN_SCOPES
     assert codex_routes.EMAIL_READ_SCOPES <= ALL_API_TOKEN_SCOPES
-    assert codex_routes.COOKBOOK_READ_SCOPES.isdisjoint(ALL_API_TOKEN_SCOPES)
-    assert codex_routes.COOKBOOK_LAUNCH_SCOPES.isdisjoint(ALL_API_TOKEN_SCOPES)
+    assert not hasattr(codex_routes, "COOKBOOK_READ_SCOPES")
+    assert not hasattr(codex_routes, "COOKBOOK_LAUNCH_SCOPES")
+
+
+def test_bundled_integrations_do_not_advertise_retired_cookbook_access():
+    from pathlib import Path
+
+    files = [
+        Path("static/js/admin.js"),
+        Path("static/js/settings.js"),
+        Path("integrations/codex/skills/odysseus/SKILL.md"),
+        Path("integrations/claude/skills/odysseus/SKILL.md"),
+        Path("integrations/codex/scripts/odysseus_api.py"),
+        Path("integrations/claude/skills/odysseus/scripts/odysseus_api.py"),
+    ]
+    for path in files:
+        source = path.read_text(encoding="utf-8")
+        assert "cookbook:read" not in source, path
+        assert "cookbook:launch" not in source, path
+
+    for path in files[-2:]:
+        source = path.read_text(encoding="utf-8")
+        assert 'command == "cookbook"' not in source, path
+        assert "/api/codex/cookbook/" not in source, path
+
+    admin_ui = files[0].read_text(encoding="utf-8")
+    settings_ui = files[1].read_text(encoding="utf-8")
+    for source in (admin_ui, settings_ui):
+        assert "retired_scopes" in source
+        assert "are inactive and will be removed" in source
+    assert "no active scopes; retired:" in settings_ui

--- a/tests/test_api_token_capabilities.py
+++ b/tests/test_api_token_capabilities.py
@@ -64,30 +64,6 @@ def test_companion_bearer_reads_all_require_chat_scope():
             "documents:write",
             "documents:read",
         ),
-        ("GET", "/api/codex/cookbook/tasks", "cookbook:read", "chat"),
-        ("GET", "/api/codex/cookbook/servers", "cookbook:launch", "chat"),
-        (
-            "GET",
-            "/api/codex/cookbook/output/serve-1",
-            "cookbook:read",
-            "chat",
-        ),
-        ("GET", "/api/codex/cookbook/cached", "cookbook:read", "chat"),
-        ("GET", "/api/codex/cookbook/presets", "cookbook:read", "chat"),
-        ("POST", "/api/codex/cookbook/serve", "cookbook:launch", "chat"),
-        (
-            "POST",
-            "/api/codex/cookbook/stop/serve-1",
-            "cookbook:launch",
-            "cookbook:read",
-        ),
-        (
-            "POST",
-            "/api/codex/cookbook/preset/default",
-            "cookbook:launch",
-            "cookbook:read",
-        ),
-        ("POST", "/api/codex/cookbook/adopt", "cookbook:launch", "chat"),
     ],
 )
 def test_codex_route_families_require_their_existing_scopes(
@@ -147,6 +123,31 @@ def test_bootstrap_downloads_require_at_least_one_accepted_scope():
 )
 def test_privileged_and_owner_attributing_ui_routes_remain_blocked(method, path):
     decision = authorize_api_token_route(method, path, ALL_API_TOKEN_SCOPES)
+
+    assert decision.allowed is False
+    assert decision.error == API_TOKEN_FORBIDDEN_ERROR
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("GET", "/api/codex/cookbook/tasks"),
+        ("GET", "/api/codex/cookbook/servers"),
+        ("GET", "/api/codex/cookbook/output/serve-1"),
+        ("GET", "/api/codex/cookbook/cached"),
+        ("GET", "/api/codex/cookbook/presets"),
+        ("POST", "/api/codex/cookbook/serve"),
+        ("POST", "/api/codex/cookbook/stop/serve-1"),
+        ("POST", "/api/codex/cookbook/preset/default"),
+        ("POST", "/api/codex/cookbook/adopt"),
+    ],
+)
+def test_legacy_cookbook_scopes_are_inert_at_the_bearer_boundary(method, path):
+    decision = authorize_api_token_route(
+        method,
+        path,
+        ["cookbook:read", "cookbook:launch"],
+    )
 
     assert decision.allowed is False
     assert decision.error == API_TOKEN_FORBIDDEN_ERROR
@@ -218,6 +219,31 @@ def test_asgi_root_path_is_removed_before_matching():
     assert wrong_prefix.allowed is False
 
 
+@pytest.mark.parametrize(
+    ("root_path", "path", "raw_path"),
+    [
+        ("/odysseus/", "/odysseus//api/models", b"/odysseus//api/models"),
+        ("/", "//api/models", b"//api/models"),
+    ],
+)
+def test_asgi_root_path_with_trailing_slash_is_removed_before_matching(
+    root_path,
+    path,
+    raw_path,
+):
+    decision = authorize_api_token_request(
+        "GET",
+        {
+            "root_path": root_path,
+            "path": path,
+            "raw_path": raw_path,
+        },
+        ["chat"],
+    )
+
+    assert decision.allowed is True
+
+
 @pytest.mark.parametrize("encoded", [b"%2f", b"%2F", b"%5c", b"%5C", b"%00"])
 def test_encoded_path_delimiters_fail_closed(encoded):
     decision = authorize_api_token_request(
@@ -230,6 +256,26 @@ def test_encoded_path_delimiters_fail_closed(encoded):
     )
 
     assert decision.allowed is False
+
+
+@pytest.mark.parametrize(
+    ("decoded", "encoded"),
+    [("?", b"%3F"), ("#", b"%23")],
+)
+def test_encoded_calendar_uid_characters_follow_the_decoded_router_path(
+    decoded,
+    encoded,
+):
+    decision = authorize_api_token_request(
+        "DELETE",
+        {
+            "path": f"/api/codex/calendar/events/team{decoded}primary",
+            "raw_path": b"/api/codex/calendar/events/team" + encoded + b"primary",
+        },
+        ["calendar:write"],
+    )
+
+    assert decision.allowed is True
 
 
 def test_encoded_static_letters_follow_the_decoded_router_path():
@@ -302,7 +348,24 @@ def test_manifest_matches_runtime_scoped_router_inventory():
         ("POST", "/api/v1/chat"),
         ("GET", "/api/models"),
     }
-    expected.update(_router_inventory(setup_codex_routes()))
+    codex_inventory = _router_inventory(setup_codex_routes())
+    cookbook_inventory = {
+        route
+        for route in codex_inventory
+        if route[1].startswith("/api/codex/cookbook/")
+    }
+    assert cookbook_inventory == {
+        ("GET", "/api/codex/cookbook/tasks"),
+        ("GET", "/api/codex/cookbook/servers"),
+        ("GET", "/api/codex/cookbook/output/{session_id}"),
+        ("GET", "/api/codex/cookbook/cached"),
+        ("GET", "/api/codex/cookbook/presets"),
+        ("POST", "/api/codex/cookbook/serve"),
+        ("POST", "/api/codex/cookbook/stop/{session_id}"),
+        ("POST", "/api/codex/cookbook/preset/{name}"),
+        ("POST", "/api/codex/cookbook/adopt"),
+    }
+    expected.update(codex_inventory - cookbook_inventory)
     expected.update(_router_inventory(setup_claude_routes()))
     expected.update(companion_inventory - companion_pairing)
     actual = {
@@ -328,8 +391,6 @@ def test_accepted_scope_catalog_is_explicit_and_has_no_admin_scope():
         "calendar:write",
         "memory:read",
         "memory:write",
-        "cookbook:read",
-        "cookbook:launch",
     }
 
 
@@ -340,4 +401,5 @@ def test_token_minting_and_route_checks_share_the_scope_catalog():
     assert ALLOWED_SCOPES is ALL_API_TOKEN_SCOPES
     assert codex_routes.TODO_READ_SCOPES <= ALL_API_TOKEN_SCOPES
     assert codex_routes.EMAIL_READ_SCOPES <= ALL_API_TOKEN_SCOPES
-    assert codex_routes.COOKBOOK_READ_SCOPES <= ALL_API_TOKEN_SCOPES
+    assert codex_routes.COOKBOOK_READ_SCOPES.isdisjoint(ALL_API_TOKEN_SCOPES)
+    assert codex_routes.COOKBOOK_LAUNCH_SCOPES.isdisjoint(ALL_API_TOKEN_SCOPES)

--- a/tests/test_api_token_middleware_integration.py
+++ b/tests/test_api_token_middleware_integration.py
@@ -61,18 +61,28 @@ def test_production_auth_middleware_enforces_api_token_capabilities(tmp_path):
         app_module._bcrypt.checkpw = lambda *_args: True
 
 
-        def _request(method, path, *, loopback):
+        def _request(
+            method,
+            path,
+            *,
+            loopback,
+            authorization=None,
+            raw_path=None,
+        ):
             return Request({
                 "type": "http",
                 "http_version": "1.1",
                 "method": method,
                 "scheme": "http",
                 "path": path,
-                "raw_path": path.encode(),
+                "raw_path": raw_path or path.encode(),
                 "root_path": "",
                 "query_string": b"",
                 "headers": [
-                    (b"authorization", f"Bearer {RAW_TOKEN}".encode()),
+                    (
+                        b"authorization",
+                        (authorization or f"Bearer {RAW_TOKEN}").encode(),
+                    ),
                 ],
                 "client": (
                     "127.0.0.1" if loopback else "192.0.2.10",
@@ -83,13 +93,28 @@ def test_production_auth_middleware_enforces_api_token_capabilities(tmp_path):
             })
 
 
-        async def _case(path, scopes, *, loopback=False, localhost_bypass=False):
+        async def _case(
+            path,
+            scopes,
+            *,
+            loopback=False,
+            localhost_bypass=False,
+            authorization=None,
+            method="GET",
+            raw_path=None,
+        ):
             app_module.LOCALHOST_BYPASS = localhost_bypass
             app_module._token_cache.clear()
             app_module._token_cache[RAW_TOKEN[:8]] = [
                 ("token-1", "unused-hash", "alice", scopes),
             ]
-            request = _request("GET", path, loopback=loopback)
+            request = _request(
+                method,
+                path,
+                loopback=loopback,
+                authorization=authorization,
+                raw_path=raw_path,
+            )
             calls = []
 
             async def call_next(received):
@@ -113,18 +138,73 @@ def test_production_auth_middleware_enforces_api_token_capabilities(tmp_path):
             try:
                 forbidden = await _case("/api/unregistered", ["chat"])
                 allowed = await _case("/api/models", ["chat"])
-                local_wrong_scope = await _case(
-                    "/api/models",
-                    ["todos:read"],
-                    loopback=True,
-                    localhost_bypass=True,
-                )
+                encoded_calendar_uids = {
+                    "question_mark": await _case(
+                        "/api/codex/calendar/events/team?primary",
+                        ["calendar:write"],
+                        method="DELETE",
+                        raw_path=(
+                            b"/api/codex/calendar/events/team%3Fprimary"
+                        ),
+                    ),
+                    "hash": await _case(
+                        "/api/codex/calendar/events/team#primary",
+                        ["calendar:write"],
+                        method="DELETE",
+                        raw_path=(
+                            b"/api/codex/calendar/events/team%23primary"
+                        ),
+                    ),
+                }
+                cookbook_forbidden = {}
+                for label, (method, path) in {
+                    "tasks": ("GET", "/api/codex/cookbook/tasks"),
+                    "servers": ("GET", "/api/codex/cookbook/servers"),
+                    "output": (
+                        "GET",
+                        "/api/codex/cookbook/output/serve-1",
+                    ),
+                    "cached": ("GET", "/api/codex/cookbook/cached"),
+                    "presets": ("GET", "/api/codex/cookbook/presets"),
+                    "serve": ("POST", "/api/codex/cookbook/serve"),
+                    "stop": (
+                        "POST",
+                        "/api/codex/cookbook/stop/serve-1",
+                    ),
+                    "preset": (
+                        "POST",
+                        "/api/codex/cookbook/preset/default",
+                    ),
+                    "adopt": ("POST", "/api/codex/cookbook/adopt"),
+                }.items():
+                    cookbook_forbidden[label] = await _case(
+                        path,
+                        ["cookbook:read", "cookbook:launch"],
+                        method=method,
+                    )
+                local_wrong_scope = {}
+                for label, authorization in {
+                    "canonical": f"Bearer {RAW_TOKEN}",
+                    "lowercase": f"bearer {RAW_TOKEN}",
+                    "uppercase": f"BEARER {RAW_TOKEN}",
+                    "mixed_case": f"bEaReR {RAW_TOKEN}",
+                    "multiple_spaces": f"Bearer   {RAW_TOKEN}",
+                }.items():
+                    local_wrong_scope[label] = await _case(
+                        "/api/models",
+                        ["todos:read"],
+                        loopback=True,
+                        localhost_bypass=True,
+                        authorization=authorization,
+                    )
             finally:
                 app_module._asyncio.create_task = original_create_task
 
             print("RESULT=" + json.dumps({
                 "forbidden": forbidden,
                 "allowed": allowed,
+                "cookbook_forbidden": cookbook_forbidden,
+                "encoded_calendar_uids": encoded_calendar_uids,
                 "local_wrong_scope": local_wrong_scope,
             }, sort_keys=True))
 
@@ -165,10 +245,35 @@ def test_production_auth_middleware_enforces_api_token_capabilities(tmp_path):
         "api_token": True,
         "owner": "alice",
     }
-    assert observed["local_wrong_scope"] == {
+    assert observed["encoded_calendar_uids"] == {
+        "question_mark": observed["allowed"],
+        "hash": observed["allowed"],
+    }
+    expected_forbidden = {
         "status": 403,
         "body": generic_error,
         "called": 0,
         "api_token": None,
         "owner": None,
+    }
+    assert observed["cookbook_forbidden"] == {
+        label: expected_forbidden
+        for label in (
+            "tasks",
+            "servers",
+            "output",
+            "cached",
+            "presets",
+            "serve",
+            "stop",
+            "preset",
+            "adopt",
+        )
+    }
+    assert observed["local_wrong_scope"] == {
+        "canonical": expected_forbidden,
+        "lowercase": expected_forbidden,
+        "uppercase": expected_forbidden,
+        "mixed_case": expected_forbidden,
+        "multiple_spaces": expected_forbidden,
     }

--- a/tests/test_api_token_middleware_integration.py
+++ b/tests/test_api_token_middleware_integration.py
@@ -1,0 +1,174 @@
+"""Behavior-level coverage for the production API-token middleware boundary."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_production_auth_middleware_enforces_api_token_capabilities(tmp_path):
+    """Drive the real ``app.AuthMiddleware`` in an isolated subprocess."""
+
+    env = os.environ.copy()
+    env.update({
+        "AUTH_ENABLED": "true",
+        "CHROMADB_CONNECT_TIMEOUT": "0.01",
+        "CHROMADB_HOST": "127.0.0.1",
+        "CHROMADB_PORT": "9",
+        "DATABASE_URL": f"sqlite:///{tmp_path / 'app.db'}",
+        "LOCALHOST_BYPASS": "false",
+        "ODYSSEUS_DATA_DIR": str(tmp_path),
+        "ODYSSEUS_DISABLE_MCP": "1",
+        "OPENAI_API_KEY": "",
+        "PYTHONPATH": str(ROOT),
+        "PYTHON_DOTENV_DISABLED": "1",
+    })
+    probe = textwrap.dedent(
+        """
+        import asyncio
+        import json
+
+        from starlette.requests import Request
+        from starlette.responses import JSONResponse
+
+        import app as app_module
+
+
+        RAW_TOKEN = "ody_" + "a" * 43
+
+
+        class _AuthManager:
+            is_configured = True
+            users = {"alice": {}}
+
+            @staticmethod
+            def validate_token(_token):
+                return False
+
+            @staticmethod
+            def get_username_for_token(_token):
+                return None
+
+
+        app_module.auth_manager = _AuthManager()
+        app_module.app.state.auth_manager = app_module.auth_manager
+        app_module.app.state._token_cache_dirty = False
+        app_module._bcrypt.checkpw = lambda *_args: True
+
+
+        def _request(method, path, *, loopback):
+            return Request({
+                "type": "http",
+                "http_version": "1.1",
+                "method": method,
+                "scheme": "http",
+                "path": path,
+                "raw_path": path.encode(),
+                "root_path": "",
+                "query_string": b"",
+                "headers": [
+                    (b"authorization", f"Bearer {RAW_TOKEN}".encode()),
+                ],
+                "client": (
+                    "127.0.0.1" if loopback else "192.0.2.10",
+                    4321,
+                ),
+                "server": ("testserver", 80),
+                "app": app_module.app,
+            })
+
+
+        async def _case(path, scopes, *, loopback=False, localhost_bypass=False):
+            app_module.LOCALHOST_BYPASS = localhost_bypass
+            app_module._token_cache.clear()
+            app_module._token_cache[RAW_TOKEN[:8]] = [
+                ("token-1", "unused-hash", "alice", scopes),
+            ]
+            request = _request("GET", path, loopback=loopback)
+            calls = []
+
+            async def call_next(received):
+                calls.append(received)
+                return JSONResponse({"reached": True})
+
+            middleware = app_module.AuthMiddleware(app_module.app)
+            response = await middleware.dispatch(request, call_next)
+            return {
+                "status": response.status_code,
+                "body": json.loads(response.body),
+                "called": len(calls),
+                "api_token": getattr(request.state, "api_token", None),
+                "owner": getattr(request.state, "api_token_owner", None),
+            }
+
+
+        async def main():
+            original_create_task = app_module._asyncio.create_task
+            app_module._asyncio.create_task = lambda coroutine: coroutine.close()
+            try:
+                forbidden = await _case("/api/unregistered", ["chat"])
+                allowed = await _case("/api/models", ["chat"])
+                local_wrong_scope = await _case(
+                    "/api/models",
+                    ["todos:read"],
+                    loopback=True,
+                    localhost_bypass=True,
+                )
+            finally:
+                app_module._asyncio.create_task = original_create_task
+
+            print("RESULT=" + json.dumps({
+                "forbidden": forbidden,
+                "allowed": allowed,
+                "local_wrong_scope": local_wrong_scope,
+            }, sort_keys=True))
+
+
+        asyncio.run(main())
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    result_line = next(
+        (line for line in result.stdout.splitlines() if line.startswith("RESULT=")),
+        None,
+    )
+    assert result_line is not None, result.stdout
+    observed = json.loads(result_line.removeprefix("RESULT="))
+
+    generic_error = {"error": "API token is not authorized for this endpoint"}
+    assert observed["forbidden"] == {
+        "status": 403,
+        "body": generic_error,
+        "called": 0,
+        "api_token": None,
+        "owner": None,
+    }
+    assert observed["allowed"] == {
+        "status": 200,
+        "body": {"reached": True},
+        "called": 1,
+        "api_token": True,
+        "owner": "alice",
+    }
+    assert observed["local_wrong_scope"] == {
+        "status": 403,
+        "body": generic_error,
+        "called": 0,
+        "api_token": None,
+        "owner": None,
+    }

--- a/tests/test_api_token_routes.py
+++ b/tests/test_api_token_routes.py
@@ -231,7 +231,7 @@ def test_list_tokens_returns_safe_display_fields_only(monkeypatch, token_routes_
         owner="alice",
         token_prefix="ody_prod",
         token_hash="$2b$12$SHOULDNEVERAPPEAR",
-        scopes="chat,research",
+        scopes="chat,research,cookbook:read,cookbook:launch",
         is_active=True,
         last_used_at=datetime.datetime(2024, 1, 15, 10, 0),
         created_at=datetime.datetime(2024, 1, 1, 0, 0),
@@ -259,14 +259,16 @@ def test_list_tokens_returns_safe_display_fields_only(monkeypatch, token_routes_
 
     assert len(result) == 2
 
-    safe_fields = {"id", "name", "owner", "token_prefix", "scopes", "is_active", "last_used_at", "created_at"}
+    safe_fields = {"id", "name", "owner", "token_prefix", "scopes", "retired_scopes", "is_active", "last_used_at", "created_at"}
     for item in result:
         assert set(item.keys()) == safe_fields
         assert "token" not in item
         assert "token_hash" not in item
 
     assert result[0]["scopes"] == ["chat", "research"]
+    assert result[0]["retired_scopes"] == ["cookbook:read", "cookbook:launch"]
     assert result[1]["scopes"] == ["chat"]
+    assert result[1]["retired_scopes"] == []
 
 
 # ---------------------------------------------------------------------------
@@ -348,7 +350,7 @@ def test_update_token_rename_preserves_scopes(monkeypatch, token_routes_mod):
 
     token = SimpleNamespace(
         id="tok123", name="original", owner="alice",
-        token_prefix="ody_orig", scopes="email:read,email:draft", is_active=True,
+        token_prefix="ody_orig", scopes="email:read,email:draft,cookbook:read", is_active=True,
     )
     fake_session = MagicMock()
     fake_session.query.return_value.filter.return_value.first.return_value = token
@@ -359,8 +361,9 @@ def test_update_token_rename_preserves_scopes(monkeypatch, token_routes_mod):
     update_token = _get_handler(mod, "PATCH", "/tokens/{token_id}")
     resp = asyncio.run(update_token(request=req, token_id="tok123"))
 
-    assert token.scopes == "email:read,email:draft"  # untouched
+    assert token.scopes == "email:read,email:draft,cookbook:read"  # untouched
     assert resp["scopes"] == ["email:read", "email:draft"]
+    assert resp["retired_scopes"] == ["cookbook:read"]
     assert token.name == "renamed"
     invalidator.assert_called_once()
 
@@ -372,18 +375,50 @@ def test_update_token_applies_explicit_scopes(monkeypatch, token_routes_mod):
 
     token = SimpleNamespace(
         id="tok123", name="original", owner="alice",
-        token_prefix="ody_orig", scopes="email:read,email:draft", is_active=True,
+        token_prefix="ody_orig", scopes="email:read,email:draft,cookbook:read", is_active=True,
     )
     fake_session = MagicMock()
     fake_session.query.return_value.filter.return_value.first.return_value = token
     monkeypatch.setattr(mod, "get_db_session", lambda: _db_ctx(fake_session))
 
-    req = _patch_request(MagicMock(), {"scopes": ["chat"]})
+    req = _patch_request(MagicMock(), {"scopes": ["chat", "cookbook:read"]})
     update_token = _get_handler(mod, "PATCH", "/tokens/{token_id}")
     resp = asyncio.run(update_token(request=req, token_id="tok123"))
 
     assert token.scopes == "chat"
     assert resp["scopes"] == ["chat"]
+    assert resp["retired_scopes"] == []
+
+
+@pytest.mark.parametrize("scopes", [None, "", [], ["cookbook:read", "cookbook:launch"]])
+def test_update_token_rejects_permission_edit_without_active_scopes(
+    monkeypatch,
+    token_routes_mod,
+    scopes,
+):
+    monkeypatch.setenv("AUTH_ENABLED", "true")
+    mod = token_routes_mod
+
+    token = SimpleNamespace(
+        id="tok123", name="original", owner="alice",
+        token_prefix="ody_orig", scopes="cookbook:read,cookbook:launch", is_active=True,
+    )
+    fake_session = MagicMock()
+    fake_session.query.return_value.filter.return_value.first.return_value = token
+    monkeypatch.setattr(mod, "get_db_session", lambda: _db_ctx(fake_session))
+
+    invalidator = MagicMock()
+    req = _patch_request(invalidator, {"scopes": scopes})
+    update_token = _get_handler(mod, "PATCH", "/tokens/{token_id}")
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(update_token(request=req, token_id="tok123"))
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "At least one active token scope is required"
+    assert token.scopes == "cookbook:read,cookbook:launch"
+    fake_session.add.assert_not_called()
+    invalidator.assert_not_called()
 
 
 def test_update_missing_token_returns_404(monkeypatch, token_routes_mod):

--- a/tests/test_api_token_routes.py
+++ b/tests/test_api_token_routes.py
@@ -192,7 +192,12 @@ def test_create_token_attributes_owner_hashes_secret_and_returns_raw_once(monkey
     invalidator.assert_called_once()
 
 
-def test_create_token_accepts_cookbook_read_scope(monkeypatch, token_routes_mod):
+@pytest.mark.parametrize("scope", ["cookbook:read", "cookbook:launch"])
+def test_create_token_rejects_retired_cookbook_scopes(
+    monkeypatch,
+    token_routes_mod,
+    scope,
+):
     monkeypatch.setenv("AUTH_ENABLED", "true")
     mod = token_routes_mod
 
@@ -202,24 +207,12 @@ def test_create_token_accepts_cookbook_read_scope(monkeypatch, token_routes_mod)
 
     req = _req("alice", is_admin=True)
     create_token = _get_handler(mod, "POST", "/tokens")
-    resp = create_token(request=req, name="cookbook-reader", scopes="cookbook:read")
+    with pytest.raises(HTTPException) as exc:
+        create_token(request=req, name="retired-cookbook", scopes=scope)
 
-    assert resp["scopes"] == ["cookbook:read"]
-
-
-def test_cookbook_launch_scope_implies_read(monkeypatch, token_routes_mod):
-    monkeypatch.setenv("AUTH_ENABLED", "true")
-    mod = token_routes_mod
-
-    fake_session = MagicMock()
-    monkeypatch.setattr(mod, "get_db_session", lambda: _db_ctx(fake_session))
-    monkeypatch.setattr(mod, "get_current_user", lambda req: req.state.current_user)
-
-    req = _req("alice", is_admin=True)
-    create_token = _get_handler(mod, "POST", "/tokens")
-    resp = create_token(request=req, name="cookbook-launcher", scopes="cookbook:launch")
-
-    assert resp["scopes"] == ["cookbook:read", "cookbook:launch"]
+    assert exc.value.status_code == 400
+    assert exc.value.detail == f"Unknown token scope: {scope}"
+    fake_session.add.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_codex_cookbook_admin_gate.py
+++ b/tests/test_codex_cookbook_admin_gate.py
@@ -5,18 +5,15 @@ routes (tasks, servers, output, stop, adopt, presets, etc.) through
 normal cookie sessions because _scope_owner only checked login status,
 not admin privileges.
 
-After the fix, cookie-session callers must be admin; API-token callers
-are still governed by scope checks only.
+After retirement of Cookbook bearer access, cookie-session callers must be
+admin and API-token callers must always be rejected.
 """
 import pytest
 from types import SimpleNamespace
 from fastapi import HTTPException
 
-from routes.codex_routes import _require_cookbook_scope
-
-
-COOKBOOK_READ_SCOPES = {"cookbook:read", "cookbook:launch"}
-COOKBOOK_LAUNCH_SCOPES = {"cookbook:launch"}
+from routes.codex_routes import _require_cookbook_admin, setup_codex_routes
+from src.api_token_capabilities import API_TOKEN_FORBIDDEN_ERROR
 
 
 def _cookie_request(*, current_user="bob", is_admin=False):
@@ -56,48 +53,66 @@ class TestCookieSessionAdminGate:
         monkeypatch.setenv("AUTH_ENABLED", "true")
         req = _cookie_request(is_admin=False)
         with pytest.raises(HTTPException) as exc:
-            _require_cookbook_scope(req, COOKBOOK_READ_SCOPES)
+            _require_cookbook_admin(req)
         assert exc.value.status_code == 403
 
     def test_non_admin_rejected_launch(self, monkeypatch):
         monkeypatch.setenv("AUTH_ENABLED", "true")
         req = _cookie_request(is_admin=False)
         with pytest.raises(HTTPException) as exc:
-            _require_cookbook_scope(req, COOKBOOK_LAUNCH_SCOPES)
+            _require_cookbook_admin(req)
         assert exc.value.status_code == 403
 
     def test_admin_allowed_read(self, monkeypatch):
         monkeypatch.setenv("AUTH_ENABLED", "true")
         req = _cookie_request(is_admin=True)
-        owner = _require_cookbook_scope(req, COOKBOOK_READ_SCOPES)
+        owner = _require_cookbook_admin(req)
         assert owner == "bob"
 
     def test_admin_allowed_launch(self, monkeypatch):
         monkeypatch.setenv("AUTH_ENABLED", "true")
         req = _cookie_request(is_admin=True)
-        owner = _require_cookbook_scope(req, COOKBOOK_LAUNCH_SCOPES)
+        owner = _require_cookbook_admin(req)
         assert owner == "bob"
 
 
-class TestApiTokenScopeGate:
-    """API-token callers are governed by scope, not admin status."""
+class TestApiTokenGate:
+    """API-token callers cannot reach Cookbook through retired scopes."""
 
-    def test_token_with_scope_allowed(self, monkeypatch):
+    def test_token_with_retired_scope_rejected(self, monkeypatch):
         monkeypatch.setenv("AUTH_ENABLED", "true")
         req = _api_token_request(scopes=["cookbook:read"])
-        owner = _require_cookbook_scope(req, COOKBOOK_READ_SCOPES)
-        assert owner == "alice"
+        with pytest.raises(HTTPException) as exc:
+            _require_cookbook_admin(req)
+        assert exc.value.status_code == 403
+        assert exc.value.detail == API_TOKEN_FORBIDDEN_ERROR
 
     def test_token_missing_scope_rejected(self, monkeypatch):
         monkeypatch.setenv("AUTH_ENABLED", "true")
         req = _api_token_request(scopes=["unrelated:scope"])
         with pytest.raises(HTTPException) as exc:
-            _require_cookbook_scope(req, COOKBOOK_READ_SCOPES)
+            _require_cookbook_admin(req)
         assert exc.value.status_code == 403
+        assert exc.value.detail == API_TOKEN_FORBIDDEN_ERROR
+
+
+def test_capabilities_omit_cookbook_and_retired_scopes():
+    router = setup_codex_routes()
+    endpoint = next(
+        route.endpoint
+        for route in router.routes
+        if route.path == "/api/codex/capabilities" and "GET" in route.methods
+    )
+    request = _api_token_request(scopes=["chat", "cookbook:read", "cookbook:launch"])
+
+    result = endpoint(request)
+
+    assert result["token_scopes"] == ["chat"]
+    assert "cookbook" not in result["tools"]
 
 
 class TestSourceCodeGate:
-    """Static checks: all cookbook routes use _require_cookbook_scope."""
+    """Static checks: all Cookbook routes use the cookie/admin gate."""
 
     def test_no_raw_scope_owner_in_cookbook_routes(self):
         from pathlib import Path
@@ -114,5 +129,7 @@ class TestSourceCodeGate:
             if in_cookbook and "_scope_owner(request" in line:
                 violations.append((i, line.strip()))
         assert violations == [], (
-            f"Cookbook routes still use _scope_owner instead of _require_cookbook_scope: {violations}"
+            f"Cookbook routes still use _scope_owner instead of _require_cookbook_admin: {violations}"
         )
+        assert source.count("_require_cookbook_admin(request)") == 9
+        assert "_require_cookbook_scope" not in source

--- a/tests/test_codex_ssh_host_validation.py
+++ b/tests/test_codex_ssh_host_validation.py
@@ -8,6 +8,7 @@ These pin validation on the host/port before they reach the ssh string, matching
 the validators the rest of the cookbook routes already apply.
 """
 import asyncio
+from types import SimpleNamespace
 
 import pytest
 from fastapi import APIRouter, HTTPException
@@ -25,6 +26,10 @@ def _route_endpoint(path: str, method: str, router=None):
 
 
 def _launch_request() -> Request:
+    auth_manager = SimpleNamespace(
+        is_configured=True,
+        is_admin=lambda user: user == "alice",
+    )
     request = Request(
         {
             "type": "http",
@@ -32,11 +37,11 @@ def _launch_request() -> Request:
             "path": "/api/codex/cookbook/adopt",
             "headers": [],
             "state": {},
+            "app": SimpleNamespace(state=SimpleNamespace(auth_manager=auth_manager)),
         }
     )
-    request.state.api_token = True
-    request.state.api_token_owner = "alice"
-    request.state.api_token_scopes = ["cookbook:launch"]
+    request.state.current_user = "alice"
+    request.state.api_token = False
     return request
 
 

--- a/tests/test_companion_readonly.py
+++ b/tests/test_companion_readonly.py
@@ -117,12 +117,16 @@ def _ep(
     )
 
 
-def _models_route():
+def _companion_route(path):
     for route in setup_companion_routes().routes:
-        if getattr(route, "path", "") == "/api/companion/models":
+        if getattr(route, "path", "") == path:
             assert "GET" in getattr(route, "methods", set())
             return route.endpoint
-    raise AssertionError("GET /api/companion/models route not found")
+    raise AssertionError(f"GET {path} route not found")
+
+
+def _models_route():
+    return _companion_route("/api/companion/models")
 
 
 def _call_models_route(monkeypatch, rows, request):
@@ -254,6 +258,38 @@ def test_models_route_rejects_api_token_without_chat_scope(monkeypatch):
 
     assert exc.value.status_code == 403
     assert "chat scope" in exc.value.detail
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/companion/ping",
+        "/api/companion/info",
+        "/api/companion/models",
+    ],
+)
+def test_all_companion_bearer_reads_reject_tokens_without_chat_scope(path):
+    with pytest.raises(HTTPException) as exc:
+        _companion_route(path)(
+            _request(
+                api_token=True,
+                api_token_owner="alice",
+                api_token_scopes=["todos:read"],
+                current_user="api",
+            )
+        )
+
+    assert exc.value.status_code == 403
+    assert "chat scope" in exc.value.detail
+
+
+@pytest.mark.parametrize("path", ["/api/companion/ping", "/api/companion/info"])
+def test_companion_identity_reads_still_allow_cookie_sessions(path):
+    result = _companion_route(path)(
+        _request(api_token=False, current_user="alice")
+    )
+
+    assert isinstance(result, dict)
 
 
 def test_models_route_unresolved_owner_returns_only_shared_rows(monkeypatch):

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -1684,7 +1684,83 @@ def test_api_models_scopes_api_token_to_token_owner(monkeypatch):
     result = _route_endpoint(router, "/api/models")(request)
 
     assert [item["endpoint_name"] for item in result["items"]] == ["alice", "shared"]
-    assert admin_checks == ["alice"]
+    assert admin_checks == []
+
+
+def test_api_models_admin_owned_token_does_not_reuse_cookie_admin_inventory(monkeypatch):
+    rows = [
+        _route_ep("admin", "http://admin.example/v1", cached_models=["admin-model"], owner="admin"),
+        _route_ep("shared", "http://shared.example/v1", cached_models=["shared-model"], owner=None),
+        _route_ep("alice", "http://alice.example/v1", cached_models=["alice-model"], owner="alice"),
+    ]
+    db = _RouteDb(rows)
+    router = model_routes.setup_model_routes(model_discovery=None)
+    admin_checks = []
+
+    monkeypatch.setattr(model_routes, "ModelEndpoint", _RouteModelEndpoint)
+    monkeypatch.setattr(model_routes, "SessionLocal", lambda: db)
+
+    auth_manager = SimpleNamespace(
+        is_configured=True,
+        is_admin=lambda user: admin_checks.append(user) or True,
+    )
+    cookie_request = SimpleNamespace(
+        state=SimpleNamespace(current_user="admin", api_token=False),
+        app=SimpleNamespace(state=SimpleNamespace(auth_manager=auth_manager)),
+    )
+    token_request = SimpleNamespace(
+        state=SimpleNamespace(
+            current_user="api",
+            api_token=True,
+            api_token_owner="admin",
+            api_token_scopes=["chat"],
+        ),
+        app=SimpleNamespace(state=SimpleNamespace(auth_manager=auth_manager)),
+    )
+
+    endpoint = _route_endpoint(router, "/api/models")
+    cookie_result = endpoint(cookie_request)
+    token_result = endpoint(token_request)
+
+    assert [item["endpoint_name"] for item in cookie_result["items"]] == ["admin", "shared", "alice"]
+    assert [item["endpoint_name"] for item in token_result["items"]] == ["admin", "shared"]
+    assert admin_checks == ["admin"]
+
+
+@pytest.mark.parametrize("refresh_kwargs", [{"refresh": True}, {"background": True}])
+def test_api_models_api_token_never_starts_global_refresh(monkeypatch, refresh_kwargs):
+    rows = [
+        _route_ep("alice", "http://alice.example/v1", cached_models=["alice-model"], owner="alice"),
+        _route_ep("bob", "http://bob.example/v1", cached_models=["bob-model"], owner="bob"),
+    ]
+    db = _RouteDb(rows)
+    router = model_routes.setup_model_routes(model_discovery=None)
+
+    monkeypatch.setattr(model_routes, "ModelEndpoint", _RouteModelEndpoint)
+    monkeypatch.setattr(model_routes, "SessionLocal", lambda: db)
+
+    def fail_thread(*args, **kwargs):
+        raise AssertionError("bearer model inventory must not start the global refresher")
+
+    monkeypatch.setattr(threading, "Thread", fail_thread)
+
+    request = SimpleNamespace(
+        state=SimpleNamespace(
+            current_user="api",
+            api_token=True,
+            api_token_owner="alice",
+            api_token_scopes=["chat"],
+        ),
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                auth_manager=SimpleNamespace(is_configured=True, is_admin=lambda user: True),
+            ),
+        ),
+    )
+
+    result = _route_endpoint(router, "/api/models")(request, **refresh_kwargs)
+
+    assert [item["endpoint_name"] for item in result["items"]] == ["alice"]
 
 
 def test_api_models_returns_only_pinned_proxy_models_without_refresh_probe(monkeypatch):


### PR DESCRIPTION
## Summary


This replaces #5680, which GitHub closed during the repository transfer and fork-network separation. The branch has been rebuilt on the current dev history; the implementation scope is unchanged.

Refresh #3150 onto current `dev` and make bearer-token access default-deny at the middleware boundary. Valid `ody_` credentials may reach only explicitly registered method/path capabilities with matching scopes; browser/admin, token-management, session, upload, shell, workspace, Cookbook administration, and other unregistered routes remain unavailable. Supported generic chat/model and unrelated Codex/Claude APIs keep their documented behavior. Only the three temporary companion discovery/model reads remain during this slice. Existing bearer access to generic session, history, upload, and stream routes is intentionally not carried into the explicit capability manifest; the final companion-removal draft then deletes the remaining `/api/companion/*` bridge.

This branch preserves Musaab Hasan's original authored capability commit from #3150, then reconciles the route inventory, owner-scoped model behavior, ASGI path normalization, production-middleware coverage, retired Cookbook scopes, and current tests. Existing tokens may retain legacy Cookbook strings, but those strings are inert and new tokens cannot mint them.

This draft follows #5678 and PR #5679, the focused implementation for #5676, and must merge before the companion-removal draft. After those prerequisites merge, this branch should be rebased and its temporary path/Cookbook overlap deduplicated before review for merge. It must not merge directly on current `dev`: until #5676 lands, the old token forms still submit the Cookbook scopes retired here.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3149

Part of #5674

## Type of Change

- [x] Bug fix (fixes a confirmed authorization gap; the compatibility break is marked below)
- [ ] New feature (non-breaking — adds explicit route capabilities)
- [x] Breaking change (removes implicit bearer access to unregistered route families)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs and reviewed the existing draft #3150.
- [x] This PR targets `dev`.
- [x] My changes are limited to the API-token route/capability boundary and regressions found while validating it.
- [ ] I ran the full app interactively. This remains a draft until maintainer review and deployment-level verification are complete.

## How to Test

1. Run `python -m pytest -q tests/test_api_token_capabilities.py tests/test_api_token_middleware_integration.py tests/test_api_token_routes.py tests/test_api_token_user_route_gate.py tests/test_auth_policy.py tests/test_auth_regressions.py tests/test_session_owner_attribution.py`. The isolated focused run passes all 126 tests.
2. Verify a chat-scoped token can call `POST /api/v1/chat` and `GET /api/models`, while the same valid token receives non-enumerating `403` responses on unregistered or wrong-scope routes.
3. Verify explicit bearer credentials do not inherit cookie/admin behavior or `LOCALHOST_BYPASS`, model inventory stays scoped to the token owner, and bearer requests cannot trigger endpoint refreshes.
4. Verify bearer calls to previously implicit session, history, upload, stream, shell, workspace, and token-management routes receive the same generic `403`; this intentional compatibility break is why the companion-removal follow-up is part of the ordered stack.
5. Verify every `/api/codex/cookbook/*` request receives the generic `403` before its handler even when the stored token carries legacy Cookbook scopes, and verify new token creation rejects those retired scopes.
6. Run `python -m pytest -q`. The isolated full suite completes with 4,740 passing and 5 skipped tests. Its 12 failures exactly match the clean current-`dev` runner baseline: the omitted `.env.example`, one offline URL-join check, two backup-recovery checks, and eight offline web-fetch checks.

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable. No UI or rendering files are changed.

