### PR TITLE
fix(chat): stop ArrowUp from eating an unsent multi-line prompt

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3908,85 +3908,10 @@ function startOdysseusApp() {
   const messageInput = el('message');
   const modelPickerWrap = document.getElementById('model-picker-wrap');
 
-  function _readComposerPromptHistory() {
-    const chatBox = document.getElementById('chat-history');
-    if (!chatBox) return [];
-    return Array.from(chatBox.querySelectorAll('.msg-user'))
-      .reverse()
-      .map(msg => {
-        const body = msg.querySelector('.body');
-        return msg.dataset?.raw || (body ? body.textContent : '') || '';
-      })
-      .filter(Boolean);
-  }
-
-  if (messageInput && !messageInput._odysseusPromptRecallCapture) {
-    messageInput._odysseusPromptRecallCapture = true;
-    let recallHistory = [];
-    let recallIndex = -1;
-    let lastRecalled = '';
-    const norm = (v) => String(v || '').replace(/\r\n/g, '\n').trimEnd();
-    messageInput.addEventListener('input', () => {
-      if (norm(messageInput.value) === norm(lastRecalled)) return;
-      recallHistory = [];
-      recallIndex = -1;
-      lastRecalled = '';
-      try { delete messageInput.dataset.odysseusRecallIndex; } catch {}
-    }, true);
-    messageInput.addEventListener('keydown', (e) => {
-      if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
-      if (e.shiftKey || e.altKey || e.ctrlKey || e.metaKey || e.isComposing) return;
-      if (window._ghostAutocomplete?.isActive?.()) return;
-      const fresh = _readComposerPromptHistory();
-      const history = fresh.length ? fresh : recallHistory;
-      if (!history.length) return;
-      const current = norm(messageInput.value);
-      let currentIndex = current ? history.findIndex(item => norm(item) === current) : -1;
-      if (current && currentIndex < 0 && current === norm(lastRecalled)) currentIndex = recallIndex;
-      if (current && currentIndex < 0) {
-        const markedIndex = Number(messageInput.dataset.odysseusRecallIndex);
-        if (Number.isInteger(markedIndex) && markedIndex >= 0 && markedIndex < history.length) {
-          currentIndex = markedIndex;
-        }
-      }
-      e.preventDefault();
-      e.stopPropagation();
-      e.stopImmediatePropagation();
-      if (e.key === 'ArrowDown') {
-        if (currentIndex < 0) return;
-        const nextIndex = currentIndex - 1;
-        if (nextIndex < 0) {
-          recallHistory = history;
-          recallIndex = -1;
-          lastRecalled = '';
-          try { delete messageInput.dataset.odysseusRecallIndex; } catch {}
-          messageInput.value = '';
-          try { messageInput.selectionStart = messageInput.selectionEnd = 0; } catch {}
-          try { uiModule.autoResize(messageInput); } catch {}
-          return;
-        }
-        const recalled = history[nextIndex];
-        recallHistory = history;
-        recallIndex = nextIndex;
-        lastRecalled = recalled;
-        try { messageInput.dataset.odysseusRecallIndex = String(nextIndex); } catch {}
-        messageInput.value = recalled;
-        try { messageInput.selectionStart = messageInput.selectionEnd = recalled.length; } catch {}
-        try { uiModule.autoResize(messageInput); } catch {}
-        return;
-      }
-      const nextIndex = currentIndex >= 0 ? Math.min(currentIndex + 1, history.length - 1) : 0;
-      const recalled = history[nextIndex];
-      if (!recalled) return;
-      recallHistory = history;
-      recallIndex = nextIndex;
-      lastRecalled = recalled;
-      try { messageInput.dataset.odysseusRecallIndex = String(nextIndex); } catch {}
-      messageInput.value = recalled;
-      try { messageInput.selectionStart = messageInput.selectionEnd = recalled.length; } catch {}
-      try { uiModule.autoResize(messageInput); } catch {}
-    }, true);
-  }
+  // ArrowUp/ArrowDown prompt recall on #message lives in
+  // static/js/composerArrowUpRecall.js (wired from chat.js). Do not re-add a
+  // copy here: two capture-phase listeners on the same textarea meant the one
+  // without the draft guard won and ate unsent multi-line prompts (#5862).
 
   const _sendIcon = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V5M5 12l7-7 7 7"/></svg>';
   const _micIcon = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/></svg>';

--- a/static/js/composerArrowUpRecall.js
+++ b/static/js/composerArrowUpRecall.js
@@ -143,9 +143,9 @@ export function wireArrowUpRecall(composer, getUserMessages, options = {}) {
       return;
     }
 
-    // ArrowUp owns prompt history in the chat composer. If the current text
-    // is not already a recalled prompt, start from newest instead of letting
-    // the browser move the caret inside the textarea.
+    // ArrowUp walks older prompts. An unmatched draft already returned above,
+    // so reaching here means the composer is empty or holds a recalled prompt
+    // — the caret-navigation case is never hijacked.
     const nextIndex = currentIndex >= 0 ? Math.min(currentIndex + 1, history.length - 1) : 0;
     const recalled = history[nextIndex];
     if (!recalled) {

--- a/tests/test_composer_arrow_up_recall_js.py
+++ b/tests/test_composer_arrow_up_recall_js.py
@@ -306,3 +306,24 @@ def test_integration_recalls_from_chat_history_dom():
     )
     assert proc.returncode == 0, proc.stderr
     assert json.loads(proc.stdout.strip()) == {"value": "stored prompt", "prevented": True}
+
+
+def test_prompt_recall_is_not_duplicated_in_app_js():
+    """Only composerArrowUpRecall.js may own ArrowUp on #message (issue #5862).
+
+    static/app.js once carried a near-verbatim copy of this recall logic, wired
+    as a second capture-phase listener on the same textarea. That copy lacked
+    the draft guard here, and because it called stopImmediatePropagation it won
+    regardless of registration order — so a typed multi-line prompt was replaced
+    by the last sent one instead of the caret moving up a line.
+    """
+    app_js = (_REPO / "static" / "app.js").read_text(encoding="utf-8")
+    for marker in (
+        "_odysseusPromptRecallCapture",
+        "_readComposerPromptHistory",
+        "odysseusRecallIndex",
+    ):
+        assert marker not in app_js, (
+            f"static/app.js reintroduces prompt recall ({marker!r}); "
+            "it belongs to static/js/composerArrowUpRecall.js alone"
+        )


### PR DESCRIPTION
## Summary

ArrowUp on the chat composer replaced an unsent multi-line prompt with the last sent one instead of moving the caret up a line. The cause was **two** prompt-recall implementations bound to the same `#message` textarea, both in the capture phase:

1. `static/js/composerArrowUpRecall.js` — the documented, tested one. It guards drafts at `composerArrowUpRecall.js:109`: if the composer is non-empty and its text doesn't match a history entry, it returns **without** `preventDefault()`, letting the browser move the caret.
2. `static/app.js` — a near-verbatim copy, untested, that **omits that guard**. It called `preventDefault()` + `stopPropagation()` + `stopImmediatePropagation()` unconditionally, then fell through to `nextIndex = currentIndex >= 0 ? … : 0`, recalling the newest prompt over the draft.

The copy won regardless of listener registration order: registered first, its `stopImmediatePropagation()` meant the module never saw the event; registered second, it still got the event because the module correctly declines to stop propagation on a draft. Either way the guard was unreachable on the real page.

Both copies arrived in the same squashed merge commit (`d8a2059`), which also left a comment in the module describing the *duplicate's* behavior, contradicting the guard 35 lines above it.

This PR deletes the duplicate (80 lines from `static/app.js`), leaving a comment pointing at the module so it doesn't come back; corrects that stale comment; and adds a regression test asserting `app.js` doesn't reintroduce a second handler. No behavior is added — it restores what `static/js/MODULE_SUMMARY.md` documents ("Recall last user message with `↑` on an empty composer") and what `tests/test_composer_arrow_up_recall_js.py` already pins via `test_non_empty_composer_does_not_recall` and `test_multiline_caret_navigation_preserved`.

### Behavior after the fix

| Composer state | ArrowUp |
|---|---|
| Empty | recalls newest prompt (unchanged) |
| Multi-line draft you typed | caret moves up a line, draft intact ✅ |
| Unedited prompt you just recalled | walks to the next-older prompt |
| Recalled prompt after any edit | caret moves up a line, text intact |

Row 3 is deliberate and unchanged: it's how shell history behaves, and it's what makes repeated `↑` walk backwards at all. Removing it would make a multi-line prompt in your history a wall you can't `↑` past. The issue's literal wording asks for line-walking there too; the reported symptom — "causing loss of the current unsent prompt" — is row 2, which this fixes.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #5862

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in. (The one adjacent edit is the stale comment in `composerArrowUpRecall.js`, which described the behavior this PR removes and would otherwise invite the regression back.)
- [x] I actually ran the app (`docker compose up`) and verified the change works end-to-end, in the browser, before and after.

## How to Test

**Reproduce first (on `dev`, before this patch).** Open a chat with a few sent prompts in it, then in the browser console:

```js
const t = document.getElementById('message');
t.value = 'line one\nline two'; t.selectionStart = t.selectionEnd = t.value.length;
t.dispatchEvent(new KeyboardEvent('keydown', {key:'ArrowUp', bubbles:true, cancelable:true}));
console.log(JSON.stringify(t.value));  // before: your last sent prompt — the draft is gone
```

**Then with this patch** the same snippet echoes `"line one\nline two"` back. By hand: type a multi-line prompt and press ↑ (caret moves up a line, draft intact); clear the composer and press ↑ (history recall still works, unchanged).

Note that `static/` is baked into the image, so verifying in Docker needs either `docker compose up -d --build odysseus` or a bind mount of `./static:/app/static:ro`, plus a hard refresh — `app.js` is served with a `?v=` string that this change does not bump.

**Tests:**

```
docker compose run --rm --no-deps -T \
  -v ~/odysseus/tests:/app/tests:ro -v ~/odysseus/static:/app/static:ro \
  --entrypoint python odysseus -m pytest tests/test_composer_arrow_up_recall_js.py -q
# 12 passed
```

The new test is not vacuous: run against the pre-fix `app.js` it fails (the old file has 9 hits for the removed markers, the new one has 0). Wiring both real handlers onto one textarea, with a multi-line draft and the caret on line 2:

| Wiring | Draft survived | `preventDefault` |
|---|---|---|
| module alone (the tested one) | **yes** | no — caret moves |
| `app.js` copy alone | **no** → `"newest prompt"` | yes |
| both, module registered first | **no** → `"newest prompt"` | yes |
| both, `app.js` registered first | **no** → `"newest prompt"` | yes |

## Visual / UI changes

No rendering change. This PR only deletes a keyboard event listener and edits two comments — no CSS, HTML, SVG, colors, spacing, or DOM-drawing code is touched, so there is nothing to screenshot. The composer looks identical; only what ArrowUp does to its contents differs.

## Disclosure

Written with the assistance of an LLM agent (Claude Code), per `CONTRIBUTING.md`. This is not a bulk auto-generated PR: it addresses a single pre-existing third-party issue (#5862), and the root cause, the reproduction, and the fix were each verified by hand in a running instance before submitting.
