### PR TITLE
fix(copilot): guard reasoning_effort+tools 400 on Copilot chat/completions too

### DIFF
--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -1046,7 +1046,18 @@ def _is_openai_hosted_chat_url(url: str) -> bool:
     except Exception:
         return False
     path = (parsed.path or "").rstrip("/")
-    return _host_match(url, "openai.com") and path.endswith("/chat/completions")
+    if not path.endswith("/chat/completions"):
+        return False
+    if _host_match(url, "openai.com"):
+        return True
+    # GitHub Copilot proxies OpenAI's GPT-5.x models through its own
+    # chat/completions endpoint and rejects the same reasoning_effort+tools
+    # combination as OpenAI's own host does (400 on e.g. gpt-5.6-sol) — apply
+    # the same guard there.
+    from src.copilot import is_copilot_base
+    if is_copilot_base(url):
+        return True
+    return False
 
 
 def _model_disallows_reasoning_effort_with_chat_tools(model: str) -> bool:

--- a/tests/test_llm_core_openai_reasoning_tools.py
+++ b/tests/test_llm_core_openai_reasoning_tools.py
@@ -71,3 +71,31 @@ def test_non_gpt5_model_leaves_reasoning_effort_unchanged():
     )
 
     assert payload["reasoning_effort"] == "high"
+
+
+def test_copilot_chat_tools_force_gpt5_reasoning_effort_none():
+    # GitHub Copilot proxies OpenAI's GPT-5.x models through its own
+    # /chat/completions endpoint and 400s on reasoning_effort + tools the
+    # same way api.openai.com does — the guard must also cover it.
+    for model in ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5"]:
+        payload = {"tools": [_tool()], "reasoning_effort": "medium"}
+
+        llm_core._scrub_openai_chat_tool_reasoning(
+            payload,
+            "https://api.githubcopilot.com/chat/completions",
+            model,
+        )
+
+        assert payload["reasoning_effort"] == "none"
+
+
+def test_copilot_enterprise_chat_tools_force_gpt5_reasoning_effort_none():
+    payload = {"tools": [_tool()], "reasoning_effort": "medium"}
+
+    llm_core._scrub_openai_chat_tool_reasoning(
+        payload,
+        "https://copilot-api.example-enterprise.com/chat/completions",
+        "gpt-5.6-sol",
+    )
+
+    assert payload["reasoning_effort"] == "none"


### PR DESCRIPTION
## Problem
GPT-5.x queries routed through the GitHub Copilot endpoint (e.g. `gpt-5.6-sol`) were 400ing. Root cause: Copilot proxies OpenAI's GPT-5.x models through its own `/chat/completions` endpoint at `api.githubcopilot.com`, which rejects `reasoning_effort` + `tools` in the same request the same way `api.openai.com` does. The existing guard (`_scrub_openai_chat_tool_reasoning` via `_is_openai_hosted_chat_url`) only matched `api.openai.com`, so it never applied when dispatching through Copilot.

## Fix
Extend `_is_openai_hosted_chat_url` in `src/llm_core.py` to also recognize Copilot bases (public `api.githubcopilot.com` and GitHub Enterprise `copilot-api.<domain>`) via `src.copilot.is_copilot_base`, so the existing reasoning_effort scrub now covers Copilot dispatch too.

## Tests
Added regression tests in `tests/test_llm_core_openai_reasoning_tools.py`:
- `test_copilot_chat_tools_force_gpt5_reasoning_effort_none` (public Copilot base, gpt-5.6-sol/terra/gpt-5)
- `test_copilot_enterprise_chat_tools_force_gpt5_reasoning_effort_none` (enterprise Copilot base)

All 45 tests in the affected suites (endpoint_resolver_*, llm_core_openai_reasoning_tools) pass. Note: a handful of unrelated test files fail to collect on this branch due to a pre-existing `NameError: name 'Any' is not defined` in `src/agent_loop.py` (confirmed present before this change too, via `git stash`) — unrelated to this fix.