### PR TITLE
fix(skills): require manage_skills action

### DIFF
--- a/src/tools/system.py
+++ b/src/tools/system.py
@@ -46,7 +46,9 @@ async def do_manage_skills(content: str, owner: Optional[str] = None) -> Dict:
     except ValueError:
         return {"error": "Invalid JSON arguments", "exit_code": 1}
 
-    action = (args.get("action") or "").lower()
+    action = (args.get("action") or "").strip().lower()
+    if not action:
+        return {"error": "action is required (list|view|view_ref|add|edit|patch|publish|delete|search)", "exit_code": 1}
     from services.memory.skills import SkillsManager
     from services.memory.skill_format import Skill, slugify
     from src.constants import DATA_DIR
@@ -55,7 +57,7 @@ async def do_manage_skills(content: str, owner: Optional[str] = None) -> Dict:
     # Accept legacy `skill_id` as an alias for `name`.
     name = (args.get("name") or args.get("skill_id") or "").strip()
 
-    if action in ("list", "index", ""):
+    if action in ("list", "index"):
         all_skills = sm.load(owner=owner)
         if not all_skills:
             return {"results": "No skills yet. Create one with action='add'."}

--- a/tests/test_manage_skills_action_required.py
+++ b/tests/test_manage_skills_action_required.py
@@ -1,0 +1,24 @@
+import json
+
+import pytest
+
+from src.tools.system import do_manage_skills
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"action": ""},
+        {"action": "   "},
+        {"name": "demo", "description": "x", "procedure": ["step"]},
+    ],
+)
+async def test_manage_skills_requires_action(payload):
+    result = await do_manage_skills(json.dumps(payload), owner="test")
+
+    assert result == {
+        "error": "action is required (list|view|view_ref|add|edit|patch|publish|delete|search)",
+        "exit_code": 1,
+    }


### PR DESCRIPTION
## Summary

  Require `manage_skills` calls to provide an explicit `action` so malformed add/edit attempts fail
  with an error instead of silently returning the skills index. This keeps explicit `list`/`index`
  behavior working while making missing or blank actions visible to tool callers.

  ## Target branch

  - [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the
  maintainer at each release.

  ## Linked Issue

  Fixes #5604

  ## Type of Change

  - [x] Bug fix (non-breaking — fixes a confirmed issue)

  ## Checklist

  - [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs]
  (https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
  - [x] This PR targets `dev`
  - [x] My changes are limited to the scope described above — no unrelated refactors or whitespace
  changes mixed in.
  - [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change
  works end-to-end. Type-checks and unit tests are not enough.

  ## How to Test

  1. Run `python3 -m py_compile src/tools/system.py`.
  2. Run `pytest -q tests/test_manage_skills_action_required.py`.
  3. Confirm `manage_skills` with `{}` or an add-shaped payload missing `action` returns `exit_code:
  1`, while `{"action": "list"}` still returns the skills index.

  ## Visual / UI changes — REQUIRED if you touched anything that renders

  No visual/UI rendering changes.

  - [x] **No new component patterns.**

  ### Screenshots / clips

  Not applicable.