### PR TITLE
fix(chat): clear stale new-chat session restore state

### DIFF
--- a/static/js/sessions.js
+++ b/static/js/sessions.js
@@ -285,10 +285,14 @@ let _sessionListFocused = false;
 function _deselectCurrentSession(sid) {
   if (currentSessionId !== sid) return;
   currentSessionId = null;
+  try { window.__odysseusLastSelectedSessionId = ''; } catch (_) {}
   uiModule.el('chat-history').innerHTML = '';
   uiModule.el('current-meta').textContent = 'Odysseus Chat';
   Storage.remove('lastSessionId');
   history.replaceState(null, '', window.location.pathname);
+  document.querySelectorAll('.list-item.active-session, .session-item.active').forEach(el => {
+    el.classList.remove('active-session', 'active');
+  });
   if (window.chatModule && window.chatModule.showWelcomeScreen) {
     window.chatModule.showWelcomeScreen();
   }

--- a/tests/test_new_chat_session_isolation.py
+++ b/tests/test_new_chat_session_isolation.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+
+APP_JS = Path("static/app.js")
+CHAT_JS = Path("static/js/chat.js")
+SESSIONS_JS = Path("static/js/sessions.js")
+
+
+def _slice(source, start_marker, end_marker):
+    start = source.index(start_marker)
+    end = source.index(end_marker, start)
+    return source[start:end]
+
+
+def test_fresh_chat_clears_restore_and_active_session_state():
+    app = APP_JS.read_text(encoding="utf-8")
+    sessions = SESSIONS_JS.read_text(encoding="utf-8")
+
+    fresh_chat = _slice(app, "function _startFreshChat()", "/** Sync Research indicator")
+    deselect_current = _slice(sessions, "function _deselectCurrentSession(sid)", "// Reset send button to idle state")
+    set_current_session = _slice(sessions, "export function setCurrentSessionId(id)", "export function getSortMode()")
+
+    assert "sessionModule.setCurrentSessionId(null)" in fresh_chat
+    assert "window.__odysseusLastSelectedSessionId = id || ''" in set_current_session
+    assert "window.__odysseusLastSelectedSessionId = ''" in deselect_current
+    assert "Storage.remove('lastSessionId')" in set_current_session
+    assert "Storage.remove('lastSessionId')" in deselect_current
+    assert ".list-item.active-session, .session-item.active" in set_current_session
+    assert ".list-item.active-session, .session-item.active" in deselect_current
+
+
+def test_first_send_in_new_chat_posts_materialized_session_id():
+    chat = CHAT_JS.read_text(encoding="utf-8")
+    send_path = _slice(chat, "export async function handleChatSubmit(e)", "export function abortCurrentRequest")
+
+    materialize_positions = [
+        idx
+        for idx in range(len(send_path))
+        if send_path.startswith("sessionModule.materializePendingSession()", idx)
+    ]
+    stream_id_pos = send_path.index("const streamSessionId = sessionModule.getCurrentSessionId();")
+    post_session_pos = send_path.index("fd.append('session', streamSessionId);")
+
+    assert materialize_positions
+    assert max(materialize_positions) < stream_id_pos < post_session_pos


### PR DESCRIPTION
## Summary

  Clears stale selected-session restore state when the current chat is deselected, so the first
  message after New Chat or deleting the active chat cannot be adopted into the previous session. Adds
  focused regression coverage for both stale-session cleanup and the new-chat materialization path.

  ## Target branch

  - [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the
  maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change
  the base.

  ## Linked Issue

  Fixes #5852

  ## Type of Change

  - [x] Bug fix (non-breaking — fixes a confirmed issue)
  - [ ] New feature (non-breaking — adds new behaviour)
  - [ ] Breaking change (changes or removes existing behaviour)
  - [ ] Refactor / cleanup (behaviour unchanged)
  - [ ] Documentation only
  - [ ] CI / tooling / configuration

  ## Checklist

  - [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open
  PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
  - [x] This PR targets `dev`
  - [x] My changes are limited to the scope described above — no unrelated refactors or whitespace
  changes mixed in.
  - [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change
  works end-to-end. Type-checks and unit tests are not enough.

  ## How to Test

  1. Run `node --check static/js/sessions.js`.
  2. Run `docker run --rm --entrypoint pytest -v /home/ada/odysseus:/src -w /src odysseus-issue-5852-
  dev -q tests/test_new_chat_clears_input.py tests/test_new_chat_model_preference.py tests/
  test_new_chat_session_isolation.py`.
  3. In the running Docker app, create two chats, start a new chat, send a first message, and verify
  the message appears in a new session instead of the previous chat.
  4. Delete the active chat, send a new first message, and verify it does not reuse the deleted/
  previous chat’s restore state.

  ## Visual / UI changes — REQUIRED if you touched anything that renders

  **Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing,
  layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the
  following. PRs that change rendering without these WILL be closed.**

  - [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile
  screenshot too if the change affects mobile.
  - [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
    - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not
    introduce new color values, font sizes, or spacing units.
    - Reuse existing button/input/card/border classes. Don't invent parallel styling.
    - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already
    in `static/index.html`) or plain text.
    - Monospaced font (`Fira Code`) for primary UI text. Don't override.
    - Dark theme is the default; any light-mode work must be wired through the existing theme system,
    not hard-coded.
  - [x] **No new component patterns.** If a similar widget already exists in the app, extend it
  instead of writing a parallel one.
  - [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing
  the problem first — bulk auto-generated PRs that don't match the project's visual style are closed
  on sight, even when the underlying fix is correct.

  ### Screenshots / clips

  No visual rendering changes. This only clears stale session state.