### PR TITLE
fix(agent): show Ollama replies after tool calls

### DIFF
--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -2228,6 +2228,8 @@ async def _stream_llm_inner(url: str, model: str, messages: List[Dict], temperat
         # <think> blocks. Ollama /v1 accepts "think": false as a top-level param.
         if _is_ollama_openai_compat_url(url) and _supports_thinking(model):
             payload["think"] = False
+            if tools:
+                payload["reasoning_effort"] = "none"
         _apply_local_cache_affinity(payload, url, session_id)
         _apply_local_generation_stability(payload, target_url, model)
         _scrub_openai_chat_tool_reasoning(payload, target_url, model)


### PR DESCRIPTION
## Summary

When using a thinking-capable model such as `qwen3.5:latest` through Ollama's OpenAI-compatible `/v1/chat/completions` endpoint, Agent mode can execute a tool successfully but return no visible final response. The model places the answer in the `reasoning` field while `content` remains empty.

This change sends `reasoning_effort: "none"` for tool-enabled Ollama OpenAI-compatible requests so the final answer is returned as visible content.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #5824

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes are mixed in.
- [x] I ran the app with Docker and verified the change works end-to-end.

## How to Test

1. Configure an Ollama OpenAI-compatible endpoint using `/v1/chat/completions`.
2. Use `qwen3.5:latest` and enable native tool support.
3. Start a new Agent chat.
4. Ask: `Search the web for the latest Ollama release and summarize the main changes.`
5. Verify that `web_search` completes and the Agent displays a visible final summary.
6. Without this change, the second model round returns an empty `content` field and places the answer in `reasoning`.
7. With this change, the final answer is returned correctly in `content`.

## Visual / UI changes

Not applicable. This PR does not change UI rendering, CSS, HTML, JavaScript, icons, layout, or styling.