### PR TITLE
fix(tool_parsing): require a pipe on the Qwen bare end marker

### DIFF
--- a/src/tool_parsing.py
+++ b/src/tool_parsing.py
@@ -187,8 +187,12 @@ _FUNCTION_MODEL_NAME_RE = re.compile(
 _FUNCTION_MODEL_PARAMS_OPEN_RE = re.compile(r"<parameters>\s*", re.IGNORECASE)
 _FUNCTION_MODEL_PARAMS_CLOSE_RE = re.compile(r"</parameters>", re.IGNORECASE)
 _QWEN_ROLE_MARKER_RE = re.compile(r"</?\|(?:assistant|assistan|user|system|tool)\|>?|</\|end\|>?", re.IGNORECASE)
+# At least one pipe is required around `end`. Both pipes used to be optional
+# (`\|?end\|?`), which also matched a bare `end` on its own line and deleted it
+# from ordinary prose and from Ruby/Lua/shell snippets that close blocks with
+# one; see #5547. `|end`, `end|`, `|end|` and `/|end|` still strip as before.
 _QWEN_BARE_MARKER_RE = re.compile(
-    r"(?:^|[\t\r\n ])(?:\|?end\|?|/?\|end\|)(?=[\t\r\n ]|$)|"
+    r"(?:^|[\t\r\n ])(?:/?\|end\||\|end|end\|)(?=[\t\r\n ]|$)|"
     r"(?:^|[\t\r\n ])assistan(?:t)?(?=[\t\r\n ]|$)",
     re.IGNORECASE,
 )

--- a/static/js/chatRenderer.js
+++ b/static/js/chatRenderer.js
@@ -478,7 +478,10 @@ const DSML_STRAY_RE = /<\s*\/?\s*[｜|]+\s*DSML\s*[｜|]+[^>]*>/gi;
 const DSML_INVOKE_RE = /<\s*[｜|]+\s*DSML\s*[｜|]+\s*invoke\b[^>]*>[\s\S]*?(?:<\s*\/\s*[｜|]+\s*DSML\s*[｜|]+\s*invoke\s*>|$)/gi;
 const RAW_OPENAI_TOOL_JSON_RE = /(?:\[\s*)?\{\s*"function"\s*:\s*\{[\s\S]*?\}\s*,\s*"id"\s*:\s*"[^"]*"\s*,\s*"type"\s*:\s*"function"\s*\}\s*\]?/gi;
 const QWEN_ROLE_MARKER_RE = /<\/?\|(?:assistant|assistan|user|system|tool)\|>?|<\/\|end\|>?/gi;
-const QWEN_BARE_MARKER_RE = /(?:^|[\t\r\n ])(?:\|?end\|?|\/?\|end\|)(?=[\t\r\n ]|$)|(?:^|[\t\r\n ])assistan(?:t)?(?=[\t\r\n ]|$)/gi;
+// Keep in sync with _QWEN_BARE_MARKER_RE in src/tool_parsing.py. At least one
+// pipe is required around `end`: with both optional (`\|?end\|?`) this also ate
+// a bare `end` on its own line, breaking Ruby/Lua/shell snippets (#5547).
+const QWEN_BARE_MARKER_RE = /(?:^|[\t\r\n ])(?:\/?\|end\||\|end|end\|)(?=[\t\r\n ]|$)|(?:^|[\t\r\n ])assistan(?:t)?(?=[\t\r\n ]|$)/gi;
 // Self-narration about tool results (model echoing stdout/exit_code)
 const TOOL_NARRATION_RE = /(?:The (?:result|output) shows?:?\s*)?-?\s*(?:stdout|stderr|exit_code):\s*.+/gi;
 

--- a/tests/test_tool_parsing_bare_end_marker.py
+++ b/tests/test_tool_parsing_bare_end_marker.py
@@ -1,0 +1,96 @@
+"""Regression: the Qwen bare-marker scrub must not eat a lone `end` (#5547).
+
+`_QWEN_BARE_MARKER_RE` cleans Qwen turn markers that leak into content. Its
+`end` branch was `\\|?end\\|?` — both pipes optional — so it also matched a bare
+`end` surrounded by whitespace and replaced it with a space. Any message
+containing Ruby, Lua or shell code that closes a block with a lone `end` had
+those lines silently deleted, in the stored text and in the rendered message.
+
+Requiring at least one pipe keeps every real marker (`|end`, `end|`, `|end|`,
+`/|end|`) stripping as before. The same pattern is duplicated in
+static/js/chatRenderer.js, so the JS copy is checked here too — the two must
+not drift.
+"""
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import src.agent_tools  # noqa: F401  (break agent_tools<->tool_parsing import cycle)
+from src.tool_parsing import strip_tool_blocks
+
+_REPO = Path(__file__).resolve().parent.parent
+_CHAT_RENDERER = _REPO / "static" / "js" / "chatRenderer.js"
+
+# Inputs that must survive untouched, and the substring that proves they did.
+KEPT = [
+    ("loop do\n    puts \"yo\"\nend\n", "\nend"),          # the reported Ruby case
+    ("if x then\nend", "\nend"),
+    ("function f()\nend\n", "\nend"),
+    ("a end b", "a end b"),
+    ("append end", "append end"),
+    ("END", "END"),
+    ("\nEnd\n", "End"),
+]
+
+# Real markers — at least one pipe, plus the role word — with the exact output
+# they must still produce. Asserted as equality rather than "marker not in out"
+# so narrowing the pattern can't pass by deleting more than it should.
+STRIPPED = [
+    ("a |end| b", "a  b"),
+    ("a /|end| b", "a  b"),
+    ("a |end b", "a  b"),
+    ("a end| b", "a  b"),
+    ("x assistant y", "x  y"),
+]
+
+
+@pytest.mark.parametrize("text,kept", KEPT)
+def test_bare_end_survives_stripping(text, kept):
+    assert kept in strip_tool_blocks(text)
+
+
+@pytest.mark.parametrize("text,expected", STRIPPED)
+def test_piped_end_markers_are_still_stripped(text, expected):
+    assert strip_tool_blocks(text) == expected
+
+
+def test_bare_end_inside_a_fenced_block_survives():
+    """The scrub runs over the whole message, fenced regions included."""
+    out = strip_tool_blocks("Here:\n```ruby\nloop do\n  puts 1\nend\n```\nDone.")
+    assert "\nend\n" in out
+
+
+def _js_bare_marker_regex_source():
+    src = _CHAT_RENDERER.read_text(encoding="utf-8")
+    m = re.search(r"^const QWEN_BARE_MARKER_RE = (/.*/[gimsuy]*);$", src, re.MULTILINE)
+    assert m, "QWEN_BARE_MARKER_RE literal not found in chatRenderer.js"
+    return m.group(1)
+
+
+def test_js_copy_of_the_pattern_matches_the_python_one():
+    """Guard the duplication: the JS branch must require a pipe too."""
+    if shutil.which("node") is None:
+        pytest.skip("node binary not on PATH")
+
+    cases = [text for text, _ in KEPT] + [text for text, _ in STRIPPED]
+    script = (
+        "const RE = %s;\n"
+        "const cases = JSON.parse(process.argv[1]);\n"
+        "console.log(JSON.stringify(cases.map(c => c.replace(RE, ' '))));"
+        % _js_bare_marker_regex_source()
+    )
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", script, json.dumps(cases)],
+        cwd=_REPO, capture_output=True, timeout=15, text=True,
+    )
+    assert result.returncode == 0, f"node failed:\n{result.stderr}"
+    got = json.loads(result.stdout.splitlines()[-1])
+
+    for (text, kept), out in zip(KEPT, got):
+        assert kept in out, f"JS regex dropped {kept!r} from {text!r}"
+    for (text, expected), out in zip(STRIPPED, got[len(KEPT):]):
+        assert out == expected, f"JS regex: {text!r} -> {out!r}, expected {expected!r}"


### PR DESCRIPTION
## Summary

`_QWEN_BARE_MARKER_RE` scrubs Qwen turn markers that leak into model output. Its `end` branch had **both pipes optional**:

```python
r"(?:^|[\t\r\n ])(?:\|?end\|?|/?\|end\|)(?=[\t\r\n ]|$)|"
```

`\|?end\|?` therefore also matches a bare `end` between whitespace, and the pass replaces it with a space. Any message containing Ruby, Lua or shell code that closes a block with a lone `end` loses those lines, which is the report in #5547. Ordinary prose loses the word too — `append end` renders as `append`, and a message of just `END` renders empty.

The scrub runs over the whole message with no fenced-region exemption, so code blocks are not protected. It also runs regardless of role (`chatRenderer.js` applies it to `textRaw` before markdown), so your own sent message is mangled as well as the model's reply — matching the report.

This requires **at least one pipe** around `end`, so only real markers match. `|end`, `end|`, `|end|` and `/|end|` all strip exactly as before; only the fully bare keyword stops matching. `<|end|>` is unaffected either way — `_QWEN_ROLE_MARKER_RE` handles it one line earlier.

The same pattern is duplicated in `static/js/chatRenderer.js`, which is where the user-visible rendering happens; both copies are changed together.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #5547

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up`) and verified the change works end-to-end. Screenshots below.

## How to Test

1. `docker compose up -d --build`, open the app, and send this in chat — no model needed, the stripping happens on your own message:

   ````
   ```ruby
   loop do
       puts "yo"
   end
   ```
   ````

   Before the fix the `end` line is missing from the rendered bubble. After it, all three lines are there. Screenshots below.

2. Deterministic check on the backend:

   ```python
   import src.agent_tools  # break the agent_tools<->tool_parsing import cycle
   from src.tool_parsing import strip_tool_blocks
   strip_tool_blocks('loop do\n  puts 1\nend\n')
   # before: 'loop do\n  puts 1'      (end deleted)
   # after:  'loop do\n  puts 1\nend'
   strip_tool_blocks('a |end| b')     # 'a  b' — unchanged by this PR
   ```

3. Tests:

   ```bash
   python -m pytest tests/test_tool_parsing_bare_end_marker.py -q      # 14 passed
   python -m pytest tests/test_tool_parsing_nonstring.py \
                    tests/test_odysseus_doc_fence_normalization.py \
                    tests/test_redos_xml_tool_parsers.py \
                    tests/test_markdown_rendering_js.py -q             # 46 passed
   node --check static/js/chatRenderer.js
   ```

   9 of the 14 new tests were confirmed **failing** against unpatched `dev`; the other 5 are the "still strips real markers" guards, which must pass on both sides. I also ran every test file that imports `tool_parsing` (19 files) before and after the change and got identical results.

## Tests added

`tests/test_tool_parsing_bare_end_marker.py`:

| Test | Guards against |
|---|---|
| `test_bare_end_survives_stripping` | the reported regression — Ruby/Lua/shell `end`, plus `end` in prose and uppercase `END` |
| `test_bare_end_inside_a_fenced_block_survives` | the fenced-code case from the issue |
| `test_piped_end_markers_are_still_stripped` | over-narrowing the pattern; asserts exact output so it can't pass by deleting more than it should |
| `test_js_copy_of_the_pattern_matches_the_python_one` | the two copies drifting — it reads the regex literal out of `chatRenderer.js` and runs the same cases through Node |

## Visual / UI changes

- [x] **Screenshots** of the change in the running app, below.
- [x] **Style match**: no CSS, markup, class, icon, font, spacing or layout changes. `chatRenderer.js` is touched only to fix one regex that deletes text from message content; nothing about how messages are styled or laid out changes, so there is no new color, unit or component involved.
- [x] **No new component patterns.**
- [x] **I am not an LLM agent submitting a bulk PR.** This is a single targeted fix against an existing issue — see Disclosure below.

### Screenshots

**Before** — the `end` line is gone from the sent message:

<img width="360" alt="before: end line missing" src="https://raw.githubusercontent.com/husamemadH/odysseus/pr-assets-5547/5547-before.png">

**After** — the block renders verbatim:

<img width="360" alt="after: end line present" src="https://raw.githubusercontent.com/husamemadH/odysseus/pr-assets-5547/5547-after.png">

## Scope

The second branch of the same regex, `assistan(?:t)?`, over-matches in the same way — it deletes the word "assistant" from prose and code. That is a separate visible bug and not what #5547 reports, so it is left alone here rather than widened into this PR.

## Disclosure

The patch was drafted with Claude Code. I reproduced the bug against current `dev`, reviewed the change, verified the new tests fail before they pass, and confirmed the before/after in the running app. Flagging it per CONTRIBUTING.md's note on agent-generated PRs — this is a single targeted fix against an existing issue, not a bulk submission.
