### PR TITLE
fix(macos): adopt a running Apfel instead of racing for its port

### DIFF
--- a/start-macos.sh
+++ b/start-macos.sh
@@ -170,7 +170,13 @@ ODYSSEUS_SKIP_RUN_HINT=1 ./venv/bin/python setup.py
 MACHINE_ARCH="$(uname -m)"
 APFEL_PID=""
 if [ "$MACHINE_ARCH" = "arm64" ]; then
-    if command -v apfel >/dev/null 2>&1; then
+    if (exec 3<>"/dev/tcp/127.0.0.1/11435") 2>/dev/null; then
+        # An Apfel from a previous run can outlive it (nohup'd child + a trap
+        # that never fires on force-quit). Adopt it instead of blindly racing
+        # for the port — same policy as ChromaDB below. APFEL_PID stays empty,
+        # so the EXIT trap won't kill a server this run didn't start.
+        echo "▶ Apfel already running on 127.0.0.1:11435 — using it."
+    elif command -v apfel >/dev/null 2>&1; then
         APFEL_LOG="${TMPDIR:-/tmp}/odysseus-apfel.log"
         echo "▶ Starting Apfel server in the background on port 11435…"
         echo "  logging to $APFEL_LOG"


### PR DESCRIPTION
## Summary

`start-macos.sh` launches Apfel with a blind `nohup apfel --serve --port 11435 &` and no check for an existing instance, even though the ChromaDB block ~25 lines below probes its port first and adopts a live one. Apfel is a `nohup`'d child reaped by the `EXIT INT TERM` trap, so when that trap doesn't fire (force-quit, `SIGKILL`, crash) the server outlives its run and every later start logs `error: Port 11435 is already in use`. This makes Apfel follow the policy ChromaDB already uses: probe `127.0.0.1:11435`, and adopt a running instance instead of racing it. `APFEL_PID` is deliberately left empty on the adopt path, so the EXIT trap — which guards each PID with `[ -n "$VAR" ]` — won't kill a server this run didn't start, matching `CHROMA_PID` ownership semantics exactly.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #5866

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

Reproduce the bug on `dev` first:

1. `./start-macos.sh` and wait for Apfel to bind 11435.
2. Force-quit the terminal window (do **not** Ctrl+C) so the EXIT trap never runs.
3. `lsof -nP -iTCP:11435 -sTCP:LISTEN` — Apfel is still listening.
4. `./start-macos.sh` again → `error: Port 11435 is already in use`.

Then with this branch checked out:

5. `./start-macos.sh` with the stray Apfel still listening → logs `▶ Apfel already running on 127.0.0.1:11435 — using it.` and starts cleanly, no error.
6. Confirm ownership is respected: exit the script normally (Ctrl+C), then re-run `lsof -nP -iTCP:11435 -sTCP:LISTEN`. The adopted instance is **still running** — the trap correctly did not kill a server this run didn't start.
7. Now kill the stray (`kill $(lsof -t -iTCP:11435 -sTCP:LISTEN)`) and run `./start-macos.sh` on a clean machine state → Apfel starts via the original path, and Ctrl+C **does** reap it (`lsof` comes back empty).
8. `bash -n start-macos.sh` passes.

Verified end-to-end on macOS 27.0 / Apple Silicon: full stack up on :7860 with ChromaDB :8100 and Apfel :11435, in both the adopt and the self-start paths.

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable — this changes only shell startup logic in `start-macos.sh`. No UI, CSS, HTML, SVG, or `static/js/` files are touched.

- [x] **No new component patterns.**
- [x] **Not a bulk PR.** Disclosure: this was prepared with agent assistance at a user's direction, and the commit carries a `Co-Authored-By` trailer to that effect. It is a single targeted fix for a bug the user hit on their own machine — the problem is described separately in #5866, per the guidance in this template — not an auto-generated bulk submission.