### PR TITLE
fix(ui): skills panel cache not consistently showing skills present on disk until a hard browser refresh

### DIFF
--- a/static/js/skills.js
+++ b/static/js/skills.js
@@ -83,11 +83,9 @@ export async function loadSkills(cascade = false) {
   // Play the domino-in entrance on this load (set when the tab is opened,
   // not for the silent re-loads after an edit/delete).
   if (cascade) _cascadeNext = true;
-  if (cascade && loaded && !_loadPromise && _playSkillsCascade()) {
-    _cascadeNext = false;
-    updateCount();
-    return;
-  }
+  // Always re-fetch when the tab is explicitly opened — the cascade
+  // animation is handled inside renderSkillsList() via _cascadeNext.
+  // Skipping the fetch here caused stale data on panel close/reopen (#5870).
   if (_loadPromise) return _loadPromise;
   _loadPromise = (async () => {
   try {


### PR DESCRIPTION
## Summary

The Skills panel in the Memory modal cached rendered DOM and never refetched from the API when the tab was reopened. This meant newly added, edited, or deleted skills were invisible until a full page reload. The root cause was an early-return guard in loadSkills() that skipped both the API fetch and renderSkillsList() when data had already been loaded once. This removes that guard so every explicit tab-open triggers a fresh fetch + render. The cascade entrance animation is preserved inside renderSkillsList().

## Target branch

- [X] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

<!-- Every PR should be linked to an issue.
     Use one of:  Fixes #NNN  |  Part of #NNN  |  Closes #NNN  -->

Part of #5870

## Type of Change
- [X] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [X] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [X] This PR targets `dev`
- [X] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [X] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Open the Memory modal → Skills tab to seed the panel.
2. Add a new skill, edit an existing skill, or delete one through for example modifying the files in /odysseus/data/skills
3. Close the Memory modal.
4. Reopen the Memory modal → Skills tab.
5. Confirm the skills list reflects the changes made in step 2, without a full page reload.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [X] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [X] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [X] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [X] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

https://github.com/user-attachments/assets/ddd39e34-dcdf-41ad-9ecf-f4b24917d9df

