### PR TITLE
feat(notifications): add durable notification inbox

### DIFF
--- a/app.py
+++ b/app.py
@@ -763,6 +763,9 @@ set_task_scheduler(task_scheduler)
 from routes.task_routes import setup_task_routes
 app.include_router(setup_task_routes(task_scheduler))
 
+from routes.notification_routes import setup_notification_routes
+app.include_router(setup_notification_routes())
+
 from routes.assistant_routes import setup_assistant_routes
 app.include_router(setup_assistant_routes(task_scheduler))
 

--- a/core/database.py
+++ b/core/database.py
@@ -743,6 +743,65 @@ class TaskRun(Base):
     )
 
 
+class NotificationEvent(Base):
+    """Durable notification/audit event.
+
+    System events are logged here even when they do not deserve a visible UI
+    entry. Events that should appear in the notification inbox are paired with
+    one or more NotificationInboxItem rows.
+    """
+    __tablename__ = "notification_events"
+
+    id = Column(String, primary_key=True, index=True)
+    owner = Column(String, nullable=True, index=True)
+    event_class = Column(String, nullable=False, default="system_event", index=True)
+    title = Column(String, nullable=False, default="")
+    body = Column(Text, nullable=True)
+    source_type = Column(String, nullable=True, index=True)
+    source_id = Column(String, nullable=True, index=True)
+    source_url = Column(Text, nullable=True)
+    severity = Column(String, nullable=False, default="info", index=True)
+    category = Column(String, nullable=True, index=True)
+    dedupe_key = Column(String, nullable=True, index=True)
+    metadata_json = Column(JSON, nullable=True)
+    retention_expires_at = Column(DateTime, nullable=True, index=True)
+    created_at = Column(DateTime, nullable=False, default=utcnow_naive, index=True)
+
+    __table_args__ = (
+        Index('ix_notification_events_owner_created', 'owner', 'created_at'),
+        Index('ix_notification_events_owner_class_created', 'owner', 'event_class', 'created_at'),
+        Index('ix_notification_events_owner_dedupe', 'owner', 'dedupe_key'),
+    )
+
+
+class NotificationInboxItem(Base):
+    """Visible/dismissible notification inbox entry derived from an event."""
+    __tablename__ = "notification_inbox_items"
+
+    id = Column(String, primary_key=True, index=True)
+    owner = Column(String, nullable=True, index=True)
+    event_id = Column(String, ForeignKey("notification_events.id", ondelete="CASCADE"), nullable=False, index=True)
+    notification_kind = Column(String, nullable=False, default="inbox_record", index=True)
+    primary_action = Column(String, nullable=True)
+    action_url = Column(Text, nullable=True)
+    is_read = Column(Boolean, default=False, nullable=False, index=True)
+    read_at = Column(DateTime, nullable=True)
+    dismissed_at = Column(DateTime, nullable=True, index=True)
+    archived_at = Column(DateTime, nullable=True, index=True)
+    created_at = Column(DateTime, nullable=False, default=utcnow_naive, index=True)
+
+    event = relationship(
+        "NotificationEvent",
+        backref=backref("inbox_items", cascade="all, delete-orphan"),
+    )
+
+    __table_args__ = (
+        Index('ix_notification_inbox_owner_created', 'owner', 'created_at'),
+        Index('ix_notification_inbox_owner_unread', 'owner', 'is_read', 'created_at'),
+        Index('ix_notification_inbox_owner_visible', 'owner', 'archived_at', 'dismissed_at', 'created_at'),
+    )
+
+
 class Memory(Base):
     """
     SQLAlchemy model for Memory table.

--- a/core/database.py
+++ b/core/database.py
@@ -743,6 +743,13 @@ class TaskRun(Base):
     )
 
 
+NOTIFICATION_RETENTION_DAYS = {
+    "system_event": 30,
+    "inbox_record": 90,
+    "actionable": 180,
+}
+
+
 class NotificationEvent(Base):
     """Durable notification/audit event.
 
@@ -771,6 +778,14 @@ class NotificationEvent(Base):
         Index('ix_notification_events_owner_created', 'owner', 'created_at'),
         Index('ix_notification_events_owner_class_created', 'owner', 'event_class', 'created_at'),
         Index('ix_notification_events_owner_dedupe', 'owner', 'dedupe_key'),
+        Index(
+            'uq_notification_events_owner_dedupe',
+            func.coalesce(owner, ''),
+            dedupe_key,
+            unique=True,
+            sqlite_where=dedupe_key.is_not(None),
+            postgresql_where=dedupe_key.is_not(None),
+        ),
     )
 
 
@@ -799,6 +814,7 @@ class NotificationInboxItem(Base):
         Index('ix_notification_inbox_owner_created', 'owner', 'created_at'),
         Index('ix_notification_inbox_owner_unread', 'owner', 'is_read', 'created_at'),
         Index('ix_notification_inbox_owner_visible', 'owner', 'archived_at', 'dismissed_at', 'created_at'),
+        Index('uq_notification_inbox_event', 'event_id', unique=True),
     )
 
 
@@ -1939,6 +1955,131 @@ def _migrate_seed_email_account():
         logging.getLogger(__name__).warning(f"seed email account migration: {e}")
 
 
+def _migrate_notification_retention_and_uniqueness():
+    """Backfill retention and enforce durable notification deduplication.
+
+    The notification tables were introduced without unique constraints, so a
+    database that has already run that schema may contain duplicate events or
+    inbox mappings. Collapse those rows before adding the indexes. This is an
+    idempotent SQLite migration; fresh databases receive the same indexes from
+    SQLAlchemy metadata during ``create_all``.
+    """
+    if engine.url.get_backend_name() != "sqlite":
+        return
+    try:
+        with engine.begin() as conn:
+            tables = {
+                row[0]
+                for row in conn.execute(text(
+                    "SELECT name FROM sqlite_master WHERE type='table' "
+                    "AND name IN ('notification_events', 'notification_inbox_items')"
+                ))
+            }
+            if tables != {"notification_events", "notification_inbox_items"}:
+                return
+
+            system_days = NOTIFICATION_RETENTION_DAYS["system_event"]
+            inbox_days = NOTIFICATION_RETENTION_DAYS["inbox_record"]
+            actionable_days = NOTIFICATION_RETENTION_DAYS["actionable"]
+            conn.execute(text(f"""
+                UPDATE notification_events
+                   SET retention_expires_at = CASE event_class
+                       WHEN 'actionable' THEN datetime(created_at, '+{actionable_days} days')
+                       WHEN 'inbox_record' THEN datetime(created_at, '+{inbox_days} days')
+                       ELSE datetime(created_at, '+{system_days} days')
+                   END
+                 WHERE retention_expires_at IS NULL
+            """))
+
+            duplicate_events = conn.execute(text("""
+                SELECT COALESCE(owner, '') AS owner_key, dedupe_key
+                  FROM notification_events
+                 WHERE dedupe_key IS NOT NULL
+                 GROUP BY COALESCE(owner, ''), dedupe_key
+                HAVING COUNT(*) > 1
+            """)).fetchall()
+            for owner_key, dedupe_key in duplicate_events:
+                params = {"owner_key": owner_key, "dedupe_key": dedupe_key}
+                event_ids = [
+                    row[0]
+                    for row in conn.execute(text("""
+                        SELECT id
+                          FROM notification_events
+                         WHERE COALESCE(owner, '') = :owner_key
+                           AND dedupe_key = :dedupe_key
+                         ORDER BY created_at DESC, id DESC
+                    """), params)
+                ]
+                keeper_event_id = event_ids[0]
+                keeper_item = conn.execute(text("""
+                    SELECT id
+                      FROM notification_inbox_items
+                     WHERE event_id IN (
+                         SELECT id FROM notification_events
+                          WHERE COALESCE(owner, '') = :owner_key
+                            AND dedupe_key = :dedupe_key
+                     )
+                     ORDER BY created_at DESC, id DESC
+                     LIMIT 1
+                """), params).fetchone()
+                if keeper_item:
+                    params["keeper_item_id"] = keeper_item[0]
+                    conn.execute(text("""
+                        DELETE FROM notification_inbox_items
+                         WHERE event_id IN (
+                             SELECT id FROM notification_events
+                              WHERE COALESCE(owner, '') = :owner_key
+                                AND dedupe_key = :dedupe_key
+                         )
+                           AND id != :keeper_item_id
+                    """), params)
+                    conn.execute(text("""
+                        UPDATE notification_inbox_items
+                           SET event_id = :keeper_event_id
+                         WHERE id = :keeper_item_id
+                    """), {**params, "keeper_event_id": keeper_event_id})
+                conn.execute(text("""
+                    DELETE FROM notification_events
+                     WHERE COALESCE(owner, '') = :owner_key
+                       AND dedupe_key = :dedupe_key
+                       AND id != :keeper_event_id
+                """), {**params, "keeper_event_id": keeper_event_id})
+
+            duplicate_items = conn.execute(text("""
+                SELECT event_id
+                  FROM notification_inbox_items
+                 GROUP BY event_id
+                HAVING COUNT(*) > 1
+            """)).fetchall()
+            for (event_id,) in duplicate_items:
+                keeper_item_id = conn.execute(text("""
+                    SELECT id
+                      FROM notification_inbox_items
+                     WHERE event_id = :event_id
+                     ORDER BY created_at DESC, id DESC
+                     LIMIT 1
+                """), {"event_id": event_id}).scalar()
+                conn.execute(text("""
+                    DELETE FROM notification_inbox_items
+                     WHERE event_id = :event_id
+                       AND id != :keeper_item_id
+                """), {"event_id": event_id, "keeper_item_id": keeper_item_id})
+
+            conn.execute(text("""
+                CREATE UNIQUE INDEX IF NOT EXISTS uq_notification_events_owner_dedupe
+                    ON notification_events(COALESCE(owner, ''), dedupe_key)
+                 WHERE dedupe_key IS NOT NULL
+            """))
+            conn.execute(text("""
+                CREATE UNIQUE INDEX IF NOT EXISTS uq_notification_inbox_event
+                    ON notification_inbox_items(event_id)
+            """))
+    except Exception as e:
+        logging.getLogger(__name__).warning(
+            "notification retention/uniqueness migration failed: %s", e
+        )
+
+
 # WARNING: Foreign-key enforcement is enabled globally for all SQLite connections.
 # Any future migrations or schema changes that temporarily violate foreign-key
 # constraints will fail. To perform such operations, foreign_keys must be
@@ -1950,6 +2091,7 @@ def init_db():
     """
     _migrate_model_endpoints()
     Base.metadata.create_all(bind=engine)
+    _migrate_notification_retention_and_uniqueness()
     # Lock the DB file (and any SQLite sidecars) to 0o600 — it holds bearer-token
     # + bcrypt hashes and encrypted provider keys. POSIX only; safe_chmod no-ops
     # on Windows (ACL-restricted profile dir) and the path helper returns None for

--- a/routes/notification_routes.py
+++ b/routes/notification_routes.py
@@ -1,0 +1,87 @@
+"""Routes for durable notification events and inbox items."""
+
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+from src.auth_helpers import require_user
+from src.notifications import (
+    archive_notification,
+    count_unread_notifications,
+    dismiss_notification,
+    list_inbox_notifications,
+    list_notification_events,
+    mark_notification_read,
+)
+
+
+class NotificationReadRequest(BaseModel):
+    read: bool = True
+
+
+def setup_notification_routes() -> APIRouter:
+    router = APIRouter(prefix="/api/notifications", tags=["notifications"])
+
+    @router.get("")
+    async def list_notifications(
+        request: Request,
+        limit: int = 50,
+        include_archived: bool = False,
+        include_dismissed: bool = False,
+    ):
+        owner = require_user(request)
+        return {
+            "notifications": list_inbox_notifications(
+                owner=owner,
+                limit=limit,
+                include_archived=include_archived,
+                include_dismissed=include_dismissed,
+            )
+        }
+
+    @router.get("/count")
+    async def notification_count(request: Request):
+        owner = require_user(request)
+        return {"unread": count_unread_notifications(owner=owner)}
+
+    @router.get("/events")
+    async def notification_events(
+        request: Request,
+        limit: int = 100,
+        event_class: Optional[str] = None,
+    ):
+        owner = require_user(request)
+        return {
+            "events": list_notification_events(
+                owner=owner,
+                limit=limit,
+                event_class=event_class,
+            )
+        }
+
+    @router.post("/{item_id}/read")
+    async def read_notification(request: Request, item_id: str, body: NotificationReadRequest):
+        owner = require_user(request)
+        item = mark_notification_read(item_id=item_id, owner=owner, read=body.read)
+        if not item:
+            raise HTTPException(404, "Notification not found")
+        return item
+
+    @router.post("/{item_id}/dismiss")
+    async def dismiss_inbox_notification(request: Request, item_id: str):
+        owner = require_user(request)
+        item = dismiss_notification(item_id=item_id, owner=owner)
+        if not item:
+            raise HTTPException(404, "Notification not found")
+        return item
+
+    @router.post("/{item_id}/archive")
+    async def archive_inbox_notification(request: Request, item_id: str):
+        owner = require_user(request)
+        item = archive_notification(item_id=item_id, owner=owner)
+        if not item:
+            raise HTTPException(404, "Notification not found")
+        return item
+
+    return router

--- a/src/database.py
+++ b/src/database.py
@@ -23,6 +23,8 @@ from core.database import (  # explicit re-exports for IDE/type-checker visibili
     CrewMember,
     ScheduledTask,
     TaskRun,
+    NotificationEvent,
+    NotificationInboxItem,
     Memory,
     init_db,
     get_db,

--- a/src/notifications.py
+++ b/src/notifications.py
@@ -1,0 +1,438 @@
+"""Durable notification event and inbox helpers."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy.orm import Session as OrmSession
+
+from core.database import (
+    NotificationEvent,
+    NotificationInboxItem,
+    SessionLocal,
+    utcnow_naive,
+)
+
+SYSTEM_EVENT = "system_event"
+INBOX_RECORD = "inbox_record"
+ACTIONABLE = "actionable"
+
+EVENT_CLASSES = {SYSTEM_EVENT, INBOX_RECORD, ACTIONABLE}
+INBOX_CLASSES = {INBOX_RECORD, ACTIONABLE}
+SEVERITIES = {"info", "attention", "urgent", "error"}
+
+
+def _normalize_owner(owner: str | None) -> str | None:
+    owner = (owner or "").strip()
+    return owner or None
+
+
+def _clamp_text(value: str | None, limit: int) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    return text if len(text) <= limit else text[: limit - 1] + "..."
+
+
+def _safe_limit(limit: int | None, default: int = 50, maximum: int = 200) -> int:
+    try:
+        n = int(limit or default)
+    except (TypeError, ValueError):
+        n = default
+    return max(1, min(maximum, n))
+
+
+def _iso(dt: datetime | None) -> str | None:
+    if not dt:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _owner_query(query, model, owner: str | None):
+    owner = _normalize_owner(owner)
+    if owner is None:
+        return query.filter(model.owner == None)  # noqa: E711
+    return query.filter(model.owner == owner)
+
+
+def _validate_event_class(event_class: str) -> str:
+    value = (event_class or SYSTEM_EVENT).strip()
+    if value not in EVENT_CLASSES:
+        raise ValueError(f"Unknown notification event_class: {value}")
+    return value
+
+
+def _validate_severity(severity: str) -> str:
+    value = (severity or "info").strip()
+    if value not in SEVERITIES:
+        raise ValueError(f"Unknown notification severity: {value}")
+    return value
+
+
+def _serialize_event(event: NotificationEvent) -> dict[str, Any]:
+    return {
+        "id": event.id,
+        "owner": event.owner,
+        "event_class": event.event_class,
+        "title": event.title,
+        "body": event.body,
+        "source_type": event.source_type,
+        "source_id": event.source_id,
+        "source_url": event.source_url,
+        "severity": event.severity,
+        "category": event.category,
+        "dedupe_key": event.dedupe_key,
+        "metadata": event.metadata_json or {},
+        "retention_expires_at": _iso(event.retention_expires_at),
+        "created_at": _iso(event.created_at),
+    }
+
+
+def _serialize_item(item: NotificationInboxItem) -> dict[str, Any]:
+    event = item.event
+    return {
+        "id": item.id,
+        "owner": item.owner,
+        "event_id": item.event_id,
+        "notification_kind": item.notification_kind,
+        "primary_action": item.primary_action,
+        "action_url": item.action_url,
+        "is_read": bool(item.is_read),
+        "read_at": _iso(item.read_at),
+        "dismissed_at": _iso(item.dismissed_at),
+        "archived_at": _iso(item.archived_at),
+        "created_at": _iso(item.created_at),
+        "event": _serialize_event(event) if event else None,
+        "event_class": event.event_class if event else None,
+        "title": event.title if event else "",
+        "body": event.body if event else None,
+        "source_type": event.source_type if event else None,
+        "source_id": event.source_id if event else None,
+        "source_url": event.source_url if event else None,
+        "severity": event.severity if event else "info",
+        "category": event.category if event else None,
+        "metadata": event.metadata_json if event and event.metadata_json else {},
+    }
+
+
+def _upsert_event(
+    db: OrmSession,
+    *,
+    owner: str | None,
+    event_class: str,
+    title: str,
+    body: str | None = None,
+    source_type: str | None = None,
+    source_id: str | None = None,
+    source_url: str | None = None,
+    severity: str = "info",
+    category: str | None = None,
+    dedupe_key: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    retention_expires_at: datetime | None = None,
+) -> NotificationEvent:
+    owner = _normalize_owner(owner)
+    event_class = _validate_event_class(event_class)
+    severity = _validate_severity(severity)
+    event = None
+    if dedupe_key:
+        event = _owner_query(db.query(NotificationEvent), NotificationEvent, owner).filter(
+            NotificationEvent.dedupe_key == dedupe_key
+        ).first()
+    if event is None:
+        event = NotificationEvent(
+            id=str(uuid.uuid4()),
+            owner=owner,
+            dedupe_key=dedupe_key,
+            created_at=utcnow_naive(),
+        )
+        db.add(event)
+
+    event.event_class = event_class
+    event.title = _clamp_text(title or "Notification", 240) or "Notification"
+    event.body = _clamp_text(body, 20000)
+    event.source_type = _clamp_text(source_type, 80)
+    event.source_id = _clamp_text(source_id, 240)
+    event.source_url = _clamp_text(source_url, 2000)
+    event.severity = severity
+    event.category = _clamp_text(category, 80)
+    event.metadata_json = metadata or {}
+    event.retention_expires_at = retention_expires_at
+    return event
+
+
+def record_notification_event(
+    *,
+    owner: str | None,
+    event_class: str = SYSTEM_EVENT,
+    title: str,
+    body: str | None = None,
+    source_type: str | None = None,
+    source_id: str | None = None,
+    source_url: str | None = None,
+    severity: str = "info",
+    category: str | None = None,
+    dedupe_key: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    retention_expires_at: datetime | None = None,
+) -> dict[str, Any]:
+    db = SessionLocal()
+    try:
+        event = _upsert_event(
+            db,
+            owner=owner,
+            event_class=event_class,
+            title=title,
+            body=body,
+            source_type=source_type,
+            source_id=source_id,
+            source_url=source_url,
+            severity=severity,
+            category=category,
+            dedupe_key=dedupe_key,
+            metadata=metadata,
+            retention_expires_at=retention_expires_at,
+        )
+        db.commit()
+        db.refresh(event)
+        return _serialize_event(event)
+    finally:
+        db.close()
+
+
+def create_inbox_notification(
+    *,
+    owner: str | None,
+    notification_kind: str = INBOX_RECORD,
+    title: str,
+    body: str | None = None,
+    source_type: str | None = None,
+    source_id: str | None = None,
+    source_url: str | None = None,
+    severity: str = "info",
+    category: str | None = None,
+    dedupe_key: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    primary_action: str | None = None,
+    action_url: str | None = None,
+    retention_expires_at: datetime | None = None,
+) -> dict[str, Any]:
+    if notification_kind not in INBOX_CLASSES:
+        raise ValueError(f"Unknown inbox notification_kind: {notification_kind}")
+    db = SessionLocal()
+    try:
+        event = _upsert_event(
+            db,
+            owner=owner,
+            event_class=notification_kind,
+            title=title,
+            body=body,
+            source_type=source_type,
+            source_id=source_id,
+            source_url=source_url,
+            severity=severity,
+            category=category,
+            dedupe_key=dedupe_key,
+            metadata=metadata,
+            retention_expires_at=retention_expires_at,
+        )
+        db.flush()
+        item = db.query(NotificationInboxItem).filter(
+            NotificationInboxItem.event_id == event.id
+        ).first()
+        if item is None:
+            item = NotificationInboxItem(
+                id=str(uuid.uuid4()),
+                owner=_normalize_owner(owner),
+                event_id=event.id,
+                notification_kind=notification_kind,
+                created_at=utcnow_naive(),
+            )
+            db.add(item)
+        item.notification_kind = notification_kind
+        item.primary_action = _clamp_text(primary_action, 80)
+        item.action_url = _clamp_text(action_url, 2000)
+        db.commit()
+        db.refresh(item)
+        return _serialize_item(item)
+    finally:
+        db.close()
+
+
+def record_task_notification(
+    *,
+    task_name: str,
+    status: str,
+    task_id: str | None = None,
+    owner: str | None = None,
+    body: str | None = None,
+    run_id: str | None = None,
+    output_target: str | None = None,
+) -> dict[str, Any]:
+    """Persist the durable counterpart to the transient task notification."""
+    clean_status = (status or "").strip().lower() or "unknown"
+    ok = clean_status == "success"
+    clean_name = (task_name or "Task").strip() or "Task"
+    metadata = {
+        "task_id": task_id,
+        "run_id": run_id,
+        "status": clean_status,
+        "output_target": output_target or "session",
+    }
+    source_id = run_id or task_id
+    dedupe_key = f"task-run:{run_id}:{clean_status}" if run_id else None
+
+    if ok and body:
+        return create_inbox_notification(
+            owner=owner,
+            notification_kind=INBOX_RECORD,
+            title=clean_name,
+            body=body,
+            source_type="task_run",
+            source_id=source_id,
+            source_url="#tasks",
+            severity="info",
+            category="task",
+            dedupe_key=dedupe_key,
+            metadata=metadata,
+            primary_action="open_task",
+            action_url=f"odysseus://tasks/{task_id or ''}",
+        )
+
+    if not ok:
+        return create_inbox_notification(
+            owner=owner,
+            notification_kind=ACTIONABLE,
+            title=f"Task failed: {clean_name}",
+            body=body,
+            source_type="task_run",
+            source_id=source_id,
+            source_url="#tasks",
+            severity="error",
+            category="task",
+            dedupe_key=dedupe_key,
+            metadata=metadata,
+            primary_action="open_task",
+            action_url=f"odysseus://tasks/{task_id or ''}",
+        )
+
+    return record_notification_event(
+        owner=owner,
+        event_class=SYSTEM_EVENT,
+        title=f"Task finished: {clean_name}",
+        body=None,
+        source_type="task_run",
+        source_id=source_id,
+        source_url="#tasks",
+        severity="info",
+        category="task",
+        dedupe_key=dedupe_key,
+        metadata=metadata,
+    )
+
+
+def list_inbox_notifications(
+    *,
+    owner: str | None,
+    limit: int = 50,
+    include_archived: bool = False,
+    include_dismissed: bool = False,
+) -> list[dict[str, Any]]:
+    db = SessionLocal()
+    try:
+        q = _owner_query(db.query(NotificationInboxItem), NotificationInboxItem, owner)
+        if not include_archived:
+            q = q.filter(NotificationInboxItem.archived_at == None)  # noqa: E711
+        if not include_dismissed:
+            q = q.filter(NotificationInboxItem.dismissed_at == None)  # noqa: E711
+        items = q.order_by(NotificationInboxItem.created_at.desc()).limit(_safe_limit(limit)).all()
+        return [_serialize_item(item) for item in items]
+    finally:
+        db.close()
+
+
+def list_notification_events(
+    *,
+    owner: str | None,
+    limit: int = 100,
+    event_class: str | None = None,
+) -> list[dict[str, Any]]:
+    db = SessionLocal()
+    try:
+        q = _owner_query(db.query(NotificationEvent), NotificationEvent, owner)
+        if event_class:
+            q = q.filter(NotificationEvent.event_class == event_class)
+        events = q.order_by(NotificationEvent.created_at.desc()).limit(_safe_limit(limit, default=100)).all()
+        return [_serialize_event(event) for event in events]
+    finally:
+        db.close()
+
+
+def count_unread_notifications(*, owner: str | None) -> int:
+    db = SessionLocal()
+    try:
+        q = _owner_query(db.query(NotificationInboxItem), NotificationInboxItem, owner).filter(
+            NotificationInboxItem.is_read == False,  # noqa: E712
+            NotificationInboxItem.dismissed_at == None,  # noqa: E711
+            NotificationInboxItem.archived_at == None,  # noqa: E711
+        )
+        return int(q.count())
+    finally:
+        db.close()
+
+
+def mark_notification_read(*, item_id: str, owner: str | None, read: bool = True) -> dict[str, Any] | None:
+    db = SessionLocal()
+    try:
+        item = _owner_query(db.query(NotificationInboxItem), NotificationInboxItem, owner).filter(
+            NotificationInboxItem.id == item_id
+        ).first()
+        if not item:
+            return None
+        item.is_read = bool(read)
+        item.read_at = utcnow_naive() if read else None
+        db.commit()
+        db.refresh(item)
+        return _serialize_item(item)
+    finally:
+        db.close()
+
+
+def dismiss_notification(*, item_id: str, owner: str | None) -> dict[str, Any] | None:
+    db = SessionLocal()
+    try:
+        item = _owner_query(db.query(NotificationInboxItem), NotificationInboxItem, owner).filter(
+            NotificationInboxItem.id == item_id
+        ).first()
+        if not item:
+            return None
+        item.is_read = True
+        item.read_at = item.read_at or utcnow_naive()
+        item.dismissed_at = utcnow_naive()
+        db.commit()
+        db.refresh(item)
+        return _serialize_item(item)
+    finally:
+        db.close()
+
+
+def archive_notification(*, item_id: str, owner: str | None) -> dict[str, Any] | None:
+    db = SessionLocal()
+    try:
+        item = _owner_query(db.query(NotificationInboxItem), NotificationInboxItem, owner).filter(
+            NotificationInboxItem.id == item_id
+        ).first()
+        if not item:
+            return None
+        item.is_read = True
+        item.read_at = item.read_at or utcnow_naive()
+        item.archived_at = utcnow_naive()
+        db.commit()
+        db.refresh(item)
+        return _serialize_item(item)
+    finally:
+        db.close()

--- a/src/notifications.py
+++ b/src/notifications.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
+import time
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
+from sqlalchemy import or_
+from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlalchemy.orm import Session as OrmSession
 
 from core.database import (
+    NOTIFICATION_RETENTION_DAYS,
     NotificationEvent,
     NotificationInboxItem,
     SessionLocal,
@@ -22,6 +26,10 @@ ACTIONABLE = "actionable"
 EVENT_CLASSES = {SYSTEM_EVENT, INBOX_RECORD, ACTIONABLE}
 INBOX_CLASSES = {INBOX_RECORD, ACTIONABLE}
 SEVERITIES = {"info", "attention", "urgent", "error"}
+
+NOTIFICATION_PURGE_BATCH_SIZE = 500
+NOTIFICATION_PURGE_INTERVAL_SECONDS = 60 * 60
+_DEDUPE_WRITE_ATTEMPTS = 3
 
 
 def _normalize_owner(owner: str | None) -> str | None:
@@ -50,6 +58,59 @@ def _iso(dt: datetime | None) -> str | None:
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
     return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _utc_naive(dt: datetime) -> datetime:
+    if dt.tzinfo is not None:
+        return dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return dt
+
+
+def _retention_expiry(
+    event_class: str,
+    retention_expires_at: datetime | None,
+    *,
+    now: datetime,
+) -> datetime:
+    if retention_expires_at is not None:
+        return _utc_naive(retention_expires_at)
+    return now + timedelta(days=NOTIFICATION_RETENTION_DAYS[event_class])
+
+
+def _event_is_active(now: datetime | None = None):
+    return NotificationEvent.retention_expires_at > (now or utcnow_naive())
+
+
+def _retryable_dedupe_conflict(exc: Exception) -> bool:
+    if isinstance(exc, IntegrityError):
+        return True
+    if isinstance(exc, OperationalError):
+        message = str(exc).lower()
+        return "database is locked" in message or "database table is locked" in message
+    return False
+
+
+def _commit_with_dedupe_retry(*, dedupe_key: str | None, write, serialize):
+    attempts = _DEDUPE_WRITE_ATTEMPTS if dedupe_key else 1
+    for attempt in range(attempts):
+        db = SessionLocal()
+        try:
+            row = write(db)
+            db.commit()
+            db.refresh(row)
+            return serialize(row)
+        except (IntegrityError, OperationalError) as exc:
+            db.rollback()
+            if (
+                not dedupe_key
+                or not _retryable_dedupe_conflict(exc)
+                or attempt + 1 >= attempts
+            ):
+                raise
+            time.sleep(0.01 * (2 ** attempt))
+        finally:
+            db.close()
+    raise RuntimeError("Notification dedupe retry exhausted")
 
 
 def _owner_query(query, model, owner: str | None):
@@ -138,6 +199,7 @@ def _upsert_event(
     owner = _normalize_owner(owner)
     event_class = _validate_event_class(event_class)
     severity = _validate_severity(severity)
+    now = utcnow_naive()
     event = None
     if dedupe_key:
         event = _owner_query(db.query(NotificationEvent), NotificationEvent, owner).filter(
@@ -148,7 +210,7 @@ def _upsert_event(
             id=str(uuid.uuid4()),
             owner=owner,
             dedupe_key=dedupe_key,
-            created_at=utcnow_naive(),
+            created_at=now,
         )
         db.add(event)
 
@@ -161,7 +223,11 @@ def _upsert_event(
     event.severity = severity
     event.category = _clamp_text(category, 80)
     event.metadata_json = metadata or {}
-    event.retention_expires_at = retention_expires_at
+    event.retention_expires_at = _retention_expiry(
+        event_class,
+        retention_expires_at,
+        now=now,
+    )
     return event
 
 
@@ -180,9 +246,8 @@ def record_notification_event(
     metadata: dict[str, Any] | None = None,
     retention_expires_at: datetime | None = None,
 ) -> dict[str, Any]:
-    db = SessionLocal()
-    try:
-        event = _upsert_event(
+    def _write(db):
+        return _upsert_event(
             db,
             owner=owner,
             event_class=event_class,
@@ -197,11 +262,12 @@ def record_notification_event(
             metadata=metadata,
             retention_expires_at=retention_expires_at,
         )
-        db.commit()
-        db.refresh(event)
-        return _serialize_event(event)
-    finally:
-        db.close()
+
+    return _commit_with_dedupe_retry(
+        dedupe_key=dedupe_key,
+        write=_write,
+        serialize=_serialize_event,
+    )
 
 
 def create_inbox_notification(
@@ -223,8 +289,8 @@ def create_inbox_notification(
 ) -> dict[str, Any]:
     if notification_kind not in INBOX_CLASSES:
         raise ValueError(f"Unknown inbox notification_kind: {notification_kind}")
-    db = SessionLocal()
-    try:
+
+    def _write(db):
         event = _upsert_event(
             db,
             owner=owner,
@@ -256,11 +322,13 @@ def create_inbox_notification(
         item.notification_kind = notification_kind
         item.primary_action = _clamp_text(primary_action, 80)
         item.action_url = _clamp_text(action_url, 2000)
-        db.commit()
-        db.refresh(item)
-        return _serialize_item(item)
-    finally:
-        db.close()
+        return item
+
+    return _commit_with_dedupe_retry(
+        dedupe_key=dedupe_key,
+        write=_write,
+        serialize=_serialize_item,
+    )
 
 
 def record_task_notification(
@@ -344,7 +412,10 @@ def list_inbox_notifications(
 ) -> list[dict[str, Any]]:
     db = SessionLocal()
     try:
-        q = _owner_query(db.query(NotificationInboxItem), NotificationInboxItem, owner)
+        q = _owner_query(db.query(NotificationInboxItem), NotificationInboxItem, owner).join(
+            NotificationEvent,
+            NotificationInboxItem.event_id == NotificationEvent.id,
+        ).filter(_event_is_active())
         if not include_archived:
             q = q.filter(NotificationInboxItem.archived_at == None)  # noqa: E711
         if not include_dismissed:
@@ -363,7 +434,9 @@ def list_notification_events(
 ) -> list[dict[str, Any]]:
     db = SessionLocal()
     try:
-        q = _owner_query(db.query(NotificationEvent), NotificationEvent, owner)
+        q = _owner_query(db.query(NotificationEvent), NotificationEvent, owner).filter(
+            _event_is_active()
+        )
         if event_class:
             q = q.filter(NotificationEvent.event_class == event_class)
         events = q.order_by(NotificationEvent.created_at.desc()).limit(_safe_limit(limit, default=100)).all()
@@ -375,7 +448,11 @@ def list_notification_events(
 def count_unread_notifications(*, owner: str | None) -> int:
     db = SessionLocal()
     try:
-        q = _owner_query(db.query(NotificationInboxItem), NotificationInboxItem, owner).filter(
+        q = _owner_query(db.query(NotificationInboxItem), NotificationInboxItem, owner).join(
+            NotificationEvent,
+            NotificationInboxItem.event_id == NotificationEvent.id,
+        ).filter(
+            _event_is_active(),
             NotificationInboxItem.is_read == False,  # noqa: E712
             NotificationInboxItem.dismissed_at == None,  # noqa: E711
             NotificationInboxItem.archived_at == None,  # noqa: E711
@@ -388,7 +465,11 @@ def count_unread_notifications(*, owner: str | None) -> int:
 def mark_notification_read(*, item_id: str, owner: str | None, read: bool = True) -> dict[str, Any] | None:
     db = SessionLocal()
     try:
-        item = _owner_query(db.query(NotificationInboxItem), NotificationInboxItem, owner).filter(
+        item = _owner_query(db.query(NotificationInboxItem), NotificationInboxItem, owner).join(
+            NotificationEvent,
+            NotificationInboxItem.event_id == NotificationEvent.id,
+        ).filter(
+            _event_is_active(),
             NotificationInboxItem.id == item_id
         ).first()
         if not item:
@@ -405,7 +486,11 @@ def mark_notification_read(*, item_id: str, owner: str | None, read: bool = True
 def dismiss_notification(*, item_id: str, owner: str | None) -> dict[str, Any] | None:
     db = SessionLocal()
     try:
-        item = _owner_query(db.query(NotificationInboxItem), NotificationInboxItem, owner).filter(
+        item = _owner_query(db.query(NotificationInboxItem), NotificationInboxItem, owner).join(
+            NotificationEvent,
+            NotificationInboxItem.event_id == NotificationEvent.id,
+        ).filter(
+            _event_is_active(),
             NotificationInboxItem.id == item_id
         ).first()
         if not item:
@@ -423,7 +508,11 @@ def dismiss_notification(*, item_id: str, owner: str | None) -> dict[str, Any] |
 def archive_notification(*, item_id: str, owner: str | None) -> dict[str, Any] | None:
     db = SessionLocal()
     try:
-        item = _owner_query(db.query(NotificationInboxItem), NotificationInboxItem, owner).filter(
+        item = _owner_query(db.query(NotificationInboxItem), NotificationInboxItem, owner).join(
+            NotificationEvent,
+            NotificationInboxItem.event_id == NotificationEvent.id,
+        ).filter(
+            _event_is_active(),
             NotificationInboxItem.id == item_id
         ).first()
         if not item:
@@ -434,5 +523,49 @@ def archive_notification(*, item_id: str, owner: str | None) -> dict[str, Any] |
         db.commit()
         db.refresh(item)
         return _serialize_item(item)
+    finally:
+        db.close()
+
+
+def purge_expired_notifications(
+    *,
+    limit: int = NOTIFICATION_PURGE_BATCH_SIZE,
+    now: datetime | None = None,
+) -> dict[str, int]:
+    """Delete at most one bounded batch of expired events and inbox rows."""
+    try:
+        bounded_limit = int(limit)
+    except (TypeError, ValueError):
+        bounded_limit = NOTIFICATION_PURGE_BATCH_SIZE
+    bounded_limit = max(1, min(NOTIFICATION_PURGE_BATCH_SIZE, bounded_limit))
+    cutoff = _utc_naive(now) if now is not None else utcnow_naive()
+
+    db = SessionLocal()
+    try:
+        event_ids = [
+            row[0]
+            for row in db.query(NotificationEvent.id).filter(
+                or_(
+                    NotificationEvent.retention_expires_at == None,  # noqa: E711
+                    NotificationEvent.retention_expires_at <= cutoff,
+                )
+            ).order_by(
+                NotificationEvent.retention_expires_at.asc(),
+                NotificationEvent.created_at.asc(),
+            ).limit(bounded_limit).all()
+        ]
+        if not event_ids:
+            return {"events_deleted": 0, "inbox_items_deleted": 0}
+        inbox_items_deleted = db.query(NotificationInboxItem).filter(
+            NotificationInboxItem.event_id.in_(event_ids)
+        ).delete(synchronize_session=False)
+        events_deleted = db.query(NotificationEvent).filter(
+            NotificationEvent.id.in_(event_ids)
+        ).delete(synchronize_session=False)
+        db.commit()
+        return {
+            "events_deleted": int(events_deleted or 0),
+            "inbox_items_deleted": int(inbox_items_deleted or 0),
+        }
     finally:
         db.close()

--- a/src/task_scheduler.py
+++ b/src/task_scheduler.py
@@ -343,6 +343,7 @@ class TaskScheduler:
         self._executing_lock = asyncio.Lock()
         self._pending_notifications = []  # completed task notifications
         self._durable_notifications_enabled = True
+        self._last_notification_purge = None
         self._task_defer_counts = {}
         # Strict serial execution — exactly one task runs at a time. Anything
         # else (manual trigger, scheduled dispatch, task chain) waits behind
@@ -613,6 +614,33 @@ class TaskScheduler:
                 except asyncio.CancelledError: pass
         logger.info("Task scheduler stopped")
 
+    async def _purge_expired_notifications_if_due(self):
+        """Run one bounded purge on startup and then at most once per hour."""
+        from src.notifications import (
+            NOTIFICATION_PURGE_BATCH_SIZE,
+            NOTIFICATION_PURGE_INTERVAL_SECONDS,
+            purge_expired_notifications,
+        )
+
+        now = time.monotonic()
+        last_purge = getattr(self, "_last_notification_purge", None)
+        if last_purge is not None and now - last_purge < NOTIFICATION_PURGE_INTERVAL_SECONDS:
+            return
+        self._last_notification_purge = now
+        try:
+            result = await asyncio.to_thread(
+                purge_expired_notifications,
+                limit=NOTIFICATION_PURGE_BATCH_SIZE,
+            )
+            if result["events_deleted"]:
+                logger.info(
+                    "Purged %d expired notification events and %d inbox items",
+                    result["events_deleted"],
+                    result["inbox_items_deleted"],
+                )
+        except Exception:
+            logger.warning("Expired notification purge failed", exc_info=True)
+
     async def _note_pings_loop(self):
         """Built-in note-due scanner — ticks every 60s inside the scheduler.
         Pure infra (no LLM), doesn't surface in the Tasks UI. Iterates
@@ -689,6 +717,7 @@ class TaskScheduler:
                 await self._check_due_tasks()
             except Exception:
                 logger.exception("Error in task scheduler loop")
+            await self._purge_expired_notifications_if_due()
             # Sleep until the next scheduled run, capped at 60s. A `* * * * *`
             # cron task previously fired up to ~60s late because we always
             # slept the full minute; now the loop wakes near the boundary.

--- a/src/task_scheduler.py
+++ b/src/task_scheduler.py
@@ -342,6 +342,7 @@ class TaskScheduler:
         # tasks could be double-dispatched.
         self._executing_lock = asyncio.Lock()
         self._pending_notifications = []  # completed task notifications
+        self._durable_notifications_enabled = True
         self._task_defer_counts = {}
         # Strict serial execution — exactly one task runs at a time. Anything
         # else (manual trigger, scheduled dispatch, task chain) waits behind
@@ -397,12 +398,35 @@ class TaskScheduler:
             logger.debug("Task abort marker failed for %s", task_id, exc_info=True)
             return False
 
-    def add_notification(self, task_name: str, status: str, task_id: str = None, owner: str = None, body: str = None):
+    def add_notification(
+        self,
+        task_name: str,
+        status: str,
+        task_id: str = None,
+        owner: str = None,
+        body: str = None,
+        run_id: str = None,
+        output_target: str = None,
+    ):
         """Store a notification about a completed task run. Tagged with the
         task's owner so `pop_notifications` can return only that user's
         notifications and prevent cross-tenant drain. `body` is the result
         text — populated when output_target='notification' so the client can
         show a rich browser Notification, not just a toast."""
+        if getattr(self, "_durable_notifications_enabled", False):
+            try:
+                from src.notifications import record_task_notification
+                record_task_notification(
+                    task_name=task_name,
+                    status=status,
+                    task_id=task_id,
+                    owner=owner,
+                    body=body,
+                    run_id=run_id,
+                    output_target=output_target,
+                )
+            except Exception:
+                logger.debug("Durable task notification write failed", exc_info=True)
         self._pending_notifications.append({
             "task_name": task_name,
             "status": status,
@@ -1042,6 +1066,8 @@ class TaskScheduler:
                     task_id,
                     owner=task.owner,
                     body=run.result if output == "notification" else None,
+                    run_id=run_id,
+                    output_target=output,
                 )
             elif run.status == "error":
                 self.add_notification(
@@ -1050,6 +1076,8 @@ class TaskScheduler:
                     task_id,
                     owner=task.owner,
                     body=run.error or run.result,
+                    run_id=run_id,
+                    output_target=output,
                 )
 
             # Log result to the assistant chat so all task activity is visible.
@@ -1095,7 +1123,14 @@ class TaskScheduler:
             except Exception:
                 _should_notify_error = False
             if _should_notify_error:
-                self.add_notification(f"Task {task_id}", "error", task_id, owner=_owner)
+                self.add_notification(
+                    f"Task {task_id}",
+                    "error",
+                    task_id,
+                    owner=_owner,
+                    body=f"{type(exec_exc).__name__}: {exec_exc}",
+                    run_id=run_id,
+                )
             try:
                 # Persist the actual exception message so the UI can show it
                 err_text = f"{type(exec_exc).__name__}: {exec_exc}"

--- a/static/app.js
+++ b/static/app.js
@@ -23,6 +23,7 @@ import voiceRecorderModule from './js/voiceRecorder.js';
 import censorModule from './js/censor.js';
 import galleryModule from './js/gallery.js';
 import tasksModule from './js/tasks.js?v=20260723tasksbulkfeedback1';
+import notificationsModule from './js/notifications.js';
 import calendarModule from './js/calendar.js';
 import notesModule from './js/notes.js';
 import adminModule from './js/admin.js?v=20260716openrouter3';
@@ -3736,6 +3737,9 @@ function startOdysseusApp() {
   // Initialize compare module
   if (compareModule) {
     compareModule.init(API_BASE);
+  }
+  if (notificationsModule) {
+    notificationsModule.init(API_BASE);
   }
   researchPanelModule.init(API_BASE, markdownModule, sessionModule);
   // Initialize document editor module

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -1,0 +1,428 @@
+import uiModule from './ui.js';
+
+let API_BASE = window.location.origin;
+let _panelOpen = false;
+let _mode = 'inbox';
+let _countTimer = null;
+let _bound = false;
+let _anchorButton = null;
+
+const ICONS = {
+  bell: '<path d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/>',
+  list: '<line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/>',
+  inbox: '<polyline points="22 12 16 12 14 15 10 15 8 12 2 12"/><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/>',
+  open: '<path d="M7 7h10v10"/><path d="M7 17 17 7"/>',
+  check: '<path d="M20 6 9 17l-5-5"/>',
+  archive: '<rect x="3" y="4" width="18" height="4" rx="1"/><path d="M5 8v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8"/><path d="M10 12h4"/>',
+  x: '<line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>',
+};
+
+function _svg(path, size = 16) {
+  return `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${path}</svg>`;
+}
+
+function _esc(value) {
+  return String(value == null ? '' : value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function _relativeTime(iso) {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  const diff = Date.now() - d.getTime();
+  const abs = Math.abs(diff);
+  if (abs < 60000) return 'just now';
+  if (abs < 3600000) return `${Math.round(abs / 60000)}m ago`;
+  if (abs < 86400000) return `${Math.round(abs / 3600000)}h ago`;
+  return `${Math.round(abs / 86400000)}d ago`;
+}
+
+function _ensureShell() {
+  const rail = document.getElementById('icon-rail');
+  if (!document.getElementById('notification-inbox-btn')) {
+    const railBtn = document.createElement('button');
+    railBtn.id = 'notification-inbox-btn';
+    railBtn.className = 'icon-rail-btn notification-inbox-btn';
+    railBtn.type = 'button';
+    railBtn.title = 'Notifications';
+    railBtn.setAttribute('aria-label', 'Notifications');
+    railBtn.innerHTML = `${_svg(ICONS.bell, 16)}<span class="notification-inbox-badge hidden">0</span>`;
+    const separator = rail?.querySelector('.rail-separator');
+    if (separator) separator.insertAdjacentElement('afterend', railBtn);
+    else if (rail) rail.appendChild(railBtn);
+    else document.body.appendChild(railBtn);
+  }
+
+  if (!document.getElementById('notification-inbox-sidebar-btn')) {
+    const sidebarBtn = document.createElement('div');
+    sidebarBtn.id = 'notification-inbox-sidebar-btn';
+    sidebarBtn.className = 'list-item notification-sidebar-item';
+    sidebarBtn.title = 'Notifications';
+    sidebarBtn.setAttribute('role', 'button');
+    sidebarBtn.setAttribute('tabindex', '0');
+    sidebarBtn.innerHTML = `
+      ${_svg(ICONS.bell, 14)}
+      <span class="grow">Notifications</span>
+      <span class="notification-inbox-badge notification-sidebar-badge hidden">0</span>
+    `;
+    const searchBtn = document.getElementById('sidebar-search-btn');
+    const sessionsSection = document.getElementById('sessions-section');
+    if (searchBtn) searchBtn.insertAdjacentElement('afterend', sidebarBtn);
+    else if (sessionsSection) sessionsSection.insertAdjacentElement('beforebegin', sidebarBtn);
+    else document.getElementById('sidebar')?.appendChild(sidebarBtn);
+  }
+
+  if (!document.getElementById('notification-inbox-panel')) {
+    const panel = document.createElement('div');
+    panel.id = 'notification-inbox-panel';
+    panel.className = 'notification-inbox-panel hidden';
+    panel.innerHTML = `
+      <div class="notification-inbox-head">
+        <div class="notification-inbox-title">${_svg(ICONS.inbox, 15)}<span id="notification-inbox-title">Notifications</span></div>
+        <div class="notification-inbox-tools">
+          <button id="notification-inbox-mode" class="notification-icon-btn" type="button" title="System log">${_svg(ICONS.list, 15)}</button>
+          <button id="notification-inbox-close" class="notification-icon-btn" type="button" title="Close">${_svg(ICONS.x, 15)}</button>
+        </div>
+      </div>
+      <div id="notification-inbox-list" class="notification-inbox-list"></div>
+    `;
+    document.body.appendChild(panel);
+  }
+}
+
+function _setBadge(n) {
+  const count = Number(n || 0);
+  document.querySelectorAll('.notification-inbox-badge').forEach((badge) => {
+    badge.textContent = count > 99 ? '99+' : String(count);
+    badge.classList.toggle('hidden', count <= 0);
+  });
+  document.querySelectorAll('.notification-inbox-btn, .notification-sidebar-item').forEach((btn) => {
+    btn.classList.toggle('has-unread', count > 0);
+  });
+}
+
+async function refreshCount() {
+  try {
+    const res = await fetch(`${API_BASE}/api/notifications/count`, { credentials: 'same-origin' });
+    if (!res.ok) return;
+    const data = await res.json();
+    _setBadge(data.unread || 0);
+  } catch (_) {}
+}
+
+function _setLoading() {
+  const list = document.getElementById('notification-inbox-list');
+  if (list) list.innerHTML = '<div class="notification-empty">Loading...</div>';
+}
+
+function _setEmpty(text) {
+  const list = document.getElementById('notification-inbox-list');
+  if (list) list.innerHTML = `<div class="notification-empty">${_esc(text)}</div>`;
+}
+
+async function _loadPanel() {
+  const title = document.getElementById('notification-inbox-title');
+  const modeBtn = document.getElementById('notification-inbox-mode');
+  if (title) title.textContent = _mode === 'events' ? 'System log' : 'Notifications';
+  if (modeBtn) modeBtn.title = _mode === 'events' ? 'Notifications' : 'System log';
+  _setLoading();
+  try {
+    const path = _mode === 'events'
+      ? `${API_BASE}/api/notifications/events?limit=80`
+      : `${API_BASE}/api/notifications?limit=80`;
+    const res = await fetch(path, { credentials: 'same-origin' });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    if (_mode === 'events') _renderEvents(data.events || []);
+    else _renderInbox(data.notifications || []);
+    _positionPanel();
+  } catch (e) {
+    _setEmpty('Could not load notifications');
+    _positionPanel();
+  }
+}
+
+function _renderInbox(items) {
+  const list = document.getElementById('notification-inbox-list');
+  if (!list) return;
+  if (!items.length) {
+    _setEmpty('Nothing new');
+    return;
+  }
+  list.innerHTML = items.map((item) => {
+    const summary = item.body ? `<div class="notification-body">${_esc(item.body)}</div>` : '';
+    const cls = [
+      'notification-item',
+      item.is_read ? 'is-read' : 'is-unread',
+      `severity-${_esc(item.severity || 'info')}`,
+    ].join(' ');
+    return `
+      <div class="${cls}" data-id="${_esc(item.id)}">
+        <button class="notification-main" type="button" data-action="open">
+          <span class="notification-item-title">${_esc(item.title || 'Notification')}</span>
+          <span class="notification-item-meta">${_esc(_relativeTime(item.created_at))}</span>
+          ${summary}
+        </button>
+        <div class="notification-actions">
+          <button class="notification-icon-btn" type="button" title="Open" data-action="open">${_svg(ICONS.open, 14)}</button>
+          <button class="notification-icon-btn" type="button" title="Mark read" data-action="read">${_svg(ICONS.check, 14)}</button>
+          <button class="notification-icon-btn" type="button" title="Archive" data-action="archive">${_svg(ICONS.archive, 14)}</button>
+          <button class="notification-icon-btn" type="button" title="Dismiss" data-action="dismiss">${_svg(ICONS.x, 14)}</button>
+        </div>
+      </div>
+    `;
+  }).join('');
+  list.querySelectorAll('.notification-item').forEach((row) => {
+    row.addEventListener('click', (e) => {
+      const action = e.target.closest('[data-action]')?.dataset?.action;
+      const item = items.find(n => n.id === row.dataset.id);
+      if (!item || !action) return;
+      e.stopPropagation();
+      _handleItemAction(item, action);
+    });
+  });
+}
+
+function _renderEvents(events) {
+  const list = document.getElementById('notification-inbox-list');
+  if (!list) return;
+  if (!events.length) {
+    _setEmpty('No events');
+    return;
+  }
+  list.innerHTML = events.map((event) => `
+    <div class="notification-item is-read severity-${_esc(event.severity || 'info')}">
+      <div class="notification-main static">
+        <span class="notification-item-title">${_esc(event.title || 'Event')}</span>
+        <span class="notification-item-meta">${_esc(_relativeTime(event.created_at))}</span>
+        ${event.body ? `<div class="notification-body">${_esc(event.body)}</div>` : ''}
+      </div>
+    </div>
+  `).join('');
+}
+
+async function _postItem(item, action) {
+  const body = action === 'read' ? { read: true } : undefined;
+  const res = await fetch(`${API_BASE}/api/notifications/${encodeURIComponent(item.id)}/${action}`, {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: body ? { 'Content-Type': 'application/json' } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return await res.json();
+}
+
+async function _handleItemAction(item, action) {
+  try {
+    if (action === 'open') {
+      if (!item.is_read) await _postItem(item, 'read');
+      _openTarget(item);
+      _closePanel();
+    } else {
+      await _postItem(item, action);
+    }
+    await refreshCount();
+    if (_panelOpen) await _loadPanel();
+  } catch (e) {
+    if (uiModule) uiModule.showError('Notification action failed');
+  }
+}
+
+function _openTarget(item) {
+  const meta = item.metadata || {};
+  const taskId = meta.task_id || '';
+  const actionUrl = item.action_url || item.source_url || '';
+  if ((item.source_type === 'task_run' || actionUrl.startsWith('odysseus://tasks')) && window.tasksModule) {
+    window.tasksModule.openTasks(taskId || null);
+    return;
+  }
+  if (
+    (item.source_type || '').startsWith('email')
+    || actionUrl.startsWith('odysseus://email')
+    || actionUrl.startsWith('#email')
+  ) {
+    _openEmailTarget(actionUrl);
+    return;
+  }
+  if (
+    item.source_type === 'chat_session'
+    || item.source_type === 'session'
+    || actionUrl.startsWith('odysseus://chat')
+    || actionUrl.startsWith('odysseus://session')
+    || actionUrl.startsWith('#chat=')
+    || actionUrl.startsWith('#session=')
+  ) {
+    _openChatTarget(item, actionUrl);
+    return;
+  }
+  if (actionUrl && actionUrl.startsWith('#')) {
+    window.location.hash = actionUrl;
+    return;
+  }
+  if (actionUrl && /^https?:\/\//.test(actionUrl)) {
+    window.location.assign(actionUrl);
+  }
+}
+
+function _openEmailTarget(actionUrl) {
+  import('./emailLibrary.js')
+    .then((mod) => {
+      const open = mod.openEmailLibrary || (mod.default && mod.default.openEmailLibrary);
+      if (typeof open !== 'function') throw new Error('Email library unavailable');
+      open(_emailTargetOptions(actionUrl));
+    })
+    .catch(() => {
+      document.querySelector('#email-section .section-header-flex')?.click();
+    });
+}
+
+function _emailTargetOptions(actionUrl) {
+  const opts = {};
+  const match = String(actionUrl || '').match(/#email=([^:]+):(.+)$/);
+  if (match) {
+    opts.folder = decodeURIComponent(match[1]);
+    opts.uid = decodeURIComponent(match[2]);
+  }
+  return opts;
+}
+
+function _openChatTarget(item, actionUrl) {
+  const meta = item.metadata || {};
+  const sessionId = meta.session_id || item.source_id || _chatTargetId(actionUrl);
+  if (!sessionId || !window.sessionModule) return;
+  const open = () => window.sessionModule.selectSession(sessionId);
+  const sessions = window.sessionModule.getSessions?.() || [];
+  if (sessions.some((s) => s.id === sessionId)) {
+    open();
+    return;
+  }
+  const load = window.sessionModule.loadSessions?.();
+  if (load && typeof load.then === 'function') {
+    load.then(open).catch(open);
+  } else {
+    open();
+  }
+}
+
+function _chatTargetId(actionUrl) {
+  const raw = String(actionUrl || '');
+  const match = raw.match(/^odysseus:\/\/(?:chat|session)s?\/(.+)$/)
+    || raw.match(/^#(?:chat|session)=(.+)$/);
+  return match ? decodeURIComponent(match[1]) : '';
+}
+
+function _isNotificationTrigger(node) {
+  return !!node?.closest?.('#notification-inbox-btn, #notification-inbox-sidebar-btn');
+}
+
+function _closePanel() {
+  _panelOpen = false;
+  const panel = document.getElementById('notification-inbox-panel');
+  if (!panel) return;
+  panel.classList.add('hidden');
+  panel.style.left = '';
+  panel.style.right = '';
+  panel.style.top = '';
+}
+
+function _positionPanel(anchor = _anchorButton) {
+  const panel = document.getElementById('notification-inbox-panel');
+  if (!panel || panel.classList.contains('hidden')) return;
+  const rect = anchor?.getBoundingClientRect?.();
+  const margin = 10;
+  const width = Math.min(360, window.innerWidth - margin * 2);
+  panel.style.width = `${width}px`;
+  panel.style.right = 'auto';
+  panel.style.left = `${margin}px`;
+  panel.style.top = `${margin}px`;
+  const panelRect = panel.getBoundingClientRect();
+  if (!rect) return;
+
+  const railOnRight = rect.left > window.innerWidth / 2;
+  const left = railOnRight
+    ? Math.max(margin, rect.left - panelRect.width - 8)
+    : Math.min(window.innerWidth - panelRect.width - margin, rect.right + 8);
+  const top = Math.min(
+    window.innerHeight - panelRect.height - margin,
+    Math.max(margin, rect.top - 8)
+  );
+  panel.style.left = `${Math.max(margin, left)}px`;
+  panel.style.top = `${Math.max(margin, top)}px`;
+}
+
+function _openPanel(anchor) {
+  _anchorButton = anchor || document.getElementById('notification-inbox-btn');
+  _panelOpen = true;
+  const panel = document.getElementById('notification-inbox-panel');
+  if (!panel) return;
+  panel.classList.remove('hidden');
+  _positionPanel();
+  _loadPanel();
+}
+
+function _togglePanel(anchor) {
+  if (_panelOpen && _anchorButton === anchor) {
+    _closePanel();
+    return;
+  }
+  _openPanel(anchor);
+}
+
+function _bindEvents() {
+  if (_bound) return;
+  _bound = true;
+  document.querySelectorAll('#notification-inbox-btn, #notification-inbox-sidebar-btn').forEach((btn) => {
+    btn.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      _togglePanel(btn);
+    });
+    btn.addEventListener('keydown', (e) => {
+      if (e.key !== 'Enter' && e.key !== ' ') return;
+      e.preventDefault();
+      _togglePanel(btn);
+    });
+  });
+  document.getElementById('notification-inbox-close')?.addEventListener('click', () => {
+    _closePanel();
+  });
+  document.getElementById('notification-inbox-mode')?.addEventListener('click', () => {
+    _mode = _mode === 'events' ? 'inbox' : 'events';
+    _loadPanel();
+  });
+  document.addEventListener('pointerdown', (e) => {
+    if (!_panelOpen) return;
+    const panel = document.getElementById('notification-inbox-panel');
+    const path = e.composedPath ? e.composedPath() : [];
+    if (path.includes(panel) || _isNotificationTrigger(e.target)) return;
+    _closePanel();
+  }, true);
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && _panelOpen) _closePanel();
+  }, true);
+  window.addEventListener('resize', () => {
+    if (_panelOpen) _positionPanel();
+  });
+  document.addEventListener('odysseus:notifications-changed', () => {
+    refreshCount();
+    if (_panelOpen) _loadPanel();
+  });
+}
+
+export function init(apiBase = window.location.origin) {
+  API_BASE = apiBase || window.location.origin;
+  _ensureShell();
+  _bindEvents();
+  refreshCount();
+  if (!_countTimer) _countTimer = setInterval(refreshCount, 45000);
+}
+
+const notificationsModule = { init, refreshCount };
+export default notificationsModule;
+window.notificationsModule = notificationsModule;

--- a/static/js/tasks.js
+++ b/static/js/tasks.js
@@ -3127,6 +3127,9 @@ async function _pollTaskNotifications() {
     if (!res.ok) return;
     const data = await res.json();
     const notes = data.notifications || [];
+    if (notes.length) {
+      document.dispatchEvent(new CustomEvent('odysseus:notifications-changed'));
+    }
     for (const n of notes) {
       const ok = n.status === 'success';
       if (ok) {

--- a/static/style.css
+++ b/static/style.css
@@ -4519,6 +4519,205 @@ body.bg-pattern-sparkles {
       border-left-color: var(--color-error);
       color: var(--color-error);
     }
+    .notification-inbox-btn,
+    .notification-sidebar-item {
+      position: relative;
+    }
+    .notification-inbox-btn {
+      color: var(--accent, var(--red));
+    }
+    .notification-inbox-btn:hover,
+    .notification-inbox-btn.has-unread {
+      border-color: color-mix(in srgb, var(--accent, var(--red)) 55%, transparent);
+      color: var(--accent, var(--red));
+      background: color-mix(in srgb, var(--panel) 86%, var(--accent, var(--red)) 14%);
+    }
+    .notification-sidebar-item.has-unread {
+      background: color-mix(in srgb, var(--panel) 86%, var(--accent, var(--red)) 14%);
+    }
+    .notification-inbox-btn:active,
+    .notification-sidebar-item:active { transform: translateY(1px); }
+    .notification-sidebar-item svg {
+      flex-shrink: 0;
+      color: var(--accent, var(--red));
+      opacity: 1;
+    }
+    .notification-inbox-badge {
+      position: absolute;
+      min-width: 16px;
+      height: 16px;
+      top: 2px;
+      right: 2px;
+      padding: 0 4px;
+      border-radius: 999px;
+      background: var(--color-error);
+      color: #fff;
+      font-size: 10px;
+      font-weight: 700;
+      line-height: 16px;
+      text-align: center;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+    }
+    .notification-sidebar-badge {
+      position: relative;
+      top: auto;
+      right: auto;
+      margin-left: auto;
+      margin-right: 2px;
+      flex-shrink: 0;
+    }
+    .notification-inbox-panel {
+      position: fixed;
+      top: 10px;
+      left: calc(var(--icon-rail-w, 48px) + 10px);
+      right: auto;
+      z-index: 9299;
+      width: min(360px, calc(100vw - 24px));
+      max-height: min(520px, calc(100vh - 20px));
+      border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+      border-radius: 8px;
+      background: color-mix(in srgb, var(--panel) 96%, #000 4%);
+      color: var(--fg);
+      box-shadow: 0 18px 52px rgba(0,0,0,0.42);
+      backdrop-filter: blur(18px);
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+    }
+    .notification-inbox-panel.hidden {
+      display: none;
+    }
+    .notification-inbox-head {
+      height: 42px;
+      flex: 0 0 42px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      padding: 0 10px 0 12px;
+      border-bottom: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+    }
+    .notification-inbox-title {
+      min-width: 0;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 12px;
+      font-weight: 650;
+    }
+    .notification-inbox-tools,
+    .notification-actions {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      flex-shrink: 0;
+    }
+    .notification-icon-btn {
+      width: 26px;
+      height: 26px;
+      border: 1px solid transparent;
+      border-radius: 7px;
+      background: transparent;
+      color: color-mix(in srgb, var(--fg) 76%, transparent);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      transition: background 0.15s, border-color 0.15s, color 0.15s;
+    }
+    .notification-icon-btn:hover {
+      border-color: color-mix(in srgb, var(--border) 75%, transparent);
+      background: color-mix(in srgb, var(--fg) 8%, transparent);
+      color: var(--fg);
+    }
+    .notification-inbox-list {
+      min-height: 86px;
+      overflow: auto;
+      padding: 6px;
+      display: flex;
+      flex-direction: column;
+      gap: 5px;
+    }
+    .notification-item {
+      border: 1px solid color-mix(in srgb, var(--border) 62%, transparent);
+      border-left: 3px solid color-mix(in srgb, var(--fg) 22%, transparent);
+      border-radius: 7px;
+      background: color-mix(in srgb, var(--panel) 91%, var(--fg) 4%);
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 6px;
+      align-items: stretch;
+      overflow: hidden;
+    }
+    .notification-item.severity-error { border-left-color: var(--color-error); }
+    .notification-item.severity-urgent { border-left-color: var(--accent-primary, var(--accent)); }
+    .notification-item.severity-attention { border-left-color: var(--color-warning, var(--warn)); }
+    .notification-item.is-read {
+      opacity: 0.72;
+      background: color-mix(in srgb, var(--panel) 95%, transparent);
+    }
+    .notification-main {
+      min-width: 0;
+      border: 0;
+      padding: 9px 4px 9px 10px;
+      background: transparent;
+      color: inherit;
+      text-align: left;
+      cursor: pointer;
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 3px 8px;
+      align-content: start;
+      font: inherit;
+    }
+    .notification-main.static {
+      cursor: default;
+      grid-column: 1 / -1;
+    }
+    .notification-item-title {
+      min-width: 0;
+      font-size: 12px;
+      font-weight: 650;
+      line-height: 1.25;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .notification-item-meta {
+      font-size: 10px;
+      color: color-mix(in srgb, var(--fg) 54%, transparent);
+      white-space: nowrap;
+      line-height: 1.4;
+    }
+    .notification-body {
+      grid-column: 1 / -1;
+      color: color-mix(in srgb, var(--fg) 74%, transparent);
+      font-size: 11px;
+      line-height: 1.35;
+      max-height: 4.05em;
+      overflow: hidden;
+      overflow-wrap: anywhere;
+    }
+    .notification-actions {
+      align-self: start;
+      padding: 7px 6px 0 0;
+    }
+    .notification-empty {
+      min-height: 74px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: color-mix(in srgb, var(--fg) 58%, transparent);
+      font-size: 12px;
+    }
+    @media (max-width: 768px) {
+      .notification-inbox-panel {
+        top: 10px;
+        left: 10px;
+        right: auto;
+        width: calc(100vw - 24px);
+      }
+    }
     /* When the notes panel is docked to the right, the default top-right toast
        sits directly over the Archive / View-toggle buttons in the panel header.
        Flip it to the top-left so you can still reach the header after an

--- a/tests/test_notification_inbox.py
+++ b/tests/test_notification_inbox.py
@@ -1,0 +1,145 @@
+"""Durable notification event and inbox behavior."""
+
+import os
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from tests.helpers.import_state import clear_fake_database_modules
+from tests.helpers.sqlite_db import make_temp_sqlite
+
+clear_fake_database_modules()
+
+import core.database as cdb  # noqa: E402
+import routes.notification_routes as notification_routes  # noqa: E402
+import src.notifications as notifications  # noqa: E402
+
+
+@pytest.fixture()
+def notification_db(monkeypatch):
+    SessionLocal, engine, tmpfile = make_temp_sqlite(cdb.Base.metadata)
+    monkeypatch.setattr(notifications, "SessionLocal", SessionLocal)
+    try:
+        yield SessionLocal
+    finally:
+        engine.dispose()
+        tmpfile.close()
+        try:
+            os.unlink(tmpfile.name)
+        except OSError:
+            pass
+
+
+def _req(user="alice"):
+    return SimpleNamespace(state=SimpleNamespace(current_user=user))
+
+
+def _endpoint(method, path):
+    router = notification_routes.setup_notification_routes()
+    for route in router.routes:
+        if getattr(route, "path", None) == path and method in getattr(route, "methods", set()):
+            return route.endpoint
+    raise RuntimeError(f"{method} {path} not found")
+
+
+def test_system_events_are_logged_without_creating_inbox_items(notification_db):
+    event = notifications.record_notification_event(
+        owner="alice",
+        title="Folder created",
+        body="Inbox/Receipts",
+        category="email",
+        dedupe_key="email-folder:receipts",
+    )
+
+    assert event["event_class"] == notifications.SYSTEM_EVENT
+    assert notifications.list_notification_events(owner="alice")[0]["title"] == "Folder created"
+    assert notifications.list_inbox_notifications(owner="alice") == []
+    assert notifications.count_unread_notifications(owner="alice") == 0
+
+
+def test_task_notification_body_creates_deduped_inbox_record(notification_db):
+    first = notifications.record_task_notification(
+        owner="alice",
+        task_name="Morning digest",
+        status="success",
+        task_id="task-1",
+        run_id="run-1",
+        output_target="notification",
+        body="Three urgent messages need review.",
+    )
+    second = notifications.record_task_notification(
+        owner="alice",
+        task_name="Morning digest",
+        status="success",
+        task_id="task-1",
+        run_id="run-1",
+        output_target="notification",
+        body="Three urgent messages need review.",
+    )
+
+    inbox = notifications.list_inbox_notifications(owner="alice")
+    assert first["id"] == second["id"]
+    assert len(inbox) == 1
+    assert inbox[0]["notification_kind"] == notifications.INBOX_RECORD
+    assert inbox[0]["body"] == "Three urgent messages need review."
+    assert notifications.count_unread_notifications(owner="alice") == 1
+
+
+def test_task_failure_creates_owner_scoped_actionable_notification(notification_db):
+    notifications.record_task_notification(
+        owner="alice",
+        task_name="Urgent email check",
+        status="error",
+        task_id="alice-task",
+        run_id="alice-run",
+        body="Provider timeout",
+    )
+    notifications.record_task_notification(
+        owner="bob",
+        task_name="Bob task",
+        status="error",
+        task_id="bob-task",
+        run_id="bob-run",
+        body="Hidden from Alice",
+    )
+
+    inbox = notifications.list_inbox_notifications(owner="alice")
+    assert len(inbox) == 1
+    assert inbox[0]["notification_kind"] == notifications.ACTIONABLE
+    assert inbox[0]["title"] == "Task failed: Urgent email check"
+    assert inbox[0]["severity"] == "error"
+    assert inbox[0]["metadata"]["task_id"] == "alice-task"
+    assert inbox[0]["action_url"].endswith("/alice-task")
+
+
+@pytest.mark.asyncio
+async def test_notification_routes_mark_read_and_reject_cross_owner(notification_db):
+    item = notifications.create_inbox_notification(
+        owner="alice",
+        notification_kind=notifications.ACTIONABLE,
+        title="Reply needed",
+        body="Urgent email from finance",
+        source_type="email",
+        source_id="uid-1",
+    )
+    count_endpoint = _endpoint("GET", "/api/notifications/count")
+    read_endpoint = _endpoint("POST", "/api/notifications/{item_id}/read")
+
+    assert await count_endpoint(_req("alice")) == {"unread": 1}
+
+    marked = await read_endpoint(
+        _req("alice"),
+        item["id"],
+        notification_routes.NotificationReadRequest(read=True),
+    )
+    assert marked["is_read"] is True
+    assert await count_endpoint(_req("alice")) == {"unread": 0}
+
+    with pytest.raises(HTTPException) as exc:
+        await read_endpoint(
+            _req("bob"),
+            item["id"],
+            notification_routes.NotificationReadRequest(read=True),
+        )
+    assert exc.value.status_code == 404

--- a/tests/test_notification_inbox.py
+++ b/tests/test_notification_inbox.py
@@ -1,10 +1,14 @@
 """Durable notification event and inbox behavior."""
 
 import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
+from sqlalchemy import create_engine, text
 
 from tests.helpers.import_state import clear_fake_database_modules
 from tests.helpers.sqlite_db import make_temp_sqlite
@@ -84,6 +88,221 @@ def test_task_notification_body_creates_deduped_inbox_record(notification_db):
     assert inbox[0]["notification_kind"] == notifications.INBOX_RECORD
     assert inbox[0]["body"] == "Three urgent messages need review."
     assert notifications.count_unread_notifications(owner="alice") == 1
+
+
+def test_notification_retention_defaults_follow_event_class(notification_db):
+    system = notifications.record_notification_event(
+        owner="alice",
+        title="System audit event",
+        dedupe_key="retention:system",
+    )
+    inbox = notifications.create_inbox_notification(
+        owner="alice",
+        notification_kind=notifications.INBOX_RECORD,
+        title="Inbox record",
+        dedupe_key="retention:inbox",
+    )
+    actionable = notifications.create_inbox_notification(
+        owner="alice",
+        notification_kind=notifications.ACTIONABLE,
+        title="Action required",
+        dedupe_key="retention:actionable",
+    )
+
+    def _parse(value):
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+    assert _parse(system["retention_expires_at"]) - _parse(system["created_at"]) == timedelta(days=30)
+    assert _parse(inbox["event"]["retention_expires_at"]) - _parse(inbox["event"]["created_at"]) == timedelta(days=90)
+    assert _parse(actionable["event"]["retention_expires_at"]) - _parse(
+        actionable["event"]["created_at"]
+    ) == timedelta(days=180)
+
+
+def test_expired_notifications_are_hidden_and_purged_in_bounded_batches(notification_db):
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    active = notifications.create_inbox_notification(
+        owner="alice",
+        title="Still active",
+        dedupe_key="retention:active",
+        retention_expires_at=now + timedelta(days=1),
+    )
+    expired = [
+        notifications.create_inbox_notification(
+            owner="alice",
+            title=f"Expired {idx}",
+            dedupe_key=f"retention:expired:{idx}",
+            retention_expires_at=now - timedelta(minutes=idx + 1),
+        )
+        for idx in range(5)
+    ]
+
+    assert [item["id"] for item in notifications.list_inbox_notifications(owner="alice")] == [active["id"]]
+    assert notifications.count_unread_notifications(owner="alice") == 1
+    assert [event["id"] for event in notifications.list_notification_events(owner="alice")] == [
+        active["event_id"]
+    ]
+    assert notifications.mark_notification_read(
+        item_id=expired[0]["id"], owner="alice"
+    ) is None
+
+    first = notifications.purge_expired_notifications(limit=2, now=now)
+    second = notifications.purge_expired_notifications(limit=2, now=now)
+    third = notifications.purge_expired_notifications(limit=2, now=now)
+    assert [first["events_deleted"], second["events_deleted"], third["events_deleted"]] == [2, 2, 1]
+    assert [first["inbox_items_deleted"], second["inbox_items_deleted"], third["inbox_items_deleted"]] == [2, 2, 1]
+
+    db = notification_db()
+    try:
+        assert db.query(cdb.NotificationEvent).count() == 1
+        assert db.query(cdb.NotificationInboxItem).count() == 1
+    finally:
+        db.close()
+
+
+def test_concurrent_sessions_create_one_deduped_inbox_item(notification_db, monkeypatch):
+    original_upsert = notifications._upsert_event
+    barrier = threading.Barrier(2)
+    call_lock = threading.Lock()
+    first_calls = 0
+
+    def racing_upsert(*args, **kwargs):
+        nonlocal first_calls
+        event = original_upsert(*args, **kwargs)
+        with call_lock:
+            first_calls += 1
+            wait_for_peer = first_calls <= 2
+        if wait_for_peer:
+            barrier.wait(timeout=10)
+        return event
+
+    monkeypatch.setattr(notifications, "_upsert_event", racing_upsert)
+
+    def create_one():
+        return notifications.create_inbox_notification(
+            owner="alice",
+            notification_kind=notifications.ACTIONABLE,
+            title="Concurrent alert",
+            dedupe_key="concurrent:one",
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(lambda _index: create_one(), range(2)))
+
+    assert results[0]["id"] == results[1]["id"]
+    assert notifications.count_unread_notifications(owner="alice") == 1
+    db = notification_db()
+    try:
+        assert db.query(cdb.NotificationEvent).count() == 1
+        assert db.query(cdb.NotificationInboxItem).count() == 1
+    finally:
+        db.close()
+
+
+def test_notification_migration_backfills_retention_and_collapses_duplicates(tmp_path, monkeypatch):
+    legacy_engine = create_engine(f"sqlite:///{tmp_path / 'legacy-notifications.db'}")
+    with legacy_engine.begin() as conn:
+        conn.execute(text("""
+            CREATE TABLE notification_events (
+                id TEXT PRIMARY KEY,
+                owner TEXT,
+                event_class TEXT NOT NULL,
+                dedupe_key TEXT,
+                retention_expires_at DATETIME,
+                created_at DATETIME NOT NULL
+            )
+        """))
+        conn.execute(text("""
+            CREATE TABLE notification_inbox_items (
+                id TEXT PRIMARY KEY,
+                event_id TEXT NOT NULL,
+                created_at DATETIME NOT NULL
+            )
+        """))
+        conn.execute(text("""
+            INSERT INTO notification_events
+                (id, owner, event_class, dedupe_key, created_at)
+            VALUES
+                ('event-old', 'alice', 'actionable', 'same-key', '2026-01-01 00:00:00'),
+                ('event-new', 'alice', 'actionable', 'same-key', '2026-01-02 00:00:00'),
+                ('event-system', NULL, 'system_event', NULL, '2026-01-03 00:00:00')
+        """))
+        conn.execute(text("""
+            INSERT INTO notification_inbox_items (id, event_id, created_at)
+            VALUES
+                ('item-old', 'event-old', '2026-01-01 00:00:00'),
+                ('item-new', 'event-new', '2026-01-02 00:00:00'),
+                ('item-system-old', 'event-system', '2026-01-03 00:00:00'),
+                ('item-system-new', 'event-system', '2026-01-04 00:00:00')
+        """))
+
+    monkeypatch.setattr(cdb, "engine", legacy_engine)
+    cdb._migrate_notification_retention_and_uniqueness()
+    cdb._migrate_notification_retention_and_uniqueness()
+
+    with legacy_engine.connect() as conn:
+        events = conn.execute(text("""
+            SELECT id, retention_expires_at
+              FROM notification_events
+             ORDER BY id
+        """)).fetchall()
+        items = conn.execute(text("""
+            SELECT id, event_id
+              FROM notification_inbox_items
+             ORDER BY id
+        """)).fetchall()
+        event_indexes = {
+            row[1]: row[2]
+            for row in conn.execute(text("PRAGMA index_list(notification_events)"))
+        }
+        inbox_indexes = {
+            row[1]: row[2]
+            for row in conn.execute(text("PRAGMA index_list(notification_inbox_items)"))
+        }
+
+    assert events == [
+        ("event-new", "2026-07-01 00:00:00"),
+        ("event-system", "2026-02-02 00:00:00"),
+    ]
+    assert items == [
+        ("item-new", "event-new"),
+        ("item-system-new", "event-system"),
+    ]
+    assert event_indexes["uq_notification_events_owner_dedupe"] == 1
+    assert inbox_indexes["uq_notification_inbox_event"] == 1
+    legacy_engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_scheduler_runs_bounded_notification_purge_on_hourly_cadence(monkeypatch):
+    import src.task_scheduler as task_scheduler
+
+    scheduler = task_scheduler.TaskScheduler.__new__(task_scheduler.TaskScheduler)
+    scheduler._last_notification_purge = None
+    ticks = iter((100.0, 200.0, 3701.0))
+    calls = []
+
+    monkeypatch.setattr(
+        task_scheduler,
+        "time",
+        SimpleNamespace(monotonic=lambda: next(ticks)),
+    )
+    monkeypatch.setattr(notifications, "NOTIFICATION_PURGE_BATCH_SIZE", 500)
+    monkeypatch.setattr(notifications, "NOTIFICATION_PURGE_INTERVAL_SECONDS", 3600)
+    monkeypatch.setattr(
+        notifications,
+        "purge_expired_notifications",
+        lambda *, limit: calls.append(limit) or {
+            "events_deleted": 0,
+            "inbox_items_deleted": 0,
+        },
+    )
+
+    await scheduler._purge_expired_notifications_if_due()
+    await scheduler._purge_expired_notifications_if_due()
+    await scheduler._purge_expired_notifications_if_due()
+
+    assert calls == [500, 500]
 
 
 def test_task_failure_creates_owner_scoped_actionable_notification(notification_db):


### PR DESCRIPTION
## Summary

Recreates the closed #5243 durable notification inbox feature after the July 23 repository cleanup wiped old PR refs/diffs. The branch restores durable notification storage, routes, scheduler integration, inbox UI, and focused tests.

The review follow-up in `fc601112` also hardens the feature for production use:

- Applies explicit retention by event class: 30 days for system events, 90 days for inbox records, and 180 days for actionable notifications.
- Excludes expired notifications from inbox/event reads, unread counts, and mutation routes.
- Runs an hourly, bounded purge of at most 500 expired events, with an idempotent SQLite migration that backfills legacy expiry values.
- Enforces database uniqueness for `(owner, dedupe_key)` (including anonymous owners) and the inbox-to-event mapping.
- Retries concurrent dedupe conflicts in a fresh session and reloads the committed record.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release.

## Linked Issue

Supersedes #5243 after the July 23 repository cleanup wiped old PR refs/diffs and closed the original PR unmerged.

## Type of Change

- [ ] Bug fix (non-breaking - fixes a confirmed issue)
- [x] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) - this is not a duplicate; it is a recovery of closed #5243.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run the notification regression tests:

```text
python -m pytest tests/test_notification_inbox.py -q
```

Expected: `9 passed`.

2. Run the complete suite:

```text
python -m pytest -q
```

Expected in the isolated review image: `4793 passed, 4 skipped`.

3. Run static checks:

```text
git diff --check origin/dev...HEAD
node --check static/app.js
node --check static/js/notifications.js
node --check static/js/tasks.js
python -m py_compile app.py core/database.py routes/notification_routes.py src/database.py src/notifications.py src/task_scheduler.py tests/test_notification_inbox.py
```

4. Start the app with a clean SQLite database, create active and expired notifications, and verify:

   - only active rows appear in inbox/event APIs and the unread badge;
   - Mark read and Archive update the row and badge;
   - System log mode shows durable events;
   - the notification panel stays within the viewport on desktop and at 390x844;
   - concurrent writes with the same owner/dedupe key return the same inbox item.

## Validation performed

- Focused notification suite: `9 passed, 1 warning`.
- Notification/scheduler/database regression selection: `38 passed, 4 warnings`.
- Complete pytest suite: `4793 passed, 4 skipped, 63 warnings`.
- Live isolated app/API verification confirmed class retention, hidden expired records, unread counts, and event/inbox persistence.
- In-app browser verification covered Inbox/System log switching, Mark read, Archive, Close, badge updates, desktop layout, and a 390x844 mobile viewport with no horizontal overflow.
- Current `dev` merge simulation completed without conflicts.
- CSS validation reported only three existing `env(safe-area-inset-bottom, ...)` parser compatibility warnings outside this PR's diff.

## Visual / UI changes

**REQUIRED if you touched anything that renders.** Touches notification inbox UI and task notification behavior.

- [ ] Screenshot or short clip of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] Style match: the change uses Odysseus's existing visual language and recovered code paths.
- [x] No new component patterns beyond the recovered original PR scope.
- [x] I am not an LLM agent submitting a bulk PR. This is a targeted recovery of #5243 after the repository cleanup event.

### Screenshots / clips

No image is attached, but the desktop and 390x844 mobile layouts were verified in the running app during this review pass.
