### PR TITLE
feat(dock): add snapped window side tabs

### DIFF
--- a/static/js/edgeDockOwners.js
+++ b/static/js/edgeDockOwners.js
@@ -1,0 +1,51 @@
+import { TOOL_WINDOW_SELECTOR } from './toolWindowZOrder.js';
+
+const SIDE_OWNER_SELECTORS = Object.freeze({
+  left: '.modal-left-docked, .email-snap-left',
+  right: '.modal-right-docked',
+});
+const NOTES_BACKDROP_SELECTOR = 'body > .notes-pane-backdrop';
+
+export function dockOwnerSelectorForSide(side) {
+  return SIDE_OWNER_SELECTORS[side] || '';
+}
+
+export function isApplicationDockOwner(owner) {
+  if (!owner || typeof owner.matches !== 'function') return false;
+  if (owner.matches('.notes-pane')) {
+    return !!owner.parentElement?.matches?.(NOTES_BACKDROP_SELECTOR);
+  }
+  return owner.matches(TOOL_WINDOW_SELECTOR);
+}
+
+export function isUsableDockOwner(owner, options = {}) {
+  const {
+    resolveContent = (candidate) => candidate?.querySelector?.('.modal-content') || candidate,
+    getStyle = globalThis.getComputedStyle,
+  } = options;
+  if (!isApplicationDockOwner(owner) || !owner.isConnected) return false;
+  if (owner.classList?.contains('hidden') || owner.classList?.contains('modal-minimized')) return false;
+  const ownerStyle = typeof getStyle === 'function' ? getStyle(owner) : owner.style;
+  if (ownerStyle?.display === 'none' || ownerStyle?.visibility === 'hidden') return false;
+
+  const content = resolveContent(owner);
+  if (!content || !content.isConnected) return false;
+  if (content.classList?.contains('hidden') || content.classList?.contains('modal-minimized')) return false;
+  const contentStyle = typeof getStyle === 'function' ? getStyle(content) : content.style;
+  if (contentStyle?.display === 'none' || contentStyle?.visibility === 'hidden') return false;
+  const rect = content.getBoundingClientRect?.();
+  return !!rect && rect.width > 0 && rect.height > 0;
+}
+
+export function dockOwnersForSide(side, options = {}) {
+  const {
+    root = globalThis.document,
+    resolveContent,
+    getStyle,
+  } = options;
+  const selector = dockOwnerSelectorForSide(side);
+  if (!selector || !root || typeof root.querySelectorAll !== 'function') return [];
+  return Array.from(root.querySelectorAll(selector)).filter((owner) => (
+    isUsableDockOwner(owner, { resolveContent, getStyle })
+  ));
+}

--- a/static/js/emailLibrary.js
+++ b/static/js/emailLibrary.js
@@ -24,7 +24,7 @@ import {
 } from './emailLibrary/signatureFold.js';
 import { state } from './emailLibrary/state.js';
 import { getSettings } from './appConfig.js';
-import { collapseSidebarToRail } from './modalSnap.js';
+import { collapseSidebarToRail, reconcileDockSide, syncDockSideWidth } from './modalSnap.js';
 import { emailApiUrl } from './emailShared.js';
 import { bindMenuDismiss, dismissOrRemove } from './escMenuStack.js';
 
@@ -1162,6 +1162,7 @@ function _prepareEmailWindowForDocument(modal) {
   if (modal.classList.contains('email-snap-left') || modal.classList.contains('modal-left-docked')) {
     const rect = modal.querySelector('.modal-content')?.getBoundingClientRect?.();
     _setEmailDocumentSplit(rect?.left || _emailSplitLeftEdge(), rect?.width || 420);
+    syncDockSideWidth('left', rect?.width || 420);
     _scheduleEmailDocumentSplitMeasure(modal);
     return false;
   }
@@ -3338,12 +3339,17 @@ export async function openEmailLibrarySettings() {
 export function closeEmailLibrary() {
   _cancelEmailPrewarm();
   const modal = document.getElementById('email-lib-modal');
+  const dockWidth = (modal?.classList?.contains('email-snap-left')
+    || modal?.classList?.contains('modal-left-docked'))
+    ? modal.querySelector('.modal-content')?.getBoundingClientRect?.().width || 0
+    : 0;
   if (modal) modal.remove();
   if (_libSyncTicker) {
     clearInterval(_libSyncTicker);
     _libSyncTicker = null;
   }
   _clearEmailDocumentSplit();
+  if (dockWidth) reconcileDockSide('left', dockWidth);
   if (state._libEscHandler) {
     document.removeEventListener('keydown', state._libEscHandler, true);
     state._libEscHandler = null;
@@ -3404,6 +3410,7 @@ function _makeDraggable(content, modal, fsClass) {
       if (!modal.classList.contains('email-snap-left')) return;
       modal.classList.remove('email-snap-left');
       _clearEmailDocumentSplit();
+      reconcileDockSide('left', rect.width || 0);
       content.style.position = 'fixed';
       content.style.left = `${Math.round(rect.left)}px`;
       content.style.top = `${Math.round(rect.top)}px`;
@@ -3461,6 +3468,7 @@ function _snapEmailModalToLeftSidebar(modal) {
   content.style.transform = 'none';
   content.style.margin = '0';
   _setEmailDocumentSplit(left, W);
+  syncDockSideWidth('left', W);
   _scheduleEmailDocumentSplitMeasure(modal);
   return true;
 }

--- a/static/js/modalSnap.js
+++ b/static/js/modalSnap.js
@@ -1,3 +1,6 @@
+import { dockOwnersForSide } from './edgeDockOwners.js';
+import { nextToolWindowZ } from './toolWindowZOrder.js';
+
 // Right-edge snap docking for draggable modals.
 //
 // Adds a "drag-to-right" gesture that docks a modal as a right-side panel
@@ -23,6 +26,7 @@ const MIN_CHAT_WIDTH = 380;
 const EMAIL_DOC_SPLIT_WIDTH_KEY = 'odysseus-email-doc-split-width';
 const EDGE_DOCK_WIDTH_KEY_PREFIX = 'odysseus-edge-dock-width';
 const MIN_EDGE_DOCK_WIDTH = 320;
+const EDGE_DOCK_SWITCHER_FLAG = 'odysseus-edge-dock-switcher';
 
 let _edgeDockHandlePositioner = null;
 
@@ -30,13 +34,105 @@ function _positionEdgeDockResizeHandles() {
   try { _edgeDockHandlePositioner && _edgeDockHandlePositioner(); } catch (_) {}
 }
 
+function _notifyEdgeDockChanged(side, owner = null) {
+  try {
+    window.dispatchEvent(new CustomEvent('odysseus:edge-dock-changed', {
+      detail: { side, owner },
+    }));
+  } catch (_) {}
+}
+
 function _dockClassForSide(side) {
   return side === 'left' ? 'modal-left-docked' : 'modal-right-docked';
 }
 
+function _dockOwnerSurface(owner) {
+  return owner?.closest?.('.notes-pane-backdrop') || owner;
+}
+
+function _zIndexForElement(el, fallback = 250) {
+  const raw = el ? window.getComputedStyle(el).zIndex : '';
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function _dockOwnersForSide(side) {
+  return dockOwnersForSide(side, {
+    root: document,
+    resolveContent: (candidate) => _resolveDockNodes(candidate)?.content,
+  });
+}
+
+function _activeDockOwnerForSide(side) {
+  let best = null;
+  let bestZ = -Infinity;
+  _dockOwnersForSide(side).forEach((owner) => {
+    const z = _zIndexForElement(_dockOwnerSurface(owner), 250);
+    if (z >= bestZ) {
+      best = owner;
+      bestZ = z;
+    }
+  });
+  return best;
+}
+
+function _applyDockWidthToOwner(owner, side, width, left = _leftNavRight()) {
+  const content = _resolveDockNodes(owner)?.content;
+  if (!content || !width) return;
+  const w = Math.round(width);
+  content._userDockWidth = w;
+  if (side === 'right') {
+    content.style.left = 'auto';
+    content.style.right = '0';
+    content.style.width = w + 'px';
+    content.style.maxWidth = w + 'px';
+    if (_shouldAutoCollapseSidebar(w)) {
+      _collapseSidebarToRail();
+      if (content._preDockSnapshot) content._preDockSnapshot.collapsedSidebar = true;
+    }
+  } else {
+    content._emailDocSplitUserW = w;
+    content.style.left = left + 'px';
+    content.style.right = 'auto';
+    content.style.width = w + 'px';
+    content.style.maxWidth = w + 'px';
+  }
+}
+
+export function syncDockSideWidth(side, requestedWidth, owners = _dockOwnersForSide(side)) {
+  if (side !== 'left' && side !== 'right') return 0;
+  if (!owners.length) return 0;
+  let w = 0;
+  if (side === 'right') {
+    w = _clampRightDockWidth(requestedWidth || _activeDockWidth('right') || _defaultDockWidth());
+    document.body.classList.add('right-dock-active');
+    document.documentElement.style.setProperty('--right-dock-w', w + 'px');
+    owners.forEach((owner) => _applyDockWidthToOwner(owner, side, w));
+  } else {
+    const left = _leftNavRight();
+    const splitActive = document.body.classList.contains('email-doc-split-active')
+      && document.body.classList.contains('doc-view');
+    const fallbackWidth = _resolveDockNodes(owners.find(_isEmailDockOwner))?.content?.getBoundingClientRect?.().width
+      || _activeDockWidth('left')
+      || _defaultDockWidth();
+    w = splitActive
+      ? _clampEmailDocSplitWidth(requestedWidth || fallbackWidth, left)
+      : _clampLeftDockWidth(requestedWidth || fallbackWidth, left);
+    document.body.classList.add('left-dock-active');
+    document.documentElement.style.setProperty(
+      '--left-dock-w',
+      splitActive ? '0px' : w + 'px',
+    );
+    document.documentElement.style.setProperty('--left-dock-visual-w', w + 'px');
+    owners.forEach((owner) => _applyDockWidthToOwner(owner, side, w, left));
+    if (splitActive) _applyEmailDocSplitGeometry(left, w);
+  }
+  _positionEdgeDockResizeHandles();
+  return w;
+}
+
 function _hasOtherDockedWindow(side, owner) {
-  const cls = _dockClassForSide(side);
-  return Array.from(document.querySelectorAll(`.${cls}`)).some((el) => {
+  return _dockOwnersForSide(side).some((el) => {
     if (!el || el === owner) return false;
     if (owner && el.contains && el.contains(owner)) return false;
     if (owner && owner.contains && owner.contains(el)) return false;
@@ -53,10 +149,23 @@ export function clearDockSide(side, owner = null) {
   if (_hasOtherDockedWindow(side, owner)) return;
   document.body.classList.remove(side === 'left' ? 'left-dock-active' : 'right-dock-active');
   document.documentElement.style.removeProperty(side === 'left' ? '--left-dock-w' : '--right-dock-w');
+  if (side === 'left') document.documentElement.style.removeProperty('--left-dock-visual-w');
   if (side === 'left') {
     try { window._restoreSidebarIfRouteCollapsed?.(); } catch (_) {}
   }
   _positionEdgeDockResizeHandles();
+}
+
+export function reconcileDockSide(side, requestedWidth = 0) {
+  const owners = _dockOwnersForSide(side);
+  if (!owners.length) {
+    clearDockSide(side);
+    _notifyEdgeDockChanged(side);
+    return 0;
+  }
+  const width = syncDockSideWidth(side, requestedWidth, owners);
+  _notifyEdgeDockChanged(side, owners[owners.length - 1]);
+  return width;
 }
 
 // Default dock width: ~38% of viewport, clamped to a reasonable band.
@@ -98,6 +207,14 @@ function _activeDockWidth(side) {
   const raw = getComputedStyle(document.documentElement).getPropertyValue(prop);
   const n = parseFloat(raw || '');
   return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+function _activeDockVisualWidth(side) {
+  if (side !== 'left') return _activeDockWidth(side);
+  if (!document.body.classList.contains('left-dock-active')) return 0;
+  const raw = getComputedStyle(document.documentElement).getPropertyValue('--left-dock-visual-w');
+  const n = parseFloat(raw || '');
+  return Number.isFinite(n) && n > 0 ? n : _activeDockWidth(side);
 }
 
 function _clampDockWidthToSpace(width, min, max) {
@@ -277,8 +394,13 @@ function _resolveEmailDocSplitWidth(content, left) {
 function _anchorLeftDock(content) {
   if (!content || content._dockSide !== 'left') return;
   const left = _leftNavRight();
-  const w = document.body.classList.contains('doc-view')
-    ? _resolveEmailDocSplitWidth(content, left)
+  const owners = _dockOwnersForSide('left');
+  const emailOwner = owners.find(_isEmailDockOwner)
+    || (_isEmailDockOwner(content._dockOwner) ? content._dockOwner : null);
+  const splitContent = _resolveDockNodes(emailOwner)?.content || content;
+  const splitActive = document.body.classList.contains('doc-view') && !!emailOwner;
+  const w = splitActive
+    ? _resolveEmailDocSplitWidth(splitContent, left)
     : _resolveLeftDockWidth(content, left);
   content.style.left = left + 'px';
   content.style.width = w + 'px';
@@ -288,17 +410,20 @@ function _anchorLeftDock(content) {
   // the doc-pane becomes position:fixed starting at the email's right edge.
   // No flex/max-width fighting; the doc just owns the right side from the
   // email's right edge to the viewport edge — they touch flush, no gap.
-  const docOpen = document.body.classList.contains('doc-view') && _isEmailDockOwner(content._dockOwner);
-  if (docOpen) {
+  if (splitActive) {
     if (!document.body.classList.contains('email-doc-split-active')) {
       document.body.classList.add('email-doc-split-active');
     }
     document.documentElement.style.setProperty('--left-dock-w', '0px');
+    document.documentElement.style.setProperty('--left-dock-visual-w', w + 'px');
+    owners.forEach((owner) => _applyDockWidthToOwner(owner, 'left', w, left));
     _applyEmailDocSplitGeometry(left, w);
-  } else if (document.body.classList.contains('email-doc-split-active')) {
-    _clearEmailDocSplitGeometry();
   } else {
+    if (document.body.classList.contains('email-doc-split-active')) {
+      _clearEmailDocSplitGeometry();
+    }
     document.documentElement.style.setProperty('--left-dock-w', w + 'px');
+    document.documentElement.style.setProperty('--left-dock-visual-w', w + 'px');
   }
 }
 
@@ -347,6 +472,7 @@ function _applyDockInternal(modal, side, dockClass) {
   if (!nodes) return 0;
   const content = nodes.content;
   if (!content) return 0;
+  const existingSideWidth = _hasOtherDockedWindow(side, modal) ? _activeDockVisualWidth(side) : 0;
   // If the modal is currently docked on the OTHER side (e.g. the user
   // manually docked it right, then a reply re-docks it left), clear that
   // side's class + body push first. Otherwise both sides' state coexist —
@@ -357,8 +483,10 @@ function _applyDockInternal(modal, side, dockClass) {
   // the floating window's real left/right inline styles below.
   const otherSide = side === 'left' ? 'right' : 'left';
   const otherClass = _dockClassForSide(otherSide);
-  if (modal.classList.contains(otherClass)) {
+  const hadLegacyLeftClass = otherSide === 'left' && modal.classList.contains('email-snap-left');
+  if (modal.classList.contains(otherClass) || hadLegacyLeftClass) {
     modal.classList.remove(otherClass);
+    if (hadLegacyLeftClass) modal.classList.remove('email-snap-left');
     clearDockSide(otherSide, modal);
     // Reset the edge anchors so the new side positions from a clean slate
     // (the right dock pins right:0; the left dock pins left:<nav>).
@@ -418,6 +546,7 @@ function _applyDockInternal(modal, side, dockClass) {
       '--left-dock-w',
       document.body.classList.contains('email-doc-split-active') ? '0px' : w + 'px',
     );
+    document.documentElement.style.setProperty('--left-dock-visual-w', w + 'px');
     // Re-anchor the email when the sidebar is toggled (expanded/collapsed) so
     // the nav slides the window over instead of growing on top of it. Also
     // re-anchor when the document editor pane appears/disappears (signaled by
@@ -509,7 +638,13 @@ function _applyDockInternal(modal, side, dockClass) {
   }
   content._dockSide = side;
   content._dockOwner = modal;
-  _positionEdgeDockResizeHandles();
+  const sideOwners = _dockOwnersForSide(side);
+  if (sideOwners.length > 1) {
+    const syncedWidth = syncDockSideWidth(side, existingSideWidth || w, sideOwners);
+    if (syncedWidth) w = syncedWidth;
+  } else {
+    _positionEdgeDockResizeHandles();
+  }
   // Watch for the docked modal disappearing (removed from DOM or hidden
   // via .hidden class) and clean up the body padding + sidebar in that
   // case. Without this, closing a docked window leaves a phantom strip
@@ -539,6 +674,7 @@ function _applyDockInternal(modal, side, dockClass) {
       modal._dockCloseWatcher = { obs };
     }
   }
+  _notifyEdgeDockChanged(side, modal);
   return w;
 }
 
@@ -556,7 +692,8 @@ function _onDockedModalGone(modal, dockClass) {
   const _c = modal.querySelector ? modal.querySelector('.modal-content') : null;
   _disconnectLeftDockObservers(_c);
   const hadRight = modal.classList.contains('modal-right-docked');
-  const hadLeft = modal.classList.contains('modal-left-docked');
+  const hadLegacyLeft = modal.classList.contains('email-snap-left');
+  const hadLeft = modal.classList.contains('modal-left-docked') || hadLegacyLeft;
   // Clear body-level dock state only for the side this modal owned, and only
   // when another docked window is not still using that side.
   if (hadRight) clearDockSide('right', modal);
@@ -571,6 +708,9 @@ function _onDockedModalGone(modal, dockClass) {
   }
   modal.classList.remove('modal-right-docked');
   modal.classList.remove('modal-left-docked');
+  modal.classList.remove('email-snap-left');
+  if (hadRight) _notifyEdgeDockChanged('right', modal);
+  if (hadLeft) _notifyEdgeDockChanged('left', modal);
   // Clear the content's docked inline geometry. Singleton modals (plan,
   // workspace, calendar, …) reuse the same element across open/close, so if we
   // only drop the body push the element stays positioned (position:fixed;
@@ -610,10 +750,13 @@ export function clearRightDock(modal, cx, cy, dockClass) {
   const content = nodes.content;
   if (!content) return;
   // Figure out which side was docked — fall back to right for legacy callers.
-  const side = content._dockSide || (modal.classList.contains('modal-left-docked') ? 'left' : 'right');
+  const side = content._dockSide
+    || (modal.classList.contains('modal-left-docked') || modal.classList.contains('email-snap-left') ? 'left' : 'right');
   if (!dockClass) dockClass = side === 'left' ? 'modal-left-docked' : 'modal-right-docked';
-  if (!modal.classList.contains(dockClass)) return;
+  const hasLegacyLeftClass = side === 'left' && modal.classList.contains('email-snap-left');
+  if (!modal.classList.contains(dockClass) && !hasLegacyLeftClass) return;
   modal.classList.remove(dockClass);
+  if (hasLegacyLeftClass) modal.classList.remove('email-snap-left');
   clearDockSide(side, modal);
   if (side === 'left' && !_hasOtherDockedWindow('left', modal)) {
     _clearEmailDocSplitGeometry();
@@ -666,6 +809,7 @@ export function clearRightDock(modal, cx, cy, dockClass) {
   delete content._preDockSnapshot;
   delete content._dockSuspended;
   _positionEdgeDockResizeHandles();
+  _notifyEdgeDockChanged(side, modal);
 }
 
 // Temporarily release a docked modal's body push (chat returns to full
@@ -711,6 +855,7 @@ export function suspendDock(modal) {
   }
   content._dockSuspended = side;
   _positionEdgeDockResizeHandles();
+  _notifyEdgeDockChanged(side, modal);
   return side;
 }
 
@@ -785,6 +930,192 @@ export function makeEdgeDockController(modal, side = 'right', dockClass) {
   };
 }
 
+(function _initEdgeDockSwitcher() {
+  if (typeof document === 'undefined' || typeof window === 'undefined') return;
+
+  const bars = { left: null, right: null };
+  let refreshTimer = 0;
+  let refreshInterval = 0;
+
+  const _enabled = () => {
+    try { return localStorage.getItem(EDGE_DOCK_SWITCHER_FLAG) !== '0'; }
+    catch (_) { return true; }
+  };
+
+  const _ownerSurface = _dockOwnerSurface;
+
+  const _bringOwnerToFront = (owner) => {
+    const surface = _ownerSurface(owner);
+    if (!surface) return;
+    const z = nextToolWindowZ({
+      exclude: surface,
+      current: window.getComputedStyle(surface).zIndex,
+    });
+    surface.style.setProperty('z-index', String(z), 'important');
+    try {
+      window.dispatchEvent(new CustomEvent('odysseus:modal-opened', {
+        detail: { id: owner?.id || '', modal: owner },
+      }));
+    } catch (_) {}
+  };
+
+  const _simpleTitleForOwner = (owner) => {
+    const id = owner?.id || '';
+    const labels = {
+      'assistant-settings-modal': 'Assistant',
+      'calendar-modal': 'Calendar',
+      'compare-model-overlay': 'Compare',
+      'cookbook-modal': 'Cookbook',
+      'doc-editor-pane': 'Document',
+      'doclib-modal': 'Library',
+      'email-lib-modal': 'Email',
+      'gallery-modal': 'Gallery',
+      'library-modal': 'Library',
+      'notes-pane': 'Notes',
+      'research-overlay': 'Deep Research',
+      'research-pane': 'Deep Research',
+      'settings-modal': 'Settings',
+      'tasks-modal': 'Tasks',
+    };
+    return labels[id] || '';
+  };
+
+  const _cleanTabLabel = (label) => (label || '')
+    .replace(/\s+/g, ' ')
+    .replace(/\s+\d+\s+(photos?|research|tasks?|notes?|documents?|docs?|items?|emails?|chats?|sessions?|models?)$/i, '')
+    .trim();
+
+  const _labelForOwner = (owner) => {
+    const simple = _simpleTitleForOwner(owner);
+    if (simple) return simple;
+    const content = _resolveDockNodes(owner)?.content || owner;
+    const titleEl = content?.querySelector?.('.modal-header h4, .notes-pane-title, .modal-title, [data-window-title]');
+    const text = _cleanTabLabel(titleEl?.textContent || owner?.getAttribute?.('aria-label') || owner?.id || 'Window');
+    return text || 'Window';
+  };
+
+  const _activeOwner = (owners) => {
+    let best = null;
+    let bestZ = -Infinity;
+    owners.forEach((owner) => {
+      const z = _zIndexForElement(_ownerSurface(owner), 250);
+      if (z >= bestZ) {
+        best = owner;
+        bestZ = z;
+      }
+    });
+    return best || owners[owners.length - 1] || null;
+  };
+
+  const _hideBar = (side) => {
+    const bar = bars[side];
+    if (!bar) return;
+    bar.replaceChildren();
+    bar.hidden = true;
+    bar.parentElement?.classList?.remove('edge-dock-switcher-host');
+  };
+
+  const _ensureBar = (side) => {
+    if (!bars[side]?.isConnected) {
+      const bar = document.createElement('div');
+      bar.className = `edge-dock-switcher edge-dock-switcher-${side}`;
+      bar.hidden = true;
+      bar.setAttribute('role', 'tablist');
+      bar.setAttribute('aria-label', `${side} docked windows`);
+      bar.addEventListener('pointerdown', (event) => event.stopPropagation());
+      bar.addEventListener('mousedown', (event) => event.stopPropagation());
+      bar.addEventListener('touchstart', (event) => event.stopPropagation(), { passive: true });
+      bars[side] = bar;
+    }
+    const oldParent = bars[side]?.parentElement;
+    if (oldParent && oldParent !== document.body) oldParent.classList.remove('edge-dock-switcher-host');
+    if (bars[side].parentElement !== document.body) document.body.appendChild(bars[side]);
+    return bars[side];
+  };
+
+  const _renderSide = (side) => {
+    const owners = _enabled() && window.innerWidth > 768 ? _dockOwnersForSide(side) : [];
+    if (owners.length < 2) {
+      _hideBar(side);
+      return;
+    }
+    const active = _activeOwner(owners);
+    const bar = _ensureBar(side);
+    bar.replaceChildren();
+    owners.forEach((owner) => {
+      const label = _labelForOwner(owner);
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = `edge-dock-switcher-tab${owner === active ? ' active' : ''}`;
+      btn.title = label;
+      btn.setAttribute('role', 'tab');
+      btn.setAttribute('aria-selected', owner === active ? 'true' : 'false');
+      btn.addEventListener('pointerdown', (event) => event.stopPropagation());
+      btn.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        _bringOwnerToFront(owner);
+        _scheduleRefresh(40);
+      });
+      const labelEl = document.createElement('span');
+      labelEl.className = 'edge-dock-switcher-tab-label';
+      labelEl.textContent = label;
+      btn.appendChild(labelEl);
+      bar.appendChild(btn);
+    });
+    bar.hidden = false;
+  };
+
+  function _refresh() {
+    if (!document.body) return;
+    _renderSide('left');
+    _renderSide('right');
+  }
+
+  function _scheduleRefresh(delay = 180) {
+    if (refreshTimer) clearTimeout(refreshTimer);
+    refreshTimer = setTimeout(() => {
+      refreshTimer = 0;
+      requestAnimationFrame(_refresh);
+    }, delay);
+  }
+
+  const _start = () => {
+    _scheduleRefresh(0);
+    window.addEventListener('resize', () => _scheduleRefresh(120));
+    window.addEventListener('odysseus:modal-opened', () => _scheduleRefresh(120));
+    window.addEventListener('odysseus:edge-dock-changed', () => _scheduleRefresh(320));
+    document.addEventListener('keyup', (event) => {
+      if (event.key === 'Escape') _scheduleRefresh(120);
+    }, true);
+    refreshInterval = window.setInterval(() => {
+      if (document.visibilityState !== 'hidden') _refresh();
+    }, 1500);
+    window.odysseusEdgeDockSwitcher = {
+      refresh: _refresh,
+      disable() {
+        try { localStorage.setItem(EDGE_DOCK_SWITCHER_FLAG, '0'); } catch (_) {}
+        _refresh();
+      },
+      enable() {
+        try { localStorage.removeItem(EDGE_DOCK_SWITCHER_FLAG); } catch (_) {}
+        _refresh();
+      },
+      stop() {
+        if (refreshInterval) window.clearInterval(refreshInterval);
+        refreshInterval = 0;
+        bars.left?.remove();
+        bars.right?.remove();
+        bars.left = null;
+        bars.right = null;
+      },
+    };
+  };
+
+  if (document.body) _start();
+  else document.addEventListener('DOMContentLoaded', _start, { once: true });
+})();
+
 (function _initEdgeDockResizeHandles() {
   if (typeof document === 'undefined') return;
   if (!document.body) {
@@ -820,33 +1151,7 @@ export function makeEdgeDockController(modal, side = 'right', dockClass) {
     document.body.appendChild(handle);
   }
 
-  const _isUsableDockOwner = (owner) => {
-    if (!owner || !owner.isConnected) return false;
-    if (owner.classList?.contains('hidden')) return false;
-    if (owner.style?.display === 'none') return false;
-    const nodes = _resolveDockNodes(owner);
-    const content = nodes?.content;
-    if (!content || !content.isConnected) return false;
-    if (content.classList?.contains('hidden')) return false;
-    if (content.style?.display === 'none') return false;
-    const r = content.getBoundingClientRect();
-    return r.width > 0 && r.height > 0;
-  };
-
-  const _activeDockOwner = (side) => {
-    const cls = _dockClassForSide(side);
-    const all = Array.from(document.querySelectorAll(`.${cls}`));
-    for (const owner of all.reverse()) {
-      if (_isUsableDockOwner(owner)) return owner;
-    }
-    return null;
-  };
-
-  const _zIndexFor = (el, fallback = 250) => {
-    const raw = el ? window.getComputedStyle(el).zIndex : '';
-    const n = parseInt(raw, 10);
-    return Number.isFinite(n) ? n : fallback;
-  };
+  const _activeDockOwner = (side) => _activeDockOwnerForSide(side);
 
   const _hasVisibleFloatingModal = (owner) => {
     const all = Array.from(document.querySelectorAll('.modal:not(.hidden):not(.modal-minimized)'));
@@ -863,40 +1168,18 @@ export function makeEdgeDockController(modal, side = 'right', dockClass) {
     });
   };
 
-  const _setWidth = (owner, side, clientX) => {
-    const nodes = _resolveDockNodes(owner);
-    const content = nodes?.content;
-    if (!content) return 0;
+  const _setWidth = (owner, side, clientX, resizeOwners = null) => {
+    const targets = (resizeOwners && resizeOwners.length) ? resizeOwners : [owner].filter(Boolean);
+    if (!targets.length) return 0;
     let w = 0;
     if (side === 'right') {
       w = _clampRightDockWidth(window.innerWidth - clientX);
-      content._userDockWidth = w;
-      content.style.left = 'auto';
-      content.style.right = '0';
-      content.style.width = w + 'px';
-      content.style.maxWidth = w + 'px';
-      document.body.classList.add('right-dock-active');
-      document.documentElement.style.setProperty('--right-dock-w', w + 'px');
-      if (_shouldAutoCollapseSidebar(w)) {
-        _collapseSidebarToRail();
-        if (content._preDockSnapshot) content._preDockSnapshot.collapsedSidebar = true;
-      }
+      syncDockSideWidth(side, w, targets);
     } else {
       const left = _leftNavRight();
       w = _clampLeftDockWidth(clientX - left, left);
-      content._userDockWidth = w;
-      content._emailDocSplitUserW = w;
-      content.style.left = left + 'px';
-      content.style.right = 'auto';
-      content.style.width = w + 'px';
-      content.style.maxWidth = w + 'px';
-      document.body.classList.add('left-dock-active');
-      document.documentElement.style.setProperty(
-        '--left-dock-w',
-        document.body.classList.contains('email-doc-split-active') ? '0px' : w + 'px',
-      );
+      syncDockSideWidth(side, w, targets);
     }
-    _positionEdgeDockResizeHandles();
     return w;
   };
 
@@ -928,7 +1211,7 @@ export function makeEdgeDockController(modal, side = 'right', dockClass) {
       }
       _setStyle(handle, 'display', 'block');
       _setStyle(handle, 'left', (x - 5) + 'px');
-      _setStyle(handle, 'zIndex', String(_zIndexFor(owner) + 1));
+      _setStyle(handle, 'zIndex', String(_zIndexForElement(_dockOwnerSurface(owner), 250) + 1));
     }
   };
 
@@ -943,15 +1226,17 @@ export function makeEdgeDockController(modal, side = 'right', dockClass) {
       handle.setPointerCapture?.(e.pointerId);
       const nodes = _resolveDockNodes(owner);
       const content = nodes?.content;
+      const resizeOwners = _dockOwnersForSide(side);
+      if (!resizeOwners.includes(owner)) resizeOwners.push(owner);
       const prevCursor = document.body.style.cursor;
       const prevUserSelect = document.body.style.userSelect;
       document.body.style.cursor = 'col-resize';
       document.body.style.userSelect = 'none';
       document.body.classList.add('edge-dock-resizing');
-      _setWidth(owner, side, e.clientX);
+      _setWidth(owner, side, e.clientX, resizeOwners);
       const onMove = (ev) => {
         ev.preventDefault();
-        _setWidth(owner, side, ev.clientX);
+        _setWidth(owner, side, ev.clientX, resizeOwners);
       };
       const onUp = (ev) => {
         try { handle.releasePointerCapture?.(e.pointerId); } catch (_) {}
@@ -964,7 +1249,12 @@ export function makeEdgeDockController(modal, side = 'right', dockClass) {
         const finalW = side === 'right'
           ? parseFloat(document.documentElement.style.getPropertyValue('--right-dock-w')) || content?.getBoundingClientRect?.().width || 0
           : content?.getBoundingClientRect?.().width || 0;
-        if (finalW) _saveDockWidth(owner, content, side, finalW);
+        if (finalW) {
+          resizeOwners.forEach((dockOwner) => {
+            const dockContent = _resolveDockNodes(dockOwner)?.content;
+            if (dockContent) _saveDockWidth(dockOwner, dockContent, side, finalW);
+          });
+        }
         ev.preventDefault();
       };
       document.addEventListener('pointermove', onMove, true);
@@ -1031,11 +1321,9 @@ export function makeEdgeDockController(modal, side = 'right', dockClass) {
     if (!content) return;
     const left = _leftNavRight();
     const w = _clampEmailDocSplitWidth(clientX - left, left);
-    content._emailDocSplitUserW = w;
-    content.style.left = left + 'px';
-    content.style.width = w + 'px';
-    content.style.maxWidth = w + 'px';
-    _applyEmailDocSplitGeometry(left, w);
+    const owners = _dockOwnersForSide('left');
+    if (!owners.length) return;
+    syncDockSideWidth('left', w, owners);
     _position();
   };
 
@@ -1063,7 +1351,14 @@ export function makeEdgeDockController(modal, side = 'right', dockClass) {
       document.body.style.userSelect = prevUserSelect;
       const rightX = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--email-doc-split-right-x')) || 0;
       const left = _leftNavRight();
-      if (rightX > left) _saveEmailDocSplitWidth(rightX - left);
+      if (rightX > left) {
+        const width = rightX - left;
+        _saveEmailDocSplitWidth(width);
+        _dockOwnersForSide('left').forEach((owner) => {
+          const dockContent = _resolveDockNodes(owner)?.content;
+          if (dockContent) _saveDockWidth(owner, dockContent, 'left', width);
+        });
+      }
       ev.preventDefault();
     };
     document.addEventListener('pointermove', onMove, true);

--- a/static/style.css
+++ b/static/style.css
@@ -16371,6 +16371,91 @@ body.right-dock-active .chat-container,
 body.right-dock-active:not(.email-doc-split-active) .doc-editor-pane {
   margin-right: var(--right-dock-w, 0px);
 }
+.edge-dock-switcher {
+  position: fixed;
+  top: 18px;
+  z-index: 1200;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 4px;
+  min-width: 0;
+  max-height: calc(100dvh - 36px);
+  margin: 0;
+  padding: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+  pointer-events: auto;
+}
+.edge-dock-switcher[hidden] {
+  display: none !important;
+}
+.edge-dock-switcher-right {
+  right: calc(var(--right-dock-w, 0px) - 1px);
+}
+.edge-dock-switcher-left {
+  left: calc(var(--icon-rail-w, 48px) + var(--sidebar-w, 0px) + var(--left-dock-visual-w, var(--left-dock-w, 0px)) - 1px);
+}
+.edge-dock-switcher-tab {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 124px;
+  flex: 0 0 124px;
+  overflow: hidden;
+  padding: 0;
+  background: color-mix(in srgb, var(--panel) 92%, var(--bg));
+  border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
+  color: color-mix(in srgb, var(--fg) 78%, transparent);
+  font: inherit;
+  font-size: 10px;
+  line-height: 1;
+  text-align: center;
+  cursor: pointer;
+}
+.edge-dock-switcher-right .edge-dock-switcher-tab {
+  border-right-color: color-mix(in srgb, var(--panel) 85%, var(--bg));
+  border-radius: 6px 0 0 6px;
+}
+.edge-dock-switcher-left .edge-dock-switcher-tab {
+  border-left-color: color-mix(in srgb, var(--panel) 85%, var(--bg));
+  border-radius: 0 6px 6px 0;
+}
+.edge-dock-switcher-tab-label {
+  display: block;
+  flex: 0 0 auto;
+  width: max-content;
+  max-width: none;
+  overflow: visible;
+  text-overflow: clip;
+  white-space: nowrap;
+  pointer-events: none;
+}
+.edge-dock-switcher-right .edge-dock-switcher-tab-label {
+  transform: rotate(-90deg);
+}
+.edge-dock-switcher-left .edge-dock-switcher-tab-label {
+  transform: rotate(90deg);
+}
+.edge-dock-switcher-tab:hover {
+  color: var(--fg);
+  border-color: color-mix(in srgb, var(--accent, var(--red)) 48%, var(--border));
+  background: color-mix(in srgb, var(--accent, var(--red)) 9%, var(--panel));
+}
+.edge-dock-switcher-tab.active {
+  color: var(--fg);
+  border-color: color-mix(in srgb, var(--accent, var(--red)) 65%, var(--border));
+  background: color-mix(in srgb, var(--accent, var(--red)) 16%, var(--panel));
+}
+.edge-dock-switcher-right .edge-dock-switcher-tab.active {
+  border-right-color: color-mix(in srgb, var(--panel) 85%, var(--bg));
+}
+.edge-dock-switcher-left .edge-dock-switcher-tab.active {
+  border-left-color: color-mix(in srgb, var(--panel) 85%, var(--bg));
+}
 .modal.modal-right-docked {
   align-items: stretch;
   justify-content: flex-end;

--- a/tests/test_edge_dock_owners_js.py
+++ b/tests/test_edge_dock_owners_js.py
@@ -1,0 +1,181 @@
+"""Node-driven coverage for the shared edge-dock owner model."""
+
+import json
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HELPER = ROOT / "static" / "js" / "edgeDockOwners.js"
+pytestmark = pytest.mark.skipif(not shutil.which("node"), reason="node binary not on PATH")
+
+
+def _node_eval(source: str):
+    proc = subprocess.run(
+        ["node", "--input-type=module"],
+        input=source,
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout.strip())
+
+
+def test_left_owner_discovery_includes_legacy_email_and_rejects_nested_markup():
+    values = _node_eval(
+        textwrap.dedent(
+            f"""
+            import {{ dockOwnersForSide }} from '{HELPER.as_uri()}';
+
+            const body = {{ tagName: 'BODY' }};
+            const classes = (...names) => ({{
+              contains(name) {{ return names.includes(name); }},
+            }});
+            const makeSurface = (id, names, parent = body) => {{
+              const node = {{
+                id,
+                parentElement: parent,
+                isConnected: true,
+                classList: classes(...names),
+                style: {{}},
+                computed: {{ display: 'block', visibility: 'visible' }},
+                matches(selector) {{
+                  if (selector === '.notes-pane') return names.includes('notes-pane');
+                  if (!selector.includes('body > .modal')) return false;
+                  return parent === body && (
+                    names.includes('modal')
+                    || names.includes('research-overlay')
+                    || names.includes('notes-pane-backdrop')
+                  );
+                }},
+              }};
+              node.content = {{
+                isConnected: true,
+                classList: classes(),
+                style: {{}},
+                computed: {{ display: 'block', visibility: 'visible' }},
+                getBoundingClientRect() {{ return {{ width: 420, height: 700 }}; }},
+              }};
+              return node;
+            }};
+
+            const modern = makeSurface('calendar-modal', ['modal', 'modal-left-docked']);
+            const legacy = makeSurface('email-lib-modal', ['modal', 'email-snap-left']);
+            const emailModal = makeSurface('outer-email', ['modal']);
+            const injected = makeSurface('sanitized-descendant', ['modal', 'modal-left-docked'], emailModal);
+            let selector = '';
+            const root = {{
+              querySelectorAll(value) {{
+                selector = value;
+                return [modern, legacy, injected];
+              }},
+            }};
+            const owners = dockOwnersForSide('left', {{
+              root,
+              resolveContent: (owner) => owner.content,
+              getStyle: (element) => element.computed,
+            }});
+            console.log(JSON.stringify({{ selector, ids: owners.map((owner) => owner.id) }}));
+            """
+        )
+    )
+
+    assert values == {
+        "selector": ".modal-left-docked, .email-snap-left",
+        "ids": ["calendar-modal", "email-lib-modal"],
+    }
+
+
+def test_owner_discovery_counts_only_visible_usable_application_surfaces():
+    values = _node_eval(
+        textwrap.dedent(
+            f"""
+            import {{ dockOwnersForSide }} from '{HELPER.as_uri()}';
+
+            const body = {{ tagName: 'BODY' }};
+            const classes = (...names) => ({{ contains: (name) => names.includes(name) }});
+            const makeOwner = (id, ownerClasses = [], ownerStyle = {{}}, contentStyle = {{}}, rect = {{ width: 400, height: 600 }}) => {{
+              const owner = {{
+                id,
+                parentElement: body,
+                isConnected: true,
+                classList: classes('modal', 'modal-right-docked', ...ownerClasses),
+                computed: {{ display: 'block', visibility: 'visible', ...ownerStyle }},
+                matches(selector) {{
+                  if (selector === '.notes-pane') return false;
+                  return selector.includes('body > .modal');
+                }},
+              }};
+              owner.content = {{
+                isConnected: true,
+                classList: classes(),
+                computed: {{ display: 'block', visibility: 'visible', ...contentStyle }},
+                getBoundingClientRect() {{ return rect; }},
+              }};
+              return owner;
+            }};
+
+            const candidates = [
+              makeOwner('visible'),
+              makeOwner('hidden-class', ['hidden']),
+              makeOwner('minimized', ['modal-minimized']),
+              makeOwner('display-none', [], {{ display: 'none' }}),
+              makeOwner('visibility-hidden', [], {{ visibility: 'hidden' }}),
+              makeOwner('content-hidden', [], {{}}, {{ visibility: 'hidden' }}),
+              makeOwner('zero-rect', [], {{}}, {{}}, {{ width: 0, height: 600 }}),
+            ];
+            const owners = dockOwnersForSide('right', {{
+              root: {{ querySelectorAll() {{ return candidates; }} }},
+              resolveContent: (owner) => owner.content,
+              getStyle: (element) => element.computed,
+            }});
+            console.log(JSON.stringify(owners.map((owner) => owner.id)));
+            """
+        )
+    )
+
+    assert values == ["visible"]
+
+
+def test_notes_owner_is_accepted_only_through_its_top_level_backdrop():
+    values = _node_eval(
+        textwrap.dedent(
+            f"""
+            import {{ isApplicationDockOwner }} from '{HELPER.as_uri()}';
+            const body = {{ tagName: 'BODY' }};
+            const backdrop = {{
+              parentElement: body,
+              matches(selector) {{ return selector === 'body > .notes-pane-backdrop'; }},
+            }};
+            const nestedHost = {{
+              parentElement: {{ tagName: 'DIV' }},
+              matches() {{ return false; }},
+            }};
+            const topLevelModal = {{
+              parentElement: body,
+              matches(selector) {{ return selector.includes('body > .modal'); }},
+            }};
+            const makePane = (parent) => ({{
+              parentElement: parent,
+              matches(selector) {{ return selector === '.notes-pane'; }},
+            }});
+            console.log(JSON.stringify({{
+              topLevel: isApplicationDockOwner(makePane(backdrop)),
+              nested: isApplicationDockOwner(makePane(nestedHost)),
+              spoofedInsideModal: isApplicationDockOwner(makePane(topLevelModal)),
+            }}));
+            """
+        )
+    )
+
+    assert values == {
+        "topLevel": True,
+        "nested": False,
+        "spoofedInsideModal": False,
+    }

--- a/tests/test_edge_dock_review_regressions.py
+++ b/tests/test_edge_dock_review_regressions.py
@@ -1,0 +1,82 @@
+"""Structural integration coverage for PR #5840 review regressions."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODAL_SNAP = (ROOT / "static/js/modalSnap.js").read_text(encoding="utf-8")
+EMAIL = (ROOT / "static/js/emailLibrary.js").read_text(encoding="utf-8")
+CSS = (ROOT / "static/style.css").read_text(encoding="utf-8")
+
+
+def _section(source: str, start: str, end: str) -> str:
+    return source.split(start, 1)[1].split(end, 1)[0]
+
+
+def test_cleanup_counts_only_shared_usable_owner_discovery():
+    cleanup = _section(
+        MODAL_SNAP,
+        "function _hasOtherDockedWindow(side, owner)",
+        "function _hasAnyOtherDockedWindow(owner)",
+    )
+    assert "_dockOwnersForSide(side).some" in cleanup
+    assert "querySelectorAll" not in cleanup
+
+
+def test_split_width_sync_updates_every_left_owner_and_document_geometry():
+    sync = _section(
+        MODAL_SNAP,
+        "export function syncDockSideWidth",
+        "function _hasOtherDockedWindow",
+    )
+    assert "splitActive" in sync
+    assert "owners.forEach" in sync
+    assert "_applyDockWidthToOwner" in sync
+    assert "_applyEmailDocSplitGeometry(left, w)" in sync
+    assert "return requestedWidth" not in sync
+
+    split_drag = _section(
+        MODAL_SNAP,
+        "const _dragTo = (clientX) =>",
+        "stripe.addEventListener('pointerdown'",
+    )
+    assert "_dockOwnersForSide('left')" in split_drag
+    assert "syncDockSideWidth('left', w, owners)" in split_drag
+
+    apply_dock = _section(
+        MODAL_SNAP,
+        "function _applyDockInternal(modal, side, dockClass)",
+        "function _onDockedModalGone",
+    )
+    assert "_activeDockVisualWidth(side)" in apply_dock
+
+
+def test_legacy_email_lifecycle_uses_shared_sync_and_reconciliation():
+    assert "reconcileDockSide, syncDockSideWidth" in EMAIL
+    assert EMAIL.count("syncDockSideWidth('left'") >= 2
+    assert EMAIL.count("reconcileDockSide('left'") >= 2
+    assert "'.modal-left-docked, .email-snap-left'" in (
+        ROOT / "static/js/edgeDockOwners.js"
+    ).read_text(encoding="utf-8")
+
+
+def test_switcher_uses_runtime_nav_geometry_and_scrolls_large_tab_stacks():
+    left_rule = _section(CSS, ".edge-dock-switcher-left {", "}")
+    assert "var(--icon-rail-w, 48px)" in left_rule
+    assert "var(--sidebar-w, 0px)" in left_rule
+    assert "var(--left-dock-visual-w" in left_rule
+    assert "calc(48px" not in left_rule
+
+    switcher_rule = _section(CSS, ".edge-dock-switcher {", "}")
+    assert "max-height: calc(100dvh - 36px)" in switcher_rule
+    assert "overflow-y: auto" in switcher_rule
+    assert "overflow-x: hidden" in switcher_rule
+    tab_rule = _section(CSS, ".edge-dock-switcher-tab {", "}")
+    assert "flex: 0 0 124px" in tab_rule
+
+
+def test_switcher_fronting_uses_canonical_top_level_tool_stack():
+    assert "import { nextToolWindowZ } from './toolWindowZOrder.js'" in MODAL_SNAP
+    fronting = _section(MODAL_SNAP, "const _bringOwnerToFront = (owner) =>", "const _simpleTitleForOwner")
+    assert "nextToolWindowZ" in fronting
+    assert "querySelectorAll('.modal" not in fronting


### PR DESCRIPTION
## Summary

Recreates the closed #3916 snapped-window side-tab feature after the July 23 repository cleanup wiped old PR refs/diffs. The branch is rebuilt on current dev (25c9e735) and restores the passive edge dock tabs plus shared snapped pane resize width behavior.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release.

## Linked Issue

Supersedes #3916 after the July 23 repository cleanup wiped old PR refs/diffs and closed the original PR unmerged.

## Type of Change

- [ ] Bug fix (non-breaking - fixes a confirmed issue)
- [x] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) - this is not a duplicate; it is a recovery of closed #3916.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Review the recovered branch against current `dev` and confirm it only contains the recreated #3916 scope.
2. Run the local checks used for this recovery:

```text
 git diff --check origin/dev...HEAD
node --check static/js/modalSnap.js 
```

3. In a full Odysseus dev environment, run the focused pytest file(s) added or touched by this PR where applicable. I could not run pytest here because this Windows environment has no system Python/pytest and the bundled Python runtime does not include pytest.

## Visual / UI changes

**REQUIRED if you touched anything that renders.**  Touches snapped modal UI behavior and CSS. No fresh screenshot or clip is attached in this recovery PR because this environment cannot run the app UI; please verify by snapping a tool window to an edge.
- [ ] Screenshot or short clip of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] Style match: the change uses Odysseus's existing visual language and recovered code paths.
- [x] No new component patterns beyond the recovered original PR scope.
- [x] I am not an LLM agent submitting a bulk PR. This is a targeted recovery of #3916 after the repository cleanup event.

### Screenshots / clips

Not attached in this recovery pass.