### PR TITLE
fix(mcp): keep fresh installs on the v1 SDK line

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,10 @@ python-dateutil
 caldav
 cryptography
 bcrypt
-mcp
+# Built-in servers use the v1 low-level Server decorator API. MCP SDK v2 is a
+# breaking rewrite, so keep fresh installs on the maintained v1 line until the
+# servers are migrated together.
+mcp<2
 pyotp
 qrcode[pil]
 croniter

--- a/tests/test_mcp_dependency_compatibility.py
+++ b/tests/test_mcp_dependency_compatibility.py
@@ -1,0 +1,15 @@
+"""Regression coverage for the built-in MCP servers' SDK compatibility line."""
+
+from pathlib import Path
+
+
+REQUIREMENTS = Path(__file__).resolve().parents[1] / "requirements.txt"
+
+
+def test_mcp_requirement_excludes_breaking_v2_sdk():
+    requirements = [
+        line.split("#", 1)[0].strip().replace(" ", "")
+        for line in REQUIREMENTS.read_text(encoding="utf-8").splitlines()
+    ]
+
+    assert "mcp<2" in requirements


### PR DESCRIPTION
## Summary

Keep fresh Odysseus installs on the maintained MCP Python SDK v1 line until the built-in email, memory, and RAG servers are intentionally migrated to v2. The unconstrained dependency began resolving MCP 2.0.0, whose breaking low-level server API removed the decorators these servers register at import time and caused pytest collection to fail across code-bearing PRs.

This adds the documented `<2` compatibility boundary and a focused regression that keeps the requirement explicit. No MCP server behavior changes for the supported v1 SDK.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #5816

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the MCP SDK compatibility boundary and its regression guard — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. This dependency-only CI repair was validated in a clean Python environment instead.

## How to Test

1. Create a clean Python environment and run `pip install -r requirements.txt`.
2. Run `python -c 'import importlib.metadata as metadata; from mcp.server import Server; print(metadata.version("mcp")); print(hasattr(Server("probe"), "list_tools")); print(hasattr(Server("probe"), "call_tool"))'` and verify the resolver selects the latest maintained v1 release and both decorators are present.
3. Run `python -m pytest -q tests/test_mcp_dependency_compatibility.py tests/test_imap_mailbox_quoting.py tests/test_mcp_email_decode_header_spaces.py tests/test_mcp_memory_owner_scope.py tests/test_rag_server_directory_nonstring.py`. The clean-environment focused run passes all 25 tests with MCP 1.29.0.
4. Run `python -m pytest -q`. The clean-environment full suite reaches 4,760 passing and 3 skipped tests; the remaining two failures are the unrelated existing upload-index backup-recovery tests.

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable. This changes one Python dependency constraint and its regression test; no UI or rendering files are touched.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. No visual files are changed.
- [x] **No new component patterns.** No component is added or changed.
- [x] **I am not an LLM agent submitting a bulk PR.** This is a focused, one-off repair requested explicitly after issue #5816 was opened.

### Screenshots / clips

Not applicable; there is no rendered change.
