### PR TITLE
fix(brain): give the Add Memory form a submit button and reliable Enter handling

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1689,11 +1689,19 @@ function initializeEventListeners() {
   
   const newMemoryInput = el('new-memory-input');
   if (newMemoryInput) {
-    newMemoryInput.addEventListener('keypress', (e) => {
-      if (e.key === 'Enter') {
+    // keydown, not the deprecated keypress: keypress is not guaranteed to
+    // fire for Enter everywhere, which left the Add Memory form with no
+    // working submit path (#5828).
+    newMemoryInput.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' && !e.isComposing) {
+        e.preventDefault();
         memoryModule.addNewMemory();
       }
     });
+  }
+  const newMemoryAddBtn = el('new-memory-add-btn');
+  if (newMemoryAddBtn) {
+    newMemoryAddBtn.addEventListener('click', () => memoryModule.addNewMemory());
   }
 
 // Voice recording is handled by the dual-purpose send/mic button (see below)

--- a/static/index.html
+++ b/static/index.html
@@ -365,6 +365,7 @@
                 <span class="skill-rich-ph"><span class="k">Add a memory</span> &mdash; e.g. 'I prefer concise replies' <svg class="k" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-left:4px;" aria-hidden="true"><polyline points="9 10 4 15 9 20"/><path d="M20 4v7a4 4 0 0 1-4 4H4"/></svg></span>
               </div>
               <select id="new-memory-category" class="memory-edit-cat-select" aria-label="Memory category"></select>
+              <button type="button" id="new-memory-add-btn" class="theme-io-btn" title="Save this memory" style="flex:none;height:28px;font-size:12px;"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px;" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>Add</button>
             </div>
           </div>
           <div class="admin-card">

--- a/tests/test_memory_add_submit_regression.py
+++ b/tests/test_memory_add_submit_regression.py
@@ -1,0 +1,54 @@
+"""The Brain > Add Memory form must be submittable (#5828).
+
+The form previously had no submit button and relied on a deprecated
+``keypress`` listener for Enter, which is not guaranteed to fire on all
+platforms — leaving the form with no working submit path. Pins:
+
+- a visible, keyboard-accessible submit button next to the category select;
+- the button wired to ``memoryModule.addNewMemory()``;
+- Enter handled via ``keydown`` with ``preventDefault()`` (and no lingering
+  ``keypress`` handler on the input).
+"""
+from pathlib import Path
+
+APP_JS = Path("static/app.js")
+INDEX_HTML = Path("static/index.html")
+
+
+def _add_memory_row(html):
+    start = html.index('id="new-memory-input"')
+    end = html.index("</div>", html.index('id="new-memory-add-btn"', start))
+    return html[start:end]
+
+
+def test_add_memory_form_renders_a_submit_button():
+    html = INDEX_HTML.read_text()
+    row = _add_memory_row(html)
+
+    assert 'id="new-memory-category"' in row, "button must sit in the same row as the form fields"
+    btn_start = row.index('id="new-memory-add-btn"')
+    btn_tag = row[row.rindex("<button", 0, btn_start):row.index(">", btn_start)]
+    assert 'type="button"' in btn_tag, "must not rely on implicit submit semantics"
+
+
+def _new_memory_wiring_block(source):
+    start = source.index("const newMemoryInput = el('new-memory-input');")
+    end = source.index("// Voice recording", start)
+    return source[start:end]
+
+
+def test_submit_button_is_wired_to_add_new_memory():
+    block = _new_memory_wiring_block(APP_JS.read_text())
+
+    assert "el('new-memory-add-btn')" in block
+    assert "addEventListener('click', () => memoryModule.addNewMemory())" in block
+
+
+def test_enter_uses_keydown_with_prevent_default():
+    block = _new_memory_wiring_block(APP_JS.read_text())
+
+    assert "addEventListener('keydown'" in block
+    assert "addEventListener('keypress'" not in block, "keypress is deprecated and unreliable for Enter"
+    assert "e.preventDefault();" in block
+    assert "!e.isComposing" in block, "IME composition must not submit the form"
+    assert "memoryModule.addNewMemory();" in block


### PR DESCRIPTION
## Summary

The Brain > Add tab rendered the Add Memory text input and category select with no submit control at all, and Enter-to-save relied on a deprecated `keypress` listener that is not guaranteed to fire for Enter on every platform — on the reporter's Windows v1.0.2 session no save request ever reached the server, making the form unusable (the `/memory add` chat command was the only workaround). This PR adds a visible, keyboard-accessible **Add** submit button to the form row (styled exactly like the neighbouring Skill Import button: `theme-io-btn`, inline monochrome SVG, same height/font), wires it to the existing `memoryModule.addNewMemory()`, and moves Enter handling to `keydown` with `preventDefault()` plus an `isComposing` guard so IME composition can't trigger an accidental submit. A source-level regression test pins both submit paths.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #5828

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run the app (`uvicorn app:app`), log in, open **Brain** from the sidebar, and select the **Add** tab.
2. Type a memory into **Add a memory**, pick a category, and click the new **Add** button — the input clears, a "Memory added" toast appears, and the Memories tab count increments.
3. Type a second memory and press **Enter** — same result, and the page does not reload/refocus (default is prevented).
4. Open the **Memories** tab and confirm both memories are listed.
5. `pytest tests/test_memory_add_submit_regression.py` — 3 tests pin the button markup, the click wiring, and the keydown/preventDefault/isComposing handling.

## Visual / UI changes — REQUIRED if you touched anything that renders

- [x] **Screenshot or short clip** of the change in the running app, attached below.
- [x] **Style match**: the change uses Odysseus's existing visual language:
  - No new colors, font sizes, or spacing units — the button reuses the existing `theme-io-btn` class and the same inline style (`flex:none;height:28px;font-size:12px;`) as the adjacent Skill Import button, so it inherits the `.memory-add-row .theme-io-btn` rules already in `style.css`.
  - No Unicode emoji — the icon is an inline monochrome stroke SVG (feather-style plus) matching the Import/Export buttons in the same card.
  - Monospaced UI font inherited; dark theme untouched.
- [x] **No new component patterns** — this is the exact widget pattern already used one card below (Skill Import URL row: input + `theme-io-btn` in a `memory-add-row`).
- [x] The problem was reported and triaged in issue #5828 first; this is a single focused fix for that issue, not a bulk submission.

### Screenshots / clips

**Add tab — the form now has a visible submit button next to the category select:**

![Add Memory form with the new Add button](https://raw.githubusercontent.com/wbaxterh/odysseus/assets-pr5828/pr5828/pr5828-add-memory-form.png)

**Both submit paths verified in the running app — first memory saved with the Add button, second saved by pressing Enter:**

![Memories tab showing both test memories saved](https://raw.githubusercontent.com/wbaxterh/odysseus/assets-pr5828/pr5828/pr5828-memories-saved.png)