### PR TITLE
fix(chat): keep streaming TTS visible to errors

### DIFF
--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -1367,6 +1367,7 @@ import { wireArrowUpRecall, getUserMessagesFromChatHistory } from './composerArr
     let _renderStream = () => {};
     let _cancelThinkingTimer = () => {};
     let _removeThinkingSpinner = () => {};
+    let streamingTTS = false;
     let timeoutId = null;
     let responseTimeoutCleared = false;
     let clearResponseTimeout = () => {};
@@ -1897,7 +1898,7 @@ import { wireArrowUpRecall, getUserMessagesFromChatHistory } from './composerArr
       let isThinking = false;
       let thinkingStartTime = null;
       // Streaming TTS: synthesize sentence-by-sentence during streaming
-      const streamingTTS = !!(window.aiTTSManager && window.aiTTSManager.autoPlay && window.aiTTSManager.available);
+      streamingTTS = !!(window.aiTTSManager && window.aiTTSManager.autoPlay && window.aiTTSManager.available);
       if (streamingTTS) window.aiTTSManager.streamingStart();
       // Multi-bubble agent tracking
       let roundHolder = holder;       // Current AI text bubble (changes per round)

--- a/tests/test_chat_stream_scope.py
+++ b/tests/test_chat_stream_scope.py
@@ -12,8 +12,11 @@ def test_stream_render_helpers_are_visible_to_catch_block():
     assert "let _renderStream = () => {};" in outer_scope
     assert "let _cancelThinkingTimer = () => {};" in outer_scope
     assert "let _removeThinkingSpinner = () => {};" in outer_scope
+    assert "let streamingTTS = false;" in outer_scope
 
     assert "_renderStream = () => {" in try_body
     assert "_cancelThinkingTimer = () => {" in try_body
     assert "_removeThinkingSpinner = () => {" in try_body
+    assert "streamingTTS = !!(" in try_body
     assert "function _renderStream()" not in try_body
+    assert "const streamingTTS" not in try_body


### PR DESCRIPTION
## Summary

  Keep the chat error path from throwing a secondary `ReferenceError` when a request fails before
  streaming TTS is initialized. `streamingTTS` now lives in the outer stream state, so the catch block
  can clean up safely and show the original backend error.

  ## Target branch

  - [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the
  maintainer at each release.

  ## Linked Issue

  Fixes #5599

  ## Type of Change

  - [x] Bug fix (non-breaking — fixes a confirmed issue)

  ## Checklist

  - [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs]
  (https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
  - [x] This PR targets `dev`
  - [x] My changes are limited to the scope described above — no unrelated refactors or whitespace
  changes mixed in.
  - [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change
  works end-to-end. Type-checks and unit tests are not enough.

  ## How to Test

  1. Run `node --check static/js/chat.js`.
  2. Run `pytest -q tests/test_chat_stream_scope.py`.
  3. Trigger a chat request that fails before streaming starts and confirm the real error is shown
  instead of `ReferenceError: streamingTTS is not defined`.

  ## Visual / UI changes — REQUIRED if you touched anything that renders

  No visual/UI rendering changes. This only changes error-path variable scope in chat streaming.

  - [x] **No new component patterns.**

  ### Screenshots / clips

  Not applicable.