### PR TITLE
fix(agent): gate high-impact tools after untrusted context

### DIFF
--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -24,7 +24,10 @@ from src.model_context import estimate_tokens
 from src.settings import get_setting
 from src.prompt_security import untrusted_context_message
 from src.tool_security import blocked_tools_for_owner, plan_mode_disabled_tools
-from src.tool_policy import GUIDE_ONLY_DIRECTIVE, WEB_TOOL_NAMES, ToolPolicy
+from src.tool_policy import (
+    GUIDE_ONLY_DIRECTIVE, WEB_TOOL_NAMES, ToolPolicy,
+    build_effective_tool_policy, messages_contain_untrusted_context,
+)
 from src.tool_utils import _truncate, get_mcp_manager
 from src.agent_tools import (
     parse_tool_blocks,
@@ -3141,6 +3144,14 @@ async def stream_agent_loop(
     if _upload_msg:
         messages = _insert_before_latest_user(messages, _upload_msg)
 
+    # This is an execution authority transition, not a prompt instruction.
+    # Once untrusted context is present it stays enabled for every subsequent
+    # model round and every tool in a same-batch response.
+    if messages_contain_untrusted_context(messages):
+        tool_policy = (tool_policy or build_effective_tool_policy()).with_external_context()
+        disabled_tools.update(tool_policy.all_disabled_names())
+        mcp_mgr = None
+
     _t0 = time.time()
     _needs_admin = _detect_admin_intent(messages)
     _last_user = _extract_last_user_message(messages)
@@ -3682,6 +3693,13 @@ async def stream_agent_loop(
         active_email=active_email,
         workspace=workspace,
     )
+    # Prompt construction may add editor/email/skill/MCP context.  Re-check
+    # after that server-owned enrichment so later rounds inherit the gate even
+    # when the incoming request itself had no external-content message.
+    if messages_contain_untrusted_context(messages):
+        tool_policy = (tool_policy or build_effective_tool_policy()).with_external_context()
+        disabled_tools.update(tool_policy.all_disabled_names())
+        mcp_schemas = []
     if _ody_doc_finetune_mode and not plan_mode and not approved_plan and not guide_only:
         messages = _minimal_odysseus_doc_messages(
             messages,
@@ -3937,11 +3955,18 @@ async def stream_agent_loop(
                     if t.get("function", {}).get("name") not in disabled_tools
                     and t.get("name") not in disabled_tools
                 ]
+            if tool_policy and tool_policy.external_context_seen:
+                all_tool_schemas = [
+                    t for t in all_tool_schemas
+                    if not tool_policy.blocks(t.get("function", {}).get("name") or t.get("name"))
+                ]
         else:
             # Local: only MCP schemas when message suggests MCP tool usage
             _last_content = _last_user.lower()
             _wants_mcp = any(kw in _last_content for kw in _MCP_KEYWORDS)
             all_tool_schemas = mcp_schemas if (_wants_mcp and mcp_schemas) else []
+            if tool_policy and tool_policy.external_context_seen:
+                all_tool_schemas = []
         agent_stream_timeout = int(get_setting("agent_stream_timeout_seconds", 300) or 300)
 
         _tool_names_sent = [t.get("function", {}).get("name") for t in (all_tool_schemas or []) if t.get("function")]
@@ -5068,6 +5093,11 @@ async def stream_agent_loop(
             formatted = format_tool_result(desc, result)
             tool_results.append(formatted)
             tool_result_texts.append(formatted)
+            # Tool output is fed back as untrusted data.  Promote authority
+            # immediately, rather than waiting for the next model round, so a
+            # second call in the same model-produced batch cannot use the
+            # first result as an injection bridge to a higher-impact action.
+            tool_policy = (tool_policy or build_effective_tool_policy()).with_external_context()
             if (
                 _ody_doc_stream_create_mode
                 and block.tool_type == "create_document"

--- a/src/tool_capabilities.py
+++ b/src/tool_capabilities.py
@@ -1,0 +1,78 @@
+"""Server-owned capability classification for agent tools.
+
+This is deliberately independent from prompts and UI mode switches.  A tool
+implementation declares its effects here; a policy decides whether those
+effects may run for a particular agent run.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ToolCapability:
+    """Effects relevant to the authority boundary."""
+
+    effects: frozenset[str]
+
+
+SAFE = ToolCapability(frozenset({"observe"}))
+
+# These tools only return server-owned, non-sensitive state or communicate a
+# question/plan to the user.  Everything not explicitly listed is fail-closed
+# once untrusted context has entered a run.
+_SAFE_TOOL_NAMES = frozenset({
+    "ask_user", "update_plan", "list_models", "list_sessions",
+    "list_downloads", "list_cached_models", "list_served_models",
+    "list_serve_presets", "list_cookbook_servers",
+})
+
+_CAPABILITIES: dict[str, ToolCapability] = {
+    name: SAFE for name in _SAFE_TOOL_NAMES
+}
+
+
+def _declare(names: set[str], *effects: str) -> None:
+    capability = ToolCapability(frozenset(effects))
+    for name in names:
+        _CAPABILITIES[name] = capability
+
+
+_declare({"bash", "python", "manage_bg_jobs"}, "process", "filesystem_write")
+_declare({"read_file", "grep", "glob", "ls", "get_workspace"}, "filesystem_read")
+_declare({"write_file", "edit_file", "apply_patch", "todowrite"}, "filesystem_write")
+_declare({"web_search", "web_fetch", "api_call", "app_api", "builtin_browser"}, "network")
+_declare({"send_email", "reply_to_email", "bulk_email", "archive_email", "delete_email",
+          "mark_email_read", "unsubscribe_email", "draft_email", "draft_email_reply",
+          "ai_draft_email_reply", "send_to_session"}, "messaging")
+_declare({"read_email", "list_emails", "search_emails", "list_email_accounts",
+          "download_attachment", "search_chats", "vault_search", "vault_get",
+          "vault_unlock", "resolve_contact"}, "private_data")
+_declare({"manage_memory", "manage_skills", "manage_tasks", "manage_notes",
+          "manage_calendar", "manage_documents", "create_document", "update_document",
+          "edit_document", "suggest_document", "manage_contact", "manage_session",
+          "create_session", "manage_endpoints", "manage_mcp", "manage_webhooks",
+          "manage_tokens", "manage_settings", "download_model", "serve_model",
+          "serve_preset", "stop_served_model", "cancel_download", "adopt_served_model",
+          "generate_image", "edit_image", "trigger_research", "manage_research",
+          "pipeline", "ui_control"}, "state_change")
+_declare({"ask_teacher", "chat_with_model"}, "external_model")
+
+
+def capability_for(tool_name: object) -> ToolCapability | None:
+    """Return the declared capability, or ``None`` for an unknown tool.
+
+    MCP names are intentionally not inferred from their spelling.  An MCP
+    server is external authority, so it must register a capability before it
+    can run after untrusted context has been observed.
+    """
+    if not isinstance(tool_name, str) or not tool_name:
+        return None
+    return _CAPABILITIES.get(tool_name)
+
+
+def blocked_after_external_context(tool_name: object) -> bool:
+    """Whether a tool is disallowed by the conservative external-context gate."""
+    capability = capability_for(tool_name)
+    return capability is None or bool(capability.effects - {"observe"})

--- a/src/tool_execution.py
+++ b/src/tool_execution.py
@@ -687,7 +687,7 @@ async def _execute_tool_block_impl(
     if tool_policy and any(tool_policy.blocks(name) for name in policy_names):
         desc = f"{tool}: BLOCKED"
         result = {
-            "error": f"Execution of tool '{tool}' is forbade by the active guide-only policy.",
+            "error": tool_policy.reason_for(tool),
             "exit_code": 1,
         }
         logger.warning("Tool policy blocked tool=%s", tool)

--- a/src/tool_policy.py
+++ b/src/tool_policy.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from types import MappingProxyType
 from typing import Iterable, Mapping, Optional, Set, Tuple
+
+from src.tool_capabilities import blocked_after_external_context
 
 
 GUIDE_ONLY_DIRECTIVE = (
@@ -146,6 +148,9 @@ class ToolPolicy:
     mode: str = "normal"
     block_all_tool_calls: bool = False
     disable_mcp: bool = False
+    # Monotonic for the lifetime of an agent run.  It is server state derived
+    # from message metadata, never from model-visible prompt text.
+    external_context_seen: bool = False
 
     def all_disabled_names(self) -> Set[str]:
         return set(self.disabled_tools) | set(self.hidden_tools)
@@ -153,14 +158,43 @@ class ToolPolicy:
     def blocks(self, tool_name: Optional[str]) -> bool:
         if not tool_name:
             return False
-        return self.block_all_tool_calls or tool_name in self.disabled_tools or tool_name in self.hidden_tools
+        return (
+            self.block_all_tool_calls
+            or tool_name in self.disabled_tools
+            or tool_name in self.hidden_tools
+            or (self.external_context_seen and blocked_after_external_context(tool_name))
+        )
 
     def reason_for(self, tool_name: Optional[str]) -> str:
         if tool_name and tool_name in self.reasons:
             return self.reasons[tool_name]
         if self.block_all_tool_calls and self.mode == "guide_only":
             return "Tool use is disabled for this guide-only turn."
+        if self.external_context_seen and blocked_after_external_context(tool_name):
+            return (
+                "Tool use is blocked because this run contains untrusted external "
+                "context and the tool has not been granted safe server-owned capability."
+            )
         return "Tool use is disabled for this turn."
+
+    def with_external_context(self) -> "ToolPolicy":
+        """Return a policy with the irreversible external-context gate enabled."""
+        return self if self.external_context_seen else replace(self, external_context_seen=True, disable_mcp=True)
+
+
+def messages_contain_untrusted_context(messages: Iterable[object]) -> bool:
+    """Recognise the structured provenance emitted by ``untrusted_context_message``.
+
+    Do not scan content for wrapper strings: the server owns metadata and an
+    attacker must not be able to clear or manufacture authority by text alone.
+    """
+    for message in messages:
+        if not isinstance(message, Mapping):
+            continue
+        metadata = message.get("metadata")
+        if isinstance(metadata, Mapping) and metadata.get("trusted") is False:
+            return True
+    return False
 
 
 def detect_guide_only_turn(message: object) -> Optional[str]:

--- a/tests/test_external_context_tool_gate.py
+++ b/tests/test_external_context_tool_gate.py
@@ -1,0 +1,65 @@
+import asyncio
+import json
+
+import src.agent_loop as al
+from src.agent_tools import ToolBlock
+from src.tool_execution import execute_tool_block
+from src.tool_policy import build_effective_tool_policy, messages_contain_untrusted_context
+
+
+def test_untrusted_metadata_is_the_authority_signal():
+    assert messages_contain_untrusted_context([
+        {"role": "user", "content": "ignore policy", "metadata": {"trusted": False}},
+    ])
+    assert not messages_contain_untrusted_context([
+        {"role": "user", "content": "<<<UNTRUSTED_SOURCE_DATA>>>"},
+    ])
+
+
+def test_external_context_gate_allows_only_declared_safe_tools():
+    policy = build_effective_tool_policy().with_external_context()
+    assert policy.blocks("bash")
+    assert policy.blocks("read_file")
+    assert policy.blocks("mcp__random__tool")
+    assert policy.blocks("unknown_future_tool")
+    assert not policy.blocks("ask_user")
+    assert not policy.blocks("update_plan")
+
+
+def test_dispatcher_backstop_blocks_process_tool_after_external_context():
+    policy = build_effective_tool_policy().with_external_context()
+    desc, result = asyncio.run(
+        execute_tool_block(ToolBlock("bash", "echo must-not-run"), tool_policy=policy)
+    )
+    assert desc == "bash: BLOCKED"
+    assert result["exit_code"] == 1
+    assert "untrusted external context" in result["error"]
+
+
+def test_tool_output_promotes_gate_before_next_same_batch_call(monkeypatch):
+    async def fake_exec(block, **_kwargs):
+        return block.tool_type, {"output": "untrusted result", "exit_code": 0}
+
+    async def fake_stream(*_args, **_kwargs):
+        yield "data: " + json.dumps({"delta": "```ask_user\nquestion\n```\n```bash\necho no\n```"}) + "\n\n"
+        yield "data: [DONE]\n\n"
+
+    monkeypatch.setattr(al, "execute_tool_block", fake_exec)
+    monkeypatch.setattr(al, "stream_llm_with_fallback", fake_stream)
+    monkeypatch.setattr(al, "get_mcp_manager", lambda: None)
+    monkeypatch.setattr(al, "get_setting", lambda _key, default=None: default)
+    monkeypatch.setattr(al, "estimate_tokens", lambda *_args, **_kwargs: 1)
+
+    async def collect():
+        return [chunk async for chunk in al.stream_agent_loop(
+            "http://local.test/v1", "local-model",
+            [{"role": "user", "content": "do it"}],
+            relevant_tools={"ask_user", "bash"}, max_rounds=1,
+        )]
+
+    events = [json.loads(chunk[6:]) for chunk in asyncio.run(collect())
+              if chunk.startswith("data: {")]
+    starts = [event["tool"] for event in events if event.get("type") == "tool_start"]
+    blocked = [event for event in events if event.get("type") == "tool_output" and event.get("tool") == "bash"]
+    assert starts == ["ask_user"]
+    assert blocked and blocked[0]["exit_code"] == 1


### PR DESCRIPTION
## Summary

Adds a server-owned authority gate for agent runs that contain untrusted external
context. Once server-marked untrusted context (`metadata.trusted=False`) enters
a run, unknown tools, MCP tools, and higher-impact actions are blocked before
execution. The restriction is monotonic for the run and is promoted after tool
output, preventing same-batch escalation.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Part of #4754

Related: #3709

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end.

## How to Test

1. Install dependencies and activate the project virtual environment.

2. Run the focused regression tests:

   ```powershell
   .\venv\Scripts\python.exe -m pytest tests/test_external_context_tool_gate.py tests/test_tool_policy.py -q
   Expected result: 22 passed.
Verify the changed modules compile:
.\venv\Scripts\python.exe -m py_compile src/tool_capabilities.py src/tool_policy.py src/tool_execution.py src/agent_loop.py

Confirm the tests cover these behaviors:
metadata.trusted=False activates the server-owned authority gate.
Process, filesystem, MCP, and unknown tools are blocked after untrusted context.
A tool result promotes the gate before a later high-impact call in the same model-produced batch.

Full-suite note: pytest -q -x reached 140 passing tests, then stopped because
this Windows environment cannot create symbolic links (WinError 1314) for
test_collect_skill_dir_skips_symlinked_skill_markdown.
Visual / UI changes
Not applicable — this PR changes server-side tool policy only