### PR TITLE
fix(cookbook): prevent duplicate dependency installs

### DIFF
--- a/static/js/cookbook.js
+++ b/static/js/cookbook.js
@@ -1067,6 +1067,36 @@ export function _persistEnvState() {
 // ── Dependencies ──
 
 // Category colors removed — using theme CSS classes instead
+const _pendingDepInstalls = new Set();
+const _ACTIVE_DEP_STATUSES = new Set(['queued', 'running']);
+
+function _depHostKey(host) {
+  const h = String(host || '').trim();
+  return (!h || h === 'local' || h === 'localhost' || h === '127.0.0.1') ? 'local' : h;
+}
+
+function _depInstallKey(pipName, host = '', port = '', envPath = '') {
+  return [
+    String(pipName || '').trim(),
+    _depHostKey(host),
+    String(port || '').trim(),
+    String(envPath || '').trim(),
+  ].join('\n');
+}
+
+function _taskDepInstallKey(task) {
+  if (!task?.payload?._dep || !task.payload.repo_id) return '';
+  return _depInstallKey(
+    task.payload.repo_id,
+    task.remoteHost || task.payload.remote_host || '',
+    task.sshPort || task.payload.ssh_port || '',
+    task.payload.env_path || task.payload._envPath || ''
+  );
+}
+
+function _isActiveDepTask(task) {
+  return !!task?.payload?._dep && _ACTIVE_DEP_STATUSES.has(task.status || '');
+}
 
 async function _fetchDependencies() {
   const list = document.getElementById('cookbook-deps-list');
@@ -1128,9 +1158,31 @@ async function _fetchDependencies() {
     if (!pkgs.length) { list.innerHTML = '<div class="hwfit-loading">No packages found</div>'; return; }
     const _winUnsupported = new Set(['hf_transfer', 'vllm', 'rembg', 'gfpgan']);
     const _systemInstallable = new Set(['tmux']);
+    const _activeDepTasks = new Map();
+    _loadTasks().forEach(task => {
+      if (!_isActiveDepTask(task)) return;
+      const key = _taskDepInstallKey(task);
+      if (key && !_activeDepTasks.has(key)) _activeDepTasks.set(key, task);
+    });
+    _pendingDepInstalls.forEach(key => {
+      if (key && !_activeDepTasks.has(key)) _activeDepTasks.set(key, { _pending: true });
+    });
 
-    const _statusTag = (pkg, isLocal, isSystemDep, winBlocked) => {
+    const _depTarget = (isLocal) => isLocal
+      ? { host: '', port: '', envPath: '' }
+      : { host: _depHost, port: _depPort, envPath: _depVenv };
+    const _activeDepFor = (pkg, isLocal) => {
+      if (!pkg?.pip) return null;
+      const target = _depTarget(isLocal);
+      return _activeDepTasks.get(_depInstallKey(pkg.pip, target.host, target.port, target.envPath)) || null;
+    };
+
+    const _statusTag = (pkg, isLocal, isSystemDep, winBlocked, activeDep) => {
       if (winBlocked) return `<span class="cookbook-dep-tag cookbook-dep-na">N/A</span>`;
+      if (activeDep) {
+        const session = activeDep.sessionId ? ` (${activeDep.sessionId})` : '';
+        return `<span class="cookbook-dep-tag cookbook-dep-downloading" title="Dependency install is already running${esc(session)}">downloading</span>`;
+      }
       if (pkg.installed && isSystemDep) return `<span class="cookbook-dep-tag cookbook-dep-installed" title="Found on selected server">Installed</span>`;
       if (pkg.installed && pkg.pip_update_available === false && pkg.name !== 'llama_cpp') {
         const tip = esc(pkg.update_note || pkg.status_note || 'Found externally; update outside Odysseus.');
@@ -1174,6 +1226,7 @@ async function _fetchDependencies() {
       const isLocal = pkg.target === 'local';
       const isSystemDep = pkg.kind === 'system';
       const winBlocked = !isLocal && _isWindows() && _winUnsupported.has(pkg.name);
+      const activeDep = _activeDepFor(pkg, isLocal);
       const note = pkg.status_note ? `<div class="memory-item-meta" style="font-size:10px;opacity:0.65;margin-top:3px;">${esc(pkg.status_note)}</div>` : '';
       const updateNote = pkg.installed && pkg.pip_update_available === false && pkg.update_note ? `<div class="memory-item-meta" style="font-size:10px;opacity:0.55;margin-top:3px;">${esc(pkg.update_note)}</div>` : '';
       // Inline rebuild/reinstall tag. Styled as a .cookbook-dep-tag so it
@@ -1183,7 +1236,11 @@ async function _fetchDependencies() {
       // diagnosis-style `_launchServeTask` with `pip install --force-reinstall`
       // so the user can watch the pip install in the Running tab.
       let _rebuildBtn = '';
-      if (pkg.name === 'vllm' && pkg.installed) {
+      if (activeDep) {
+        _rebuildBtn = '';
+      } else if (pkg.name === 'llama_cpp') {
+        _rebuildBtn = `<button type="button" class="cookbook-dep-tag cookbook-dep-rebuild" id="cookbook-rebuild-engine" title="Clear the cached llama.cpp build so the next serve recompiles from source (use after installing a CUDA/ROCm toolkit to turn a CPU-only build into a GPU build).">Rebuild</button>`;
+      } else if (pkg.name === 'vllm' && pkg.installed) {
         _rebuildBtn = `<button type="button" class="cookbook-dep-tag cookbook-dep-rebuild cookbook-dep-reinstall" data-reinstall-pkg="vllm" title="Force-reinstall vLLM (pulls a matching torch). Runs as a tmux task in the Running tab.">Reinstall</button>`;
       } else if (pkg.name === 'sglang' && pkg.installed) {
         _rebuildBtn = `<button type="button" class="cookbook-dep-tag cookbook-dep-rebuild cookbook-dep-reinstall" data-reinstall-pkg="sglang" title="Force-reinstall SGLang (pulls a matching torch). Runs as a tmux task in the Running tab.">Reinstall</button>`;
@@ -1229,7 +1286,7 @@ async function _fetchDependencies() {
         + _rebuildBtn
         + _buildDepsBtn
         + `<span class="cookbook-dep-tag cookbook-dep-cat">${esc(pkg.category)}</span>`
-        + _statusTag(pkg, isLocal, isSystemDep, winBlocked)
+        + _statusTag(pkg, isLocal, isSystemDep, winBlocked, activeDep)
         + recipeCaret
         + `</div>`
         + recipePanel;
@@ -1417,6 +1474,28 @@ async function _fetchDependencies() {
       }
       const targetPlatform = isLocalOnly ? (_envState.hostPlatform || _envState.platform || '') : (targetServer?.platform || _envState.platform || '');
       const targetRemoteHost = isLocalOnly ? '' : (targetServer?.host || _envState.remoteHost || '');
+      const activeKey = _depInstallKey(
+        pipName,
+        targetRemoteHost || '',
+        isLocalOnly ? '' : (_getPort(targetRemoteHost) || ''),
+        targetEnvPath || ''
+      );
+      if (_pendingDepInstalls.has(activeKey) || _loadTasks().some(task => _isActiveDepTask(task) && _taskDepInstallKey(task) === activeKey)) {
+        uiModule.showToast(`${pkgName} is already downloading on ${targetHost}.`);
+        if (statusEl) {
+          statusEl.textContent = 'downloading';
+          statusEl.disabled = true;
+          statusEl.classList.add('cookbook-dep-downloading');
+        }
+        return;
+      }
+      _pendingDepInstalls.add(activeKey);
+      if (statusEl) {
+        statusEl.textContent = 'downloading';
+        statusEl.disabled = true;
+        statusEl.classList.add('cookbook-dep-downloading');
+        statusEl.title = `${pkgName} is already downloading`;
+      }
       // Always go through `python -m pip` so the leading token is `python`
       // — matches the /api/model/serve allow-list (bare `pip` is blocked).
       // Inside a venv/conda env, `--user` is invalid (pip refuses), so we
@@ -1488,13 +1567,20 @@ async function _fetchDependencies() {
             action: 'OK',
             onAction: () => {},
           });
+          _pendingDepInstalls.delete(activeKey);
+          if (statusEl) {
+            statusEl.textContent = upgrade ? 'Update' : 'Install';
+            statusEl.disabled = false;
+            statusEl.classList.remove('cookbook-dep-downloading');
+            statusEl.title = '';
+          }
           return;
         }
         // _dep flags this as a pip dependency/driver install (not a servable
         // model) so the running-task card doesn't offer a "Serve →" button.
-        const payload = { repo_id: depTaskId, _cmd: cmd, remote_host: targetRemoteHost || '', _dep: true, env_path: targetEnvPath || '', platform: targetPlatform || '' };
+        const payload = { repo_id: depTaskId, _cmd: cmd, remote_host: targetRemoteHost || '', ssh_port: isLocalOnly ? '' : (_getPort(targetRemoteHost) || ''), _dep: true, _dep_action: upgrade ? 'update' : 'install', env_path: targetEnvPath || '', platform: targetPlatform || '' };
         _addTask(data.session_id, 'pip ' + pkgName, 'download', payload);
-        if (statusEl) { statusEl.textContent = upgrade ? 'Updating...' : 'Installing...'; statusEl.disabled = true; }
+        _pendingDepInstalls.delete(activeKey);
         uiModule.showToast(`${upgrade ? 'Updating' : 'Installing'} ${pkgName} on ${targetHost}...`);
       } catch (err) {
         uiModule.showToast('Install failed: ' + err.message, {
@@ -1502,6 +1588,13 @@ async function _fetchDependencies() {
           action: 'OK',
           onAction: () => {},
         });
+        _pendingDepInstalls.delete(activeKey);
+        if (statusEl) {
+          statusEl.textContent = upgrade ? 'Update' : 'Install';
+          statusEl.disabled = false;
+          statusEl.classList.remove('cookbook-dep-downloading');
+          statusEl.title = '';
+        }
       }
     }
 

--- a/static/js/cookbook.js
+++ b/static/js/cookbook.js
@@ -9,6 +9,14 @@ import { providerLogo } from './providers.js';
 import { makeWindowDraggable } from './windowDrag.js';
 import { _diagnose, _showDiagnosis, _clearDiagnosis, _runQuickCmd, ERROR_PATTERNS } from './cookbook-diagnosis.js';
 import { RECIPE_BACKENDS, recipesForBackend, pickRecipe, recipeCommands, RECIPE_DEFAULT_VARIANT } from './cookbook-deps-recipes.js';
+import {
+  dependencyCandidateKeys,
+  depInstallKey,
+  findActiveDepTask,
+  isActiveDepTask,
+  sameDependencyTarget,
+  taskDepInstallKeys,
+} from './cookbookDepTasks.js';
 import { _hwfitCache, _hwfitDebounce, _hwfitFetch, _hwfitInit, _hwfitRenderList, _hwfitRenderHw, _renderGpuToggles, _expandModelRow, _fitColors, _hwfitColumns, _cachedModelIds, _gpuToggleTotal, _resetGpuToggleState } from './cookbook-hwfit.js';
 
 // Sub-modules
@@ -1068,39 +1076,109 @@ export function _persistEnvState() {
 
 // Category colors removed — using theme CSS classes instead
 const _pendingDepInstalls = new Set();
-const _ACTIVE_DEP_STATUSES = new Set(['queued', 'running']);
 
-function _depHostKey(host) {
-  const h = String(host || '').trim();
-  return (!h || h === 'local' || h === 'localhost' || h === '127.0.0.1') ? 'local' : h;
+function _selectedDependencyTarget() {
+  let host = '', port = '', envPath = '', platform = '';
+  const select = document.getElementById('hwfit-deps-server');
+  const server = select && select.value !== 'local' ? _serverByVal(select.value) : null;
+  if (server) {
+    host = server.host || '';
+    port = server.port || _getPort(host) || '';
+    envPath = server.envPath || '';
+    platform = server.platform || '';
+  } else if (_envState.remoteHost) {
+    host = _envState.remoteHost;
+    port = _getPort(_envState.remoteHost) || '';
+    envPath = _envState.envPath || '';
+    platform = _envState.platform || '';
+  }
+  return { host, port, envPath, platform };
 }
 
-function _depInstallKey(pipName, host = '', port = '', envPath = '') {
-  return [
-    String(pipName || '').trim(),
-    _depHostKey(host),
-    String(port || '').trim(),
-    String(envPath || '').trim(),
-  ].join('\n');
+function _setDependencyButtonState(element, active, idleText = 'Install') {
+  if (!element) return;
+  element.textContent = active ? 'downloading' : idleText;
+  element.disabled = active;
+  element.classList.toggle('cookbook-dep-downloading', active);
+  element.title = active ? 'Dependency install is already running' : '';
 }
 
-function _taskDepInstallKey(task) {
-  if (!task?.payload?._dep || !task.payload.repo_id) return '';
-  return _depInstallKey(
-    task.payload.repo_id,
-    task.remoteHost || task.payload.remote_host || '',
-    task.sshPort || task.payload.ssh_port || '',
-    task.payload.env_path || task.payload._envPath || ''
-  );
+async function _launchDependencyTask(options) {
+  const {
+    pipSpec, catalogName, command, target = {}, envPrefix = '', requestRepoId,
+    taskName, statusEl = null, idleText = 'Install', action = 'install',
+    successMessage = '', failureLabel = 'Install failed',
+  } = options;
+  const candidateKeys = dependencyCandidateKeys(pipSpec, catalogName, target);
+  const activeKey = candidateKeys[0] || depInstallKey(pipSpec || catalogName, target.host, target.port, target.envPath);
+  const activeTask = findActiveDepTask(_loadTasks(), candidateKeys);
+  if (candidateKeys.some(key => _pendingDepInstalls.has(key)) || activeTask) {
+    uiModule.showToast(`${catalogName || pipSpec} is already downloading on ${target.host || 'this server'}.`);
+    _setDependencyButtonState(statusEl, true, idleText);
+    return { ok: false, duplicate: true };
+  }
+
+  _pendingDepInstalls.add(activeKey);
+  _setDependencyButtonState(statusEl, true, idleText);
+  try {
+    const reqBody = {
+      repo_id: requestRepoId || String(catalogName || pipSpec || 'dependency').trim().replace(/\s+/g, '_'),
+      cmd: command,
+      remote_host: target.host || undefined,
+      ssh_port: target.port || undefined,
+      env_prefix: envPrefix || undefined,
+      platform: target.platform || undefined,
+    };
+    const response = await fetch('/api/model/serve', {
+      method: 'POST', credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(reqBody),
+    });
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok || !data.ok) {
+      const reason = data.detail || data.error || `HTTP ${response.status}`;
+      uiModule.showToast(`${failureLabel}: ${String(reason).slice(0, 400)}`, {
+        duration: 20000, action: 'OK', onAction: () => {},
+      });
+      _setDependencyButtonState(statusEl, false, idleText);
+      return { ok: false, duplicate: false };
+    }
+    const payload = {
+      repo_id: reqBody.repo_id,
+      _cmd: command,
+      remote_host: target.host || '',
+      ssh_port: target.port || '',
+      _dep: true,
+      _dep_key: activeKey,
+      _dep_pip_spec: String(pipSpec || '').trim(),
+      _dep_catalog_name: String(catalogName || '').trim(),
+      _dep_action: action,
+      env_path: target.envPath || '',
+      platform: target.platform || '',
+    };
+    _addTask(data.session_id, taskName || `pip ${catalogName || pipSpec}`, 'download', payload);
+    if (successMessage) uiModule.showToast(successMessage);
+    return { ok: true, duplicate: false, task: data.session_id };
+  } catch (error) {
+    uiModule.showToast(`${failureLabel}: ${error.message}`, {
+      duration: 20000, action: 'OK', onAction: () => {},
+    });
+    _setDependencyButtonState(statusEl, false, idleText);
+    return { ok: false, duplicate: false };
+  } finally {
+    _pendingDepInstalls.delete(activeKey);
+  }
 }
 
-function _isActiveDepTask(task) {
-  return !!task?.payload?._dep && _ACTIVE_DEP_STATUSES.has(task.status || '');
-}
-
-async function _fetchDependencies() {
+async function _fetchDependencies(requestedTarget = null) {
   const list = document.getElementById('cookbook-deps-list');
   if (!list) return;
+  const _dsel = document.getElementById('hwfit-deps-server');
+  const selectedTarget = _selectedDependencyTarget();
+  if (requestedTarget && !sameDependencyTarget(selectedTarget, requestedTarget)) return false;
+  const effectiveTarget = requestedTarget
+    ? { ...selectedTarget, ...requestedTarget, envPath: requestedTarget.envPath || requestedTarget.venv || '' }
+    : selectedTarget;
   // Use the shared whirlpool spinner so the user sees the request is in
   // flight (the package list takes a few seconds to enumerate on slow links).
   list.innerHTML = '';
@@ -1122,14 +1200,10 @@ async function _fetchDependencies() {
   try {
     // Resolve the target server from the deps dropdown so remote-target
     // packages are checked on THAT server's venv (not just the local host).
-    let _depHost = '', _depPort = '', _depVenv = '', _depPlatform = '';
-    const _dsel = document.getElementById('hwfit-deps-server');
-    const _depSrv = _dsel && _dsel.value !== 'local' ? _serverByVal(_dsel.value) : null;
-    if (_depSrv) {
-      _depHost = _depSrv.host || ''; _depPort = _depSrv.port || ''; _depVenv = _depSrv.envPath || ''; _depPlatform = _depSrv.platform || '';
-    } else if (_envState.remoteHost) {
-      _depHost = _envState.remoteHost; _depPort = _getPort(_envState.remoteHost) || ''; _depVenv = _envState.envPath || ''; _depPlatform = _envState.platform || '';
-    }
+    const _depHost = effectiveTarget.host || '';
+    const _depPort = effectiveTarget.port || '';
+    const _depVenv = effectiveTarget.envPath || '';
+    const _depPlatform = effectiveTarget.platform || '';
     const _pkgParams = new URLSearchParams();
     if (_depHost) {
       _pkgParams.set('host', _depHost);
@@ -1160,9 +1234,10 @@ async function _fetchDependencies() {
     const _systemInstallable = new Set(['tmux']);
     const _activeDepTasks = new Map();
     _loadTasks().forEach(task => {
-      if (!_isActiveDepTask(task)) return;
-      const key = _taskDepInstallKey(task);
-      if (key && !_activeDepTasks.has(key)) _activeDepTasks.set(key, task);
+      if (!isActiveDepTask(task)) return;
+      taskDepInstallKeys(task).forEach(key => {
+        if (key && !_activeDepTasks.has(key)) _activeDepTasks.set(key, task);
+      });
     });
     _pendingDepInstalls.forEach(key => {
       if (key && !_activeDepTasks.has(key)) _activeDepTasks.set(key, { _pending: true });
@@ -1174,7 +1249,8 @@ async function _fetchDependencies() {
     const _activeDepFor = (pkg, isLocal) => {
       if (!pkg?.pip) return null;
       const target = _depTarget(isLocal);
-      return _activeDepTasks.get(_depInstallKey(pkg.pip, target.host, target.port, target.envPath)) || null;
+      const keys = dependencyCandidateKeys(pkg.pip, pkg.name, target);
+      return keys.map(key => _activeDepTasks.get(key)).find(Boolean) || null;
     };
 
     const _statusTag = (pkg, isLocal, isSystemDep, winBlocked, activeDep) => {
@@ -1474,28 +1550,7 @@ async function _fetchDependencies() {
       }
       const targetPlatform = isLocalOnly ? (_envState.hostPlatform || _envState.platform || '') : (targetServer?.platform || _envState.platform || '');
       const targetRemoteHost = isLocalOnly ? '' : (targetServer?.host || _envState.remoteHost || '');
-      const activeKey = _depInstallKey(
-        pipName,
-        targetRemoteHost || '',
-        isLocalOnly ? '' : (_getPort(targetRemoteHost) || ''),
-        targetEnvPath || ''
-      );
-      if (_pendingDepInstalls.has(activeKey) || _loadTasks().some(task => _isActiveDepTask(task) && _taskDepInstallKey(task) === activeKey)) {
-        uiModule.showToast(`${pkgName} is already downloading on ${targetHost}.`);
-        if (statusEl) {
-          statusEl.textContent = 'downloading';
-          statusEl.disabled = true;
-          statusEl.classList.add('cookbook-dep-downloading');
-        }
-        return;
-      }
-      _pendingDepInstalls.add(activeKey);
-      if (statusEl) {
-        statusEl.textContent = 'downloading';
-        statusEl.disabled = true;
-        statusEl.classList.add('cookbook-dep-downloading');
-        statusEl.title = `${pkgName} is already downloading`;
-      }
+      const targetPort = isLocalOnly ? '' : (targetServer?.port || _getPort(targetRemoteHost) || '');
       // Always go through `python -m pip` so the leading token is `python`
       // — matches the /api/model/serve allow-list (bare `pip` is blocked).
       // Inside a venv/conda env, `--user` is invalid (pip refuses), so we
@@ -1540,70 +1595,27 @@ async function _fetchDependencies() {
           envPrefix = 'eval "$(conda shell.bash hook)" && conda activate ' + _shellQuote(targetEnvPath);
         }
       }
-      try {
-        const reqBody = {
-          repo_id: depTaskId,
-          cmd: cmd,
-          remote_host: targetRemoteHost || undefined,
-          ssh_port: _getPort(targetRemoteHost) || undefined,
-          env_prefix: envPrefix || undefined,
-          platform: targetPlatform || undefined,
-        };
-        const res = await fetch('/api/model/serve', {
-          method: 'POST', credentials: 'same-origin',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(reqBody),
-        });
-        const data = await res.json().catch(() => ({}));
-        if (!res.ok || !data.ok) {
-          // FastAPI HTTPException returns {detail: …}; the route's own
-          // path returns {ok:false, error:…}. Surface whichever we get.
-          // Long duration + an OK button — the default 1.2s toast was
-          // disappearing before the user could read multi-clause errors
-          // like "tmux missing on remote".
-          const reason = data.detail || data.error || `HTTP ${res.status}`;
-          uiModule.showToast('Install failed: ' + String(reason).slice(0, 400), {
-            duration: 20000,
-            action: 'OK',
-            onAction: () => {},
-          });
-          _pendingDepInstalls.delete(activeKey);
-          if (statusEl) {
-            statusEl.textContent = upgrade ? 'Update' : 'Install';
-            statusEl.disabled = false;
-            statusEl.classList.remove('cookbook-dep-downloading');
-            statusEl.title = '';
-          }
-          return;
-        }
-        // _dep flags this as a pip dependency/driver install (not a servable
-        // model) so the running-task card doesn't offer a "Serve →" button.
-        const payload = { repo_id: depTaskId, _cmd: cmd, remote_host: targetRemoteHost || '', ssh_port: isLocalOnly ? '' : (_getPort(targetRemoteHost) || ''), _dep: true, _dep_action: upgrade ? 'update' : 'install', env_path: targetEnvPath || '', platform: targetPlatform || '' };
-        _addTask(data.session_id, 'pip ' + pkgName, 'download', payload);
-        _pendingDepInstalls.delete(activeKey);
-        uiModule.showToast(`${upgrade ? 'Updating' : 'Installing'} ${pkgName} on ${targetHost}...`);
-      } catch (err) {
-        uiModule.showToast('Install failed: ' + err.message, {
-          duration: 20000,
-          action: 'OK',
-          onAction: () => {},
-        });
-        _pendingDepInstalls.delete(activeKey);
-        if (statusEl) {
-          statusEl.textContent = upgrade ? 'Update' : 'Install';
-          statusEl.disabled = false;
-          statusEl.classList.remove('cookbook-dep-downloading');
-          statusEl.title = '';
-        }
-      }
+      return _launchDependencyTask({
+        pipSpec: pipName,
+        catalogName: pkgName,
+        command: cmd,
+        target: { host: targetRemoteHost, port: targetPort, envPath: targetEnvPath, platform: targetPlatform },
+        envPrefix,
+        requestRepoId: depTaskId,
+        taskName: 'pip ' + pkgName,
+        statusEl,
+        idleText: upgrade ? 'Update' : 'Install',
+        action: upgrade ? 'update' : 'install',
+        successMessage: `${upgrade ? 'Updating' : 'Installing'} ${pkgName} on ${targetHost}...`,
+      });
     }
 
     // Wire install buttons (not-installed packages)
-    list.querySelectorAll('.cookbook-dep-install:not(.cookbook-dep-recipe-run):not(.cookbook-dep-install-sysdeps)').forEach(btn => {
+    list.querySelectorAll('.cookbook-dep-install:not(.cookbook-dep-recipe-run):not(.cookbook-dep-install-sysdeps):not(.cookbook-dep-install-gpu-wheel)').forEach(btn => {
       btn.addEventListener('click', async (e) => {
         e.stopPropagation();
         const pipName = btn.dataset.depPip;
-        const pkgName = btn.closest('.cookbook-dep-row')?.querySelector('.memory-item-title')?.textContent || pipName;
+        const pkgName = btn.closest('.cookbook-dep-row')?.dataset.pkgName || pipName;
         await _installDep(pipName, pkgName, btn.dataset.depTarget === 'local', !!btn.dataset.upgrade, btn);
       });
     });
@@ -1619,44 +1631,36 @@ async function _fetchDependencies() {
     // forces pip install with the abetlen CUDA wheel index to add GPU
     // offload). Same install flow used at launch-time auto-fix, but
     // user-initiated here so they don't have to launch + wait + retry.
-    list.querySelectorAll('.cookbook-dep-partial').forEach(btn => {
+    list.querySelectorAll('.cookbook-dep-install-gpu-wheel').forEach(btn => {
       btn.addEventListener('click', async (e) => {
         e.stopPropagation();
-        const action = btn.dataset.depPartialAction || '';
-        if (action !== 'reinstall_llama_cpp_cuda') return;
         const isLocal = btn.dataset.depTarget === 'local';
+        let targetServer = null;
         if (!isLocal) {
           const depsServerSel = document.getElementById('hwfit-deps-server');
-          if (depsServerSel) _applyServerSelection(depsServerSel.value);
+          if (depsServerSel) {
+            targetServer = _serverByVal(depsServerSel.value);
+            _applyServerSelection(depsServerSel.value);
+          }
         }
         const targetLabel = isLocal ? 'this server' : (_envState.remoteHost || 'remote');
-        const cmd = 'CMAKE_ARGS="-DGGML_CUDA=on" python3 -m pip install --user --break-system-packages --force-reinstall --no-cache-dir "llama-cpp-python[server]" --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cu124';
-        try {
-          const reqBody = {
-            repo_id: 'llama-cpp-python-cuda',
-            cmd,
-            remote_host: _envState.remoteHost || undefined,
-            ssh_port: _getPort(_envState.remoteHost) || undefined,
-            platform: _envState.platform || undefined,
-          };
-          const res = await fetch('/api/model/serve', {
-            method: 'POST', credentials: 'same-origin',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(reqBody),
-          });
-          const data = await res.json().catch(() => ({}));
-          if (res.ok && data.ok) {
-            const payload = { repo_id: 'pip llama-cpp-python[CUDA]', _cmd: cmd, remote_host: _envState.remoteHost || '', _dep: true };
-            _addTask(data.session_id, 'pip llama-cpp-python[CUDA]', 'download', payload);
-            uiModule.showToast(`Reinstalling llama-cpp-python with CUDA wheels on ${targetLabel} (~1-3 min)…`, 4000);
-          } else {
-            uiModule.showToast('Upgrade failed: ' + String(data.detail || data.error || `HTTP ${res.status}`).slice(0, 300), {
-              duration: 20000, action: 'OK', onAction: () => {},
-            });
-          }
-        } catch (err) {
-          uiModule.showToast('Upgrade request failed: ' + err.message, { duration: 20000, action: 'OK', onAction: () => {} });
-        }
+        const cmd = btn.dataset.depGpuCmd || '';
+        const host = isLocal ? '' : (targetServer?.host || _envState.remoteHost || '');
+        const port = isLocal ? '' : (targetServer?.port || _getPort(host) || '');
+        const envPath = isLocal ? '' : (targetServer?.envPath || _envState.envPath || '');
+        await _launchDependencyTask({
+          pipSpec: 'llama-cpp-python[server]',
+          catalogName: 'llama_cpp',
+          command: cmd,
+          target: { host, port, envPath, platform: isLocal ? (_envState.hostPlatform || '') : (targetServer?.platform || _envState.platform || '') },
+          requestRepoId: 'llama-cpp-python-cuda',
+          taskName: 'pip llama-cpp-python[CUDA]',
+          statusEl: btn,
+          idleText: 'Install GPU wheel',
+          action: 'reinstall_gpu_wheel',
+          failureLabel: 'Upgrade failed',
+          successMessage: `Reinstalling llama-cpp-python with CUDA wheels on ${targetLabel} (~1-3 min)…`,
+        });
       });
     });
 
@@ -1841,31 +1845,27 @@ async function _fetchDependencies() {
         } else if (recipeEnv === 'conda' && _envState.envPath) {
           envPrefix = 'eval "$(conda shell.bash hook)" && conda activate ' + _shellQuote(_envState.envPath);
         }
-        const reqBody = {
-          repo_id: `${backend} setup`,
-          cmd: cmd,
-          remote_host: _envState.remoteHost || undefined,
-          ssh_port: _getPort(_envState.remoteHost) || undefined,
-          env_prefix: envPrefix || undefined,
-          platform: _envState.platform || undefined,
-        };
-        try {
-          const res = await fetch('/api/model/serve', {
-            method: 'POST', credentials: 'same-origin',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(reqBody),
-          });
-          const data = await res.json().catch(() => ({}));
-          if (!res.ok || !data.ok) {
-            uiModule.showToast('Run failed: ' + String(data.detail || data.error || `HTTP ${res.status}`).slice(0, 200));
-            return;
-          }
-          const payload = { repo_id: `${backend} setup`, _cmd: cmd, remote_host: _envState.remoteHost || '', _dep: true };
-          _addTask(data.session_id, `${backend} setup`, 'download', payload);
-          uiModule.showToast(`Running ${backend} setup on ${targetHost}…`);
-        } catch (err) {
-          uiModule.showToast('Run failed: ' + err.message);
-        }
+        const requestRepoId = `${backend} setup`;
+        const row = btn.closest('.cookbook-dep-row');
+        await _launchDependencyTask({
+          pipSpec: row?.dataset.depPip || backend,
+          catalogName: row?.dataset.pkgName || backend,
+          command: cmd,
+          target: {
+            host: _envState.remoteHost || '',
+            port: _getPort(_envState.remoteHost) || '',
+            envPath: _envState.envPath || '',
+            platform: _envState.platform || '',
+          },
+          envPrefix,
+          requestRepoId,
+          taskName: `${backend} setup`,
+          statusEl: btn,
+          idleText: 'Run',
+          action: 'recipe',
+          failureLabel: 'Run failed',
+          successMessage: `Running ${backend} setup on ${targetHost}…`,
+        });
       });
     });
 
@@ -2321,14 +2321,35 @@ function _wireTabEvents(body) {
       ev.preventDefault();
       ev.stopPropagation();
       const sel = document.getElementById('hwfit-deps-server');
+      const server = sel && sel.value !== 'local' ? _serverByVal(sel.value) : null;
       if (sel) _applyServerSelection(sel.value);
-      const host = _envState.remoteHost || '';
+      const host = server?.host || _envState.remoteHost || '';
       const where = host || 'this server';
       if (!confirm(`Reinstall ${pkg} on ${where}?\n\nRuns "pip install --force-reinstall --no-deps ${pkg}" as a tmux task. Watch progress in the Running tab.`)) return;
-      const _venvPy = (_envState.env === 'venv' && _envState.envPath)
-        ? `${_envState.envPath.replace(/\/+$/, '')}/bin/python3`
+      const envPath = server?.envPath || _envState.envPath || '';
+      const envKind = server?.env || _envState.env || '';
+      const _venvPy = (envKind === 'venv' && envPath)
+        ? `${envPath.replace(/\/+$/, '')}/bin/python3`
         : 'python3';
-      _launchServeTask(`reinstall-${pkg}`, 'pip-reinstall', `${_venvPy} -m pip install --force-reinstall --no-deps ${pkg}`);
+      const row = btn.closest('.cookbook-dep-row');
+      await _launchDependencyTask({
+        pipSpec: row?.dataset.depPip || pkg,
+        catalogName: row?.dataset.pkgName || pkg,
+        command: `${_venvPy} -m pip install --force-reinstall --no-deps ${pkg}`,
+        target: {
+          host,
+          port: server?.port || _getPort(host) || '',
+          envPath,
+          platform: server?.platform || _envState.platform || '',
+        },
+        requestRepoId: `reinstall-${pkg}`,
+        taskName: `reinstall-${pkg}`,
+        statusEl: btn,
+        idleText: 'Reinstall',
+        action: 'reinstall',
+        failureLabel: 'Reinstall failed',
+        successMessage: `Reinstalling ${pkg} on ${where}…`,
+      });
     }, true);
   }
 

--- a/static/js/cookbookDepTasks.js
+++ b/static/js/cookbookDepTasks.js
@@ -1,0 +1,100 @@
+const ACTIVE_DEP_STATUSES = new Set(['queued', 'running']);
+
+export function depHostKey(host) {
+  const value = String(host || '').trim();
+  return (!value || value === 'local' || value === 'localhost' || value === '127.0.0.1')
+    ? 'local'
+    : value;
+}
+
+export function depInstallKey(identity, host = '', port = '', envPath = '') {
+  return [
+    String(identity || '').trim(),
+    depHostKey(host),
+    String(port || '').trim(),
+    String(envPath || '').trim(),
+  ].join('\n');
+}
+
+function _targetParts(target = {}) {
+  return {
+    host: target.host || target.remote_host || '',
+    port: target.port || target.ssh_port || '',
+    envPath: target.envPath || target.env_path || target.venv || '',
+  };
+}
+
+export function dependencyCandidateKeys(pipSpec, catalogName, target = {}) {
+  const { host, port, envPath } = _targetParts(target);
+  const identities = [pipSpec, catalogName]
+    .map(value => String(value || '').trim())
+    .filter((value, index, all) => value && all.indexOf(value) === index);
+  const keys = identities.map(identity => depInstallKey(identity, host, port, envPath));
+  // Older tasks did not persist their venv identity. Keep a host/port-only
+  // alias so one such active task still blocks a duplicate after upgrade.
+  if (envPath) identities.forEach(identity => keys.push(depInstallKey(identity, host, port, '')));
+  return [...new Set(keys)];
+}
+
+function _legacyTaskIdentities(task) {
+  const payload = task?.payload || {};
+  const values = [payload._dep_pip_spec, payload._dep_catalog_name, payload.repo_id];
+  const repoId = String(payload.repo_id || '').trim();
+  const taskName = String(task?.name || '').trim();
+  const command = String(payload._cmd || '').trim();
+
+  if (/\bllama-cpp-python\b/i.test(`${repoId} ${taskName} ${command}`)) {
+    values.push('llama_cpp', 'llama-cpp-python[server]');
+  }
+  const setupName = repoId.match(/^(.+?)\s+setup$/i)?.[1];
+  if (setupName) values.push(setupName);
+  const reinstallName = taskName.match(/^reinstall-(.+)$/i)?.[1];
+  if (
+    reinstallName
+    && /(?:^|\s)(?:[^\s"']*[\\/])?python\d*(?:\.\d+)?(?:\.exe)?\s+-m\s+pip\s+install\b/i.test(command)
+  ) {
+    values.push(reinstallName);
+  }
+  return values
+    .map(value => String(value || '').trim())
+    .filter((value, index, all) => value && all.indexOf(value) === index);
+}
+
+export function taskDepInstallKeys(task) {
+  if (!task) return [];
+  const payload = task.payload || {};
+  const identities = _legacyTaskIdentities(task);
+  const legacyReinstall = identities.some(identity => (
+    String(task.name || '').toLowerCase() === `reinstall-${identity.toLowerCase()}`
+  ));
+  if (!payload._dep && !payload._dep_key && !legacyReinstall) return [];
+
+  const target = {
+    host: task.remoteHost || payload.remote_host || '',
+    port: task.sshPort || payload.ssh_port || '',
+    envPath: payload.env_path || payload._envPath || '',
+  };
+  const keys = payload._dep_key ? [String(payload._dep_key)] : [];
+  identities.forEach(identity => keys.push(depInstallKey(identity, target.host, target.port, target.envPath)));
+  return [...new Set(keys.filter(Boolean))];
+}
+
+export function isActiveDepTask(task) {
+  return ACTIVE_DEP_STATUSES.has(task?.status || '') && taskDepInstallKeys(task).length > 0;
+}
+
+export function findActiveDepTask(tasks, candidateKeys) {
+  const wanted = new Set(candidateKeys || []);
+  if (!wanted.size) return null;
+  return (tasks || []).find(task => (
+    isActiveDepTask(task) && taskDepInstallKeys(task).some(key => wanted.has(key))
+  )) || null;
+}
+
+export function sameDependencyTarget(left = {}, right = {}) {
+  const a = _targetParts(left);
+  const b = _targetParts(right);
+  return depHostKey(a.host) === depHostKey(b.host)
+    && String(a.port || '') === String(b.port || '')
+    && String(a.envPath || '') === String(b.envPath || '');
+}

--- a/static/js/cookbookRunning.js
+++ b/static/js/cookbookRunning.js
@@ -969,6 +969,9 @@ function _updateTask(sessionId, updates) {
       if (uptime) uptime.style.display = 'none';
     }
   }
+  if (task?.type === 'download' && task.payload?._dep && updates.status && !['queued', 'running'].includes(task.status || '')) {
+    _refreshDepsAfterInstall(task);
+  }
 }
 
 function _refreshDepsAfterInstall(task) {
@@ -980,8 +983,10 @@ function _refreshDepsAfterInstall(task) {
 
 export function _removeTask(sessionId) {
   _tombstoneTask(sessionId);  // so sync/poll can't resurrect it
-  const tasks = _loadTasks().filter(t => t.sessionId !== sessionId);
-  _saveTasks(tasks);
+  const tasks = _loadTasks();
+  const task = tasks.find(t => t.sessionId === sessionId);
+  _saveTasks(tasks.filter(t => t.sessionId !== sessionId));
+  _refreshDepsAfterInstall(task);
   _renderRunningTab();
 }
 

--- a/static/js/cookbookRunning.js
+++ b/static/js/cookbookRunning.js
@@ -10,6 +10,7 @@ import { registerMenuDismiss } from './escMenuStack.js';
 import { computeProgressSignal } from './cookbookProgressSignal.js';
 import { portOf, nextFreePort } from './cookbookPorts.js';
 import { topPortalZ } from './toolWindowZOrder.js';
+import { isActiveDepTask } from './cookbookDepTasks.js';
 
 // Human-friendly badge label for a task's internal status. Avoids surfacing
 // the word "error" in the sidebar — a server the user stopped or one that
@@ -952,6 +953,7 @@ export function _addTask(sessionId, name, type, payload) {
 function _updateTask(sessionId, updates) {
   const tasks = _loadTasks();
   const task = tasks.find(t => t.sessionId === sessionId);
+  const wasActiveDependency = isActiveDepTask(task);
   if (task) {
     Object.assign(task, updates);
     _saveTasks(tasks);
@@ -969,7 +971,7 @@ function _updateTask(sessionId, updates) {
       if (uptime) uptime.style.display = 'none';
     }
   }
-  if (task?.type === 'download' && task.payload?._dep && updates.status && !['queued', 'running'].includes(task.status || '')) {
+  if (wasActiveDependency && updates.status && !isActiveDepTask(task)) {
     _refreshDepsAfterInstall(task);
   }
 }
@@ -977,7 +979,11 @@ function _updateTask(sessionId, updates) {
 function _refreshDepsAfterInstall(task) {
   if (!task || task.type !== 'download' || !task.payload?._dep) return;
   try {
-    _refreshDependencies?.({ host: task.remoteHost || '', port: task.sshPort || '', venv: task.payload?.env_path || '' });
+    _refreshDependencies?.({
+      host: task.remoteHost || task.payload?.remote_host || '',
+      port: task.sshPort || task.payload?.ssh_port || '',
+      venv: task.payload?.env_path || task.payload?._envPath || '',
+    });
   } catch {}
 }
 
@@ -985,8 +991,9 @@ export function _removeTask(sessionId) {
   _tombstoneTask(sessionId);  // so sync/poll can't resurrect it
   const tasks = _loadTasks();
   const task = tasks.find(t => t.sessionId === sessionId);
+  const shouldRefreshDependencies = isActiveDepTask(task);
   _saveTasks(tasks.filter(t => t.sessionId !== sessionId));
-  _refreshDepsAfterInstall(task);
+  if (shouldRefreshDependencies) _refreshDepsAfterInstall(task);
   _renderRunningTab();
 }
 
@@ -3546,7 +3553,6 @@ async function _reconnectTask(el, task) {
               _updateTask(task.sessionId, { status: 'done' });
               const _sb2 = el.querySelector('.cookbook-task-serve-btn'); if (_sb2) _sb2.style.display = '';
               _showCookbookNotif();
-              _refreshDepsAfterInstall(task);
               fetch('/api/shell/exec', {
                 method: 'POST', credentials: 'same-origin',
                 headers: { 'Content-Type': 'application/json' },

--- a/static/style.css
+++ b/static/style.css
@@ -20632,6 +20632,14 @@ body.gallery-selecting .gallery-dl-btn,
   padding: 0 10px;
   box-sizing: border-box;
 }
+.cookbook-dep-downloading {
+  background: color-mix(in srgb, var(--orange, #ffb86c) 18%, transparent);
+  color: var(--orange, #ffb86c);
+  border: 1px solid color-mix(in srgb, var(--orange, #ffb86c) 35%, transparent);
+  min-width: 75.85px;
+  padding: 0 10px;
+  box-sizing: border-box;
+}
 .cookbook-dep-na {
   background: color-mix(in srgb, var(--fg) 8%, transparent);
   color: color-mix(in srgb, var(--fg) 60%, transparent);
@@ -20659,6 +20667,13 @@ body.gallery-selecting .gallery-dl-btn,
   appearance: none;
   -webkit-appearance: none;
   -moz-appearance: none;
+}
+.cookbook-dep-install.cookbook-dep-downloading {
+  background: color-mix(in srgb, var(--orange, #ffb86c) 18%, transparent);
+  color: var(--orange, #ffb86c);
+  border: 1px solid color-mix(in srgb, var(--orange, #ffb86c) 35%, transparent);
+  cursor: default;
+  opacity: 1;
 }
 /* Conditional line under the Download h2: only when the section is folded
    (collapsed). When expanded, the body content provides separation; the
@@ -20693,6 +20708,7 @@ body.gallery-selecting .gallery-dl-btn,
   padding-left: 0.5px;
 }
 .cookbook-dep-install:hover { opacity: 0.85; }
+.cookbook-dep-install.cookbook-dep-downloading:hover { opacity: 1; }
 /* Installed split button: "Installed" label + separator + ▾ caret; clicking it
    opens the actions menu (Update). Replaces the old ⋮ button. */
 .cookbook-dep-installed-btn {

--- a/tests/test_cookbook_dependency_admission_js.py
+++ b/tests/test_cookbook_dependency_admission_js.py
@@ -1,0 +1,124 @@
+"""Regression coverage for Cookbook dependency-install admission and refresh."""
+
+import json
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HELPER = ROOT / "static/js/cookbookDepTasks.js"
+COOKBOOK = (ROOT / "static/js/cookbook.js").read_text(encoding="utf-8")
+RUNNING = (ROOT / "static/js/cookbookRunning.js").read_text(encoding="utf-8")
+pytestmark = pytest.mark.skipif(not shutil.which("node"), reason="node binary not on PATH")
+
+
+def _node_eval(source: str):
+    proc = subprocess.run(
+        ["node", "--input-type=module"],
+        input=source,
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout.strip())
+
+
+def _section(source: str, start: str, end: str) -> str:
+    return source.split(start, 1)[1].split(end, 1)[0]
+
+
+def test_canonical_and_legacy_tasks_match_the_catalog_pip_identity_and_target():
+    result = _node_eval(
+        textwrap.dedent(
+            f"""
+            import {{
+              dependencyCandidateKeys, findActiveDepTask, sameDependencyTarget,
+            }} from '{HELPER.as_uri()}';
+
+            const target = {{ host: 'gpu-box', port: '2222', envPath: '/srv/venv' }};
+            const cases = [
+              {{
+                name: 'new canonical', status: 'running', remoteHost: 'gpu-box', sshPort: '2222',
+                payload: {{ _dep: true, _dep_pip_spec: 'sglang[all]', _dep_catalog_name: 'sglang', env_path: '/srv/venv' }},
+                pip: 'sglang[all]', catalog: 'sglang',
+              }},
+              {{
+                name: 'pip llama_cpp', status: 'running', remoteHost: 'gpu-box', sshPort: '2222',
+                payload: {{ _dep: true, repo_id: 'llama_cpp', env_path: '/srv/venv' }},
+                pip: 'llama-cpp-python[server]', catalog: 'llama_cpp',
+              }},
+              {{
+                name: 'sglang setup', status: 'running', remoteHost: 'gpu-box', sshPort: '2222',
+                payload: {{ _dep: true, repo_id: 'sglang setup', env_path: '/srv/venv' }},
+                pip: 'sglang[all]', catalog: 'sglang',
+              }},
+              {{
+                name: 'pip llama-cpp-python[CUDA]', status: 'running', remoteHost: 'gpu-box', sshPort: '2222',
+                payload: {{ _dep: true, repo_id: 'pip llama-cpp-python[CUDA]', env_path: '/srv/venv' }},
+                pip: 'llama-cpp-python[server]', catalog: 'llama_cpp',
+              }},
+              {{
+                name: 'reinstall-vllm', status: 'running', remoteHost: 'gpu-box', sshPort: '2222',
+                payload: {{ repo_id: 'pip-reinstall', _cmd: '/srv/venv/bin/python3 -m pip install --force-reinstall --no-deps vllm', env_path: '/srv/venv' }},
+                pip: 'vllm', catalog: 'vllm',
+              }},
+            ];
+            const matches = cases.map(item => !!findActiveDepTask(
+              [item], dependencyCandidateKeys(item.pip, item.catalog, target)
+            ));
+            const wrongTarget = !!findActiveDepTask(
+              [cases[0]], dependencyCandidateKeys('sglang[all]', 'sglang', {{ ...target, host: 'other-box' }})
+            );
+            console.log(JSON.stringify({{
+              matches,
+              wrongTarget,
+              aliases: sameDependencyTarget(
+                {{ host: 'localhost', port: '', envPath: '' }},
+                {{ host: '', port: '', venv: '' }}
+              ),
+            }}));
+            """
+        )
+    )
+    assert result == {
+        "matches": [True, True, True, True, True],
+        "wrongTarget": False,
+        "aliases": True,
+    }
+
+
+def test_every_visible_pip_install_surface_uses_shared_admission():
+    normal = _section(COOKBOOK, "async function _installDep", "// Wire install buttons")
+    gpu = _section(COOKBOOK, "list.querySelectorAll('.cookbook-dep-install-gpu-wheel')", "// Inline command")
+    recipe = _section(COOKBOOK, "list.querySelectorAll('[data-dep-recipe-run]')", "async function _rebuildLlamaCpp")
+    reinstall = _section(COOKBOOK, "// \"Reinstall\" buttons", "// Serve sort")
+
+    for block in (normal, gpu, recipe, reinstall):
+        assert "_launchDependencyTask({" in block
+    assert ":not(.cookbook-dep-install-gpu-wheel)" in COOKBOOK
+
+    admission = _section(COOKBOOK, "async function _launchDependencyTask", "async function _fetchDependencies")
+    assert admission.index("_pendingDepInstalls.add(activeKey)") < admission.index("await fetch('/api/model/serve'")
+    for field in ("_dep_key", "_dep_pip_spec", "_dep_catalog_name"):
+        assert field in admission
+
+
+def test_completion_refresh_is_target_aware_and_owned_by_status_transition():
+    fetch_deps = _section(COOKBOOK, "async function _fetchDependencies", "const _depTarget")
+    assert "const _dsel = document.getElementById('hwfit-deps-server')" in fetch_deps
+    assert "sameDependencyTarget(selectedTarget, requestedTarget)" in fetch_deps
+    assert fetch_deps.index("sameDependencyTarget") < fetch_deps.index("list.innerHTML = ''")
+
+    update = _section(RUNNING, "function _updateTask", "function _refreshDepsAfterInstall")
+    assert "wasActiveDependency" in update
+    assert "!isActiveDepTask(task)" in update
+
+    success = _section(RUNNING, "if (snapshot.includes('DOWNLOAD_OK')", "// Live status parsing")
+    assert "_updateTask(task.sessionId, { status: 'done' })" in success
+    assert "_refreshDepsAfterInstall(task)" not in success

--- a/tests/test_cookbook_dependency_completion_regression.py
+++ b/tests/test_cookbook_dependency_completion_regression.py
@@ -101,7 +101,8 @@ def test_background_poll_recovers_done_for_completed_download():
 def test_dependency_install_payload_keeps_env_path_for_refresh():
     source = _read("static/js/cookbook.js")
 
-    assert "env_path: targetEnvPath || ''" in source
+    assert "env_path: target.envPath || ''" in source
+    assert "envPath: targetEnvPath" in source
 
 
 def test_local_dependency_probe_refreshes_user_site_visibility():


### PR DESCRIPTION
## Summary

Recreates the closed #3782 cookbook dependency-install dedupe fix after the July 23 repository cleanup wiped old PR refs/diffs. The branch is rebuilt on current dev (25c9e735) and keeps the duplicate active dependency task guard while preserving the newer cookbook install flow.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release.

## Linked Issue

Supersedes #3782 after the July 23 repository cleanup wiped old PR refs/diffs and closed the original PR unmerged.

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) - this is not a duplicate; it is a recovery of closed #3782.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Review the recovered branch against current `dev` and confirm it only contains the recreated #3782 scope.
2. Run the local checks used for this recovery:

```text
 git diff --check origin/dev...HEAD
node --check static/js/cookbook.js
node --check static/js/cookbookRunning.js 
```

3. In a full Odysseus dev environment, run the focused pytest file(s) added or touched by this PR where applicable. I could not run pytest here because this Windows environment has no system Python/pytest and the bundled Python runtime does not include pytest.

## Visual / UI changes

**REQUIRED if you touched anything that renders.**  Touches cookbook UI JavaScript/CSS behavior. No fresh screenshot or clip is attached in this recovery PR because this environment cannot run the app UI; please verify in the running Cookbook panel.
- [ ] Screenshot or short clip of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] Style match: the change uses Odysseus's existing visual language and recovered code paths.
- [x] No new component patterns beyond the recovered original PR scope.
- [x] I am not an LLM agent submitting a bulk PR. This is a targeted recovery of #3782 after the repository cleanup event.

### Screenshots / clips

Not attached in this recovery pass.