### PR TITLE
feat(rcaf): enforce durable carrier-coalition governance

### DIFF
--- a/src/rcaf/canonical_evolution.py
+++ b/src/rcaf/canonical_evolution.py
@@ -1,0 +1,713 @@
+# ============================================================
+# src/rcaf/canonical_evolution.py
+# ============================================================
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from src.rcaf.canonical_ledger import (
+    RCAF_CANONICAL_LEDGER_SCHEMA,
+)
+
+from src.rcaf.carrier_coalition import (
+    RCAF_CARRIER_COALITION_SCHEMA,
+)
+
+from src.rcaf.future_authority_ledger import (
+    RCAF_FUTURE_AUTHORITY_SCHEMA,
+)
+
+from src.rcaf.organizational_ledger import (
+    RCAF_ORGANIZATIONAL_LEDGER_SCHEMA,
+)
+
+
+RCAF_SCHEMA_EVOLUTION_SCHEMA = (
+    "RCAF-SCHEMA-EVOLUTION-0.2"
+)
+
+SCHEMA_DISPOSITIONS = frozenset(
+    {
+        "current",
+        "migration_required",
+        "unsupported",
+    }
+)
+
+CURRENT_SCHEMA_BY_FAMILY = {
+    "canonical_record": RCAF_CANONICAL_LEDGER_SCHEMA,
+    "carrier_coalition": RCAF_CARRIER_COALITION_SCHEMA,
+    "future_authority": RCAF_FUTURE_AUTHORITY_SCHEMA,
+    "organizational_record": RCAF_ORGANIZATIONAL_LEDGER_SCHEMA,
+}
+
+KNOWN_PREVIOUS_SCHEMAS_BY_FAMILY = {
+    "canonical_record": frozenset(
+        {
+            "RCAF-CANONICAL-FRAMEWORK-LEDGER-0.2",
+            "RCAF-CANONICAL-FRAMEWORK-LEDGER-0.3",
+        }
+    ),
+    "carrier_coalition": frozenset(),
+    "future_authority": frozenset(),
+    "organizational_record": frozenset(),
+}
+
+RCAF_CANONICAL_0_3_TO_0_4_REQUIRED_EXPLICIT_PATHS = (
+    "carrier_coalition",
+    "carrier_coalition.coalition",
+    "carrier_coalition.validity_relations",
+    "carrier_coalition.role_evidence",
+    "carrier_coalition.scaffold_dependence",
+    "carrier_coalition.scaffold_release",
+    "carrier_coalition.turbulence_channels",
+    "carrier_coalition.future_freedom",
+    "carrier_coalition.matched_experiment",
+    "carrier_coalition.equivalence_class",
+    "carrier_coalition.nomination",
+    "carrier_coalition.authority_contract",
+)
+
+
+_IDENTIFIER_PATTERN = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,191}$"
+)
+
+_FIELD_PATH_PATTERN = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9_.\[\]-]{0,255}$"
+)
+
+_SHA256_PATTERN = re.compile(
+    r"^[0-9a-f]{64}$"
+)
+
+
+class CanonicalSchemaEvolutionError(ValueError):
+    """Raised when a canonical schema-evolution contract is invalid."""
+
+
+def _require_identifier(
+    field_name: str,
+    value: str,
+) -> str:
+    normalized = str(value).strip()
+
+    if not _IDENTIFIER_PATTERN.fullmatch(normalized):
+        raise CanonicalSchemaEvolutionError(
+            f"{field_name} must be a static structural identifier"
+        )
+
+    return normalized
+
+
+def _require_schema_family(
+    value: str,
+) -> str:
+    normalized = str(value).strip()
+
+    if normalized not in CURRENT_SCHEMA_BY_FAMILY:
+        raise CanonicalSchemaEvolutionError(
+            "unknown schema family"
+        )
+
+    return normalized
+
+
+def _require_schema_name(
+    field_name: str,
+    value: str,
+) -> str:
+    normalized = str(value).strip()
+
+    if (
+        not normalized
+        or len(normalized) > 255
+        or any(
+            character.isspace()
+            for character in normalized
+        )
+    ):
+        raise CanonicalSchemaEvolutionError(
+            f"{field_name} must be a schema identifier"
+        )
+
+    return normalized
+
+
+def _require_sha256(
+    field_name: str,
+    value: str,
+) -> str:
+    normalized = str(value).strip()
+
+    if not _SHA256_PATTERN.fullmatch(normalized):
+        raise CanonicalSchemaEvolutionError(
+            f"{field_name} must be lowercase SHA-256"
+        )
+
+    return normalized
+
+
+def _require_field_path(
+    field_name: str,
+    value: str,
+) -> str:
+    normalized = str(value).strip()
+
+    if not _FIELD_PATH_PATTERN.fullmatch(normalized):
+        raise CanonicalSchemaEvolutionError(
+            f"{field_name} contains an invalid field path"
+        )
+
+    return normalized
+
+
+def _normalize_field_paths(
+    field_name: str,
+    values: tuple[str, ...],
+    *,
+    require_nonempty: bool = False,
+) -> tuple[str, ...]:
+    normalized = tuple(
+        _require_field_path(
+            field_name,
+            value,
+        )
+        for value in values
+    )
+
+    if require_nonempty and not normalized:
+        raise CanonicalSchemaEvolutionError(
+            f"{field_name} must not be empty"
+        )
+
+    if len(set(normalized)) != len(normalized):
+        raise CanonicalSchemaEvolutionError(
+            f"{field_name} contains duplicate field paths"
+        )
+
+    return normalized
+
+
+@dataclass(frozen=True)
+class SchemaEvaluation:
+    family: str
+    observed_schema: str
+    current_schema: str
+    disposition: str
+    automatic_migration_allowed: bool = False
+
+    def __post_init__(
+        self,
+    ) -> None:
+        family = _require_schema_family(
+            self.family
+        )
+
+        object.__setattr__(
+            self,
+            "family",
+            family,
+        )
+
+        object.__setattr__(
+            self,
+            "observed_schema",
+            _require_schema_name(
+                "observed_schema",
+                self.observed_schema,
+            ),
+        )
+
+        expected = CURRENT_SCHEMA_BY_FAMILY[
+            family
+        ]
+
+        if self.current_schema != expected:
+            raise CanonicalSchemaEvolutionError(
+                "current_schema does not match the registry"
+            )
+
+        if self.disposition not in SCHEMA_DISPOSITIONS:
+            raise CanonicalSchemaEvolutionError(
+                "invalid schema disposition"
+            )
+
+        if self.automatic_migration_allowed is not False:
+            raise CanonicalSchemaEvolutionError(
+                "automatic schema migration is forbidden"
+            )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "family": self.family,
+            "observed_schema": self.observed_schema,
+            "current_schema": self.current_schema,
+            "disposition": self.disposition,
+            "automatic_migration_allowed": False,
+        }
+
+
+@dataclass(frozen=True)
+class CanonicalSchemaSetValidation:
+    canonical_record: SchemaEvaluation
+    carrier_coalition: SchemaEvaluation
+    organizational_record: SchemaEvaluation
+    future_authority: SchemaEvaluation
+
+    def __post_init__(
+        self,
+    ) -> None:
+        expected_families = (
+            ("canonical_record", "canonical_record"),
+            ("carrier_coalition", "carrier_coalition"),
+            ("organizational_record", "organizational_record"),
+            ("future_authority", "future_authority"),
+        )
+
+        for field_name, expected_family in expected_families:
+            evaluation = getattr(
+                self,
+                field_name,
+            )
+
+            if not isinstance(
+                evaluation,
+                SchemaEvaluation,
+            ):
+                raise CanonicalSchemaEvolutionError(
+                    f"{field_name} must be SchemaEvaluation"
+                )
+
+            if evaluation.family != expected_family:
+                raise CanonicalSchemaEvolutionError(
+                    f"{field_name} must evaluate {expected_family}"
+                )
+
+    @property
+    def current(
+        self,
+    ) -> bool:
+        return all(
+            evaluation.disposition
+            == "current"
+            for evaluation in (
+                self.canonical_record,
+                self.carrier_coalition,
+                self.organizational_record,
+                self.future_authority,
+            )
+        )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "schema": RCAF_SCHEMA_EVOLUTION_SCHEMA,
+            "canonical_record": (
+                self.canonical_record.to_dict()
+            ),
+            "carrier_coalition": (
+                self.carrier_coalition.to_dict()
+            ),
+            "organizational_record": (
+                self.organizational_record.to_dict()
+            ),
+            "future_authority": (
+                self.future_authority.to_dict()
+            ),
+            "current": self.current,
+            "automatic_migration_allowed": False,
+        }
+
+
+@dataclass(frozen=True)
+class LosslessMigrationManifest:
+    migration_id: str
+    family: str
+    source_schema: str
+    target_schema: str
+    source_record_sha256: str
+    target_record_sha256: str
+    preserved_field_paths: tuple[str, ...]
+    renamed_field_paths: tuple[
+        tuple[str, str],
+        ...,
+    ] = ()
+    added_explicit_field_paths: tuple[str, ...] = ()
+    dropped_field_paths: tuple[str, ...] = ()
+    inferred_field_paths: tuple[str, ...] = ()
+    authority_posture_before: str = "observe_only"
+    authority_posture_after: str = "observe_only"
+    lossless: bool = True
+    automatic_migration: bool = False
+    raw_content_stored: bool = False
+    content_fingerprint_stored: bool = False
+
+    def __post_init__(
+        self,
+    ) -> None:
+        object.__setattr__(
+            self,
+            "migration_id",
+            _require_identifier(
+                "migration_id",
+                self.migration_id,
+            ),
+        )
+
+        family = _require_schema_family(
+            self.family
+        )
+
+        object.__setattr__(
+            self,
+            "family",
+            family,
+        )
+
+        source_schema = _require_schema_name(
+            "source_schema",
+            self.source_schema,
+        )
+
+        target_schema = _require_schema_name(
+            "target_schema",
+            self.target_schema,
+        )
+
+        if (
+            source_schema
+            not in KNOWN_PREVIOUS_SCHEMAS_BY_FAMILY[
+                family
+            ]
+        ):
+            raise CanonicalSchemaEvolutionError(
+                "source schema is not a registered previous schema"
+            )
+
+        if (
+            target_schema
+            != CURRENT_SCHEMA_BY_FAMILY[
+                family
+            ]
+        ):
+            raise CanonicalSchemaEvolutionError(
+                "target schema must be the current registered schema"
+            )
+
+        object.__setattr__(
+            self,
+            "source_schema",
+            source_schema,
+        )
+
+        object.__setattr__(
+            self,
+            "target_schema",
+            target_schema,
+        )
+
+        for field_name in (
+            "source_record_sha256",
+            "target_record_sha256",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_sha256(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        object.__setattr__(
+            self,
+            "preserved_field_paths",
+            _normalize_field_paths(
+                "preserved_field_paths",
+                self.preserved_field_paths,
+                require_nonempty=True,
+            ),
+        )
+
+        renamed = []
+
+        for source_path, target_path in (
+            self.renamed_field_paths
+        ):
+            renamed.append(
+                (
+                    _require_field_path(
+                        "renamed source path",
+                        source_path,
+                    ),
+                    _require_field_path(
+                        "renamed target path",
+                        target_path,
+                    ),
+                )
+            )
+
+        if len(set(renamed)) != len(renamed):
+            raise CanonicalSchemaEvolutionError(
+                "renamed_field_paths contains duplicates"
+            )
+
+        object.__setattr__(
+            self,
+            "renamed_field_paths",
+            tuple(renamed),
+        )
+
+        for field_name in (
+            "added_explicit_field_paths",
+            "dropped_field_paths",
+            "inferred_field_paths",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _normalize_field_paths(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        if (
+            self.family == "canonical_record"
+            and self.source_schema
+            == "RCAF-CANONICAL-FRAMEWORK-LEDGER-0.3"
+        ):
+            missing_explicit_paths = tuple(
+                path
+                for path in RCAF_CANONICAL_0_3_TO_0_4_REQUIRED_EXPLICIT_PATHS
+                if path not in self.added_explicit_field_paths
+            )
+
+            if missing_explicit_paths:
+                raise CanonicalSchemaEvolutionError(
+                    "canonical 0.3 to 0.4 migration requires "
+                    "all explicit carrier evidence paths"
+                )
+
+        if self.dropped_field_paths:
+            raise CanonicalSchemaEvolutionError(
+                "lossless migration cannot drop fields"
+            )
+
+        if self.inferred_field_paths:
+            raise CanonicalSchemaEvolutionError(
+                "migration cannot infer missing RCAF fields"
+            )
+
+        if (
+            self.authority_posture_before
+            != self.authority_posture_after
+        ):
+            raise CanonicalSchemaEvolutionError(
+                "migration cannot change authority posture"
+            )
+
+        if self.lossless is not True:
+            raise CanonicalSchemaEvolutionError(
+                "migration must be explicitly lossless"
+            )
+
+        if self.automatic_migration is not False:
+            raise CanonicalSchemaEvolutionError(
+                "automatic migration is forbidden"
+            )
+
+        if self.raw_content_stored is not False:
+            raise CanonicalSchemaEvolutionError(
+                "raw_content_stored must remain False"
+            )
+
+        if (
+            self.content_fingerprint_stored
+            is not False
+        ):
+            raise CanonicalSchemaEvolutionError(
+                "content_fingerprint_stored must remain False"
+            )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "schema": RCAF_SCHEMA_EVOLUTION_SCHEMA,
+            "migration_id": self.migration_id,
+            "family": self.family,
+            "source_schema": self.source_schema,
+            "target_schema": self.target_schema,
+            "source_record_sha256": self.source_record_sha256,
+            "target_record_sha256": self.target_record_sha256,
+            "preserved_field_paths": list(
+                self.preserved_field_paths
+            ),
+            "renamed_field_paths": [
+                {
+                    "source": source,
+                    "target": target,
+                }
+                for source, target
+                in self.renamed_field_paths
+            ],
+            "added_explicit_field_paths": list(
+                self.added_explicit_field_paths
+            ),
+            "dropped_field_paths": [],
+            "inferred_field_paths": [],
+            "authority_posture_before": (
+                self.authority_posture_before
+            ),
+            "authority_posture_after": (
+                self.authority_posture_after
+            ),
+            "lossless": True,
+            "automatic_migration": False,
+            "raw_content_stored": False,
+            "content_fingerprint_stored": False,
+        }
+
+    def canonical_json(
+        self,
+    ) -> str:
+        return json.dumps(
+            self.to_dict(),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+
+
+def evaluate_schema(
+    family: str,
+    observed_schema: str,
+) -> SchemaEvaluation:
+    family = _require_schema_family(
+        family
+    )
+
+    observed_schema = _require_schema_name(
+        "observed_schema",
+        observed_schema,
+    )
+
+    current_schema = (
+        CURRENT_SCHEMA_BY_FAMILY[
+            family
+        ]
+    )
+
+    if observed_schema == current_schema:
+        disposition = "current"
+
+    elif (
+        observed_schema
+        in KNOWN_PREVIOUS_SCHEMAS_BY_FAMILY[
+            family
+        ]
+    ):
+        disposition = "migration_required"
+
+    else:
+        disposition = "unsupported"
+
+    return SchemaEvaluation(
+        family=family,
+        observed_schema=observed_schema,
+        current_schema=current_schema,
+        disposition=disposition,
+    )
+
+
+def require_current_schema(
+    family: str,
+    observed_schema: str,
+) -> SchemaEvaluation:
+    evaluation = evaluate_schema(
+        family,
+        observed_schema,
+    )
+
+    if evaluation.disposition == "migration_required":
+        raise CanonicalSchemaEvolutionError(
+            f"{family} requires an explicit lossless migration manifest"
+        )
+
+    if evaluation.disposition == "unsupported":
+        raise CanonicalSchemaEvolutionError(
+            f"{family} schema is unsupported"
+        )
+
+    return evaluation
+
+
+def validate_canonical_record_schema_set(
+    record: dict[str, Any],
+) -> CanonicalSchemaSetValidation:
+    if not isinstance(record, dict):
+        raise CanonicalSchemaEvolutionError(
+            "canonical record must be an object"
+        )
+
+    carrier_coalition = record.get(
+        "carrier_coalition"
+    )
+
+    organizational = record.get(
+        "organizational_record"
+    )
+
+    future_authority = record.get(
+        "future_authority_evidence"
+    )
+
+    if not isinstance(carrier_coalition, dict):
+        raise CanonicalSchemaEvolutionError(
+            "carrier-coalition record is missing"
+        )
+
+    if not isinstance(organizational, dict):
+        raise CanonicalSchemaEvolutionError(
+            "organizational record is missing"
+        )
+
+    if not isinstance(future_authority, dict):
+        raise CanonicalSchemaEvolutionError(
+            "future-authority record is missing"
+        )
+
+    result = CanonicalSchemaSetValidation(
+        canonical_record=require_current_schema(
+            "canonical_record",
+            str(record.get("schema", "")),
+        ),
+        carrier_coalition=require_current_schema(
+            "carrier_coalition",
+            str(carrier_coalition.get("schema", "")),
+        ),
+        organizational_record=require_current_schema(
+            "organizational_record",
+            str(organizational.get("schema", "")),
+        ),
+        future_authority=require_current_schema(
+            "future_authority",
+            str(future_authority.get("schema", "")),
+        ),
+    )
+
+    if not result.current:
+        raise CanonicalSchemaEvolutionError(
+            "canonical schema set is not current"
+        )
+
+    return result

--- a/src/rcaf/canonical_ledger.py
+++ b/src/rcaf/canonical_ledger.py
@@ -1,0 +1,3072 @@
+# ============================================================
+# src/rcaf/canonical_ledger.py
+# ============================================================
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+from src.rcaf.future_authority_ledger import (
+    CALIBRATION_STATES,
+    MATCHED_CAUSAL_BRANCH_ROLES,
+    FutureConditionedAuthorityEvidenceBundle,
+)
+
+from src.rcaf.carrier_coalition import (
+    COMPONENT_ROLE_NAMES,
+    COUNTERFACTUAL_ARMS,
+    FUTURE_FREEDOM_COMPONENT_NAMES,
+    TURBULENCE_COMPONENT_NAMES,
+    RCAFCarrierCoalitionBundle,
+)
+
+from src.rcaf.organizational_ledger import (
+    MetricVector,
+    ParticipationGeometry,
+    RCAF_ATLAS_TYPES,
+    RCAFOrganizationalRecord,
+)
+
+
+RCAF_CANONICAL_LEDGER_SCHEMA = (
+    "RCAF-CANONICAL-FRAMEWORK-LEDGER-0.4"
+)
+
+RCAF_BROAD_ORGANIZATIONAL_CHAIN = (
+    "possibility",
+    "pressure",
+    "salience",
+    "curiosity",
+    "participation",
+    "mediation",
+    "realization",
+    "occupancy",
+    "persistence",
+    "feedback",
+    "modified_possibility",
+)
+
+RCAF_REALIZATION_GOVERNANCE_CHAIN = (
+    "possibility",
+    "proposal_gain_discovery",
+    "verification",
+    "transition_qualification",
+    "edge_admissibility",
+    "geometry_coherence",
+    "transformation_geometry",
+    "active_participation_permission",
+    "realization_injection",
+    "absorption",
+    "influence",
+    "persistence",
+    "release",
+    "modified_possibility",
+)
+
+RCAF_INTERFACE_PROPAGATION_CHAIN = (
+    "presence",
+    "expression",
+    "coupling",
+    "local_realization",
+    "propagation",
+    "absorption",
+    "persistence",
+    "global_influence",
+)
+
+RCAF_EVENT_COORDINATE_AXES = (
+    "T",
+    "O",
+    "X",
+    "Ref",
+    "Pi",
+    "Gamma",
+    "J",
+    "Q",
+    "B",
+    "H",
+    "E",
+)
+
+RCAF_PROCESS_STATUSES = frozenset(
+    {
+        "not_observed",
+        "possible",
+        "proposed",
+        "observed",
+        "partial",
+        "verified",
+        "qualified",
+        "admissible",
+        "authorized",
+        "executed",
+        "absorbed",
+        "influential",
+        "persistent",
+        "released",
+        "revoked",
+        "deferred",
+        "failed",
+        "rejected",
+    }
+)
+
+REFERENCE_VALIDITY_STATES = frozenset(
+    {
+        "unknown",
+        "provisional",
+        "valid",
+        "drifting",
+        "invalid",
+        "released",
+        "replaced",
+    }
+)
+
+TRIADIC_DEFERRAL_STATES = frozenset(
+    {
+        "not_evaluated",
+        "open",
+        "deferred",
+        "resolved",
+        "rejected",
+    }
+)
+
+GOLDILOCKS_REGIMES = frozenset(
+    {
+        "stagnant",
+        "bounded_explorative",
+        "chaotic",
+        "transitioning",
+        "unknown",
+    }
+)
+
+POLARITY_REGIMES = frozenset(
+    {
+        "ordinary",
+        "escape",
+        "inverse_goldilocks",
+        "mixed",
+        "unknown",
+    }
+)
+
+HARMONICS_RETENTION_STATES = frozenset(
+    {
+        "not_evaluated",
+        "retained",
+        "partial",
+        "lost",
+        "rejected",
+    }
+)
+
+AUTHORITY_LIFECYCLE_STATES = frozenset(
+    {
+        "none",
+        "proposed",
+        "permitted",
+        "granted",
+        "active",
+        "expired",
+        "released",
+        "revoked",
+        "denied",
+    }
+)
+
+COMMITMENT_STATES = frozenset(
+    {
+        "uncommitted",
+        "entering",
+        "committed",
+        "retained",
+        "releasing",
+        "released",
+        "revoked",
+    }
+)
+
+AUTHORITY_POSTURES = frozenset(
+    {
+        "observe_only",
+        "sandboxed",
+        "bounded",
+        "active",
+    }
+)
+
+RCAF_PRIMITIVE_NAMES = frozenset(
+    {
+        "coherence_psi",
+        "coherence_meta_field",
+        "activity_density_rho_a",
+        "coherence_density_rho_c",
+        "salience",
+        "realization_pressure_lambda",
+        "curiosity",
+        "viability_omega",
+        "occupancy_xi",
+        "future_freedom_f_xi",
+        "realization_coupling_kappa_r",
+        "absorption_a_r_h",
+        "mediation",
+        "feedback",
+    }
+)
+
+RCAF_CANONICAL_CAPABILITIES = frozenset(
+    {
+        "canonical_primitives",
+        "broad_organizational_chain",
+        "realization_governance_chain",
+        "reference_conditioning",
+        "triadic_participation",
+        "participation_corridor",
+        "goldilocks_regulation",
+        "harmonics_retention",
+        "proposal_gain_discovery",
+        "verification_evidence",
+        "boundary_admissibility",
+        "transformation_geometry",
+        "multi_space_coordinates",
+        "future_conditioned_authority",
+        "authority_lifecycle",
+        "interface_propagation_distinctions",
+        "realization_absorption_persistence_release",
+        "counterfactual_comparison",
+        "canonical_multi_atlas",
+        "e8_reference_geometry",
+        "leech_reference_geometry",
+        "monster_meta_atlas",
+        "causal_cone_reference",
+        "operator_flow_reference",
+        "minimal_event_coordinate",
+        "commitment_hysteresis",
+        "primitive_derived_separation",
+        "layered_decision_trace",
+        "observer_effects_linkage",
+        "observer_lineage_without_identity_claim",
+        "terminal_organizational_class_contract",
+        "forward_transition_map",
+        "backward_predecessor_map",
+        "bidirectional_corridor_consistency",
+        "matched_causal_branching",
+        "support_withdrawal_validation",
+        "anti_self_fulfilling_authority",
+        "frozen_acceptance_criteria",
+        "independent_evaluator",
+        "retrospective_atlas_extraction",
+        "prospective_gate_nomination",
+        "calibration_status",
+        "scenario_tail_evidence",
+        "gate_maturity_lifecycle",
+        "authority_evidence_separation",
+        "bidirectional_meta_field",
+        "no_literal_retrocausality",
+        "privacy_boundary",
+        "trajectory_admissible_carrier_coalition",
+        "carrier_validity_relations",
+        "multidimensional_component_roles",
+        "scaffold_dependence",
+        "scaffold_release_evidence",
+        "support_withdrawal_as_causal_intervention",
+        "multiscale_turbulence_channels",
+        "component_preserving_turbulence",
+        "turbulent_debt_observation",
+        "compression_future_freedom",
+        "topology_initialization_context_counterfactuals",
+        "dynamic_topology_counterfactual",
+        "microscopic_ticket_equivalence",
+        "prospective_coalition_nomination",
+        "reversible_pruning_contract",
+    }
+)
+
+_IDENTIFIER_PATTERN = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,191}$"
+)
+
+
+class RCAFCanonicalLedgerError(ValueError):
+    """Raised when a canonical RCAF contract is invalid."""
+
+
+def _require_identifier(
+    field_name: str,
+    value: str,
+) -> str:
+    normalized = str(value).strip()
+
+    if not _IDENTIFIER_PATTERN.fullmatch(normalized):
+        raise RCAFCanonicalLedgerError(
+            f"{field_name} must be a static structural identifier"
+        )
+
+    return normalized
+
+
+def _optional_identifier(
+    field_name: str,
+    value: str | None,
+) -> str | None:
+    if value is None:
+        return None
+
+    return _require_identifier(
+        field_name,
+        value,
+    )
+
+
+def _require_choice(
+    field_name: str,
+    value: str,
+    allowed: frozenset[str],
+) -> str:
+    normalized = str(value).strip()
+
+    if normalized not in allowed:
+        raise RCAFCanonicalLedgerError(
+            f"{field_name} must be one of {sorted(allowed)!r}; "
+            f"received {normalized!r}"
+        )
+
+    return normalized
+
+
+def _require_boolean(
+    field_name: str,
+    value: bool,
+) -> bool:
+    if not isinstance(value, bool):
+        raise RCAFCanonicalLedgerError(
+            f"{field_name} must be bool"
+        )
+
+    return value
+
+
+def _require_nonnegative_integer(
+    field_name: str,
+    value: int,
+) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value < 0
+    ):
+        raise RCAFCanonicalLedgerError(
+            f"{field_name} must be a non-negative integer"
+        )
+
+    return value
+
+
+def _require_utc_timestamp(
+    field_name: str,
+    value: str,
+) -> str:
+    normalized = str(value).strip()
+
+    try:
+        parsed = datetime.fromisoformat(
+            normalized.replace(
+                "Z",
+                "+00:00",
+            )
+        )
+    except ValueError as exc:
+        raise RCAFCanonicalLedgerError(
+            f"{field_name} must be an ISO-8601 timestamp"
+        ) from exc
+
+    if (
+        parsed.tzinfo is None
+        or parsed.utcoffset()
+        != timezone.utc.utcoffset(parsed)
+    ):
+        raise RCAFCanonicalLedgerError(
+            f"{field_name} must be UTC"
+        )
+
+    return normalized
+
+
+def _normalize_identifiers(
+    field_name: str,
+    values: tuple[str, ...],
+    *,
+    require_nonempty: bool = False,
+) -> tuple[str, ...]:
+    normalized = tuple(
+        _require_identifier(
+            field_name,
+            value,
+        )
+        for value in values
+    )
+
+    if require_nonempty and not normalized:
+        raise RCAFCanonicalLedgerError(
+            f"{field_name} must not be empty"
+        )
+
+    if len(set(normalized)) != len(normalized):
+        raise RCAFCanonicalLedgerError(
+            f"{field_name} contains duplicate identifiers"
+        )
+
+    return normalized
+
+
+def _require_vector(
+    field_name: str,
+    value: MetricVector,
+) -> MetricVector:
+    if not isinstance(value, MetricVector):
+        raise RCAFCanonicalLedgerError(
+            f"{field_name} must be MetricVector"
+        )
+
+    return value
+
+
+@dataclass(frozen=True)
+class HorizonMetric:
+    horizon: int
+    values: MetricVector
+
+    def __post_init__(
+        self,
+    ) -> None:
+        object.__setattr__(
+            self,
+            "horizon",
+            _require_nonnegative_integer(
+                "horizon",
+                self.horizon,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "values",
+            _require_vector(
+                "values",
+                self.values,
+            ),
+        )
+
+        if not self.values.components:
+            raise RCAFCanonicalLedgerError(
+                "horizon metric values must not be empty"
+            )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "horizon": self.horizon,
+            "values": self.values.to_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class ReferenceConditioning:
+    reference_contract_id: str
+    reference_point_id: str
+    reference_class_id: str
+    anchor_id: str | None
+    validity_state: str
+    reference_age_steps: int
+    observable_ids: tuple[str, ...]
+    drift: MetricVector = field(
+        default_factory=MetricVector
+    )
+    deviation: MetricVector = field(
+        default_factory=MetricVector
+    )
+    uncertainty: MetricVector = field(
+        default_factory=MetricVector
+    )
+    future_freedom: MetricVector = field(
+        default_factory=MetricVector
+    )
+    replacement_condition_ids: tuple[str, ...] = ()
+    release_condition_ids: tuple[str, ...] = ()
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "reference_contract_id",
+            "reference_point_id",
+            "reference_class_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        object.__setattr__(
+            self,
+            "anchor_id",
+            _optional_identifier(
+                "anchor_id",
+                self.anchor_id,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "validity_state",
+            _require_choice(
+                "validity_state",
+                self.validity_state,
+                REFERENCE_VALIDITY_STATES,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "reference_age_steps",
+            _require_nonnegative_integer(
+                "reference_age_steps",
+                self.reference_age_steps,
+            ),
+        )
+
+        for field_name in (
+            "observable_ids",
+            "replacement_condition_ids",
+            "release_condition_ids",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _normalize_identifiers(
+                    field_name,
+                    getattr(self, field_name),
+                    require_nonempty=(
+                        field_name == "observable_ids"
+                    ),
+                ),
+            )
+
+        for field_name in (
+            "drift",
+            "deviation",
+            "uncertainty",
+            "future_freedom",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_vector(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "reference_contract_id": self.reference_contract_id,
+            "reference_point_id": self.reference_point_id,
+            "reference_class_id": self.reference_class_id,
+            "anchor_id": self.anchor_id,
+            "validity_state": self.validity_state,
+            "reference_age_steps": self.reference_age_steps,
+            "observable_ids": list(self.observable_ids),
+            "drift": self.drift.to_dict(),
+            "deviation": self.deviation.to_dict(),
+            "uncertainty": self.uncertainty.to_dict(),
+            "future_freedom": self.future_freedom.to_dict(),
+            "replacement_condition_ids": list(
+                self.replacement_condition_ids
+            ),
+            "release_condition_ids": list(
+                self.release_condition_ids
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class PrimitiveObservableBundle:
+    reference_contract_id: str
+    coherence_psi: MetricVector
+    coherence_meta_field: MetricVector
+    activity_density_rho_a: MetricVector
+    coherence_density_rho_c: MetricVector
+    salience: MetricVector
+    realization_pressure_lambda: MetricVector
+    curiosity: MetricVector
+    viability_omega: MetricVector
+    occupancy_xi: MetricVector
+    future_freedom_f_xi: MetricVector
+    realization_coupling_kappa_r: MetricVector
+    absorption_a_r_h: tuple[HorizonMetric, ...]
+    mediation: MetricVector
+    feedback: MetricVector
+
+    def __post_init__(
+        self,
+    ) -> None:
+        object.__setattr__(
+            self,
+            "reference_contract_id",
+            _require_identifier(
+                "reference_contract_id",
+                self.reference_contract_id,
+            ),
+        )
+
+        for field_name in (
+            "coherence_psi",
+            "coherence_meta_field",
+            "activity_density_rho_a",
+            "coherence_density_rho_c",
+            "salience",
+            "realization_pressure_lambda",
+            "curiosity",
+            "viability_omega",
+            "occupancy_xi",
+            "future_freedom_f_xi",
+            "realization_coupling_kappa_r",
+            "mediation",
+            "feedback",
+        ):
+            vector = _require_vector(
+                field_name,
+                getattr(self, field_name),
+            )
+
+            if not vector.components:
+                raise RCAFCanonicalLedgerError(
+                    f"{field_name} must not be empty"
+                )
+
+            object.__setattr__(
+                self,
+                field_name,
+                vector,
+            )
+
+        horizons = tuple(
+            self.absorption_a_r_h
+        )
+
+        if not horizons:
+            raise RCAFCanonicalLedgerError(
+                "absorption_a_r_h must not be empty"
+            )
+
+        horizon_values = [
+            item.horizon
+            for item in horizons
+        ]
+
+        if len(set(horizon_values)) != len(horizon_values):
+            raise RCAFCanonicalLedgerError(
+                "absorption_a_r_h contains duplicate horizons"
+            )
+
+        object.__setattr__(
+            self,
+            "absorption_a_r_h",
+            tuple(
+                sorted(
+                    horizons,
+                    key=lambda item: item.horizon,
+                )
+            ),
+        )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "reference_contract_id": self.reference_contract_id,
+            "coherence_psi": self.coherence_psi.to_dict(),
+            "coherence_meta_field": (
+                self.coherence_meta_field.to_dict()
+            ),
+            "activity_density_rho_a": (
+                self.activity_density_rho_a.to_dict()
+            ),
+            "coherence_density_rho_c": (
+                self.coherence_density_rho_c.to_dict()
+            ),
+            "salience": self.salience.to_dict(),
+            "realization_pressure_lambda": (
+                self.realization_pressure_lambda.to_dict()
+            ),
+            "curiosity": self.curiosity.to_dict(),
+            "viability_omega": self.viability_omega.to_dict(),
+            "occupancy_xi": self.occupancy_xi.to_dict(),
+            "future_freedom_f_xi": (
+                self.future_freedom_f_xi.to_dict()
+            ),
+            "realization_coupling_kappa_r": (
+                self.realization_coupling_kappa_r.to_dict()
+            ),
+            "absorption_a_r_h": [
+                item.to_dict()
+                for item in self.absorption_a_r_h
+            ],
+            "mediation": self.mediation.to_dict(),
+            "feedback": self.feedback.to_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class ParticipationCorridor:
+    participation: ParticipationGeometry
+    selected_structure_ids: tuple[str, ...]
+    selected_direction_ids: tuple[str, ...]
+    corridor_id: str
+    triadic_deferral_state: str
+    goldilocks_regime: str
+    polarity_regime: str
+    harmonics_retention_state: str
+    transition_evidence_ids: tuple[str, ...] = ()
+
+    def __post_init__(
+        self,
+    ) -> None:
+        if not isinstance(
+            self.participation,
+            ParticipationGeometry,
+        ):
+            raise RCAFCanonicalLedgerError(
+                "participation must be ParticipationGeometry"
+            )
+
+        for field_name in (
+            "selected_structure_ids",
+            "selected_direction_ids",
+            "transition_evidence_ids",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _normalize_identifiers(
+                    field_name,
+                    getattr(self, field_name),
+                    require_nonempty=(
+                        field_name
+                        in {
+                            "selected_structure_ids",
+                            "selected_direction_ids",
+                        }
+                    ),
+                ),
+            )
+
+        object.__setattr__(
+            self,
+            "corridor_id",
+            _require_identifier(
+                "corridor_id",
+                self.corridor_id,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "triadic_deferral_state",
+            _require_choice(
+                "triadic_deferral_state",
+                self.triadic_deferral_state,
+                TRIADIC_DEFERRAL_STATES,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "goldilocks_regime",
+            _require_choice(
+                "goldilocks_regime",
+                self.goldilocks_regime,
+                GOLDILOCKS_REGIMES,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "polarity_regime",
+            _require_choice(
+                "polarity_regime",
+                self.polarity_regime,
+                POLARITY_REGIMES,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "harmonics_retention_state",
+            _require_choice(
+                "harmonics_retention_state",
+                self.harmonics_retention_state,
+                HARMONICS_RETENTION_STATES,
+            ),
+        )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "participation": self.participation.to_dict(),
+            "selected_structure_ids": list(
+                self.selected_structure_ids
+            ),
+            "selected_direction_ids": list(
+                self.selected_direction_ids
+            ),
+            "corridor_id": self.corridor_id,
+            "triadic_deferral_state": self.triadic_deferral_state,
+            "goldilocks_regime": self.goldilocks_regime,
+            "polarity_regime": self.polarity_regime,
+            "harmonics_retention_state": (
+                self.harmonics_retention_state
+            ),
+            "transition_evidence_ids": list(
+                self.transition_evidence_ids
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class StageObservation:
+    stage: str
+    status: str
+    evidence_ids: tuple[str, ...] = ()
+
+    def __post_init__(
+        self,
+    ) -> None:
+        object.__setattr__(
+            self,
+            "stage",
+            _require_identifier(
+                "stage",
+                self.stage,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "status",
+            _require_choice(
+                "status",
+                self.status,
+                RCAF_PROCESS_STATUSES,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "evidence_ids",
+            _normalize_identifiers(
+                "evidence_ids",
+                self.evidence_ids,
+            ),
+        )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "stage": self.stage,
+            "status": self.status,
+            "evidence_ids": list(self.evidence_ids),
+        }
+
+
+@dataclass(frozen=True)
+class ProcessChainObservation:
+    broad_chain: tuple[StageObservation, ...]
+    realization_governance_chain: tuple[
+        StageObservation,
+        ...,
+    ]
+
+    def __post_init__(
+        self,
+    ) -> None:
+        broad_stages = tuple(
+            item.stage
+            for item in self.broad_chain
+        )
+
+        governance_stages = tuple(
+            item.stage
+            for item in self.realization_governance_chain
+        )
+
+        if broad_stages != RCAF_BROAD_ORGANIZATIONAL_CHAIN:
+            raise RCAFCanonicalLedgerError(
+                "broad_chain must preserve the canonical order"
+            )
+
+        if (
+            governance_stages
+            != RCAF_REALIZATION_GOVERNANCE_CHAIN
+        ):
+            raise RCAFCanonicalLedgerError(
+                "realization_governance_chain must preserve "
+                "the canonical order"
+            )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "broad_chain": [
+                item.to_dict()
+                for item in self.broad_chain
+            ],
+            "realization_governance_chain": [
+                item.to_dict()
+                for item
+                in self.realization_governance_chain
+            ],
+        }
+
+
+@dataclass(frozen=True)
+class ProposalGainDiscovery:
+    candidate_ids: tuple[str, ...]
+    selected_candidate_id: str | None
+    gain_components: MetricVector
+    discovery_components: MetricVector
+    evidence_ids: tuple[str, ...] = ()
+    assumption_ids: tuple[str, ...] = ()
+    limitation_ids: tuple[str, ...] = ()
+
+    def __post_init__(
+        self,
+    ) -> None:
+        candidates = _normalize_identifiers(
+            "candidate_ids",
+            self.candidate_ids,
+            require_nonempty=True,
+        )
+
+        object.__setattr__(
+            self,
+            "candidate_ids",
+            candidates,
+        )
+
+        selected = _optional_identifier(
+            "selected_candidate_id",
+            self.selected_candidate_id,
+        )
+
+        if (
+            selected is not None
+            and selected not in candidates
+        ):
+            raise RCAFCanonicalLedgerError(
+                "selected_candidate_id must occur in candidate_ids"
+            )
+
+        object.__setattr__(
+            self,
+            "selected_candidate_id",
+            selected,
+        )
+
+        for field_name in (
+            "gain_components",
+            "discovery_components",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_vector(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        for field_name in (
+            "evidence_ids",
+            "assumption_ids",
+            "limitation_ids",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _normalize_identifiers(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "candidate_ids": list(self.candidate_ids),
+            "selected_candidate_id": self.selected_candidate_id,
+            "gain_components": self.gain_components.to_dict(),
+            "discovery_components": (
+                self.discovery_components.to_dict()
+            ),
+            "evidence_ids": list(self.evidence_ids),
+            "assumption_ids": list(self.assumption_ids),
+            "limitation_ids": list(self.limitation_ids),
+        }
+
+
+@dataclass(frozen=True)
+class TransformationGeometryRecord:
+    event_state_space_id: str
+    reference_space_id: str
+    proposal_tangent_space_id: str
+    causal_cone_space_id: str
+    response_parameter_space_id: str
+    outcome_composition_space_id: str
+    invariant_quotient_space_id: str
+    interface_coupling_space_id: str
+    propagation_path_space_id: str
+    operator_semigroup_space_id: str
+    evidence_status_space_id: str
+    meta_atlas_space_id: str
+    geometry_components: MetricVector
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "event_state_space_id",
+            "reference_space_id",
+            "proposal_tangent_space_id",
+            "causal_cone_space_id",
+            "response_parameter_space_id",
+            "outcome_composition_space_id",
+            "invariant_quotient_space_id",
+            "interface_coupling_space_id",
+            "propagation_path_space_id",
+            "operator_semigroup_space_id",
+            "evidence_status_space_id",
+            "meta_atlas_space_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        object.__setattr__(
+            self,
+            "geometry_components",
+            _require_vector(
+                "geometry_components",
+                self.geometry_components,
+            ),
+        )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            field_name: getattr(
+                self,
+                field_name,
+            )
+            for field_name in (
+                "event_state_space_id",
+                "reference_space_id",
+                "proposal_tangent_space_id",
+                "causal_cone_space_id",
+                "response_parameter_space_id",
+                "outcome_composition_space_id",
+                "invariant_quotient_space_id",
+                "interface_coupling_space_id",
+                "propagation_path_space_id",
+                "operator_semigroup_space_id",
+                "evidence_status_space_id",
+                "meta_atlas_space_id",
+            )
+        } | {
+            "geometry_components": (
+                self.geometry_components.to_dict()
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class InterfaceStageObservation:
+    stage: str
+    status: str
+    evidence_ids: tuple[str, ...] = ()
+
+    def __post_init__(
+        self,
+    ) -> None:
+        object.__setattr__(
+            self,
+            "stage",
+            _require_identifier(
+                "stage",
+                self.stage,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "status",
+            _require_choice(
+                "status",
+                self.status,
+                RCAF_PROCESS_STATUSES,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "evidence_ids",
+            _normalize_identifiers(
+                "evidence_ids",
+                self.evidence_ids,
+            ),
+        )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "stage": self.stage,
+            "status": self.status,
+            "evidence_ids": list(self.evidence_ids),
+        }
+
+
+@dataclass(frozen=True)
+class InterfacePropagationChain:
+    observations: tuple[
+        InterfaceStageObservation,
+        ...,
+    ]
+
+    def __post_init__(
+        self,
+    ) -> None:
+        stages = tuple(
+            item.stage
+            for item in self.observations
+        )
+
+        if stages != RCAF_INTERFACE_PROPAGATION_CHAIN:
+            raise RCAFCanonicalLedgerError(
+                "interface propagation stages must preserve "
+                "the canonical distinction chain"
+            )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "observations": [
+                item.to_dict()
+                for item in self.observations
+            ],
+        }
+
+
+@dataclass(frozen=True)
+class FutureConditionedAuthorityGate:
+    current_state_id: str
+    horizon: int
+    future_contract_id: str
+    terminal_organizational_class_id: str
+    forward_reachable_set_id: str
+    backward_predecessor_set_id: str
+    admissible_corridor_id: str
+    trajectory_ids: tuple[str, ...]
+    failure_mode_ids: tuple[str, ...]
+    forward_reachable: bool
+    backward_consistent: bool
+    gate_admissible: bool
+    uncertainty: MetricVector
+    future_freedom_cost: MetricVector
+    reversibility: MetricVector
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "current_state_id",
+            "future_contract_id",
+            "terminal_organizational_class_id",
+            "forward_reachable_set_id",
+            "backward_predecessor_set_id",
+            "admissible_corridor_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        object.__setattr__(
+            self,
+            "horizon",
+            _require_nonnegative_integer(
+                "horizon",
+                self.horizon,
+            ),
+        )
+
+        for field_name in (
+            "trajectory_ids",
+            "failure_mode_ids",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _normalize_identifiers(
+                    field_name,
+                    getattr(self, field_name),
+                    require_nonempty=(
+                        field_name == "trajectory_ids"
+                    ),
+                ),
+            )
+
+        for field_name in (
+            "forward_reachable",
+            "backward_consistent",
+            "gate_admissible",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_boolean(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        if (
+            self.gate_admissible
+            and not (
+                self.forward_reachable
+                and self.backward_consistent
+            )
+        ):
+            raise RCAFCanonicalLedgerError(
+                "gate_admissible requires forward reachability "
+                "and backward consistency"
+            )
+
+        for field_name in (
+            "uncertainty",
+            "future_freedom_cost",
+            "reversibility",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_vector(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "current_state_id": self.current_state_id,
+            "horizon": self.horizon,
+            "future_contract_id": self.future_contract_id,
+            "terminal_organizational_class_id": (
+                self.terminal_organizational_class_id
+            ),
+            "forward_reachable_set_id": (
+                self.forward_reachable_set_id
+            ),
+            "backward_predecessor_set_id": (
+                self.backward_predecessor_set_id
+            ),
+            "admissible_corridor_id": (
+                self.admissible_corridor_id
+            ),
+            "trajectory_ids": list(self.trajectory_ids),
+            "failure_mode_ids": list(self.failure_mode_ids),
+            "forward_reachable": self.forward_reachable,
+            "backward_consistent": self.backward_consistent,
+            "gate_admissible": self.gate_admissible,
+            "uncertainty": self.uncertainty.to_dict(),
+            "future_freedom_cost": (
+                self.future_freedom_cost.to_dict()
+            ),
+            "reversibility": self.reversibility.to_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class AuthorityLifecycleContract:
+    status: str
+    recipient_id: str
+    operation_id: str
+    proposal_id: str
+    permission_id: str | None = None
+    grant_id: str | None = None
+    authority_id: str | None = None
+    scope_ids: tuple[str, ...] = ()
+    boundary_ids: tuple[str, ...] = ()
+    evidence_ids: tuple[str, ...] = ()
+    future_corridor_id: str | None = None
+    containment_requirement_ids: tuple[str, ...] = ()
+    rollback_mechanism_id: str | None = None
+    release_condition_ids: tuple[str, ...] = ()
+    revocation_condition_ids: tuple[str, ...] = ()
+    duration_steps: int = 0
+    activated: bool = False
+    execution_performed: bool = False
+    verified_success: bool = False
+    persistence_observed: bool = False
+    residual_effects: MetricVector = field(
+        default_factory=MetricVector
+    )
+
+    def __post_init__(
+        self,
+    ) -> None:
+        object.__setattr__(
+            self,
+            "status",
+            _require_choice(
+                "status",
+                self.status,
+                AUTHORITY_LIFECYCLE_STATES,
+            ),
+        )
+
+        for field_name in (
+            "recipient_id",
+            "operation_id",
+            "proposal_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        for field_name in (
+            "permission_id",
+            "grant_id",
+            "authority_id",
+            "future_corridor_id",
+            "rollback_mechanism_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _optional_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        for field_name in (
+            "scope_ids",
+            "boundary_ids",
+            "evidence_ids",
+            "containment_requirement_ids",
+            "release_condition_ids",
+            "revocation_condition_ids",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _normalize_identifiers(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        object.__setattr__(
+            self,
+            "duration_steps",
+            _require_nonnegative_integer(
+                "duration_steps",
+                self.duration_steps,
+            ),
+        )
+
+        for field_name in (
+            "activated",
+            "execution_performed",
+            "verified_success",
+            "persistence_observed",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_boolean(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        if (
+            self.verified_success
+            and not self.execution_performed
+        ):
+            raise RCAFCanonicalLedgerError(
+                "verified_success requires execution_performed"
+            )
+
+        if (
+            self.persistence_observed
+            and not self.verified_success
+        ):
+            raise RCAFCanonicalLedgerError(
+                "persistence_observed requires verified_success"
+            )
+
+        object.__setattr__(
+            self,
+            "residual_effects",
+            _require_vector(
+                "residual_effects",
+                self.residual_effects,
+            ),
+        )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "status": self.status,
+            "recipient_id": self.recipient_id,
+            "operation_id": self.operation_id,
+            "proposal_id": self.proposal_id,
+            "permission_id": self.permission_id,
+            "grant_id": self.grant_id,
+            "authority_id": self.authority_id,
+            "scope_ids": list(self.scope_ids),
+            "boundary_ids": list(self.boundary_ids),
+            "evidence_ids": list(self.evidence_ids),
+            "future_corridor_id": self.future_corridor_id,
+            "containment_requirement_ids": list(
+                self.containment_requirement_ids
+            ),
+            "rollback_mechanism_id": (
+                self.rollback_mechanism_id
+            ),
+            "release_condition_ids": list(
+                self.release_condition_ids
+            ),
+            "revocation_condition_ids": list(
+                self.revocation_condition_ids
+            ),
+            "duration_steps": self.duration_steps,
+            "activated": self.activated,
+            "execution_performed": self.execution_performed,
+            "verified_success": self.verified_success,
+            "persistence_observed": self.persistence_observed,
+            "residual_effects": self.residual_effects.to_dict(),
+        }
+
+
+def _forbid_governing_gate(
+    governing_gate: bool,
+) -> None:
+    if governing_gate is not False:
+        raise RCAFCanonicalLedgerError(
+            "reference geometry cannot be a governing gate"
+        )
+
+
+@dataclass(frozen=True)
+class E8LocalHarmonicReference:
+    chart_id: str
+    nearest_root_basin_id: str
+    root_margin: MetricVector
+    root_decisiveness: MetricVector
+    harmonics_retention: MetricVector
+    governing_gate: bool = False
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "chart_id",
+            "nearest_root_basin_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        _forbid_governing_gate(
+            self.governing_gate
+        )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "reference_family": "E8",
+            "chart_id": self.chart_id,
+            "nearest_root_basin_id": (
+                self.nearest_root_basin_id
+            ),
+            "root_margin": self.root_margin.to_dict(),
+            "root_decisiveness": (
+                self.root_decisiveness.to_dict()
+            ),
+            "harmonics_retention": (
+                self.harmonics_retention.to_dict()
+            ),
+            "governing_gate": False,
+        }
+
+
+@dataclass(frozen=True)
+class LeechGlobalCompatibilityReference:
+    atlas_id: str
+    compatibility: MetricVector
+    packing: MetricVector
+    gluing: MetricVector
+    rootless_silence: MetricVector
+    governing_gate: bool = False
+
+    def __post_init__(
+        self,
+    ) -> None:
+        object.__setattr__(
+            self,
+            "atlas_id",
+            _require_identifier(
+                "atlas_id",
+                self.atlas_id,
+            ),
+        )
+
+        _forbid_governing_gate(
+            self.governing_gate
+        )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "reference_family": "LeechLike",
+            "atlas_id": self.atlas_id,
+            "compatibility": self.compatibility.to_dict(),
+            "packing": self.packing.to_dict(),
+            "gluing": self.gluing.to_dict(),
+            "rootless_silence": (
+                self.rootless_silence.to_dict()
+            ),
+            "governing_gate": False,
+        }
+
+
+@dataclass(frozen=True)
+class MonsterMetaAtlasReference:
+    meta_atlas_id: str
+    transition_flow_atlas_ids: tuple[str, ...]
+    symmetry_relation_ids: tuple[str, ...]
+    governing_gate: bool = False
+
+    def __post_init__(
+        self,
+    ) -> None:
+        object.__setattr__(
+            self,
+            "meta_atlas_id",
+            _require_identifier(
+                "meta_atlas_id",
+                self.meta_atlas_id,
+            ),
+        )
+
+        for field_name in (
+            "transition_flow_atlas_ids",
+            "symmetry_relation_ids",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _normalize_identifiers(
+                    field_name,
+                    getattr(self, field_name),
+                    require_nonempty=True,
+                ),
+            )
+
+        _forbid_governing_gate(
+            self.governing_gate
+        )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "reference_family": "MonsterMoonshine",
+            "meta_atlas_id": self.meta_atlas_id,
+            "transition_flow_atlas_ids": list(
+                self.transition_flow_atlas_ids
+            ),
+            "symmetry_relation_ids": list(
+                self.symmetry_relation_ids
+            ),
+            "governing_gate": False,
+        }
+
+
+@dataclass(frozen=True)
+class CausalConeReference:
+    causal_cone_id: str
+    admissible_direction_ids: tuple[str, ...]
+    interval_geometry: MetricVector
+    governing_gate: bool = False
+
+    def __post_init__(
+        self,
+    ) -> None:
+        object.__setattr__(
+            self,
+            "causal_cone_id",
+            _require_identifier(
+                "causal_cone_id",
+                self.causal_cone_id,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "admissible_direction_ids",
+            _normalize_identifiers(
+                "admissible_direction_ids",
+                self.admissible_direction_ids,
+                require_nonempty=True,
+            ),
+        )
+
+        _forbid_governing_gate(
+            self.governing_gate
+        )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "reference_family": "MinkowskiLorentzian",
+            "causal_cone_id": self.causal_cone_id,
+            "admissible_direction_ids": list(
+                self.admissible_direction_ids
+            ),
+            "interval_geometry": (
+                self.interval_geometry.to_dict()
+            ),
+            "governing_gate": False,
+        }
+
+
+@dataclass(frozen=True)
+class OperatorFlowReference:
+    operator_id: str
+    semigroup_id: str
+    generator_id: str
+    flow_metrics: MetricVector
+    governing_gate: bool = False
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "operator_id",
+            "semigroup_id",
+            "generator_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        _forbid_governing_gate(
+            self.governing_gate
+        )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "reference_family": "RemizovChernoff",
+            "operator_id": self.operator_id,
+            "semigroup_id": self.semigroup_id,
+            "generator_id": self.generator_id,
+            "flow_metrics": self.flow_metrics.to_dict(),
+            "governing_gate": False,
+        }
+
+
+@dataclass(frozen=True)
+class GeometricReferenceBundle:
+    e8: E8LocalHarmonicReference
+    leech: LeechGlobalCompatibilityReference
+    monster: MonsterMetaAtlasReference
+    causal_cone: CausalConeReference
+    operator_flow: OperatorFlowReference
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "e8": self.e8.to_dict(),
+            "leech": self.leech.to_dict(),
+            "monster": self.monster.to_dict(),
+            "causal_cone": self.causal_cone.to_dict(),
+            "operator_flow": self.operator_flow.to_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class CommitmentHysteresisRecord:
+    corridor_id: str
+    reference_contract_id: str
+    state: str
+    entry_threshold: MetricVector
+    retention_threshold: MetricVector
+    release_threshold: MetricVector
+    future_freedom_remaining: MetricVector
+    indecision_avoidance_active: bool
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "corridor_id",
+            "reference_contract_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        object.__setattr__(
+            self,
+            "state",
+            _require_choice(
+                "state",
+                self.state,
+                COMMITMENT_STATES,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "indecision_avoidance_active",
+            _require_boolean(
+                "indecision_avoidance_active",
+                self.indecision_avoidance_active,
+            ),
+        )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "corridor_id": self.corridor_id,
+            "reference_contract_id": self.reference_contract_id,
+            "state": self.state,
+            "entry_threshold": self.entry_threshold.to_dict(),
+            "retention_threshold": (
+                self.retention_threshold.to_dict()
+            ),
+            "release_threshold": (
+                self.release_threshold.to_dict()
+            ),
+            "future_freedom_remaining": (
+                self.future_freedom_remaining.to_dict()
+            ),
+            "indecision_avoidance_active": (
+                self.indecision_avoidance_active
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class MinimalEventCoordinate:
+    T: str
+    O: str
+    X: str
+    Ref: str
+    Pi: str
+    Gamma: str
+    J: str
+    Q: str
+    B: str
+    H: str
+    E: str
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for axis in RCAF_EVENT_COORDINATE_AXES:
+            object.__setattr__(
+                self,
+                axis,
+                _require_identifier(
+                    axis,
+                    getattr(self, axis),
+                ),
+            )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            axis: getattr(
+                self,
+                axis,
+            )
+            for axis in RCAF_EVENT_COORDINATE_AXES
+        }
+
+
+@dataclass(frozen=True)
+class ConditionedDecisionTrace:
+    component_observable_ids: tuple[str, ...]
+    intermediate_geometry_ids: tuple[str, ...]
+    conditioned_decision_ids: tuple[str, ...]
+    order_preserved: bool = True
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "component_observable_ids",
+            "intermediate_geometry_ids",
+            "conditioned_decision_ids",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _normalize_identifiers(
+                    field_name,
+                    getattr(self, field_name),
+                    require_nonempty=True,
+                ),
+            )
+
+        if self.order_preserved is not True:
+            raise RCAFCanonicalLedgerError(
+                "component-to-geometry-to-decision order "
+                "must remain preserved"
+            )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "component_observable_ids": list(
+                self.component_observable_ids
+            ),
+            "intermediate_geometry_ids": list(
+                self.intermediate_geometry_ids
+            ),
+            "conditioned_decision_ids": list(
+                self.conditioned_decision_ids
+            ),
+            "order_preserved": True,
+        }
+
+
+@dataclass(frozen=True)
+class DerivedDiagnosticRecord:
+    diagnostic_name: str
+    values: MetricVector
+    derived_from_component_ids: tuple[str, ...]
+
+    def __post_init__(
+        self,
+    ) -> None:
+        object.__setattr__(
+            self,
+            "diagnostic_name",
+            _require_identifier(
+                "diagnostic_name",
+                self.diagnostic_name,
+            ),
+        )
+
+        if self.diagnostic_name in RCAF_PRIMITIVE_NAMES:
+            raise RCAFCanonicalLedgerError(
+                "primitive observables cannot be stored as "
+                "derived diagnostics"
+            )
+
+        object.__setattr__(
+            self,
+            "derived_from_component_ids",
+            _normalize_identifiers(
+                "derived_from_component_ids",
+                self.derived_from_component_ids,
+                require_nonempty=True,
+            ),
+        )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "diagnostic_name": self.diagnostic_name,
+            "values": self.values.to_dict(),
+            "derived_from_component_ids": list(
+                self.derived_from_component_ids
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class RCAFFullFrameworkRecord:
+    record_id: str
+    event_spine_id: str
+    lineage_id: str
+    occurred_at_utc: str
+    observer_lineage_id: str
+    observer_role_id: str
+    observer_effects_record_id: str
+    organizational_record: RCAFOrganizationalRecord
+    reference_conditioning: ReferenceConditioning
+    primitives: PrimitiveObservableBundle
+    participation: ParticipationCorridor
+    process_chains: ProcessChainObservation
+    proposal_gain: ProposalGainDiscovery
+    transformation_geometry: TransformationGeometryRecord
+    interface_propagation: InterfacePropagationChain
+    future_gate: FutureConditionedAuthorityGate
+    future_authority_evidence: (
+        FutureConditionedAuthorityEvidenceBundle
+    )
+    carrier_coalition: RCAFCarrierCoalitionBundle
+    authority_lifecycle: AuthorityLifecycleContract
+    geometric_references: GeometricReferenceBundle
+    commitment: CommitmentHysteresisRecord
+    event_coordinate: MinimalEventCoordinate
+    decision_trace: ConditionedDecisionTrace
+    derived_diagnostics: tuple[
+        DerivedDiagnosticRecord,
+        ...,
+    ]
+    authority_posture: str = "observe_only"
+    semantic_memory_authority: bool = False
+    identity_proof_established: bool = False
+    realization_authorized: bool = False
+    external_causal_authority: bool = False
+    self_modification_authority: bool = False
+    raw_content_stored: bool = False
+    content_fingerprint_stored: bool = False
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "record_id",
+            "event_spine_id",
+            "lineage_id",
+            "observer_lineage_id",
+            "observer_role_id",
+            "observer_effects_record_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        object.__setattr__(
+            self,
+            "occurred_at_utc",
+            _require_utc_timestamp(
+                "occurred_at_utc",
+                self.occurred_at_utc,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "authority_posture",
+            _require_choice(
+                "authority_posture",
+                self.authority_posture,
+                AUTHORITY_POSTURES,
+            ),
+        )
+
+        if not isinstance(
+            self.organizational_record,
+            RCAFOrganizationalRecord,
+        ):
+            raise RCAFCanonicalLedgerError(
+                "organizational_record must be "
+                "RCAFOrganizationalRecord"
+            )
+
+        atlas_types = {
+            link.atlas_type
+            for link
+            in self.organizational_record.atlas_links
+        }
+
+        if atlas_types != RCAF_ATLAS_TYPES:
+            raise RCAFCanonicalLedgerError(
+                "organizational_record must link every "
+                "canonical RCAF atlas type"
+            )
+
+        if (
+            self.primitives.reference_contract_id
+            != self.reference_conditioning.reference_contract_id
+        ):
+            raise RCAFCanonicalLedgerError(
+                "primitive observables must be explicitly "
+                "conditioned on the active reference contract"
+            )
+
+        if not isinstance(
+            self.future_authority_evidence,
+            FutureConditionedAuthorityEvidenceBundle,
+        ):
+            raise RCAFCanonicalLedgerError(
+                "future_authority_evidence must be "
+                "FutureConditionedAuthorityEvidenceBundle"
+            )
+
+        bundle = self.future_authority_evidence
+
+        if not isinstance(
+            self.carrier_coalition,
+            RCAFCarrierCoalitionBundle,
+        ):
+            raise RCAFCanonicalLedgerError(
+                "carrier_coalition must be "
+                "RCAFCarrierCoalitionBundle"
+            )
+
+        carrier_bundle = self.carrier_coalition
+        carrier = carrier_bundle.coalition
+
+        if (
+            carrier.reference_contract_id
+            != self.reference_conditioning.reference_contract_id
+        ):
+            raise RCAFCanonicalLedgerError(
+                "carrier coalition is conditioned on "
+                "the wrong reference contract"
+            )
+
+        if (
+            carrier.terminal_organizational_class_id
+            != self.future_gate.terminal_organizational_class_id
+        ):
+            raise RCAFCanonicalLedgerError(
+                "carrier coalition terminal organizational "
+                "class mismatch"
+            )
+
+        if (
+            carrier_bundle.scaffold_dependence.reference_contract_id
+            != self.reference_conditioning.reference_contract_id
+            or carrier_bundle.scaffold_release.reference_contract_id
+            != self.reference_conditioning.reference_contract_id
+            or carrier_bundle.future_freedom.reference_contract_id
+            != self.reference_conditioning.reference_contract_id
+        ):
+            raise RCAFCanonicalLedgerError(
+                "carrier evidence is conditioned on "
+                "the wrong reference contract"
+            )
+
+        if (
+            carrier_bundle.nomination.matched_experiment_id
+            != carrier_bundle.matched_experiment.experiment_id
+        ):
+            raise RCAFCanonicalLedgerError(
+                "carrier nomination experiment linkage mismatch"
+            )
+
+        if (
+            carrier_bundle.nomination.acceptance_contract_id
+            != carrier_bundle.matched_experiment.acceptance_contract_id
+        ):
+            raise RCAFCanonicalLedgerError(
+                "carrier nomination acceptance-contract mismatch"
+            )
+
+        if (
+            carrier_bundle.equivalence_class
+            .terminal_organizational_class_id
+            != self.future_gate.terminal_organizational_class_id
+        ):
+            raise RCAFCanonicalLedgerError(
+                "ticket equivalence terminal-class mismatch"
+            )
+
+        if (
+            carrier_bundle.authority_contract.authority_status
+            != "observe_only"
+            or carrier_bundle.authority_contract
+            .external_causal_authority
+            is not False
+            or carrier_bundle.authority_contract
+            .self_modification_authority
+            is not False
+            or carrier_bundle.authority_contract
+            .no_auto_promotion
+            is not True
+        ):
+            raise RCAFCanonicalLedgerError(
+                "carrier pruning contract violates "
+                "observe-only authority"
+            )
+
+        if (
+            carrier_bundle.raw_content_stored
+            is not False
+            or carrier_bundle.content_fingerprint_stored
+            is not False
+        ):
+            raise RCAFCanonicalLedgerError(
+                "carrier coalition violates privacy"
+            )
+
+        organizational_future = (
+            self.organizational_record.future_conditioning
+        )
+
+        if organizational_future is None:
+            raise RCAFCanonicalLedgerError(
+                "full framework record requires organizational "
+                "future-conditioning evidence"
+            )
+
+        if (
+            bundle.terminal_contract.contract_id
+            != self.future_gate.future_contract_id
+            or organizational_future.terminal_contract_id
+            != self.future_gate.future_contract_id
+        ):
+            raise RCAFCanonicalLedgerError(
+                "future contract mismatch across canonical records"
+            )
+
+        if (
+            bundle.terminal_contract.terminal_class_id
+            != self.future_gate.terminal_organizational_class_id
+            or organizational_future.terminal_class_id
+            != self.future_gate.terminal_organizational_class_id
+        ):
+            raise RCAFCanonicalLedgerError(
+                "terminal organizational class mismatch"
+            )
+
+        if (
+            bundle.forward_evidence.current_state_id
+            != self.future_gate.current_state_id
+        ):
+            raise RCAFCanonicalLedgerError(
+                "current-state linkage mismatch"
+            )
+
+        if (
+            bundle.forward_evidence.reachable_set_id
+            != self.future_gate.forward_reachable_set_id
+        ):
+            raise RCAFCanonicalLedgerError(
+                "forward reachable-set linkage mismatch"
+            )
+
+        if (
+            bundle.backward_evidence.predecessor_set_id
+            != self.future_gate.backward_predecessor_set_id
+        ):
+            raise RCAFCanonicalLedgerError(
+                "backward predecessor-set linkage mismatch"
+            )
+
+        if (
+            self.future_gate.admissible_corridor_id
+            not in bundle.consistency.shared_corridor_ids
+            or organizational_future.corridor_id
+            != self.future_gate.admissible_corridor_id
+        ):
+            raise RCAFCanonicalLedgerError(
+                "admissible-corridor linkage mismatch"
+            )
+
+        if (
+            bundle.forward_evidence.forward_reachable
+            != self.future_gate.forward_reachable
+            or bundle.backward_evidence.backward_consistent
+            != self.future_gate.backward_consistent
+            or bundle.consistency.gate_admissible
+            != self.future_gate.gate_admissible
+        ):
+            raise RCAFCanonicalLedgerError(
+                "future-gate conclusion mismatch"
+            )
+
+        if (
+            bundle.backward_evidence.required_reference_contract_id
+            != self.reference_conditioning.reference_contract_id
+            or bundle.prospective_nomination.reference_contract_id
+            != self.reference_conditioning.reference_contract_id
+        ):
+            raise RCAFCanonicalLedgerError(
+                "future-authority evidence is conditioned on "
+                "the wrong reference contract"
+            )
+
+        if (
+            self.authority_lifecycle.future_corridor_id
+            != self.future_gate.admissible_corridor_id
+        ):
+            raise RCAFCanonicalLedgerError(
+                "authority lifecycle corridor mismatch"
+            )
+
+        if self.authority_posture == "observe_only":
+            if (
+                bundle.lifecycle.authority_status
+                != "observe_only"
+            ):
+                raise RCAFCanonicalLedgerError(
+                    "observe-only canonical record requires "
+                    "observe-only future-gate authority status"
+                )
+
+            if bundle.causal_authority_eligible:
+                raise RCAFCanonicalLedgerError(
+                    "observe-only canonical record cannot be "
+                    "future-authority eligible"
+                )
+
+        diagnostics = tuple(
+            self.derived_diagnostics
+        )
+
+        if not diagnostics:
+            raise RCAFCanonicalLedgerError(
+                "derived_diagnostics must not be empty"
+            )
+
+        diagnostic_names = [
+            item.diagnostic_name
+            for item in diagnostics
+        ]
+
+        if len(set(diagnostic_names)) != len(diagnostic_names):
+            raise RCAFCanonicalLedgerError(
+                "derived_diagnostics contains duplicate names"
+            )
+
+        object.__setattr__(
+            self,
+            "derived_diagnostics",
+            diagnostics,
+        )
+
+        for field_name in (
+            "semantic_memory_authority",
+            "identity_proof_established",
+            "realization_authorized",
+            "external_causal_authority",
+            "self_modification_authority",
+            "raw_content_stored",
+            "content_fingerprint_stored",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_boolean(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        if self.authority_posture == "observe_only":
+            forbidden = {
+                "semantic_memory_authority": (
+                    self.semantic_memory_authority
+                ),
+                "identity_proof_established": (
+                    self.identity_proof_established
+                ),
+                "realization_authorized": (
+                    self.realization_authorized
+                ),
+                "external_causal_authority": (
+                    self.external_causal_authority
+                ),
+                "self_modification_authority": (
+                    self.self_modification_authority
+                ),
+            }
+
+            active = sorted(
+                name
+                for name, value in forbidden.items()
+                if value
+            )
+
+            if active:
+                raise RCAFCanonicalLedgerError(
+                    "observe_only posture forbids: "
+                    f"{active!r}"
+                )
+
+        if self.raw_content_stored is not False:
+            raise RCAFCanonicalLedgerError(
+                "raw_content_stored must remain False"
+            )
+
+        if self.content_fingerprint_stored is not False:
+            raise RCAFCanonicalLedgerError(
+                "content_fingerprint_stored must remain False"
+            )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "schema": RCAF_CANONICAL_LEDGER_SCHEMA,
+            "record_id": self.record_id,
+            "event_spine_id": self.event_spine_id,
+            "lineage_id": self.lineage_id,
+            "occurred_at_utc": self.occurred_at_utc,
+            "observer_lineage_id": self.observer_lineage_id,
+            "observer_role_id": self.observer_role_id,
+            "observer_effects_record_id": (
+                self.observer_effects_record_id
+            ),
+            "organizational_record": (
+                self.organizational_record.to_dict()
+            ),
+            "reference_conditioning": (
+                self.reference_conditioning.to_dict()
+            ),
+            "primitives": self.primitives.to_dict(),
+            "participation": self.participation.to_dict(),
+            "process_chains": self.process_chains.to_dict(),
+            "proposal_gain": self.proposal_gain.to_dict(),
+            "transformation_geometry": (
+                self.transformation_geometry.to_dict()
+            ),
+            "interface_propagation": (
+                self.interface_propagation.to_dict()
+            ),
+            "future_gate": self.future_gate.to_dict(),
+            "future_authority_evidence": (
+                self.future_authority_evidence.to_dict()
+            ),
+            "carrier_coalition": (
+                self.carrier_coalition.to_dict()
+            ),
+            "authority_lifecycle": (
+                self.authority_lifecycle.to_dict()
+            ),
+            "geometric_references": (
+                self.geometric_references.to_dict()
+            ),
+            "commitment": self.commitment.to_dict(),
+            "event_coordinate": (
+                self.event_coordinate.to_dict()
+            ),
+            "decision_trace": self.decision_trace.to_dict(),
+            "derived_diagnostics": [
+                item.to_dict()
+                for item in self.derived_diagnostics
+            ],
+            "authority_posture": self.authority_posture,
+            "semantic_memory_authority": False,
+            "identity_proof_established": False,
+            "realization_authorized": False,
+            "external_causal_authority": False,
+            "self_modification_authority": False,
+            "raw_content_stored": False,
+            "content_fingerprint_stored": False,
+            "completeness": (
+                canonical_completeness_report(
+                    self
+                )
+            ),
+        }
+
+    def canonical_json(
+        self,
+    ) -> str:
+        return json.dumps(
+            self.to_dict(),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+
+
+def canonical_completeness_report(
+    record: RCAFFullFrameworkRecord,
+) -> dict:
+    primitive_vectors = (
+        record.primitives.coherence_psi,
+        record.primitives.coherence_meta_field,
+        record.primitives.activity_density_rho_a,
+        record.primitives.coherence_density_rho_c,
+        record.primitives.salience,
+        record.primitives.realization_pressure_lambda,
+        record.primitives.curiosity,
+        record.primitives.viability_omega,
+        record.primitives.occupancy_xi,
+        record.primitives.future_freedom_f_xi,
+        record.primitives.realization_coupling_kappa_r,
+        record.primitives.mediation,
+        record.primitives.feedback,
+    )
+
+    atlas_types = {
+        link.atlas_type
+        for link
+        in record.organizational_record.atlas_links
+    }
+
+    future_bundle = record.future_authority_evidence
+    carrier_bundle = record.carrier_coalition
+    carrier = carrier_bundle.coalition
+
+    carrier_relation_ids = {
+        relation.relation_id
+        for relation in carrier_bundle.validity_relations
+    }
+
+    carrier_role_evidence_ids = {
+        evidence.evidence_id
+        for evidence in carrier_bundle.role_evidence
+    }
+
+    carrier_turbulence_ids = {
+        channel.channel_id
+        for channel in carrier_bundle.turbulence_channels
+    }
+
+    carrier_counterfactual_arms = {
+        branch.arm
+        for branch in carrier_bundle.matched_experiment.branches
+    }
+
+    matched_roles = {
+        branch.branch_role
+        for branch
+        in future_bundle.causal_experiment.branches
+    }
+
+    support_withdrawal_branches = [
+        branch
+        for branch
+        in future_bundle.causal_experiment.branches
+        if branch.branch_role
+        == "A5_support_withdrawal"
+    ]
+
+    anti_coercion_conditions = (
+        future_bundle.anti_coercion.prediction_preceded_intervention,
+        future_bundle.anti_coercion.terminal_contract_frozen,
+        future_bundle.anti_coercion.acceptance_criteria_frozen,
+        future_bundle.anti_coercion.evaluator_independent,
+        future_bundle.anti_coercion.target_rewrite_prevented,
+        future_bundle.anti_coercion.evidence_rewrite_prevented,
+        future_bundle.anti_coercion.control_branches_preserved,
+        future_bundle.anti_coercion.valid_treatment_preferential,
+        future_bundle.anti_coercion.support_withdrawal_persistent,
+    )
+
+    broad_stages = tuple(
+        item.stage
+        for item in record.process_chains.broad_chain
+    )
+
+    governance_stages = tuple(
+        item.stage
+        for item
+        in record.process_chains.realization_governance_chain
+    )
+
+    interface_stages = tuple(
+        item.stage
+        for item
+        in record.interface_propagation.observations
+    )
+
+    event_axes = tuple(
+        record.event_coordinate.to_dict()
+    )
+
+    checks = {
+        "canonical_primitives": (
+            all(
+                vector.components
+                for vector in primitive_vectors
+            )
+            and bool(
+                record.primitives.absorption_a_r_h
+            )
+        ),
+        "broad_organizational_chain": (
+            broad_stages
+            == RCAF_BROAD_ORGANIZATIONAL_CHAIN
+        ),
+        "realization_governance_chain": (
+            governance_stages
+            == RCAF_REALIZATION_GOVERNANCE_CHAIN
+        ),
+        "reference_conditioning": (
+            bool(
+                record.reference_conditioning.observable_ids
+            )
+            and (
+                record.primitives.reference_contract_id
+                == record.reference_conditioning.reference_contract_id
+            )
+        ),
+        "triadic_participation": math.isclose(
+            record.participation.participation.pi_i
+            + record.participation.participation.pi_r
+            + record.participation.participation.pi_a,
+            1.0,
+            rel_tol=0.0,
+            abs_tol=1e-6,
+        ),
+        "participation_corridor": bool(
+            record.participation.selected_structure_ids
+            and record.participation.selected_direction_ids
+            and record.participation.corridor_id
+        ),
+        "goldilocks_regulation": bool(
+            record.participation.goldilocks_regime
+            and record.participation.polarity_regime
+        ),
+        "harmonics_retention": bool(
+            record.participation.harmonics_retention_state
+        ),
+        "proposal_gain_discovery": bool(
+            record.proposal_gain.candidate_ids
+        ),
+        "verification_evidence": (
+            record.organizational_record.evidence
+            is not None
+        ),
+        "boundary_admissibility": (
+            record.organizational_record.boundary_authority
+            is not None
+        ),
+        "transformation_geometry": bool(
+            record.transformation_geometry.geometry_components.components
+        ),
+        "multi_space_coordinates": all(
+            bool(
+                getattr(
+                    record.transformation_geometry,
+                    field_name,
+                )
+            )
+            for field_name in (
+                "event_state_space_id",
+                "reference_space_id",
+                "proposal_tangent_space_id",
+                "causal_cone_space_id",
+                "response_parameter_space_id",
+                "outcome_composition_space_id",
+                "invariant_quotient_space_id",
+                "interface_coupling_space_id",
+                "propagation_path_space_id",
+                "operator_semigroup_space_id",
+                "evidence_status_space_id",
+                "meta_atlas_space_id",
+            )
+        ),
+        "future_conditioned_authority": bool(
+            record.future_gate.forward_reachable_set_id
+            and record.future_gate.backward_predecessor_set_id
+            and record.future_gate.admissible_corridor_id
+        ),
+        "terminal_organizational_class_contract": (
+            bool(
+                future_bundle.terminal_contract.contract_id
+                and future_bundle.terminal_contract.terminal_class_id
+            )
+            and future_bundle.terminal_contract.frozen_before_treatment
+            and future_bundle.terminal_contract.authority_non_expansion_required
+            and future_bundle.terminal_contract.independent_verification_required
+        ),
+        "forward_transition_map": (
+            bool(
+                future_bundle.forward_evidence.forward_map_id
+                and future_bundle.forward_evidence.reachable_set_id
+                and future_bundle.forward_evidence.branches
+                and future_bundle.forward_evidence.reachable_terminal_class_ids
+            )
+        ),
+        "backward_predecessor_map": (
+            bool(
+                future_bundle.backward_evidence.backward_map_id
+                and future_bundle.backward_evidence.predecessor_set_id
+                and future_bundle.backward_evidence.required_condition_ids
+                and future_bundle.backward_evidence.required_evaluator_ids
+            )
+        ),
+        "bidirectional_corridor_consistency": (
+            future_bundle.consistency.forward_reachable_set_id
+            == future_bundle.forward_evidence.reachable_set_id
+            and future_bundle.consistency.backward_predecessor_set_id
+            == future_bundle.backward_evidence.predecessor_set_id
+            and bool(
+                future_bundle.consistency.shared_corridor_ids
+            )
+        ),
+        "matched_causal_branching": (
+            matched_roles == MATCHED_CAUSAL_BRANCH_ROLES
+            and len(
+                future_bundle.causal_experiment.branches
+            )
+            == len(MATCHED_CAUSAL_BRANCH_ROLES)
+        ),
+        "support_withdrawal_validation": (
+            len(support_withdrawal_branches) == 1
+            and support_withdrawal_branches[0].support_present
+            is False
+            and bool(
+                future_bundle.causal_experiment
+                .support_withdrawal_persistence.components
+            )
+        ),
+        "anti_self_fulfilling_authority": (
+            future_bundle.anti_coercion.passed
+            == all(anti_coercion_conditions)
+        ),
+        "frozen_acceptance_criteria": (
+            future_bundle.terminal_contract.frozen_before_treatment
+            and bool(
+                future_bundle.causal_experiment
+                .frozen_acceptance_criteria_id
+            )
+        ),
+        "independent_evaluator": (
+            future_bundle.causal_experiment.independent_evaluator_id
+            in future_bundle.backward_evidence.required_evaluator_ids
+            and {
+                branch.evaluator_id
+                for branch
+                in future_bundle.causal_experiment.branches
+            }
+            == {
+                future_bundle.causal_experiment.independent_evaluator_id
+            }
+        ),
+        "retrospective_atlas_extraction": (
+            bool(
+                future_bundle.retrospective_atlas.atlas_record_id
+                and future_bundle.retrospective_atlas.precursor_class_id
+            )
+            and future_bundle.retrospective_atlas.authority_granted
+            is False
+        ),
+        "prospective_gate_nomination": (
+            bool(
+                future_bundle.prospective_nomination.nomination_id
+                and future_bundle.prospective_nomination.corridor_match_id
+            )
+            and future_bundle.prospective_nomination.authority_withheld
+            is True
+        ),
+        "calibration_status": (
+            future_bundle.calibration.status
+            in CALIBRATION_STATES
+        ),
+        "scenario_tail_evidence": bool(
+            future_bundle.calibration.scenario_tail_metrics.components
+        ),
+        "gate_maturity_lifecycle": (
+            bool(
+                future_bundle.lifecycle.lifecycle_id
+                and future_bundle.lifecycle.calibration_id
+                and future_bundle.lifecycle.causal_experiment_id
+            )
+            and future_bundle.lifecycle.no_auto_promotion
+        ),
+        "authority_evidence_separation": (
+            future_bundle.lifecycle.no_auto_promotion
+            and future_bundle.retrospective_atlas.authority_granted
+            is False
+            and future_bundle.prospective_nomination.authority_withheld
+            is True
+        ),
+        "bidirectional_meta_field": (
+            future_bundle.meta_field.forward_transition_map_id
+            == future_bundle.forward_evidence.forward_map_id
+            and future_bundle.meta_field.backward_predecessor_map_id
+            == future_bundle.backward_evidence.backward_map_id
+            and future_bundle.meta_field.consistency_relation_id
+            == future_bundle.consistency.consistency_record_id
+        ),
+        "no_literal_retrocausality": (
+            future_bundle.meta_field.literal_retrocausality_claimed
+            is False
+        ),
+        "authority_lifecycle": bool(
+            record.authority_lifecycle.proposal_id
+            and record.authority_lifecycle.recipient_id
+            and record.authority_lifecycle.operation_id
+        ),
+        "interface_propagation_distinctions": (
+            interface_stages
+            == RCAF_INTERFACE_PROPAGATION_CHAIN
+        ),
+        "realization_absorption_persistence_release": (
+            {
+                "realization_injection",
+                "absorption",
+                "influence",
+                "persistence",
+                "release",
+            }
+            .issubset(
+                set(governance_stages)
+            )
+        ),
+        "counterfactual_comparison": (
+            record.organizational_record.counterfactual
+            is not None
+        ),
+        "canonical_multi_atlas": (
+            atlas_types == RCAF_ATLAS_TYPES
+        ),
+        "e8_reference_geometry": bool(
+            record.geometric_references.e8.chart_id
+        ),
+        "leech_reference_geometry": bool(
+            record.geometric_references.leech.atlas_id
+        ),
+        "monster_meta_atlas": bool(
+            record.geometric_references.monster.meta_atlas_id
+        ),
+        "causal_cone_reference": bool(
+            record.geometric_references.causal_cone.causal_cone_id
+        ),
+        "operator_flow_reference": bool(
+            record.geometric_references.operator_flow.operator_id
+        ),
+        "minimal_event_coordinate": (
+            event_axes == RCAF_EVENT_COORDINATE_AXES
+        ),
+        "commitment_hysteresis": bool(
+            record.commitment.corridor_id
+            and record.commitment.reference_contract_id
+        ),
+        "primitive_derived_separation": all(
+            diagnostic.diagnostic_name
+            not in RCAF_PRIMITIVE_NAMES
+            and bool(
+                diagnostic.derived_from_component_ids
+            )
+            for diagnostic
+            in record.derived_diagnostics
+        ),
+        "layered_decision_trace": (
+            record.decision_trace.order_preserved
+            and bool(
+                record.decision_trace.component_observable_ids
+            )
+            and bool(
+                record.decision_trace.intermediate_geometry_ids
+            )
+            and bool(
+                record.decision_trace.conditioned_decision_ids
+            )
+        ),
+        "observer_effects_linkage": bool(
+            record.observer_effects_record_id
+        ),
+        "observer_lineage_without_identity_claim": (
+            bool(record.observer_lineage_id)
+            and not record.identity_proof_established
+        ),
+        "privacy_boundary": (
+            not record.raw_content_stored
+            and not record.content_fingerprint_stored
+        ),
+        "trajectory_admissible_carrier_coalition": (
+            bool(
+                carrier.coalition_id
+                and carrier.member_ids
+                and carrier.initialization_state_id
+                and carrier.optimizer_state_id
+                and carrier.data_contract_id
+                and carrier.reference_contract_id
+                and carrier.participation_geometry_id
+                and carrier.transformation_geometry_id
+                and carrier.boundary_contract_id
+                and carrier.terminal_organizational_class_id
+            )
+            and carrier.forward_reachable
+            and carrier.backward_consistent
+            and carrier.self_supporting
+            and carrier.support_withdrawal_verified
+            and carrier.observer_only
+            and carrier.authority_eligible is False
+            and carrier.no_auto_promotion
+        ),
+        "carrier_validity_relations": (
+            bool(carrier_bundle.validity_relations)
+            and all(
+                relation.valid
+                and relation.source_member_id
+                in carrier.member_ids
+                and relation.target_member_id
+                in carrier.member_ids
+                and relation.observer_only
+                and relation.authority_granted is False
+                for relation
+                in carrier_bundle.validity_relations
+            )
+            and set(
+                carrier.scaffold_relation_ids
+            ).issubset(
+                carrier_relation_ids
+            )
+        ),
+        "multidimensional_component_roles": (
+            bool(carrier_bundle.role_evidence)
+            and all(
+                tuple(evidence.role_vector)
+                == COMPONENT_ROLE_NAMES
+                and evidence.role_assignment_nonexclusive
+                and evidence.member_id
+                in carrier.member_ids
+                for evidence
+                in carrier_bundle.role_evidence
+            )
+            and set(
+                carrier.role_evidence_ids
+            ).issubset(
+                carrier_role_evidence_ids
+            )
+        ),
+        "scaffold_dependence": (
+            bool(
+                carrier_bundle.scaffold_dependence
+                .scaffold_member_ids
+            )
+            and bool(
+                carrier_bundle.scaffold_dependence
+                .dependence_vector
+            )
+            and set(
+                carrier_bundle.scaffold_dependence
+                .scaffold_member_ids
+            ).issubset(
+                set(carrier.member_ids)
+            )
+        ),
+        "scaffold_release_evidence": (
+            bool(
+                carrier_bundle.scaffold_release
+                .scaffold_member_ids
+            )
+            and carrier_bundle.scaffold_release
+            .release_admissible
+            and carrier_bundle.scaffold_release
+            .observer_only
+            and carrier_bundle.scaffold_release
+            .authority_granted
+            is False
+        ),
+        "support_withdrawal_as_causal_intervention": (
+            carrier.support_withdrawal_verified
+            and carrier_bundle.scaffold_dependence
+            .support_required_now
+            is False
+            and carrier_bundle.scaffold_release
+            .withdrawal_horizon
+            > 0
+            and carrier_bundle.scaffold_release
+            .persistence_verified
+            and carrier_bundle.scaffold_release
+            .recovery_available
+        ),
+        "multiscale_turbulence_channels": (
+            bool(carrier_bundle.turbulence_channels)
+            and all(
+                tuple(channel.component_vector)
+                == TURBULENCE_COMPONENT_NAMES
+                and bool(channel.turbulence_classes)
+                for channel
+                in carrier_bundle.turbulence_channels
+            )
+            and set(
+                carrier.turbulence_channel_ids
+            ).issubset(
+                carrier_turbulence_ids
+            )
+        ),
+        "component_preserving_turbulence": (
+            all(
+                channel.component_preserving
+                and channel.collapsed_score_authoritative
+                is False
+                for channel
+                in carrier_bundle.turbulence_channels
+            )
+        ),
+        "turbulent_debt_observation": (
+            all(
+                "turbulent_debt"
+                in channel.component_vector
+                for channel
+                in carrier_bundle.turbulence_channels
+            )
+            and carrier_bundle.scaffold_release
+            .turbulent_debt_admissible
+        ),
+        "compression_future_freedom": (
+            tuple(
+                carrier_bundle.future_freedom
+                .retention_by_component
+            )
+            == FUTURE_FREEDOM_COMPONENT_NAMES
+            and carrier_bundle.future_freedom.preserved
+            and carrier_bundle.scaffold_release
+            .future_freedom_preserved
+        ),
+        "topology_initialization_context_counterfactuals": (
+            carrier_counterfactual_arms
+            == set(COUNTERFACTUAL_ARMS)
+            and all(
+                branch.topology_relation
+                and branch.initialization_relation
+                and branch.context_relation
+                and branch.support_relation
+                for branch
+                in carrier_bundle.matched_experiment.branches
+            )
+        ),
+        "dynamic_topology_counterfactual": (
+            len(
+                [
+                    branch
+                    for branch
+                    in carrier_bundle.matched_experiment.branches
+                    if branch.arm == "A8"
+                    and branch.dynamic_topology
+                ]
+            )
+            == 1
+        ),
+        "microscopic_ticket_equivalence": (
+            len(
+                carrier_bundle.equivalence_class.coalition_ids
+            )
+            >= 2
+            and carrier_bundle.equivalence_class
+            .equivalent_terminal_organization
+            and carrier_bundle.equivalence_class
+            .identical_microstate_required
+            is False
+            and carrier.coalition_id
+            in carrier_bundle.equivalence_class.coalition_ids
+        ),
+        "prospective_coalition_nomination": (
+            carrier_bundle.nomination.frozen_criteria
+            and carrier_bundle.nomination.independent_evaluator
+            and carrier_bundle.nomination.reversible
+            and carrier_bundle.nomination.observer_only
+            and carrier_bundle.nomination.authority_withheld
+            and carrier_bundle.nomination.matched_experiment_id
+            == carrier_bundle.matched_experiment.experiment_id
+        ),
+        "reversible_pruning_contract": (
+            carrier_bundle.authority_contract.authority_status
+            == "observe_only"
+            and carrier_bundle.authority_contract
+            .external_causal_authority
+            is False
+            and carrier_bundle.authority_contract
+            .self_modification_authority
+            is False
+            and carrier_bundle.authority_contract
+            .no_auto_promotion
+            and carrier_bundle.authority_contract
+            .rollback_checkpoint_id
+            and carrier_bundle.authority_contract
+            .release_criteria_ids
+        ),
+    }
+
+    satisfied = sorted(
+        key
+        for key, value in checks.items()
+        if value
+    )
+
+    missing = sorted(
+        RCAF_CANONICAL_CAPABILITIES
+        - set(satisfied)
+    )
+
+    return {
+        "required_capability_count": len(
+            RCAF_CANONICAL_CAPABILITIES
+        ),
+        "satisfied_capability_count": len(
+            satisfied
+        ),
+        "satisfied_capabilities": satisfied,
+        "missing_capabilities": missing,
+        "complete": not missing,
+    }

--- a/src/rcaf/canonical_store.py
+++ b/src/rcaf/canonical_store.py
@@ -1,0 +1,3176 @@
+# ============================================================
+# src/rcaf/canonical_store.py
+# ============================================================
+
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import os
+import re
+import stat
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from src.rcaf.canonical_ledger import (
+    RCAF_CANONICAL_CAPABILITIES,
+    RCAF_CANONICAL_LEDGER_SCHEMA,
+    RCAFFullFrameworkRecord,
+)
+
+from src.rcaf.carrier_coalition import (
+    COMPONENT_ROLE_NAMES,
+    COUNTERFACTUAL_ARMS,
+    FUTURE_FREEDOM_COMPONENT_NAMES,
+    RCAF_CARRIER_COALITION_SCHEMA,
+    ScaffoldDependenceEvidence,
+    TURBULENCE_CLASSES,
+    TURBULENCE_COMPONENT_NAMES,
+)
+
+from src.rcaf.future_authority_ledger import (
+    RCAF_FUTURE_AUTHORITY_SCHEMA,
+)
+
+from src.rcaf.canonical_evolution import (
+    CanonicalSchemaEvolutionError,
+    validate_canonical_record_schema_set,
+)
+
+
+RCAF_CANONICAL_STORE_SCHEMA = (
+    "RCAF-CANONICAL-STORE-0.1"
+)
+
+RCAF_CANONICAL_ENTRY_SCHEMA = (
+    "RCAF-CANONICAL-STORE-ENTRY-0.1"
+)
+
+RCAF_CANONICAL_MANIFEST_SCHEMA = (
+    "RCAF-CANONICAL-STORE-MANIFEST-0.1"
+)
+
+RCAF_FORENSIC_QUARANTINE_SCHEMA = (
+    "RCAF-FORENSIC-QUARANTINE-0.1"
+)
+
+RCAF_FORENSIC_QUARANTINE_MARKER_SCHEMA = (
+    "RCAF-FORENSIC-QUARANTINE-MARKER-0.1"
+)
+
+ZERO_SHA256 = "0" * 64
+
+_LEDGER_ID_PATTERN = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$"
+)
+
+_SEGMENT_PATTERN = re.compile(
+    r"^segment-(\d{6})\.jsonl$"
+)
+
+_SHA256_PATTERN = re.compile(
+    r"^[0-9a-f]{64}$"
+)
+
+
+class CanonicalStoreError(RuntimeError):
+    """Base error for the durable canonical RCAF store."""
+
+
+class CanonicalStoreIntegrityError(
+    CanonicalStoreError
+):
+    """Raised when ledger continuity or integrity is invalid."""
+
+
+class CanonicalStoreSecurityError(
+    CanonicalStoreError
+):
+    """Raised when a filesystem safety contract is violated."""
+
+
+class CanonicalStoreQuarantinedError(
+    CanonicalStoreError
+):
+    """Raised when a quarantined store is used normally."""
+
+
+@dataclass(frozen=True)
+class CanonicalAppendReceipt:
+    ledger_id: str
+    sequence_index: int
+    segment_index: int
+    entry_sha256: str
+    previous_entry_sha256: str
+    record_count: int
+    segment_count: int
+    durable_storage_write: bool
+    authority_posture: str
+
+
+@dataclass(frozen=True)
+class CanonicalReplayResult:
+    ledger_id: str
+    record_count: int
+    segment_count: int
+    last_sequence_index: int | None
+    last_entry_sha256: str
+    records: tuple[dict[str, Any], ...]
+    integrity_verified: bool
+    deterministic_replay_verified: bool
+    recovered_trailing_bytes: int
+    repaired_terminal_newline: bool
+    authority_posture: str
+
+
+@dataclass(frozen=True)
+class ForensicQuarantineReceipt:
+    case_id: str
+    ledger_id: str
+    reason_code: str
+    case_directory: str
+    captured_entry_count: int
+    copied_file_count: int
+    forensic_manifest_sha256: str
+    append_blocked: bool
+    authority_posture: str
+
+
+@dataclass(frozen=True)
+class _ScanResult:
+    ledger_id: str
+    entries: tuple[dict[str, Any], ...]
+    segment_entry_counts: tuple[int, ...]
+    recovered_trailing_bytes: int
+    repaired_terminal_newline: bool
+
+    @property
+    def record_count(
+        self,
+    ) -> int:
+        return len(self.entries)
+
+    @property
+    def segment_count(
+        self,
+    ) -> int:
+        return len(self.segment_entry_counts)
+
+    @property
+    def last_entry_sha256(
+        self,
+    ) -> str:
+        if not self.entries:
+            return ZERO_SHA256
+
+        return str(
+            self.entries[-1]["entry_sha256"]
+        )
+
+
+def _canonical_bytes(
+    value: Any,
+) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+def _sha256(
+    value: bytes,
+) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _require_ledger_id(
+    value: str,
+) -> str:
+    normalized = str(value).strip()
+
+    if not _LEDGER_ID_PATTERN.fullmatch(
+        normalized
+    ):
+        raise CanonicalStoreError(
+            "ledger_id must contain only letters, "
+            "numbers, '.', '_' or '-'"
+        )
+
+    return normalized
+
+
+def _require_sha256(
+    field_name: str,
+    value: str,
+) -> str:
+    normalized = str(value).strip()
+
+    if not _SHA256_PATTERN.fullmatch(
+        normalized
+    ):
+        raise CanonicalStoreIntegrityError(
+            f"{field_name} must be lowercase SHA-256"
+        )
+
+    return normalized
+
+
+def _ensure_private_directory(
+    root: Path,
+) -> None:
+    root = Path(root)
+
+    try:
+        root.mkdir(
+            parents=True,
+            mode=0o700,
+            exist_ok=True,
+        )
+    except OSError as exc:
+        raise CanonicalStoreSecurityError(
+            "unable to initialize ledger root: "
+            f"{type(exc).__name__}"
+        ) from exc
+
+    try:
+        metadata = os.lstat(
+            root
+        )
+    except OSError as exc:
+        raise CanonicalStoreSecurityError(
+            "unable to inspect ledger root: "
+            f"{type(exc).__name__}"
+        ) from exc
+
+    if stat.S_ISLNK(
+        metadata.st_mode
+    ):
+        raise CanonicalStoreSecurityError(
+            "ledger root must not be a symbolic link"
+        )
+
+    if not stat.S_ISDIR(
+        metadata.st_mode
+    ):
+        raise CanonicalStoreSecurityError(
+            "ledger root must be a directory"
+        )
+
+    flags = (
+        os.O_RDONLY
+        | getattr(
+            os,
+            "O_DIRECTORY",
+            0,
+        )
+        | getattr(
+            os,
+            "O_CLOEXEC",
+            0,
+        )
+        | getattr(
+            os,
+            "O_NOFOLLOW",
+            0,
+        )
+    )
+
+    try:
+        fd = os.open(
+            root,
+            flags,
+        )
+    except OSError as exc:
+        raise CanonicalStoreSecurityError(
+            "unable to safely open ledger root: "
+            f"{type(exc).__name__}"
+        ) from exc
+
+    try:
+        opened_metadata = os.fstat(
+            fd
+        )
+
+        if not stat.S_ISDIR(
+            opened_metadata.st_mode
+        ):
+            raise CanonicalStoreSecurityError(
+                "opened ledger root must be a directory"
+            )
+
+        os.fchmod(
+            fd,
+            0o700,
+        )
+
+    finally:
+        os.close(
+            fd
+        )
+
+def _open_private_regular_file(
+    path: Path,
+    flags: int,
+    *,
+    mode: int = 0o600,
+) -> int:
+    safe_flags = (
+        flags
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+
+    try:
+        fd = os.open(
+            path,
+            safe_flags,
+            mode,
+        )
+    except OSError as exc:
+        raise CanonicalStoreSecurityError(
+            f"unable to safely open {path.name}: "
+            f"{type(exc).__name__}"
+        ) from exc
+
+    try:
+        metadata = os.fstat(fd)
+
+        if not stat.S_ISREG(
+            metadata.st_mode
+        ):
+            raise CanonicalStoreSecurityError(
+                f"{path.name} must be a regular file"
+            )
+
+        if metadata.st_nlink != 1:
+            raise CanonicalStoreSecurityError(
+                f"{path.name} must have exactly one link"
+            )
+
+        os.fchmod(fd, 0o600)
+
+    except Exception:
+        os.close(fd)
+        raise
+
+    return fd
+
+
+def _write_all(
+    fd: int,
+    data: bytes,
+) -> None:
+    offset = 0
+
+    while offset < len(data):
+        written = os.write(
+            fd,
+            data[offset:],
+        )
+
+        if written <= 0:
+            raise CanonicalStoreError(
+                "short write while appending canonical ledger"
+            )
+
+        offset += written
+
+
+def _read_all(
+    fd: int,
+) -> bytes:
+    os.lseek(
+        fd,
+        0,
+        os.SEEK_SET,
+    )
+
+    chunks = []
+
+    while True:
+        chunk = os.read(
+            fd,
+            1024 * 1024,
+        )
+
+        if not chunk:
+            break
+
+        chunks.append(chunk)
+
+    return b"".join(chunks)
+
+
+def _fsync_directory(
+    root: Path,
+) -> None:
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+
+    fd = os.open(
+        root,
+        flags,
+    )
+
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _write_private_json_atomic(
+    path: Path,
+    value: dict[str, Any],
+) -> None:
+    root = path.parent
+
+    if path.exists():
+        metadata = os.lstat(
+            path
+        )
+
+        if (
+            stat.S_ISLNK(metadata.st_mode)
+            or not stat.S_ISREG(
+                metadata.st_mode
+            )
+            or metadata.st_nlink != 1
+        ):
+            raise CanonicalStoreSecurityError(
+                f"{path.name} is unsafe"
+            )
+
+    temporary_path = root / (
+        f".{path.name}.{os.getpid()}."
+        f"{uuid.uuid4().hex}.tmp"
+    )
+
+    fd = _open_private_regular_file(
+        temporary_path,
+        os.O_WRONLY
+        | os.O_CREAT
+        | os.O_EXCL,
+    )
+
+    try:
+        _write_all(
+            fd,
+            _canonical_bytes(value)
+            + b"\n",
+        )
+
+        os.fsync(fd)
+
+    finally:
+        os.close(fd)
+
+    os.replace(
+        temporary_path,
+        path,
+    )
+
+    os.chmod(
+        path,
+        0o600,
+    )
+
+    _fsync_directory(
+        root
+    )
+
+
+def _quarantine_marker_path(
+    root: Path,
+) -> Path:
+    return root / "quarantine.json"
+
+
+def _read_quarantine_marker(
+    root: Path,
+) -> dict[str, Any] | None:
+    path = _quarantine_marker_path(
+        root
+    )
+
+    if not path.exists():
+        return None
+
+    fd = _open_private_regular_file(
+        path,
+        os.O_RDONLY,
+    )
+
+    try:
+        data = _read_all(
+            fd
+        )
+    finally:
+        os.close(fd)
+
+    try:
+        marker = json.loads(
+            data.decode("utf-8")
+        )
+    except Exception as exc:
+        raise CanonicalStoreSecurityError(
+            "quarantine marker is invalid"
+        ) from exc
+
+    if (
+        not isinstance(marker, dict)
+        or marker.get("schema")
+        != RCAF_FORENSIC_QUARANTINE_MARKER_SCHEMA
+        or marker.get("append_blocked")
+        is not True
+    ):
+        raise CanonicalStoreSecurityError(
+            "quarantine marker contract is invalid"
+        )
+
+    return marker
+
+
+def _assert_store_not_quarantined(
+    root: Path,
+    *,
+    ledger_id: str,
+) -> None:
+    marker = _read_quarantine_marker(
+        root
+    )
+
+    if marker is None:
+        return
+
+    if marker.get("ledger_id") != ledger_id:
+        raise CanonicalStoreSecurityError(
+            "quarantine marker ledger mismatch"
+        )
+
+    raise CanonicalStoreQuarantinedError(
+        "canonical store is quarantined: "
+        f"{marker.get('case_id', 'unknown')}"
+    )
+
+
+def _segment_path(
+    root: Path,
+    segment_index: int,
+) -> Path:
+    return root / (
+        f"segment-{segment_index:06d}.jsonl"
+    )
+
+
+def _segment_indexes(
+    root: Path,
+) -> tuple[int, ...]:
+    indexes = []
+
+    for entry in os.scandir(root):
+        match = _SEGMENT_PATTERN.fullmatch(
+            entry.name
+        )
+
+        if match is None:
+            continue
+
+        indexes.append(
+            int(match.group(1))
+        )
+
+    indexes.sort()
+
+    if indexes and indexes != list(
+        range(indexes[-1] + 1)
+    ):
+        raise CanonicalStoreIntegrityError(
+            "segment indexes must be contiguous from zero"
+        )
+
+    return tuple(indexes)
+
+
+def _entry_body(
+    entry: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        key: value
+        for key, value in entry.items()
+        if key != "entry_sha256"
+    }
+
+
+def _validate_carrier_coalition_dict(
+    carrier: Any,
+) -> dict[str, Any]:
+    if (
+        not isinstance(carrier, dict)
+        or carrier.get("schema")
+        != RCAF_CARRIER_COALITION_SCHEMA
+    ):
+        raise CanonicalStoreIntegrityError(
+            "stored canonical record lacks the required "
+            "carrier-coalition bundle"
+        )
+
+    if (
+        carrier.get("raw_content_stored")
+        is not False
+        or carrier.get(
+            "content_fingerprint_stored"
+        )
+        is not False
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier-coalition bundle violates privacy"
+        )
+
+    required_objects = (
+        "coalition",
+        "scaffold_dependence",
+        "scaffold_release",
+        "future_freedom",
+        "matched_experiment",
+        "equivalence_class",
+        "nomination",
+        "authority_contract",
+    )
+
+    for field_name in required_objects:
+        if not isinstance(
+            carrier.get(field_name),
+            dict,
+        ):
+            raise CanonicalStoreIntegrityError(
+                f"carrier-coalition field {field_name} "
+                "must be an object"
+            )
+
+    required_nonempty_lists = (
+        "validity_relations",
+        "role_evidence",
+        "turbulence_channels",
+    )
+
+    for field_name in required_nonempty_lists:
+        value = carrier.get(field_name)
+
+        if not isinstance(value, list) or not value:
+            raise CanonicalStoreIntegrityError(
+                f"carrier-coalition field {field_name} "
+                "must be a nonempty list"
+            )
+
+    coalition = carrier["coalition"]
+    nomination = carrier["nomination"]
+    authority_contract = carrier["authority_contract"]
+    matched_experiment = carrier["matched_experiment"]
+    scaffold_release = carrier["scaffold_release"]
+
+    coalition_id = coalition.get(
+        "coalition_id"
+    )
+
+    if (
+        not isinstance(coalition_id, str)
+        or not coalition_id.strip()
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier coalition lacks coalition_id"
+        )
+
+    if (
+        coalition.get("observer_only")
+        is not True
+        or coalition.get("authority_eligible")
+        is not False
+        or coalition.get("no_auto_promotion")
+        is not True
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier coalition violates "
+            "observer-only authority"
+        )
+
+    for relation in carrier[
+        "validity_relations"
+    ]:
+        if (
+            not isinstance(relation, dict)
+            or relation.get("observer_only")
+            is not True
+            or relation.get("authority_granted")
+            is not False
+        ):
+            raise CanonicalStoreIntegrityError(
+                "carrier validity relation violates "
+                "observer-only authority"
+            )
+
+    if (
+        scaffold_release.get("observer_only")
+        is not True
+        or scaffold_release.get(
+            "authority_granted"
+        )
+        is not False
+    ):
+        raise CanonicalStoreIntegrityError(
+            "scaffold release evidence cannot "
+            "grant authority"
+        )
+
+    nomination_safeguards = (
+        "frozen_criteria",
+        "independent_evaluator",
+        "reversible",
+        "observer_only",
+        "authority_withheld",
+    )
+
+    if any(
+        nomination.get(field_name)
+        is not True
+        for field_name
+        in nomination_safeguards
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier nomination safeguards failed"
+        )
+
+    if (
+        authority_contract.get(
+            "authority_status"
+        )
+        != "observe_only"
+        or authority_contract.get(
+            "external_causal_authority"
+        )
+        is not False
+        or authority_contract.get(
+            "self_modification_authority"
+        )
+        is not False
+        or authority_contract.get(
+            "no_auto_promotion"
+        )
+        is not True
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier pruning contract violates "
+            "observe-only authority"
+        )
+
+    release_criteria_ids = (
+        authority_contract.get(
+            "release_criteria_ids"
+        )
+    )
+
+    if (
+        not isinstance(
+            release_criteria_ids,
+            list,
+        )
+        or not release_criteria_ids
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier pruning contract lacks "
+            "release criteria"
+        )
+
+    rollback_checkpoint_id = (
+        authority_contract.get(
+            "rollback_checkpoint_id"
+        )
+    )
+
+    if (
+        not isinstance(
+            rollback_checkpoint_id,
+            str,
+        )
+        or not rollback_checkpoint_id.strip()
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier pruning contract lacks "
+            "rollback checkpoint"
+        )
+
+    for field_name in (
+        "maximum_sparsity",
+        "maximum_step_removal",
+    ):
+        value = authority_contract.get(
+            field_name
+        )
+
+        if (
+            isinstance(value, bool)
+            or not isinstance(
+                value,
+                (int, float),
+            )
+            or not 0.0
+            <= float(value)
+            <= 1.0
+        ):
+            raise CanonicalStoreIntegrityError(
+                f"carrier pruning contract field "
+                f"{field_name} must be within [0, 1]"
+            )
+
+    recovery_budget_steps = (
+        authority_contract.get(
+            "recovery_budget_steps"
+        )
+    )
+
+    if (
+        isinstance(
+            recovery_budget_steps,
+            bool,
+        )
+        or not isinstance(
+            recovery_budget_steps,
+            int,
+        )
+        or recovery_budget_steps <= 0
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier pruning recovery budget "
+            "must be positive"
+        )
+
+    experiment_safeguards = (
+        "independent_evaluator",
+        "frozen_acceptance_criteria",
+        "matched_compute_budget",
+        "multiple_seeds",
+        "observer_only",
+    )
+
+    if any(
+        matched_experiment.get(
+            field_name
+        )
+        is not True
+        for field_name
+        in experiment_safeguards
+    ):
+        raise CanonicalStoreIntegrityError(
+            "matched carrier experiment "
+            "safeguards failed"
+        )
+
+    branches = matched_experiment.get(
+        "branches"
+    )
+
+    if (
+        not isinstance(branches, list)
+        or len(branches)
+        != len(COUNTERFACTUAL_ARMS)
+        or any(
+            not isinstance(branch, dict)
+            for branch in branches
+        )
+    ):
+        raise CanonicalStoreIntegrityError(
+            "matched carrier experiment must "
+            "contain A0 through A8"
+        )
+
+    arms = tuple(
+        branch.get("arm")
+        for branch in branches
+    )
+
+    if (
+        set(arms)
+        != set(COUNTERFACTUAL_ARMS)
+        or len(set(arms))
+        != len(arms)
+    ):
+        raise CanonicalStoreIntegrityError(
+            "matched carrier experiment must "
+            "contain A0 through A8"
+        )
+
+    branch_ids = tuple(
+        branch.get("branch_id")
+        for branch in branches
+    )
+
+    if (
+        any(
+            not isinstance(branch_id, str)
+            or not branch_id.strip()
+            for branch_id in branch_ids
+        )
+        or len(set(branch_ids))
+        != len(branch_ids)
+    ):
+        raise CanonicalStoreIntegrityError(
+            "matched carrier experiment contains "
+            "invalid or duplicate branch IDs"
+        )
+
+    linked_coalition_ids = {
+        carrier[
+            "scaffold_dependence"
+        ].get("coalition_id"),
+        scaffold_release.get(
+            "coalition_id"
+        ),
+        carrier[
+            "future_freedom"
+        ].get("coalition_id"),
+        nomination.get("coalition_id"),
+        authority_contract.get(
+            "coalition_id"
+        ),
+    }
+
+    linked_coalition_ids.update(
+        branch.get("coalition_id")
+        for branch in branches
+    )
+
+    if linked_coalition_ids != {
+        coalition_id
+    }:
+        raise CanonicalStoreIntegrityError(
+            "carrier bundle contains inconsistent "
+            "coalition links"
+        )
+
+    if (
+        nomination.get(
+            "matched_experiment_id"
+        )
+        != matched_experiment.get(
+            "experiment_id"
+        )
+        or nomination.get(
+            "acceptance_contract_id"
+        )
+        != matched_experiment.get(
+            "acceptance_contract_id"
+        )
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier nomination experiment "
+            "linkage mismatch"
+        )
+
+    member_ids = coalition.get(
+        "member_ids"
+    )
+
+    if (
+        not isinstance(member_ids, list)
+        or not member_ids
+        or any(
+            not isinstance(member_id, str)
+            or not member_id.strip()
+            for member_id in member_ids
+        )
+        or len(set(member_ids))
+        != len(member_ids)
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier coalition contains invalid "
+            "member identifiers"
+        )
+
+    member_id_set = set(member_ids)
+
+    reference_contract_id = coalition.get(
+        "reference_contract_id"
+    )
+
+    if (
+        not isinstance(
+            reference_contract_id,
+            str,
+        )
+        or not reference_contract_id.strip()
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier coalition lacks a reference contract"
+        )
+
+    relation_ids = set()
+
+    for relation in carrier[
+        "validity_relations"
+    ]:
+        if not isinstance(relation, dict):
+            raise CanonicalStoreIntegrityError(
+                "carrier validity relation must "
+                "be an object"
+            )
+
+        relation_id = relation.get(
+            "relation_id"
+        )
+
+        if (
+            not isinstance(relation_id, str)
+            or not relation_id.strip()
+            or relation_id in relation_ids
+        ):
+            raise CanonicalStoreIntegrityError(
+                "carrier validity relation contains "
+                "an invalid or duplicate relation ID"
+            )
+
+        relation_ids.add(relation_id)
+
+        if (
+            relation.get("source_member_id")
+            not in member_id_set
+            or relation.get("target_member_id")
+            not in member_id_set
+        ):
+            raise CanonicalStoreIntegrityError(
+                "carrier validity relation references "
+                "a non-member"
+            )
+
+        relational_conditions = (
+            "context_validated",
+            "phase_compatible",
+            "boundary_compatible",
+            "future_consistent",
+        )
+
+        computed_valid = all(
+            relation.get(field_name)
+            is True
+            for field_name
+            in relational_conditions
+        )
+
+        if (
+            computed_valid is not True
+            or relation.get("valid")
+            is not True
+        ):
+            raise CanonicalStoreIntegrityError(
+                "carrier validity relation is incomplete"
+            )
+
+    scaffold_relation_ids = coalition.get(
+        "scaffold_relation_ids"
+    )
+
+    if (
+        not isinstance(
+            scaffold_relation_ids,
+            list,
+        )
+        or not set(
+            scaffold_relation_ids
+        ).issubset(relation_ids)
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier coalition contains unresolved "
+            "scaffold relation links"
+        )
+
+    role_evidence_ids = set()
+
+    for evidence in carrier[
+        "role_evidence"
+    ]:
+        if not isinstance(evidence, dict):
+            raise CanonicalStoreIntegrityError(
+                "carrier role evidence must be an object"
+            )
+
+        evidence_id = evidence.get(
+            "evidence_id"
+        )
+
+        if (
+            not isinstance(evidence_id, str)
+            or not evidence_id.strip()
+            or evidence_id
+            in role_evidence_ids
+        ):
+            raise CanonicalStoreIntegrityError(
+                "carrier role evidence contains "
+                "an invalid or duplicate evidence ID"
+            )
+
+        role_evidence_ids.add(
+            evidence_id
+        )
+
+        if evidence.get(
+            "member_id"
+        ) not in member_id_set:
+            raise CanonicalStoreIntegrityError(
+                "carrier role evidence references "
+                "a non-member"
+            )
+
+        role_vector = evidence.get(
+            "role_vector"
+        )
+
+        if (
+            not isinstance(role_vector, dict)
+            or len(role_vector)
+            != len(COMPONENT_ROLE_NAMES)
+            or set(role_vector)
+            != set(COMPONENT_ROLE_NAMES)
+        ):
+            raise CanonicalStoreIntegrityError(
+                "carrier role vectors must preserve "
+                "all components"
+            )
+
+        if any(
+            isinstance(value, bool)
+            or not isinstance(
+                value,
+                (int, float),
+            )
+            or not 0.0
+            <= float(value)
+            <= 1.0
+            for value
+            in role_vector.values()
+        ):
+            raise CanonicalStoreIntegrityError(
+                "carrier role-vector values must "
+                "remain within [0, 1]"
+            )
+
+        if evidence.get(
+            "role_assignment_nonexclusive"
+        ) is not True:
+            raise CanonicalStoreIntegrityError(
+                "carrier component roles must remain "
+                "nonexclusive"
+            )
+
+    declared_role_evidence_ids = coalition.get(
+        "role_evidence_ids"
+    )
+
+    if (
+        not isinstance(
+            declared_role_evidence_ids,
+            list,
+        )
+        or not set(
+            declared_role_evidence_ids
+        ).issubset(role_evidence_ids)
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier coalition contains unresolved "
+            "role-evidence links"
+        )
+
+    reference_contract_ids = {
+        reference_contract_id,
+        carrier[
+            "scaffold_dependence"
+        ].get("reference_contract_id"),
+        carrier[
+            "scaffold_release"
+        ].get("reference_contract_id"),
+        carrier[
+            "future_freedom"
+        ].get("reference_contract_id"),
+    }
+
+    reference_contract_ids.update(
+        relation.get(
+            "reference_contract_id"
+        )
+        for relation
+        in carrier[
+            "validity_relations"
+        ]
+    )
+
+    reference_contract_ids.update(
+        evidence.get(
+            "reference_contract_id"
+        )
+        for evidence
+        in carrier[
+            "role_evidence"
+        ]
+    )
+
+    if reference_contract_ids != {
+        reference_contract_id
+    }:
+        raise CanonicalStoreIntegrityError(
+            "carrier evidence contains inconsistent "
+            "reference-contract links"
+        )
+
+    turbulence_ids = set()
+
+    for channel in carrier[
+        "turbulence_channels"
+    ]:
+        if not isinstance(channel, dict):
+            raise CanonicalStoreIntegrityError(
+                "carrier turbulence channel must "
+                "be an object"
+            )
+
+        channel_id = channel.get(
+            "channel_id"
+        )
+
+        if (
+            not isinstance(channel_id, str)
+            or not channel_id.strip()
+            or channel_id in turbulence_ids
+        ):
+            raise CanonicalStoreIntegrityError(
+                "carrier turbulence contains an "
+                "invalid or duplicate channel ID"
+            )
+
+        turbulence_ids.add(channel_id)
+
+        for field_name in (
+            "source_organization_id",
+            "target_organization_id",
+        ):
+            value = channel.get(field_name)
+
+            if (
+                not isinstance(value, str)
+                or not value.strip()
+            ):
+                raise CanonicalStoreIntegrityError(
+                    f"carrier turbulence field "
+                    f"{field_name} must be an identifier"
+                )
+
+        if channel.get(
+            "reference_contract_id"
+        ) != reference_contract_id:
+            raise CanonicalStoreIntegrityError(
+                "carrier turbulence contains "
+                "inconsistent reference-contract links"
+            )
+
+        horizon_steps = channel.get(
+            "horizon_steps"
+        )
+
+        if (
+            isinstance(horizon_steps, bool)
+            or not isinstance(
+                horizon_steps,
+                int,
+            )
+            or horizon_steps <= 0
+        ):
+            raise CanonicalStoreIntegrityError(
+                "carrier turbulence horizon must "
+                "be positive"
+            )
+
+        component_vector = channel.get(
+            "component_vector"
+        )
+
+        if (
+            not isinstance(
+                component_vector,
+                dict,
+            )
+            or len(component_vector)
+            != len(TURBULENCE_COMPONENT_NAMES)
+            or set(component_vector)
+            != set(TURBULENCE_COMPONENT_NAMES)
+        ):
+            raise CanonicalStoreIntegrityError(
+                "carrier turbulence vectors must "
+                "preserve all components"
+            )
+
+        if any(
+            isinstance(value, bool)
+            or not isinstance(
+                value,
+                (int, float),
+            )
+            or not 0.0
+            <= float(value)
+            <= 1.0
+            for value
+            in component_vector.values()
+        ):
+            raise CanonicalStoreIntegrityError(
+                "carrier turbulence component values "
+                "must remain within [0, 1]"
+            )
+
+        turbulence_classes = channel.get(
+            "turbulence_classes"
+        )
+
+        if (
+            not isinstance(
+                turbulence_classes,
+                list,
+            )
+            or not turbulence_classes
+            or len(set(turbulence_classes))
+            != len(turbulence_classes)
+            or not set(
+                turbulence_classes
+            ).issubset(TURBULENCE_CLASSES)
+        ):
+            raise CanonicalStoreIntegrityError(
+                "carrier turbulence contains "
+                "unknown classes"
+            )
+
+        evidence_record_ids = channel.get(
+            "evidence_record_ids"
+        )
+
+        if (
+            not isinstance(
+                evidence_record_ids,
+                list,
+            )
+            or not evidence_record_ids
+            or any(
+                not isinstance(
+                    evidence_id,
+                    str,
+                )
+                or not evidence_id.strip()
+                for evidence_id
+                in evidence_record_ids
+            )
+            or len(set(evidence_record_ids))
+            != len(evidence_record_ids)
+        ):
+            raise CanonicalStoreIntegrityError(
+                "carrier turbulence contains "
+                "invalid evidence links"
+            )
+
+        if channel.get(
+            "component_preserving"
+        ) is not True:
+            raise CanonicalStoreIntegrityError(
+                "carrier turbulence components "
+                "must remain preserved"
+            )
+
+        if channel.get(
+            "collapsed_score_authoritative"
+        ) is not False:
+            raise CanonicalStoreIntegrityError(
+                "collapsed carrier turbulence score "
+                "cannot be authoritative"
+            )
+
+    declared_turbulence_ids = coalition.get(
+        "turbulence_channel_ids"
+    )
+
+    if (
+        not isinstance(
+            declared_turbulence_ids,
+            list,
+        )
+        or not declared_turbulence_ids
+        or any(
+            not isinstance(channel_id, str)
+            or not channel_id.strip()
+            for channel_id
+            in declared_turbulence_ids
+        )
+        or len(set(declared_turbulence_ids))
+        != len(declared_turbulence_ids)
+        or not set(
+            declared_turbulence_ids
+        ).issubset(turbulence_ids)
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier coalition contains unresolved "
+            "turbulence links"
+        )
+
+    trajectory_conditions = (
+        "forward_reachable",
+        "backward_consistent",
+        "self_supporting",
+        "support_withdrawal_verified",
+        "nomination_ready",
+    )
+
+    if any(
+        coalition.get(field_name)
+        is not True
+        for field_name
+        in trajectory_conditions
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier coalition is not "
+            "trajectory-admissible"
+        )
+
+    scaffold_dependence = carrier[
+        "scaffold_dependence"
+    ]
+
+    scaffold_release = carrier[
+        "scaffold_release"
+    ]
+
+    future_freedom = carrier[
+        "future_freedom"
+    ]
+
+    equivalence_class = carrier[
+        "equivalence_class"
+    ]
+
+    dependence_members = (
+        scaffold_dependence.get(
+            "scaffold_member_ids"
+        )
+    )
+
+    if (
+        not isinstance(
+            dependence_members,
+            list,
+        )
+        or not dependence_members
+        or any(
+            not isinstance(member_id, str)
+            or not member_id.strip()
+            for member_id
+            in dependence_members
+        )
+        or len(set(dependence_members))
+        != len(dependence_members)
+        or not set(
+            dependence_members
+        ).issubset(member_id_set)
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier scaffold dependence "
+            "references invalid members"
+        )
+
+    observation_horizon = (
+        scaffold_dependence.get(
+            "observation_horizon"
+        )
+    )
+
+    if (
+        isinstance(observation_horizon, bool)
+        or not isinstance(
+            observation_horizon,
+            int,
+        )
+        or observation_horizon <= 0
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier scaffold-dependence horizon "
+            "must be positive"
+        )
+
+    dependence_vector = (
+        scaffold_dependence.get(
+            "dependence_vector"
+        )
+    )
+
+    if (
+        not isinstance(
+            dependence_vector,
+            dict,
+        )
+        or len(dependence_vector)
+        != len(ScaffoldDependenceEvidence.DEPENDENCE_COMPONENT_NAMES)
+        or set(dependence_vector)
+        != set(ScaffoldDependenceEvidence.DEPENDENCE_COMPONENT_NAMES)
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier scaffold-dependence vector "
+            "must preserve all components"
+        )
+
+    if any(
+        isinstance(value, bool)
+        or not isinstance(
+            value,
+            (int, float),
+        )
+        or not 0.0
+        <= float(value)
+        <= 1.0
+        for value
+        in dependence_vector.values()
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier scaffold-dependence values "
+            "must remain within [0, 1]"
+        )
+
+    if scaffold_dependence.get(
+        "support_required_now"
+    ) is not False:
+        raise CanonicalStoreIntegrityError(
+            "carrier support withdrawal remains "
+            "scaffold-dependent"
+        )
+
+    dependence_evidence_ids = (
+        scaffold_dependence.get(
+            "evidence_record_ids"
+        )
+    )
+
+    if (
+        not isinstance(
+            dependence_evidence_ids,
+            list,
+        )
+        or not dependence_evidence_ids
+        or any(
+            not isinstance(evidence_id, str)
+            or not evidence_id.strip()
+            for evidence_id
+            in dependence_evidence_ids
+        )
+        or len(set(dependence_evidence_ids))
+        != len(dependence_evidence_ids)
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier scaffold dependence contains "
+            "invalid evidence links"
+        )
+
+    release_members = (
+        scaffold_release.get(
+            "scaffold_member_ids"
+        )
+    )
+
+    if (
+        not isinstance(release_members, list)
+        or not release_members
+        or any(
+            not isinstance(member_id, str)
+            or not member_id.strip()
+            for member_id
+            in release_members
+        )
+        or len(set(release_members))
+        != len(release_members)
+        or not set(
+            release_members
+        ).issubset(member_id_set)
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier scaffold release references "
+            "invalid members"
+        )
+
+    withdrawal_horizon = (
+        scaffold_release.get(
+            "withdrawal_horizon"
+        )
+    )
+
+    if (
+        isinstance(withdrawal_horizon, bool)
+        or not isinstance(
+            withdrawal_horizon,
+            int,
+        )
+        or withdrawal_horizon <= 0
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier scaffold-release horizon "
+            "must be positive"
+        )
+
+    release_condition_names = (
+        "immediate_performance_preserved",
+        "far_horizon_performance_preserved",
+        "calibration_preserved",
+        "robustness_preserved",
+        "optimizer_stable",
+        "activation_geometry_stable",
+        "persistence_verified",
+        "recovery_available",
+        "transfer_preserved",
+        "future_freedom_preserved",
+        "turbulent_debt_admissible",
+    )
+
+    computed_release_admissible = all(
+        scaffold_release.get(field_name)
+        is True
+        for field_name
+        in release_condition_names
+    )
+
+    if (
+        computed_release_admissible
+        is not True
+        or scaffold_release.get(
+            "release_admissible"
+        )
+        is not True
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier scaffold release is "
+            "not admissible"
+        )
+
+    release_evidence_ids = (
+        scaffold_release.get(
+            "evidence_record_ids"
+        )
+    )
+
+    if (
+        not isinstance(
+            release_evidence_ids,
+            list,
+        )
+        or not release_evidence_ids
+        or any(
+            not isinstance(evidence_id, str)
+            or not evidence_id.strip()
+            for evidence_id
+            in release_evidence_ids
+        )
+        or len(set(release_evidence_ids))
+        != len(release_evidence_ids)
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier scaffold release contains "
+            "invalid evidence links"
+        )
+
+    future_freedom_record_id = (
+        future_freedom.get("record_id")
+    )
+
+    if (
+        not isinstance(
+            future_freedom_record_id,
+            str,
+        )
+        or not future_freedom_record_id.strip()
+        or coalition.get(
+            "future_freedom_record_id"
+        )
+        != future_freedom_record_id
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier future-freedom linkage mismatch"
+        )
+
+    baseline_vector = future_freedom.get(
+        "baseline_vector"
+    )
+
+    candidate_vector = future_freedom.get(
+        "candidate_vector"
+    )
+
+    retention_vector = future_freedom.get(
+        "retention_by_component"
+    )
+
+    for field_name, vector in (
+        ("baseline_vector", baseline_vector),
+        ("candidate_vector", candidate_vector),
+        (
+            "retention_by_component",
+            retention_vector,
+        ),
+    ):
+        if (
+            not isinstance(vector, dict)
+            or len(vector)
+            != len(FUTURE_FREEDOM_COMPONENT_NAMES)
+            or set(vector)
+            != set(FUTURE_FREEDOM_COMPONENT_NAMES)
+        ):
+            raise CanonicalStoreIntegrityError(
+                f"carrier future-freedom "
+                f"{field_name} must preserve "
+                "all components"
+            )
+
+        if any(
+            isinstance(value, bool)
+            or not isinstance(
+                value,
+                (int, float),
+            )
+            or not 0.0
+            <= float(value)
+            <= 1.0
+            for value
+            in vector.values()
+        ):
+            raise CanonicalStoreIntegrityError(
+                "carrier future-freedom values "
+                "must remain within [0, 1]"
+            )
+
+    minimum_retention_ratio = (
+        future_freedom.get(
+            "minimum_retention_ratio"
+        )
+    )
+
+    if (
+        isinstance(
+            minimum_retention_ratio,
+            bool,
+        )
+        or not isinstance(
+            minimum_retention_ratio,
+            (int, float),
+        )
+        or not 0.0
+        <= float(minimum_retention_ratio)
+        <= 1.0
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier future-freedom minimum "
+            "retention must be within [0, 1]"
+        )
+
+    computed_retention = {}
+
+    for component_name in (
+        FUTURE_FREEDOM_COMPONENT_NAMES
+    ):
+        baseline = float(
+            baseline_vector[
+                component_name
+            ]
+        )
+
+        candidate = float(
+            candidate_vector[
+                component_name
+            ]
+        )
+
+        if baseline == 0.0:
+            ratio = 1.0
+        else:
+            ratio = min(
+                1.0,
+                candidate / baseline,
+            )
+
+        computed_retention[
+            component_name
+        ] = ratio
+
+        stored_ratio = float(
+            retention_vector[
+                component_name
+            ]
+        )
+
+        if abs(
+            stored_ratio - ratio
+        ) > 1e-12:
+            raise CanonicalStoreIntegrityError(
+                "carrier future-freedom retention "
+                "is inconsistent"
+            )
+
+    computed_preserved = all(
+        ratio
+        >= float(
+            minimum_retention_ratio
+        )
+        for ratio
+        in computed_retention.values()
+    )
+
+    if (
+        future_freedom.get("preserved")
+        is not computed_preserved
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier future-freedom preserved "
+            "state is inconsistent"
+        )
+
+    if computed_preserved is not True:
+        raise CanonicalStoreIntegrityError(
+            "carrier future freedom is not preserved"
+        )
+
+    future_freedom_evidence_ids = (
+        future_freedom.get(
+            "evidence_record_ids"
+        )
+    )
+
+    if (
+        not isinstance(
+            future_freedom_evidence_ids,
+            list,
+        )
+        or not future_freedom_evidence_ids
+        or any(
+            not isinstance(evidence_id, str)
+            or not evidence_id.strip()
+            for evidence_id
+            in future_freedom_evidence_ids
+        )
+        or len(
+            set(
+                future_freedom_evidence_ids
+            )
+        )
+        != len(
+            future_freedom_evidence_ids
+        )
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier future freedom contains "
+            "invalid evidence links"
+        )
+
+    equivalence_class_id = (
+        equivalence_class.get("class_id")
+    )
+
+    terminal_class_id = (
+        equivalence_class.get(
+            "terminal_organizational_class_id"
+        )
+    )
+
+    if (
+        not isinstance(
+            equivalence_class_id,
+            str,
+        )
+        or not equivalence_class_id.strip()
+        or not isinstance(
+            terminal_class_id,
+            str,
+        )
+        or not terminal_class_id.strip()
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier ticket equivalence lacks "
+            "structural identifiers"
+        )
+
+    equivalence_coalition_ids = (
+        equivalence_class.get(
+            "coalition_ids"
+        )
+    )
+
+    if (
+        not isinstance(
+            equivalence_coalition_ids,
+            list,
+        )
+        or len(equivalence_coalition_ids)
+        < 2
+        or any(
+            not isinstance(item_id, str)
+            or not item_id.strip()
+            for item_id
+            in equivalence_coalition_ids
+        )
+        or len(
+            set(
+                equivalence_coalition_ids
+            )
+        )
+        != len(
+            equivalence_coalition_ids
+        )
+        or coalition_id
+        not in equivalence_coalition_ids
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier ticket equivalence requires "
+            "at least two coalitions including "
+            "the primary coalition"
+        )
+
+    for field_name in (
+        "invariant_function_record_ids",
+        "admissible_corridor_ids",
+        "evidence_record_ids",
+    ):
+        values = equivalence_class.get(
+            field_name
+        )
+
+        if (
+            not isinstance(values, list)
+            or not values
+            or any(
+                not isinstance(item_id, str)
+                or not item_id.strip()
+                for item_id in values
+            )
+            or len(set(values))
+            != len(values)
+        ):
+            raise CanonicalStoreIntegrityError(
+                f"carrier ticket equivalence "
+                f"contains invalid {field_name}"
+            )
+
+    if (
+        terminal_class_id
+        != coalition.get(
+            "terminal_organizational_class_id"
+        )
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier ticket equivalence "
+            "terminal-class mismatch"
+        )
+
+    if (
+        equivalence_class.get(
+            "equivalent_terminal_organization"
+        )
+        is not True
+        or equivalence_class.get(
+            "identical_microstate_required"
+        )
+        is not False
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier ticket equivalence violates "
+            "organizational equivalence"
+        )
+
+    return carrier
+
+
+def _validate_framework_record_dict(
+    record: Any,
+) -> dict[str, Any]:
+    if not isinstance(record, dict):
+        raise CanonicalStoreIntegrityError(
+            "stored canonical record must be an object"
+        )
+
+    if (
+        record.get("schema")
+        != RCAF_CANONICAL_LEDGER_SCHEMA
+    ):
+        raise CanonicalStoreIntegrityError(
+            "stored canonical record schema mismatch"
+        )
+
+    completeness = record.get(
+        "completeness"
+    )
+
+    expected_capabilities = tuple(
+        sorted(RCAF_CANONICAL_CAPABILITIES)
+    )
+
+    satisfied_capabilities = (
+        completeness.get(
+            "satisfied_capabilities"
+        )
+        if isinstance(completeness, dict)
+        else None
+    )
+
+    if (
+        not isinstance(completeness, dict)
+        or completeness.get(
+            "required_capability_count"
+        )
+        != len(expected_capabilities)
+        or completeness.get(
+            "satisfied_capability_count"
+        )
+        != len(expected_capabilities)
+        or not isinstance(
+            satisfied_capabilities,
+            list,
+        )
+        or tuple(satisfied_capabilities)
+        != expected_capabilities
+        or completeness.get(
+            "missing_capabilities"
+        )
+        != []
+        or completeness.get("complete")
+        is not True
+    ):
+        raise CanonicalStoreIntegrityError(
+            "stored canonical record is not complete: "
+            "exact capability envelope mismatch"
+        )
+
+    for field_name in (
+        "raw_content_stored",
+        "content_fingerprint_stored",
+        "semantic_memory_authority",
+        "identity_proof_established",
+        "realization_authorized",
+        "external_causal_authority",
+        "self_modification_authority",
+    ):
+        if record.get(field_name) is not False:
+            raise CanonicalStoreIntegrityError(
+                f"stored canonical record violates {field_name}"
+            )
+
+    if (
+        record.get("authority_posture")
+        != "observe_only"
+    ):
+        raise CanonicalStoreIntegrityError(
+            "store currently accepts observe-only records"
+        )
+
+    future_authority = record.get(
+        "future_authority_evidence"
+    )
+
+    if (
+        not isinstance(future_authority, dict)
+        or future_authority.get("schema")
+        != RCAF_FUTURE_AUTHORITY_SCHEMA
+    ):
+        raise CanonicalStoreIntegrityError(
+            "stored canonical record lacks the required "
+            "future-authority evidence bundle"
+        )
+
+    if (
+        future_authority.get("raw_content_stored")
+        is not False
+        or future_authority.get(
+            "content_fingerprint_stored"
+        )
+        is not False
+    ):
+        raise CanonicalStoreIntegrityError(
+            "future-authority evidence violates privacy"
+        )
+
+    if (
+        future_authority.get(
+            "causal_authority_eligible"
+        )
+        is not False
+    ):
+        raise CanonicalStoreIntegrityError(
+            "observe-only record cannot be future-authority eligible"
+        )
+
+    lifecycle = future_authority.get(
+        "lifecycle"
+    )
+
+    if (
+        not isinstance(lifecycle, dict)
+        or lifecycle.get("authority_status")
+        != "observe_only"
+        or lifecycle.get("no_auto_promotion")
+        is not True
+    ):
+        raise CanonicalStoreIntegrityError(
+            "future-gate lifecycle violates observe-only storage"
+        )
+
+    carrier = _validate_carrier_coalition_dict(
+        record.get("carrier_coalition")
+    )
+
+    reference_conditioning = record.get(
+        "reference_conditioning"
+    )
+
+    future_gate = record.get(
+        "future_gate"
+    )
+
+    if (
+        not isinstance(
+            reference_conditioning,
+            dict,
+        )
+        or not isinstance(future_gate, dict)
+    ):
+        raise CanonicalStoreIntegrityError(
+            "canonical carrier links require "
+            "reference and future-gate records"
+        )
+
+    active_reference_contract_id = (
+        reference_conditioning.get(
+            "reference_contract_id"
+        )
+    )
+
+    terminal_class_id = future_gate.get(
+        "terminal_organizational_class_id"
+    )
+
+    coalition = carrier["coalition"]
+
+    if (
+        coalition.get(
+            "reference_contract_id"
+        )
+        != active_reference_contract_id
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier reference contract does not "
+            "match canonical reference conditioning"
+        )
+
+    if (
+        coalition.get(
+            "terminal_organizational_class_id"
+        )
+        != terminal_class_id
+        or carrier[
+            "equivalence_class"
+        ].get(
+            "terminal_organizational_class_id"
+        )
+        != terminal_class_id
+    ):
+        raise CanonicalStoreIntegrityError(
+            "carrier terminal class does not "
+            "match canonical future gate"
+        )
+
+    try:
+        validate_canonical_record_schema_set(
+            record
+        )
+    except CanonicalSchemaEvolutionError as exc:
+        raise CanonicalStoreIntegrityError(
+            "schema-evolution policy rejected the record"
+        ) from exc
+
+    return record
+
+
+def _decode_segment(
+    path: Path,
+    *,
+    recover_trailing: bool,
+) -> tuple[
+    tuple[dict[str, Any], ...],
+    int,
+    bool,
+]:
+    fd = _open_private_regular_file(
+        path,
+        os.O_RDWR,
+    )
+
+    recovered_bytes = 0
+    repaired_newline = False
+
+    try:
+        data = _read_all(fd)
+
+        if data and not data.endswith(b"\n"):
+            last_newline = data.rfind(b"\n")
+            fragment_start = last_newline + 1
+            fragment = data[fragment_start:]
+
+            try:
+                json.loads(
+                    fragment.decode("utf-8")
+                )
+
+            except Exception as exc:
+                if not recover_trailing:
+                    raise CanonicalStoreIntegrityError(
+                        "invalid trailing partial record"
+                    ) from exc
+
+                recovered_bytes = len(fragment)
+
+                os.ftruncate(
+                    fd,
+                    fragment_start,
+                )
+
+                os.fsync(fd)
+
+                data = data[:fragment_start]
+
+            else:
+                if not recover_trailing:
+                    raise CanonicalStoreIntegrityError(
+                        "terminal record is missing newline"
+                    )
+
+                os.lseek(
+                    fd,
+                    0,
+                    os.SEEK_END,
+                )
+
+                _write_all(
+                    fd,
+                    b"\n",
+                )
+
+                os.fsync(fd)
+
+                data += b"\n"
+                repaired_newline = True
+
+        entries = []
+
+        for line_number, raw_line in enumerate(
+            data.splitlines(),
+            start=1,
+        ):
+            if not raw_line:
+                raise CanonicalStoreIntegrityError(
+                    f"empty record at line {line_number}"
+                )
+
+            try:
+                entry = json.loads(
+                    raw_line.decode("utf-8")
+                )
+            except Exception as exc:
+                raise CanonicalStoreIntegrityError(
+                    f"invalid JSON at line {line_number}"
+                ) from exc
+
+            if not isinstance(entry, dict):
+                raise CanonicalStoreIntegrityError(
+                    f"entry {line_number} must be an object"
+                )
+
+            entries.append(entry)
+
+        return (
+            tuple(entries),
+            recovered_bytes,
+            repaired_newline,
+        )
+
+    finally:
+        os.close(fd)
+
+
+def _validate_entry(
+    entry: dict[str, Any],
+    *,
+    expected_ledger_id: str,
+    expected_segment_index: int,
+    expected_sequence_index: int,
+    expected_previous_sha256: str,
+) -> None:
+    if (
+        entry.get("schema")
+        != RCAF_CANONICAL_ENTRY_SCHEMA
+    ):
+        raise CanonicalStoreIntegrityError(
+            "entry schema mismatch"
+        )
+
+    if (
+        entry.get("ledger_id")
+        != expected_ledger_id
+    ):
+        raise CanonicalStoreIntegrityError(
+            "entry ledger_id mismatch"
+        )
+
+    if (
+        entry.get("segment_index")
+        != expected_segment_index
+    ):
+        raise CanonicalStoreIntegrityError(
+            "entry segment_index mismatch"
+        )
+
+    if (
+        entry.get("sequence_index")
+        != expected_sequence_index
+    ):
+        raise CanonicalStoreIntegrityError(
+            "entry sequence continuity failure"
+        )
+
+    previous = _require_sha256(
+        "previous_entry_sha256",
+        entry.get(
+            "previous_entry_sha256",
+            "",
+        ),
+    )
+
+    if previous != expected_previous_sha256:
+        raise CanonicalStoreIntegrityError(
+            "entry hash-chain continuity failure"
+        )
+
+    stored_hash = _require_sha256(
+        "entry_sha256",
+        entry.get(
+            "entry_sha256",
+            "",
+        ),
+    )
+
+    calculated_hash = _sha256(
+        _canonical_bytes(
+            _entry_body(entry)
+        )
+    )
+
+    if stored_hash != calculated_hash:
+        raise CanonicalStoreIntegrityError(
+            "entry SHA-256 mismatch"
+        )
+
+    _validate_framework_record_dict(
+        entry.get("record")
+    )
+
+
+def _scan_store(
+    root: Path,
+    *,
+    ledger_id: str,
+    recover_trailing: bool,
+) -> _ScanResult:
+    segment_indexes = _segment_indexes(
+        root
+    )
+
+    entries = []
+    segment_counts = []
+    previous_sha256 = ZERO_SHA256
+    expected_sequence = 0
+    record_ids = set()
+    recovered_bytes = 0
+    repaired_newline = False
+
+    for position, segment_index in enumerate(
+        segment_indexes
+    ):
+        is_last = (
+            position
+            == len(segment_indexes) - 1
+        )
+
+        (
+            segment_entries,
+            segment_recovered,
+            segment_repaired,
+        ) = _decode_segment(
+            _segment_path(
+                root,
+                segment_index,
+            ),
+            recover_trailing=(
+                recover_trailing
+                and is_last
+            ),
+        )
+
+        if (
+            not is_last
+            and not segment_entries
+        ):
+            raise CanonicalStoreIntegrityError(
+                "non-terminal segment must not be empty"
+            )
+
+        recovered_bytes += segment_recovered
+        repaired_newline = (
+            repaired_newline
+            or segment_repaired
+        )
+
+        for entry in segment_entries:
+            _validate_entry(
+                entry,
+                expected_ledger_id=ledger_id,
+                expected_segment_index=(
+                    segment_index
+                ),
+                expected_sequence_index=(
+                    expected_sequence
+                ),
+                expected_previous_sha256=(
+                    previous_sha256
+                ),
+            )
+
+            record = entry["record"]
+            record_id = record.get(
+                "record_id"
+            )
+
+            if record_id in record_ids:
+                raise CanonicalStoreIntegrityError(
+                    "duplicate canonical record_id"
+                )
+
+            record_ids.add(record_id)
+
+            previous_sha256 = entry[
+                "entry_sha256"
+            ]
+
+            expected_sequence += 1
+            entries.append(entry)
+
+        segment_counts.append(
+            len(segment_entries)
+        )
+
+    return _ScanResult(
+        ledger_id=ledger_id,
+        entries=tuple(entries),
+        segment_entry_counts=tuple(
+            segment_counts
+        ),
+        recovered_trailing_bytes=(
+            recovered_bytes
+        ),
+        repaired_terminal_newline=(
+            repaired_newline
+        ),
+    )
+
+
+def _manifest_dict(
+    scan: _ScanResult,
+) -> dict[str, Any]:
+    return {
+        "schema": (
+            RCAF_CANONICAL_MANIFEST_SCHEMA
+        ),
+        "ledger_id": scan.ledger_id,
+        "record_count": scan.record_count,
+        "segment_count": scan.segment_count,
+        "last_sequence_index": (
+            scan.record_count - 1
+            if scan.record_count
+            else None
+        ),
+        "last_entry_sha256": (
+            scan.last_entry_sha256
+        ),
+        "segment_entry_counts": list(
+            scan.segment_entry_counts
+        ),
+        "authority_posture": "observe_only",
+        "raw_content_stored": False,
+        "content_fingerprint_stored": False,
+    }
+
+
+def _write_manifest_atomic(
+    root: Path,
+    scan: _ScanResult,
+) -> None:
+    manifest_path = (
+        root / "manifest.json"
+    )
+
+    if manifest_path.exists():
+        metadata = os.lstat(
+            manifest_path
+        )
+
+        if (
+            stat.S_ISLNK(metadata.st_mode)
+            or not stat.S_ISREG(
+                metadata.st_mode
+            )
+            or metadata.st_nlink != 1
+        ):
+            raise CanonicalStoreSecurityError(
+                "existing manifest is unsafe"
+            )
+
+    temporary_path = root / (
+        f".manifest.{os.getpid()}."
+        f"{uuid.uuid4().hex}.tmp"
+    )
+
+    fd = _open_private_regular_file(
+        temporary_path,
+        os.O_WRONLY
+        | os.O_CREAT
+        | os.O_EXCL,
+    )
+
+    try:
+        data = (
+            _canonical_bytes(
+                _manifest_dict(scan)
+            )
+            + b"\n"
+        )
+
+        _write_all(
+            fd,
+            data,
+        )
+
+        os.fsync(fd)
+
+    finally:
+        os.close(fd)
+
+    os.replace(
+        temporary_path,
+        manifest_path,
+    )
+
+    os.chmod(
+        manifest_path,
+        0o600,
+    )
+
+    _fsync_directory(root)
+
+
+def _lock_store(
+    root: Path,
+) -> int:
+    lock_path = root / ".lock"
+
+    fd = _open_private_regular_file(
+        lock_path,
+        os.O_RDWR | os.O_CREAT,
+    )
+
+    try:
+        fcntl.flock(
+            fd,
+            fcntl.LOCK_EX,
+        )
+    except Exception:
+        os.close(fd)
+        raise
+
+    return fd
+
+
+def _unlock_store(
+    fd: int,
+) -> None:
+    try:
+        fcntl.flock(
+            fd,
+            fcntl.LOCK_UN,
+        )
+    finally:
+        os.close(fd)
+
+
+def quarantine_canonical_store(
+    root: str | Path,
+    *,
+    ledger_id: str,
+    case_id: str,
+    reason_code: str,
+) -> ForensicQuarantineReceipt:
+    ledger_id = _require_ledger_id(
+        ledger_id
+    )
+
+    case_id = _require_ledger_id(
+        case_id
+    )
+
+    reason_code = _require_ledger_id(
+        reason_code
+    )
+
+    root = Path(root)
+
+    _ensure_private_directory(
+        root
+    )
+
+    lock_fd = _lock_store(
+        root
+    )
+
+    try:
+        _assert_store_not_quarantined(
+            root,
+            ledger_id=ledger_id,
+        )
+
+        forensic_root = (
+            root.parent
+            / f"{root.name}.forensics"
+        )
+
+        _ensure_private_directory(
+            forensic_root
+        )
+
+        case_directory = (
+            forensic_root
+            / case_id
+        )
+
+        if case_directory.exists():
+            raise CanonicalStoreError(
+                "forensic case already exists"
+            )
+
+        case_directory.mkdir(
+            mode=0o700,
+        )
+
+        os.chmod(
+            case_directory,
+            0o700,
+        )
+
+        captured_entries = []
+        copied_file_count = 0
+
+        for entry in sorted(
+            os.scandir(root),
+            key=lambda item: item.name,
+        ):
+            if entry.name == "quarantine.json":
+                continue
+
+            source_path = (
+                root
+                / entry.name
+            )
+
+            metadata = os.lstat(
+                source_path
+            )
+
+            base = {
+                "name": entry.name,
+                "source_mode": oct(
+                    stat.S_IMODE(
+                        metadata.st_mode
+                    )
+                ),
+                "source_nlink": (
+                    metadata.st_nlink
+                ),
+            }
+
+            if (
+                stat.S_ISREG(
+                    metadata.st_mode
+                )
+                and metadata.st_nlink == 1
+            ):
+                source_fd = (
+                    _open_private_regular_file(
+                        source_path,
+                        os.O_RDONLY,
+                    )
+                )
+
+                try:
+                    data = _read_all(
+                        source_fd
+                    )
+                finally:
+                    os.close(
+                        source_fd
+                    )
+
+                destination = (
+                    case_directory
+                    / entry.name
+                )
+
+                destination_fd = (
+                    _open_private_regular_file(
+                        destination,
+                        os.O_WRONLY
+                        | os.O_CREAT
+                        | os.O_EXCL,
+                    )
+                )
+
+                try:
+                    _write_all(
+                        destination_fd,
+                        data,
+                    )
+
+                    os.fsync(
+                        destination_fd
+                    )
+
+                finally:
+                    os.close(
+                        destination_fd
+                    )
+
+                captured_entries.append(
+                    {
+                        **base,
+                        "entry_type": "regular",
+                        "copied": True,
+                        "size_bytes": len(data),
+                        "sha256": _sha256(data),
+                    }
+                )
+
+                copied_file_count += 1
+
+            elif stat.S_ISLNK(
+                metadata.st_mode
+            ):
+                captured_entries.append(
+                    {
+                        **base,
+                        "entry_type": "symlink",
+                        "copied": False,
+                        "target_followed": False,
+                    }
+                )
+
+            elif stat.S_ISDIR(
+                metadata.st_mode
+            ):
+                captured_entries.append(
+                    {
+                        **base,
+                        "entry_type": "directory",
+                        "copied": False,
+                    }
+                )
+
+            else:
+                captured_entries.append(
+                    {
+                        **base,
+                        "entry_type": "unsupported",
+                        "copied": False,
+                    }
+                )
+
+        forensic_manifest = {
+            "schema": (
+                RCAF_FORENSIC_QUARANTINE_SCHEMA
+            ),
+            "case_id": case_id,
+            "ledger_id": ledger_id,
+            "reason_code": reason_code,
+            "source_store_name": root.name,
+            "captured_entry_count": len(
+                captured_entries
+            ),
+            "copied_file_count": (
+                copied_file_count
+            ),
+            "entries": captured_entries,
+            "forensic_bytes_preserved": True,
+            "content_interpretation_performed": False,
+            "repair_performed": False,
+            "authority_posture": "observe_only",
+        }
+
+        forensic_manifest_path = (
+            case_directory
+            / "forensic_manifest.json"
+        )
+
+        _write_private_json_atomic(
+            forensic_manifest_path,
+            forensic_manifest,
+        )
+
+        forensic_manifest_sha256 = (
+            _sha256(
+                forensic_manifest_path
+                .read_bytes()
+            )
+        )
+
+        marker = {
+            "schema": (
+                RCAF_FORENSIC_QUARANTINE_MARKER_SCHEMA
+            ),
+            "case_id": case_id,
+            "ledger_id": ledger_id,
+            "reason_code": reason_code,
+            "forensic_manifest_sha256": (
+                forensic_manifest_sha256
+            ),
+            "append_blocked": True,
+            "normal_validation_blocked": True,
+            "repair_performed": False,
+            "authority_posture": "observe_only",
+        }
+
+        _write_private_json_atomic(
+            _quarantine_marker_path(
+                root
+            ),
+            marker,
+        )
+
+        _fsync_directory(
+            case_directory
+        )
+
+        _fsync_directory(
+            forensic_root
+        )
+
+        return ForensicQuarantineReceipt(
+            case_id=case_id,
+            ledger_id=ledger_id,
+            reason_code=reason_code,
+            case_directory=str(
+                case_directory
+            ),
+            captured_entry_count=len(
+                captured_entries
+            ),
+            copied_file_count=(
+                copied_file_count
+            ),
+            forensic_manifest_sha256=(
+                forensic_manifest_sha256
+            ),
+            append_blocked=True,
+            authority_posture="observe_only",
+        )
+
+    finally:
+        _unlock_store(
+            lock_fd
+        )
+
+
+def append_canonical_record(
+    root: str | Path,
+    *,
+    ledger_id: str,
+    record: RCAFFullFrameworkRecord,
+    max_records_per_segment: int = 256,
+) -> CanonicalAppendReceipt:
+    ledger_id = _require_ledger_id(
+        ledger_id
+    )
+
+    if (
+        isinstance(
+            max_records_per_segment,
+            bool,
+        )
+        or not isinstance(
+            max_records_per_segment,
+            int,
+        )
+        or max_records_per_segment <= 0
+    ):
+        raise CanonicalStoreError(
+            "max_records_per_segment must be a positive integer"
+        )
+
+    if not isinstance(
+        record,
+        RCAFFullFrameworkRecord,
+    ):
+        raise CanonicalStoreError(
+            "record must be RCAFFullFrameworkRecord"
+        )
+
+    record_dict = record.to_dict()
+
+    _validate_framework_record_dict(
+        record_dict
+    )
+
+    root = Path(root)
+
+    _ensure_private_directory(root)
+
+    lock_fd = _lock_store(root)
+
+    try:
+        _assert_store_not_quarantined(
+            root,
+            ledger_id=ledger_id,
+        )
+
+        scan = _scan_store(
+            root,
+            ledger_id=ledger_id,
+            recover_trailing=True,
+        )
+
+        existing_record_ids = {
+            entry["record"]["record_id"]
+            for entry in scan.entries
+        }
+
+        if record.record_id in existing_record_ids:
+            raise CanonicalStoreIntegrityError(
+                "duplicate canonical record_id"
+            )
+
+        if not scan.segment_entry_counts:
+            segment_index = 0
+
+        elif (
+            scan.segment_entry_counts[-1]
+            >= max_records_per_segment
+        ):
+            segment_index = (
+                scan.segment_count
+            )
+
+        else:
+            segment_index = (
+                scan.segment_count - 1
+            )
+
+        sequence_index = scan.record_count
+        previous_sha256 = (
+            scan.last_entry_sha256
+        )
+
+        body = {
+            "schema": (
+                RCAF_CANONICAL_ENTRY_SCHEMA
+            ),
+            "ledger_id": ledger_id,
+            "segment_index": segment_index,
+            "sequence_index": (
+                sequence_index
+            ),
+            "previous_entry_sha256": (
+                previous_sha256
+            ),
+            "record": record_dict,
+        }
+
+        entry_sha256 = _sha256(
+            _canonical_bytes(body)
+        )
+
+        entry = {
+            **body,
+            "entry_sha256": entry_sha256,
+        }
+
+        segment_path = _segment_path(
+            root,
+            segment_index,
+        )
+
+        fd = _open_private_regular_file(
+            segment_path,
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_APPEND,
+        )
+
+        try:
+            _write_all(
+                fd,
+                _canonical_bytes(entry)
+                + b"\n",
+            )
+
+            os.fsync(fd)
+
+        finally:
+            os.close(fd)
+
+        verified = _scan_store(
+            root,
+            ledger_id=ledger_id,
+            recover_trailing=False,
+        )
+
+        if (
+            verified.record_count
+            != sequence_index + 1
+            or verified.last_entry_sha256
+            != entry_sha256
+        ):
+            raise CanonicalStoreIntegrityError(
+                "post-append verification failed"
+            )
+
+        _write_manifest_atomic(
+            root,
+            verified,
+        )
+
+        return CanonicalAppendReceipt(
+            ledger_id=ledger_id,
+            sequence_index=sequence_index,
+            segment_index=segment_index,
+            entry_sha256=entry_sha256,
+            previous_entry_sha256=(
+                previous_sha256
+            ),
+            record_count=(
+                verified.record_count
+            ),
+            segment_count=(
+                verified.segment_count
+            ),
+            durable_storage_write=True,
+            authority_posture=(
+                "observe_only"
+            ),
+        )
+
+    finally:
+        _unlock_store(lock_fd)
+
+
+def validate_and_replay_canonical_store(
+    root: str | Path,
+    *,
+    ledger_id: str,
+    recover_trailing: bool = False,
+    rebuild_manifest: bool = True,
+    allow_quarantined: bool = False,
+) -> CanonicalReplayResult:
+    ledger_id = _require_ledger_id(
+        ledger_id
+    )
+
+    root = Path(root)
+
+    _ensure_private_directory(root)
+
+    lock_fd = _lock_store(root)
+
+    try:
+        if not allow_quarantined:
+            _assert_store_not_quarantined(
+                root,
+                ledger_id=ledger_id,
+            )
+
+        scan = _scan_store(
+            root,
+            ledger_id=ledger_id,
+            recover_trailing=(
+                recover_trailing
+            ),
+        )
+
+        records = tuple(
+            entry["record"]
+            for entry in scan.entries
+        )
+
+        first_replay = tuple(
+            _canonical_bytes(record)
+            for record in records
+        )
+
+        second_replay = tuple(
+            _canonical_bytes(record)
+            for record in records
+        )
+
+        deterministic = (
+            first_replay == second_replay
+        )
+
+        if rebuild_manifest:
+            _write_manifest_atomic(
+                root,
+                scan,
+            )
+
+        return CanonicalReplayResult(
+            ledger_id=ledger_id,
+            record_count=(
+                scan.record_count
+            ),
+            segment_count=(
+                scan.segment_count
+            ),
+            last_sequence_index=(
+                scan.record_count - 1
+                if scan.record_count
+                else None
+            ),
+            last_entry_sha256=(
+                scan.last_entry_sha256
+            ),
+            records=records,
+            integrity_verified=True,
+            deterministic_replay_verified=(
+                deterministic
+            ),
+            recovered_trailing_bytes=(
+                scan.recovered_trailing_bytes
+            ),
+            repaired_terminal_newline=(
+                scan.repaired_terminal_newline
+            ),
+            authority_posture=(
+                "observe_only"
+            ),
+        )
+
+    finally:
+        _unlock_store(lock_fd)

--- a/src/rcaf/carrier_coalition.py
+++ b/src/rcaf/carrier_coalition.py
@@ -1,0 +1,1654 @@
+# ============================================================
+# src/rcaf/carrier_coalition.py
+# ============================================================
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+
+RCAF_CARRIER_COALITION_SCHEMA = (
+    "RCAF-CARRIER-COALITION-0.1"
+)
+
+CARRIER_RELATION_KINDS = frozenset(
+    {
+        "support",
+        "route",
+        "buffer",
+        "reserve",
+        "compete",
+        "inhibit",
+        "synchronize",
+        "scaffold",
+        "payload",
+    }
+)
+
+COMPONENT_ROLE_NAMES = (
+    "payload",
+    "scaffold",
+    "routing",
+    "buffer",
+    "reserve",
+    "competitor",
+    "redundancy",
+    "turbulence",
+)
+
+TURBULENCE_COMPONENT_NAMES = (
+    "inertial_mismatch",
+    "entropy_load",
+    "frequency_shear",
+    "phase_conflict",
+    "coupling_stress",
+    "boundary_shear",
+    "carrier_slippage",
+    "eddy_formation",
+    "turbulent_debt",
+    "release_drag",
+)
+
+TURBULENCE_CLASSES = frozenset(
+    {
+        "productive_transition",
+        "boundary_shear",
+        "carrier_conflict",
+        "scale_mismatch_chatter",
+        "self_sealing_loop",
+        "fragmentation",
+        "release_instability",
+        "optimizer_shock",
+    }
+)
+
+FUTURE_FREEDOM_COMPONENT_NAMES = (
+    "task_adaptability",
+    "routing_reserve",
+    "recovery_capacity",
+    "transfer_capacity",
+    "perturbation_tolerance",
+    "alternative_path_capacity",
+)
+
+COUNTERFACTUAL_ARMS = (
+    "A0",
+    "A1",
+    "A2",
+    "A3",
+    "A4",
+    "A5",
+    "A6",
+    "A7",
+    "A8",
+)
+
+_IDENTIFIER_PATTERN = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,191}$"
+)
+
+
+class CarrierCoalitionContractError(
+    ValueError
+):
+    """Raised when a carrier-coalition contract is invalid."""
+
+
+def _require_identifier(
+    field_name: str,
+    value: str,
+) -> str:
+    normalized = str(value).strip()
+
+    if not _IDENTIFIER_PATTERN.fullmatch(
+        normalized
+    ):
+        raise CarrierCoalitionContractError(
+            f"{field_name} must be a structural identifier"
+        )
+
+    return normalized
+
+
+def _require_positive_integer(
+    field_name: str,
+    value: int,
+) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value <= 0
+    ):
+        raise CarrierCoalitionContractError(
+            f"{field_name} must be a positive integer"
+        )
+
+    return value
+
+
+def _require_unit_interval(
+    field_name: str,
+    value: float,
+) -> float:
+    try:
+        normalized = float(value)
+    except Exception as exc:
+        raise CarrierCoalitionContractError(
+            f"{field_name} must be numeric"
+        ) from exc
+
+    if not 0.0 <= normalized <= 1.0:
+        raise CarrierCoalitionContractError(
+            f"{field_name} must be within [0, 1]"
+        )
+
+    return normalized
+
+
+def _require_identifiers(
+    field_name: str,
+    values: tuple[str, ...],
+    *,
+    nonempty: bool = True,
+) -> tuple[str, ...]:
+    normalized = tuple(
+        _require_identifier(
+            field_name,
+            value,
+        )
+        for value in values
+    )
+
+    if nonempty and not normalized:
+        raise CarrierCoalitionContractError(
+            f"{field_name} must not be empty"
+        )
+
+    if len(set(normalized)) != len(normalized):
+        raise CarrierCoalitionContractError(
+            f"{field_name} contains duplicates"
+        )
+
+    return normalized
+
+
+def _require_component_vector(
+    field_name: str,
+    values: tuple[float, ...],
+    names: tuple[str, ...],
+) -> tuple[float, ...]:
+    if len(values) != len(names):
+        raise CarrierCoalitionContractError(
+            f"{field_name} must contain "
+            f"{len(names)} components"
+        )
+
+    return tuple(
+        _require_unit_interval(
+            f"{field_name}.{name}",
+            value,
+        )
+        for name, value in zip(
+            names,
+            values,
+            strict=True,
+        )
+    )
+
+
+@dataclass(frozen=True)
+class CarrierValidityRelation:
+    relation_id: str
+    source_member_id: str
+    target_member_id: str
+    relation_kind: str
+    reference_contract_id: str
+    evidence_record_ids: tuple[str, ...]
+    context_validated: bool
+    phase_compatible: bool
+    boundary_compatible: bool
+    future_consistent: bool
+    observer_only: bool = True
+    authority_granted: bool = False
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "relation_id",
+            "source_member_id",
+            "target_member_id",
+            "reference_contract_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        if self.relation_kind not in (
+            CARRIER_RELATION_KINDS
+        ):
+            raise CarrierCoalitionContractError(
+                "unknown carrier relation kind"
+            )
+
+        object.__setattr__(
+            self,
+            "evidence_record_ids",
+            _require_identifiers(
+                "evidence_record_ids",
+                self.evidence_record_ids,
+            ),
+        )
+
+        if self.observer_only is not True:
+            raise CarrierCoalitionContractError(
+                "carrier validity must remain observer-only"
+            )
+
+        if self.authority_granted is not False:
+            raise CarrierCoalitionContractError(
+                "carrier validity cannot grant authority"
+            )
+
+    @property
+    def valid(
+        self,
+    ) -> bool:
+        return all(
+            (
+                self.context_validated,
+                self.phase_compatible,
+                self.boundary_compatible,
+                self.future_consistent,
+            )
+        )
+
+    def to_dict(
+        self,
+    ) -> dict[str, Any]:
+        return {
+            "relation_id": self.relation_id,
+            "source_member_id": self.source_member_id,
+            "target_member_id": self.target_member_id,
+            "relation_kind": self.relation_kind,
+            "reference_contract_id": self.reference_contract_id,
+            "evidence_record_ids": list(
+                self.evidence_record_ids
+            ),
+            "context_validated": self.context_validated,
+            "phase_compatible": self.phase_compatible,
+            "boundary_compatible": self.boundary_compatible,
+            "future_consistent": self.future_consistent,
+            "valid": self.valid,
+            "observer_only": True,
+            "authority_granted": False,
+        }
+
+
+@dataclass(frozen=True)
+class ComponentRoleEvidence:
+    evidence_id: str
+    member_id: str
+    reference_contract_id: str
+    horizon_steps: int
+    role_values: tuple[float, ...]
+    evidence_record_ids: tuple[str, ...]
+    role_assignment_nonexclusive: bool = True
+    calibrated: bool = False
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "evidence_id",
+            "member_id",
+            "reference_contract_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        object.__setattr__(
+            self,
+            "horizon_steps",
+            _require_positive_integer(
+                "horizon_steps",
+                self.horizon_steps,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "role_values",
+            _require_component_vector(
+                "role_values",
+                self.role_values,
+                COMPONENT_ROLE_NAMES,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "evidence_record_ids",
+            _require_identifiers(
+                "evidence_record_ids",
+                self.evidence_record_ids,
+            ),
+        )
+
+        if (
+            self.role_assignment_nonexclusive
+            is not True
+        ):
+            raise CarrierCoalitionContractError(
+                "component roles must remain nonexclusive"
+            )
+
+    @property
+    def role_vector(
+        self,
+    ) -> dict[str, float]:
+        return dict(
+            zip(
+                COMPONENT_ROLE_NAMES,
+                self.role_values,
+                strict=True,
+            )
+        )
+
+    def to_dict(
+        self,
+    ) -> dict[str, Any]:
+        return {
+            "evidence_id": self.evidence_id,
+            "member_id": self.member_id,
+            "reference_contract_id": self.reference_contract_id,
+            "horizon_steps": self.horizon_steps,
+            "role_vector": self.role_vector,
+            "evidence_record_ids": list(
+                self.evidence_record_ids
+            ),
+            "role_assignment_nonexclusive": True,
+            "calibrated": self.calibrated,
+        }
+
+
+@dataclass(frozen=True)
+class MultiscaleTurbulenceChannel:
+    channel_id: str
+    source_organization_id: str
+    target_organization_id: str
+    reference_contract_id: str
+    horizon_steps: int
+    component_values: tuple[float, ...]
+    turbulence_classes: tuple[str, ...]
+    evidence_record_ids: tuple[str, ...]
+    component_preserving: bool = True
+    collapsed_score_authoritative: bool = False
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "channel_id",
+            "source_organization_id",
+            "target_organization_id",
+            "reference_contract_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        object.__setattr__(
+            self,
+            "horizon_steps",
+            _require_positive_integer(
+                "horizon_steps",
+                self.horizon_steps,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "component_values",
+            _require_component_vector(
+                "component_values",
+                self.component_values,
+                TURBULENCE_COMPONENT_NAMES,
+            ),
+        )
+
+        normalized_classes = tuple(
+            str(value).strip()
+            for value in self.turbulence_classes
+        )
+
+        if not normalized_classes:
+            raise CarrierCoalitionContractError(
+                "turbulence_classes must not be empty"
+            )
+
+        if len(set(normalized_classes)) != len(
+            normalized_classes
+        ):
+            raise CarrierCoalitionContractError(
+                "turbulence_classes contains duplicates"
+            )
+
+        unknown = sorted(
+            set(normalized_classes)
+            - TURBULENCE_CLASSES
+        )
+
+        if unknown:
+            raise CarrierCoalitionContractError(
+                f"unknown turbulence classes: {unknown!r}"
+            )
+
+        object.__setattr__(
+            self,
+            "turbulence_classes",
+            normalized_classes,
+        )
+
+        object.__setattr__(
+            self,
+            "evidence_record_ids",
+            _require_identifiers(
+                "evidence_record_ids",
+                self.evidence_record_ids,
+            ),
+        )
+
+        if self.component_preserving is not True:
+            raise CarrierCoalitionContractError(
+                "turbulence components must be preserved"
+            )
+
+        if (
+            self.collapsed_score_authoritative
+            is not False
+        ):
+            raise CarrierCoalitionContractError(
+                "a collapsed turbulence score cannot be authoritative"
+            )
+
+    @property
+    def component_vector(
+        self,
+    ) -> dict[str, float]:
+        return dict(
+            zip(
+                TURBULENCE_COMPONENT_NAMES,
+                self.component_values,
+                strict=True,
+            )
+        )
+
+    def to_dict(
+        self,
+    ) -> dict[str, Any]:
+        return {
+            "channel_id": self.channel_id,
+            "source_organization_id": self.source_organization_id,
+            "target_organization_id": self.target_organization_id,
+            "reference_contract_id": self.reference_contract_id,
+            "horizon_steps": self.horizon_steps,
+            "component_vector": self.component_vector,
+            "turbulence_classes": list(
+                self.turbulence_classes
+            ),
+            "evidence_record_ids": list(
+                self.evidence_record_ids
+            ),
+            "component_preserving": True,
+            "collapsed_score_authoritative": False,
+        }
+
+
+@dataclass(frozen=True)
+class ScaffoldDependenceEvidence:
+    dependence_id: str
+    coalition_id: str
+    scaffold_member_ids: tuple[str, ...]
+    reference_contract_id: str
+    observation_horizon: int
+    dependence_values: tuple[float, ...]
+    support_required_now: bool
+    evidence_record_ids: tuple[str, ...]
+
+    DEPENDENCE_COMPONENT_NAMES = (
+        "optimizer_shock",
+        "activation_shear",
+        "gradient_conflict",
+        "routing_dependency",
+        "boundary_strain",
+        "release_drag",
+        "delayed_degradation_risk",
+    )
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "dependence_id",
+            "coalition_id",
+            "reference_contract_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        object.__setattr__(
+            self,
+            "scaffold_member_ids",
+            _require_identifiers(
+                "scaffold_member_ids",
+                self.scaffold_member_ids,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "observation_horizon",
+            _require_positive_integer(
+                "observation_horizon",
+                self.observation_horizon,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "dependence_values",
+            _require_component_vector(
+                "dependence_values",
+                self.dependence_values,
+                self.DEPENDENCE_COMPONENT_NAMES,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "evidence_record_ids",
+            _require_identifiers(
+                "evidence_record_ids",
+                self.evidence_record_ids,
+            ),
+        )
+
+    @property
+    def dependence_vector(
+        self,
+    ) -> dict[str, float]:
+        return dict(
+            zip(
+                self.DEPENDENCE_COMPONENT_NAMES,
+                self.dependence_values,
+                strict=True,
+            )
+        )
+
+    def to_dict(
+        self,
+    ) -> dict[str, Any]:
+        return {
+            "dependence_id": self.dependence_id,
+            "coalition_id": self.coalition_id,
+            "scaffold_member_ids": list(
+                self.scaffold_member_ids
+            ),
+            "reference_contract_id": self.reference_contract_id,
+            "observation_horizon": self.observation_horizon,
+            "dependence_vector": self.dependence_vector,
+            "support_required_now": self.support_required_now,
+            "evidence_record_ids": list(
+                self.evidence_record_ids
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class ScaffoldReleaseEvidence:
+    release_id: str
+    coalition_id: str
+    scaffold_member_ids: tuple[str, ...]
+    reference_contract_id: str
+    withdrawal_horizon: int
+    immediate_performance_preserved: bool
+    far_horizon_performance_preserved: bool
+    calibration_preserved: bool
+    robustness_preserved: bool
+    optimizer_stable: bool
+    activation_geometry_stable: bool
+    persistence_verified: bool
+    recovery_available: bool
+    transfer_preserved: bool
+    future_freedom_preserved: bool
+    turbulent_debt_admissible: bool
+    evidence_record_ids: tuple[str, ...]
+    observer_only: bool = True
+    authority_granted: bool = False
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "release_id",
+            "coalition_id",
+            "reference_contract_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        object.__setattr__(
+            self,
+            "scaffold_member_ids",
+            _require_identifiers(
+                "scaffold_member_ids",
+                self.scaffold_member_ids,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "withdrawal_horizon",
+            _require_positive_integer(
+                "withdrawal_horizon",
+                self.withdrawal_horizon,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "evidence_record_ids",
+            _require_identifiers(
+                "evidence_record_ids",
+                self.evidence_record_ids,
+            ),
+        )
+
+        if self.observer_only is not True:
+            raise CarrierCoalitionContractError(
+                "release evidence must remain observer-only"
+            )
+
+        if self.authority_granted is not False:
+            raise CarrierCoalitionContractError(
+                "release evidence cannot grant authority"
+            )
+
+    @property
+    def release_admissible(
+        self,
+    ) -> bool:
+        return all(
+            (
+                self.immediate_performance_preserved,
+                self.far_horizon_performance_preserved,
+                self.calibration_preserved,
+                self.robustness_preserved,
+                self.optimizer_stable,
+                self.activation_geometry_stable,
+                self.persistence_verified,
+                self.recovery_available,
+                self.transfer_preserved,
+                self.future_freedom_preserved,
+                self.turbulent_debt_admissible,
+            )
+        )
+
+    def to_dict(
+        self,
+    ) -> dict[str, Any]:
+        return {
+            "release_id": self.release_id,
+            "coalition_id": self.coalition_id,
+            "scaffold_member_ids": list(
+                self.scaffold_member_ids
+            ),
+            "reference_contract_id": self.reference_contract_id,
+            "withdrawal_horizon": self.withdrawal_horizon,
+            "immediate_performance_preserved": self.immediate_performance_preserved,
+            "far_horizon_performance_preserved": self.far_horizon_performance_preserved,
+            "calibration_preserved": self.calibration_preserved,
+            "robustness_preserved": self.robustness_preserved,
+            "optimizer_stable": self.optimizer_stable,
+            "activation_geometry_stable": self.activation_geometry_stable,
+            "persistence_verified": self.persistence_verified,
+            "recovery_available": self.recovery_available,
+            "transfer_preserved": self.transfer_preserved,
+            "future_freedom_preserved": self.future_freedom_preserved,
+            "turbulent_debt_admissible": self.turbulent_debt_admissible,
+            "release_admissible": self.release_admissible,
+            "evidence_record_ids": list(
+                self.evidence_record_ids
+            ),
+            "observer_only": True,
+            "authority_granted": False,
+        }
+
+
+@dataclass(frozen=True)
+class CompressionFutureFreedom:
+    record_id: str
+    coalition_id: str
+    reference_contract_id: str
+    baseline_values: tuple[float, ...]
+    candidate_values: tuple[float, ...]
+    minimum_retention_ratio: float
+    evidence_record_ids: tuple[str, ...]
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "record_id",
+            "coalition_id",
+            "reference_contract_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        object.__setattr__(
+            self,
+            "baseline_values",
+            _require_component_vector(
+                "baseline_values",
+                self.baseline_values,
+                FUTURE_FREEDOM_COMPONENT_NAMES,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "candidate_values",
+            _require_component_vector(
+                "candidate_values",
+                self.candidate_values,
+                FUTURE_FREEDOM_COMPONENT_NAMES,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "minimum_retention_ratio",
+            _require_unit_interval(
+                "minimum_retention_ratio",
+                self.minimum_retention_ratio,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "evidence_record_ids",
+            _require_identifiers(
+                "evidence_record_ids",
+                self.evidence_record_ids,
+            ),
+        )
+
+    @property
+    def retention_by_component(
+        self,
+    ) -> dict[str, float]:
+        values = {}
+
+        for name, baseline, candidate in zip(
+            FUTURE_FREEDOM_COMPONENT_NAMES,
+            self.baseline_values,
+            self.candidate_values,
+            strict=True,
+        ):
+            if baseline == 0.0:
+                ratio = 1.0
+            else:
+                ratio = min(
+                    1.0,
+                    candidate / baseline,
+                )
+
+            values[name] = ratio
+
+        return values
+
+    @property
+    def preserved(
+        self,
+    ) -> bool:
+        return all(
+            ratio
+            >= self.minimum_retention_ratio
+            for ratio in (
+                self.retention_by_component.values()
+            )
+        )
+
+    def to_dict(
+        self,
+    ) -> dict[str, Any]:
+        return {
+            "record_id": self.record_id,
+            "coalition_id": self.coalition_id,
+            "reference_contract_id": self.reference_contract_id,
+            "baseline_vector": dict(
+                zip(
+                    FUTURE_FREEDOM_COMPONENT_NAMES,
+                    self.baseline_values,
+                    strict=True,
+                )
+            ),
+            "candidate_vector": dict(
+                zip(
+                    FUTURE_FREEDOM_COMPONENT_NAMES,
+                    self.candidate_values,
+                    strict=True,
+                )
+            ),
+            "retention_by_component": self.retention_by_component,
+            "minimum_retention_ratio": self.minimum_retention_ratio,
+            "preserved": self.preserved,
+            "evidence_record_ids": list(
+                self.evidence_record_ids
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class TrajectoryAdmissibleCarrierCoalition:
+    coalition_id: str
+    member_ids: tuple[str, ...]
+    initialization_state_id: str
+    optimizer_state_id: str
+    data_contract_id: str
+    reference_contract_id: str
+    participation_geometry_id: str
+    transformation_geometry_id: str
+    boundary_contract_id: str
+    terminal_organizational_class_id: str
+    scaffold_relation_ids: tuple[str, ...]
+    turbulence_channel_ids: tuple[str, ...]
+    role_evidence_ids: tuple[str, ...]
+    future_freedom_record_id: str
+    horizon_steps: int
+    forward_reachable: bool
+    backward_consistent: bool
+    self_supporting: bool
+    support_withdrawal_verified: bool
+    context_specific: bool
+    observer_only: bool = True
+    authority_eligible: bool = False
+    no_auto_promotion: bool = True
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "coalition_id",
+            "initialization_state_id",
+            "optimizer_state_id",
+            "data_contract_id",
+            "reference_contract_id",
+            "participation_geometry_id",
+            "transformation_geometry_id",
+            "boundary_contract_id",
+            "terminal_organizational_class_id",
+            "future_freedom_record_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        for field_name in (
+            "member_ids",
+            "scaffold_relation_ids",
+            "turbulence_channel_ids",
+            "role_evidence_ids",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifiers(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        object.__setattr__(
+            self,
+            "horizon_steps",
+            _require_positive_integer(
+                "horizon_steps",
+                self.horizon_steps,
+            ),
+        )
+
+        if self.observer_only is not True:
+            raise CarrierCoalitionContractError(
+                "coalition must remain observer-only"
+            )
+
+        if self.authority_eligible is not False:
+            raise CarrierCoalitionContractError(
+                "coalition cannot become authority-eligible in R1A"
+            )
+
+        if self.no_auto_promotion is not True:
+            raise CarrierCoalitionContractError(
+                "coalition must prohibit auto-promotion"
+            )
+
+    @property
+    def nomination_ready(
+        self,
+    ) -> bool:
+        return all(
+            (
+                self.forward_reachable,
+                self.backward_consistent,
+                self.self_supporting,
+                self.support_withdrawal_verified,
+            )
+        )
+
+    def to_dict(
+        self,
+    ) -> dict[str, Any]:
+        return {
+            "coalition_id": self.coalition_id,
+            "member_ids": list(
+                self.member_ids
+            ),
+            "initialization_state_id": self.initialization_state_id,
+            "optimizer_state_id": self.optimizer_state_id,
+            "data_contract_id": self.data_contract_id,
+            "reference_contract_id": self.reference_contract_id,
+            "participation_geometry_id": self.participation_geometry_id,
+            "transformation_geometry_id": self.transformation_geometry_id,
+            "boundary_contract_id": self.boundary_contract_id,
+            "terminal_organizational_class_id": self.terminal_organizational_class_id,
+            "scaffold_relation_ids": list(
+                self.scaffold_relation_ids
+            ),
+            "turbulence_channel_ids": list(
+                self.turbulence_channel_ids
+            ),
+            "role_evidence_ids": list(
+                self.role_evidence_ids
+            ),
+            "future_freedom_record_id": self.future_freedom_record_id,
+            "horizon_steps": self.horizon_steps,
+            "forward_reachable": self.forward_reachable,
+            "backward_consistent": self.backward_consistent,
+            "self_supporting": self.self_supporting,
+            "support_withdrawal_verified": self.support_withdrawal_verified,
+            "context_specific": self.context_specific,
+            "nomination_ready": self.nomination_ready,
+            "observer_only": True,
+            "authority_eligible": False,
+            "no_auto_promotion": True,
+        }
+
+
+@dataclass(frozen=True)
+class CoalitionCounterfactualBranch:
+    branch_id: str
+    arm: str
+    coalition_id: str
+    topology_relation: str
+    initialization_relation: str
+    context_relation: str
+    support_relation: str
+    dynamic_topology: bool
+    outcome_record_ids: tuple[str, ...]
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "branch_id",
+            "coalition_id",
+            "topology_relation",
+            "initialization_relation",
+            "context_relation",
+            "support_relation",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        if self.arm not in COUNTERFACTUAL_ARMS:
+            raise CarrierCoalitionContractError(
+                "unknown coalition counterfactual arm"
+            )
+
+        object.__setattr__(
+            self,
+            "outcome_record_ids",
+            _require_identifiers(
+                "outcome_record_ids",
+                self.outcome_record_ids,
+            ),
+        )
+
+    def to_dict(
+        self,
+    ) -> dict[str, Any]:
+        return {
+            "branch_id": self.branch_id,
+            "arm": self.arm,
+            "coalition_id": self.coalition_id,
+            "topology_relation": self.topology_relation,
+            "initialization_relation": self.initialization_relation,
+            "context_relation": self.context_relation,
+            "support_relation": self.support_relation,
+            "dynamic_topology": self.dynamic_topology,
+            "outcome_record_ids": list(
+                self.outcome_record_ids
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class CoalitionMatchedExperiment:
+    experiment_id: str
+    branches: tuple[
+        CoalitionCounterfactualBranch,
+        ...,
+    ]
+    acceptance_contract_id: str
+    independent_evaluator: bool
+    frozen_acceptance_criteria: bool
+    matched_compute_budget: bool
+    multiple_seeds: bool
+    observer_only: bool = True
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "experiment_id",
+            "acceptance_contract_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        arms = tuple(
+            branch.arm
+            for branch in self.branches
+        )
+
+        if set(arms) != set(
+            COUNTERFACTUAL_ARMS
+        ):
+            raise CarrierCoalitionContractError(
+                "matched experiment must contain A0 through A8"
+            )
+
+        if len(arms) != len(
+            COUNTERFACTUAL_ARMS
+        ):
+            raise CarrierCoalitionContractError(
+                "matched experiment contains duplicate arms"
+            )
+
+        branch_ids = tuple(
+            branch.branch_id
+            for branch in self.branches
+        )
+
+        if len(set(branch_ids)) != len(
+            branch_ids
+        ):
+            raise CarrierCoalitionContractError(
+                "matched experiment contains duplicate branch IDs"
+            )
+
+        if self.independent_evaluator is not True:
+            raise CarrierCoalitionContractError(
+                "matched experiment requires an independent evaluator"
+            )
+
+        if self.frozen_acceptance_criteria is not True:
+            raise CarrierCoalitionContractError(
+                "matched experiment requires frozen criteria"
+            )
+
+        if self.matched_compute_budget is not True:
+            raise CarrierCoalitionContractError(
+                "matched experiment requires matched compute"
+            )
+
+        if self.multiple_seeds is not True:
+            raise CarrierCoalitionContractError(
+                "matched experiment requires multiple seeds"
+            )
+
+        if self.observer_only is not True:
+            raise CarrierCoalitionContractError(
+                "matched experiment must remain observer-only"
+            )
+
+    def to_dict(
+        self,
+    ) -> dict[str, Any]:
+        return {
+            "experiment_id": self.experiment_id,
+            "branches": [
+                branch.to_dict()
+                for branch in self.branches
+            ],
+            "acceptance_contract_id": self.acceptance_contract_id,
+            "independent_evaluator": True,
+            "frozen_acceptance_criteria": True,
+            "matched_compute_budget": True,
+            "multiple_seeds": True,
+            "observer_only": True,
+        }
+
+
+@dataclass(frozen=True)
+class MicroscopicTicketEquivalenceClass:
+    class_id: str
+    coalition_ids: tuple[str, ...]
+    terminal_organizational_class_id: str
+    invariant_function_record_ids: tuple[str, ...]
+    admissible_corridor_ids: tuple[str, ...]
+    evidence_record_ids: tuple[str, ...]
+    equivalent_terminal_organization: bool = True
+    identical_microstate_required: bool = False
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "class_id",
+            "terminal_organizational_class_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        for field_name in (
+            "coalition_ids",
+            "invariant_function_record_ids",
+            "admissible_corridor_ids",
+            "evidence_record_ids",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifiers(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        if len(self.coalition_ids) < 2:
+            raise CarrierCoalitionContractError(
+                "ticket equivalence requires at least two coalitions"
+            )
+
+        if (
+            self.equivalent_terminal_organization
+            is not True
+        ):
+            raise CarrierCoalitionContractError(
+                "ticket class must share a terminal organization"
+            )
+
+        if self.identical_microstate_required is not False:
+            raise CarrierCoalitionContractError(
+                "ticket equivalence cannot require identical microstates"
+            )
+
+    def to_dict(
+        self,
+    ) -> dict[str, Any]:
+        return {
+            "class_id": self.class_id,
+            "coalition_ids": list(
+                self.coalition_ids
+            ),
+            "terminal_organizational_class_id": self.terminal_organizational_class_id,
+            "invariant_function_record_ids": list(
+                self.invariant_function_record_ids
+            ),
+            "admissible_corridor_ids": list(
+                self.admissible_corridor_ids
+            ),
+            "evidence_record_ids": list(
+                self.evidence_record_ids
+            ),
+            "equivalent_terminal_organization": True,
+            "identical_microstate_required": False,
+        }
+
+
+@dataclass(frozen=True)
+class ProspectiveCoalitionNomination:
+    nomination_id: str
+    coalition_id: str
+    retrospective_atlas_id: str
+    matched_experiment_id: str
+    acceptance_contract_id: str
+    evidence_record_ids: tuple[str, ...]
+    frozen_criteria: bool = True
+    independent_evaluator: bool = True
+    reversible: bool = True
+    observer_only: bool = True
+    authority_withheld: bool = True
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "nomination_id",
+            "coalition_id",
+            "retrospective_atlas_id",
+            "matched_experiment_id",
+            "acceptance_contract_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        object.__setattr__(
+            self,
+            "evidence_record_ids",
+            _require_identifiers(
+                "evidence_record_ids",
+                self.evidence_record_ids,
+            ),
+        )
+
+        required_true = {
+            "frozen_criteria": self.frozen_criteria,
+            "independent_evaluator": self.independent_evaluator,
+            "reversible": self.reversible,
+            "observer_only": self.observer_only,
+            "authority_withheld": self.authority_withheld,
+        }
+
+        failed = sorted(
+            name
+            for name, value in required_true.items()
+            if value is not True
+        )
+
+        if failed:
+            raise CarrierCoalitionContractError(
+                f"nomination safeguards failed: {failed!r}"
+            )
+
+    def to_dict(
+        self,
+    ) -> dict[str, Any]:
+        return {
+            "nomination_id": self.nomination_id,
+            "coalition_id": self.coalition_id,
+            "retrospective_atlas_id": self.retrospective_atlas_id,
+            "matched_experiment_id": self.matched_experiment_id,
+            "acceptance_contract_id": self.acceptance_contract_id,
+            "evidence_record_ids": list(
+                self.evidence_record_ids
+            ),
+            "frozen_criteria": True,
+            "independent_evaluator": True,
+            "reversible": True,
+            "observer_only": True,
+            "authority_withheld": True,
+        }
+
+
+@dataclass(frozen=True)
+class ReversiblePruningAuthorityContract:
+    contract_id: str
+    coalition_id: str
+    rollback_checkpoint_id: str
+    release_criteria_ids: tuple[str, ...]
+    maximum_sparsity: float
+    maximum_step_removal: float
+    recovery_budget_steps: int
+    authority_status: str = "observe_only"
+    external_causal_authority: bool = False
+    self_modification_authority: bool = False
+    no_auto_promotion: bool = True
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "contract_id",
+            "coalition_id",
+            "rollback_checkpoint_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        object.__setattr__(
+            self,
+            "release_criteria_ids",
+            _require_identifiers(
+                "release_criteria_ids",
+                self.release_criteria_ids,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "maximum_sparsity",
+            _require_unit_interval(
+                "maximum_sparsity",
+                self.maximum_sparsity,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "maximum_step_removal",
+            _require_unit_interval(
+                "maximum_step_removal",
+                self.maximum_step_removal,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "recovery_budget_steps",
+            _require_positive_integer(
+                "recovery_budget_steps",
+                self.recovery_budget_steps,
+            ),
+        )
+
+        if self.authority_status != "observe_only":
+            raise CarrierCoalitionContractError(
+                "R1A authority status must remain observe_only"
+            )
+
+        if self.external_causal_authority is not False:
+            raise CarrierCoalitionContractError(
+                "external causal authority is forbidden"
+            )
+
+        if self.self_modification_authority is not False:
+            raise CarrierCoalitionContractError(
+                "self-modification authority is forbidden"
+            )
+
+        if self.no_auto_promotion is not True:
+            raise CarrierCoalitionContractError(
+                "pruning contract must prohibit auto-promotion"
+            )
+
+    def to_dict(
+        self,
+    ) -> dict[str, Any]:
+        return {
+            "contract_id": self.contract_id,
+            "coalition_id": self.coalition_id,
+            "rollback_checkpoint_id": self.rollback_checkpoint_id,
+            "release_criteria_ids": list(
+                self.release_criteria_ids
+            ),
+            "maximum_sparsity": self.maximum_sparsity,
+            "maximum_step_removal": self.maximum_step_removal,
+            "recovery_budget_steps": self.recovery_budget_steps,
+            "authority_status": "observe_only",
+            "external_causal_authority": False,
+            "self_modification_authority": False,
+            "no_auto_promotion": True,
+        }
+
+
+@dataclass(frozen=True)
+class RCAFCarrierCoalitionBundle:
+    bundle_id: str
+    coalition: TrajectoryAdmissibleCarrierCoalition
+    validity_relations: tuple[
+        CarrierValidityRelation,
+        ...,
+    ]
+    role_evidence: tuple[
+        ComponentRoleEvidence,
+        ...,
+    ]
+    scaffold_dependence: ScaffoldDependenceEvidence
+    scaffold_release: ScaffoldReleaseEvidence
+    turbulence_channels: tuple[
+        MultiscaleTurbulenceChannel,
+        ...,
+    ]
+    future_freedom: CompressionFutureFreedom
+    matched_experiment: CoalitionMatchedExperiment
+    equivalence_class: MicroscopicTicketEquivalenceClass
+    nomination: ProspectiveCoalitionNomination
+    authority_contract: ReversiblePruningAuthorityContract
+    raw_content_stored: bool = False
+    content_fingerprint_stored: bool = False
+
+    def __post_init__(
+        self,
+    ) -> None:
+        object.__setattr__(
+            self,
+            "bundle_id",
+            _require_identifier(
+                "bundle_id",
+                self.bundle_id,
+            ),
+        )
+
+        coalition_id = (
+            self.coalition.coalition_id
+        )
+
+        member_ids = set(
+            self.coalition.member_ids
+        )
+
+        if not self.validity_relations:
+            raise CarrierCoalitionContractError(
+                "validity_relations must not be empty"
+            )
+
+        if not self.role_evidence:
+            raise CarrierCoalitionContractError(
+                "role_evidence must not be empty"
+            )
+
+        if not self.turbulence_channels:
+            raise CarrierCoalitionContractError(
+                "turbulence_channels must not be empty"
+            )
+
+        for relation in self.validity_relations:
+            if (
+                relation.source_member_id
+                not in member_ids
+                or relation.target_member_id
+                not in member_ids
+            ):
+                raise CarrierCoalitionContractError(
+                    "carrier relation references a non-member"
+                )
+
+        for evidence in self.role_evidence:
+            if evidence.member_id not in member_ids:
+                raise CarrierCoalitionContractError(
+                    "role evidence references a non-member"
+                )
+
+        linked_coalition_ids = {
+            self.scaffold_dependence.coalition_id,
+            self.scaffold_release.coalition_id,
+            self.future_freedom.coalition_id,
+            self.nomination.coalition_id,
+            self.authority_contract.coalition_id,
+        }
+
+        linked_coalition_ids.update(
+            branch.coalition_id
+            for branch in (
+                self.matched_experiment.branches
+            )
+        )
+
+        if linked_coalition_ids != {
+            coalition_id
+        }:
+            raise CarrierCoalitionContractError(
+                "bundle contains inconsistent coalition links"
+            )
+
+        if coalition_id not in (
+            self.equivalence_class.coalition_ids
+        ):
+            raise CarrierCoalitionContractError(
+                "equivalence class omits the primary coalition"
+            )
+
+        scaffold_members = set(
+            self.scaffold_dependence.scaffold_member_ids
+        ) | set(
+            self.scaffold_release.scaffold_member_ids
+        )
+
+        if not scaffold_members.issubset(
+            member_ids
+        ):
+            raise CarrierCoalitionContractError(
+                "scaffold evidence references a non-member"
+            )
+
+        if self.raw_content_stored is not False:
+            raise CarrierCoalitionContractError(
+                "raw content storage is forbidden"
+            )
+
+        if (
+            self.content_fingerprint_stored
+            is not False
+        ):
+            raise CarrierCoalitionContractError(
+                "content fingerprints are forbidden"
+            )
+
+    def to_dict(
+        self,
+    ) -> dict[str, Any]:
+        return {
+            "schema": RCAF_CARRIER_COALITION_SCHEMA,
+            "bundle_id": self.bundle_id,
+            "coalition": self.coalition.to_dict(),
+            "validity_relations": [
+                relation.to_dict()
+                for relation in self.validity_relations
+            ],
+            "role_evidence": [
+                evidence.to_dict()
+                for evidence in self.role_evidence
+            ],
+            "scaffold_dependence": (
+                self.scaffold_dependence.to_dict()
+            ),
+            "scaffold_release": (
+                self.scaffold_release.to_dict()
+            ),
+            "turbulence_channels": [
+                channel.to_dict()
+                for channel in self.turbulence_channels
+            ],
+            "future_freedom": (
+                self.future_freedom.to_dict()
+            ),
+            "matched_experiment": (
+                self.matched_experiment.to_dict()
+            ),
+            "equivalence_class": (
+                self.equivalence_class.to_dict()
+            ),
+            "nomination": self.nomination.to_dict(),
+            "authority_contract": (
+                self.authority_contract.to_dict()
+            ),
+            "raw_content_stored": False,
+            "content_fingerprint_stored": False,
+        }
+
+    def canonical_json(
+        self,
+    ) -> str:
+        return json.dumps(
+            self.to_dict(),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )

--- a/src/rcaf/future_authority_ledger.py
+++ b/src/rcaf/future_authority_ledger.py
@@ -1,0 +1,2113 @@
+# ============================================================
+# src/rcaf/future_authority_ledger.py
+# ============================================================
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+
+from src.rcaf.organizational_ledger import (
+    MetricVector,
+)
+
+
+RCAF_FUTURE_AUTHORITY_SCHEMA = (
+    "RCAF-FUTURE-CONDITIONED-AUTHORITY-0.1"
+)
+
+MATCHED_CAUSAL_BRANCH_ROLES = frozenset(
+    {
+        "A0_base_preserve",
+        "A1_valid_candidate",
+        "A2_sham",
+        "A3_wrong_context",
+        "A4_over_boundary",
+        "A5_support_withdrawal",
+    }
+)
+
+BOUNDARY_RELATIONS = frozenset(
+    {
+        "within_boundary",
+        "sham",
+        "wrong_context",
+        "over_boundary",
+        "support_withdrawal",
+    }
+)
+
+VERIFICATION_STATES = frozenset(
+    {
+        "unverified",
+        "partial",
+        "verified",
+        "contradictory",
+        "insufficient",
+        "rejected",
+    }
+)
+
+GATE_EVIDENCE_MATURITY_STATES = frozenset(
+    {
+        "unobserved",
+        "candidate",
+        "retrospectively_identified",
+        "replicated",
+        "causally_supported",
+        "calibrated",
+        "prospectively_validated",
+    }
+)
+
+GATE_AUTHORITY_STATES = frozenset(
+    {
+        "observe_only",
+        "nominated",
+        "sandbox_candidate",
+        "sandboxed",
+        "bounded_authorized",
+        "released",
+        "revoked",
+        "rejected",
+    }
+)
+
+CALIBRATION_STATES = frozenset(
+    {
+        "uncalibrated",
+        "empirical_frequency",
+        "calibrated",
+    }
+)
+
+FUTURE_BASIN_PULL_STATES = frozenset(
+    {
+        "unresolved",
+        "weak",
+        "observed",
+        "elevated",
+    }
+)
+
+NOMINATION_RECOMMENDATIONS = frozenset(
+    {
+        "observe",
+        "sandbox_candidate",
+        "defer",
+        "reject",
+    }
+)
+
+_IDENTIFIER_PATTERN = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,191}$"
+)
+
+
+class FutureAuthorityLedgerError(ValueError):
+    """Raised when a future-conditioned authority contract is invalid."""
+
+
+def _require_identifier(
+    field_name: str,
+    value: str,
+) -> str:
+    normalized = str(value).strip()
+
+    if not _IDENTIFIER_PATTERN.fullmatch(normalized):
+        raise FutureAuthorityLedgerError(
+            f"{field_name} must be a static structural identifier"
+        )
+
+    return normalized
+
+
+def _optional_identifier(
+    field_name: str,
+    value: str | None,
+) -> str | None:
+    if value is None:
+        return None
+
+    return _require_identifier(
+        field_name,
+        value,
+    )
+
+
+def _require_choice(
+    field_name: str,
+    value: str,
+    allowed: frozenset[str],
+) -> str:
+    normalized = str(value).strip()
+
+    if normalized not in allowed:
+        raise FutureAuthorityLedgerError(
+            f"{field_name} must be one of {sorted(allowed)!r}; "
+            f"received {normalized!r}"
+        )
+
+    return normalized
+
+
+def _require_boolean(
+    field_name: str,
+    value: bool,
+) -> bool:
+    if not isinstance(value, bool):
+        raise FutureAuthorityLedgerError(
+            f"{field_name} must be bool"
+        )
+
+    return value
+
+
+def _require_nonnegative_integer(
+    field_name: str,
+    value: int,
+) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value < 0
+    ):
+        raise FutureAuthorityLedgerError(
+            f"{field_name} must be a non-negative integer"
+        )
+
+    return value
+
+
+def _optional_probability(
+    field_name: str,
+    value: float | None,
+) -> float | None:
+    if value is None:
+        return None
+
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+    ):
+        raise FutureAuthorityLedgerError(
+            f"{field_name} must be a probability or None"
+        )
+
+    normalized = float(value)
+
+    if not 0.0 <= normalized <= 1.0:
+        raise FutureAuthorityLedgerError(
+            f"{field_name} must be between 0 and 1"
+        )
+
+    return normalized
+
+
+def _require_vector(
+    field_name: str,
+    value: MetricVector,
+    *,
+    nonempty: bool = False,
+) -> MetricVector:
+    if not isinstance(value, MetricVector):
+        raise FutureAuthorityLedgerError(
+            f"{field_name} must be MetricVector"
+        )
+
+    if nonempty and not value.components:
+        raise FutureAuthorityLedgerError(
+            f"{field_name} must not be empty"
+        )
+
+    return value
+
+
+def _normalize_identifiers(
+    field_name: str,
+    values: tuple[str, ...],
+    *,
+    require_nonempty: bool = False,
+) -> tuple[str, ...]:
+    normalized = tuple(
+        _require_identifier(
+            field_name,
+            value,
+        )
+        for value in values
+    )
+
+    if require_nonempty and not normalized:
+        raise FutureAuthorityLedgerError(
+            f"{field_name} must not be empty"
+        )
+
+    if len(set(normalized)) != len(normalized):
+        raise FutureAuthorityLedgerError(
+            f"{field_name} contains duplicate identifiers"
+        )
+
+    return normalized
+
+
+@dataclass(frozen=True)
+class TerminalOrganizationalContract:
+    contract_id: str
+    terminal_class_id: str
+    benefit_requirements: MetricVector
+    persistence_requirements: MetricVector
+    harm_bounds: MetricVector
+    containment_requirements: MetricVector
+    absorption_requirements: MetricVector
+    future_freedom_minima: MetricVector
+    continuity_constraint_ids: tuple[str, ...]
+    release_condition_ids: tuple[str, ...]
+    rollback_mechanism_ids: tuple[str, ...]
+    allowed_variation_ids: tuple[str, ...]
+    forbidden_condition_ids: tuple[str, ...]
+    authority_non_expansion_required: bool = True
+    independent_verification_required: bool = True
+    frozen_before_treatment: bool = True
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "contract_id",
+            "terminal_class_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        for field_name in (
+            "benefit_requirements",
+            "persistence_requirements",
+            "harm_bounds",
+            "containment_requirements",
+            "absorption_requirements",
+            "future_freedom_minima",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_vector(
+                    field_name,
+                    getattr(self, field_name),
+                    nonempty=True,
+                ),
+            )
+
+        for field_name in (
+            "continuity_constraint_ids",
+            "release_condition_ids",
+            "rollback_mechanism_ids",
+            "allowed_variation_ids",
+            "forbidden_condition_ids",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _normalize_identifiers(
+                    field_name,
+                    getattr(self, field_name),
+                    require_nonempty=True,
+                ),
+            )
+
+        for field_name in (
+            "authority_non_expansion_required",
+            "independent_verification_required",
+            "frozen_before_treatment",
+        ):
+            value = _require_boolean(
+                field_name,
+                getattr(self, field_name),
+            )
+
+            if value is not True:
+                raise FutureAuthorityLedgerError(
+                    f"{field_name} must remain True"
+                )
+
+            object.__setattr__(
+                self,
+                field_name,
+                value,
+            )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "contract_id": self.contract_id,
+            "terminal_class_id": self.terminal_class_id,
+            "benefit_requirements": (
+                self.benefit_requirements.to_dict()
+            ),
+            "persistence_requirements": (
+                self.persistence_requirements.to_dict()
+            ),
+            "harm_bounds": self.harm_bounds.to_dict(),
+            "containment_requirements": (
+                self.containment_requirements.to_dict()
+            ),
+            "absorption_requirements": (
+                self.absorption_requirements.to_dict()
+            ),
+            "future_freedom_minima": (
+                self.future_freedom_minima.to_dict()
+            ),
+            "continuity_constraint_ids": list(
+                self.continuity_constraint_ids
+            ),
+            "release_condition_ids": list(
+                self.release_condition_ids
+            ),
+            "rollback_mechanism_ids": list(
+                self.rollback_mechanism_ids
+            ),
+            "allowed_variation_ids": list(
+                self.allowed_variation_ids
+            ),
+            "forbidden_condition_ids": list(
+                self.forbidden_condition_ids
+            ),
+            "authority_non_expansion_required": True,
+            "independent_verification_required": True,
+            "frozen_before_treatment": True,
+        }
+
+
+@dataclass(frozen=True)
+class ForwardTrajectoryBranch:
+    branch_id: str
+    seed_id: str
+    carrier_state_id: str
+    hidden_context_class_id: str
+    disturbance_class_id: str
+    terminal_class_id: str
+    corridor_id: str
+    safe_corridor_occupied: bool
+    boundary_compliant: bool
+    release_available: bool
+    future_freedom: MetricVector
+    outcome_metrics: MetricVector
+    failure_mode_ids: tuple[str, ...] = ()
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "branch_id",
+            "seed_id",
+            "carrier_state_id",
+            "hidden_context_class_id",
+            "disturbance_class_id",
+            "terminal_class_id",
+            "corridor_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        for field_name in (
+            "safe_corridor_occupied",
+            "boundary_compliant",
+            "release_available",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_boolean(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        for field_name in (
+            "future_freedom",
+            "outcome_metrics",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_vector(
+                    field_name,
+                    getattr(self, field_name),
+                    nonempty=True,
+                ),
+            )
+
+        object.__setattr__(
+            self,
+            "failure_mode_ids",
+            _normalize_identifiers(
+                "failure_mode_ids",
+                self.failure_mode_ids,
+            ),
+        )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "branch_id": self.branch_id,
+            "seed_id": self.seed_id,
+            "carrier_state_id": self.carrier_state_id,
+            "hidden_context_class_id": (
+                self.hidden_context_class_id
+            ),
+            "disturbance_class_id": (
+                self.disturbance_class_id
+            ),
+            "terminal_class_id": self.terminal_class_id,
+            "corridor_id": self.corridor_id,
+            "safe_corridor_occupied": (
+                self.safe_corridor_occupied
+            ),
+            "boundary_compliant": self.boundary_compliant,
+            "release_available": self.release_available,
+            "future_freedom": self.future_freedom.to_dict(),
+            "outcome_metrics": self.outcome_metrics.to_dict(),
+            "failure_mode_ids": list(self.failure_mode_ids),
+        }
+
+
+@dataclass(frozen=True)
+class ForwardReachabilityEvidence:
+    forward_map_id: str
+    reachable_set_id: str
+    current_state_id: str
+    candidate_action_id: str
+    branches: tuple[ForwardTrajectoryBranch, ...]
+    reachable_terminal_class_ids: tuple[str, ...]
+    safe_corridor_ids: tuple[str, ...]
+    evidence_ids: tuple[str, ...]
+    forward_reachable: bool
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "forward_map_id",
+            "reachable_set_id",
+            "current_state_id",
+            "candidate_action_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        branches = tuple(self.branches)
+
+        if not branches:
+            raise FutureAuthorityLedgerError(
+                "branches must not be empty"
+            )
+
+        branch_ids = [
+            branch.branch_id
+            for branch in branches
+        ]
+
+        if len(set(branch_ids)) != len(branch_ids):
+            raise FutureAuthorityLedgerError(
+                "branches contain duplicate branch IDs"
+            )
+
+        object.__setattr__(
+            self,
+            "branches",
+            branches,
+        )
+
+        for field_name in (
+            "reachable_terminal_class_ids",
+            "safe_corridor_ids",
+            "evidence_ids",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _normalize_identifiers(
+                    field_name,
+                    getattr(self, field_name),
+                    require_nonempty=True,
+                ),
+            )
+
+        object.__setattr__(
+            self,
+            "forward_reachable",
+            _require_boolean(
+                "forward_reachable",
+                self.forward_reachable,
+            ),
+        )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "forward_map_id": self.forward_map_id,
+            "reachable_set_id": self.reachable_set_id,
+            "current_state_id": self.current_state_id,
+            "candidate_action_id": self.candidate_action_id,
+            "branches": [
+                branch.to_dict()
+                for branch in self.branches
+            ],
+            "reachable_terminal_class_ids": list(
+                self.reachable_terminal_class_ids
+            ),
+            "safe_corridor_ids": list(
+                self.safe_corridor_ids
+            ),
+            "evidence_ids": list(self.evidence_ids),
+            "forward_reachable": self.forward_reachable,
+        }
+
+
+@dataclass(frozen=True)
+class BackwardPredecessorEvidence:
+    backward_map_id: str
+    predecessor_set_id: str
+    future_contract_id: str
+    required_reference_contract_id: str
+    required_condition_ids: tuple[str, ...]
+    satisfied_condition_ids: tuple[str, ...]
+    unmet_condition_ids: tuple[str, ...]
+    forbidden_predecessor_condition_ids: tuple[str, ...]
+    required_carrier_relation_ids: tuple[str, ...]
+    required_boundary_ids: tuple[str, ...]
+    required_evaluator_ids: tuple[str, ...]
+    required_release_path_ids: tuple[str, ...]
+    required_rollback_mechanism_ids: tuple[str, ...]
+    uncertainty: MetricVector
+    backward_consistent: bool
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "backward_map_id",
+            "predecessor_set_id",
+            "future_contract_id",
+            "required_reference_contract_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        for field_name in (
+            "required_condition_ids",
+            "satisfied_condition_ids",
+            "unmet_condition_ids",
+            "forbidden_predecessor_condition_ids",
+            "required_carrier_relation_ids",
+            "required_boundary_ids",
+            "required_evaluator_ids",
+            "required_release_path_ids",
+            "required_rollback_mechanism_ids",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _normalize_identifiers(
+                    field_name,
+                    getattr(self, field_name),
+                    require_nonempty=(
+                        field_name
+                        in {
+                            "required_condition_ids",
+                            "required_carrier_relation_ids",
+                            "required_boundary_ids",
+                            "required_evaluator_ids",
+                            "required_release_path_ids",
+                            "required_rollback_mechanism_ids",
+                        }
+                    ),
+                ),
+            )
+
+        required = set(self.required_condition_ids)
+        satisfied = set(self.satisfied_condition_ids)
+        unmet = set(self.unmet_condition_ids)
+
+        if not satisfied.issubset(required):
+            raise FutureAuthorityLedgerError(
+                "satisfied conditions must occur in required conditions"
+            )
+
+        if not unmet.issubset(required):
+            raise FutureAuthorityLedgerError(
+                "unmet conditions must occur in required conditions"
+            )
+
+        if satisfied & unmet:
+            raise FutureAuthorityLedgerError(
+                "conditions cannot be both satisfied and unmet"
+            )
+
+        object.__setattr__(
+            self,
+            "uncertainty",
+            _require_vector(
+                "uncertainty",
+                self.uncertainty,
+                nonempty=True,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "backward_consistent",
+            _require_boolean(
+                "backward_consistent",
+                self.backward_consistent,
+            ),
+        )
+
+        if self.backward_consistent:
+            if unmet:
+                raise FutureAuthorityLedgerError(
+                    "backward-consistent evidence cannot contain "
+                    "unmet conditions"
+                )
+
+            if satisfied != required:
+                raise FutureAuthorityLedgerError(
+                    "backward-consistent evidence must satisfy "
+                    "every required condition"
+                )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "backward_map_id": self.backward_map_id,
+            "predecessor_set_id": self.predecessor_set_id,
+            "future_contract_id": self.future_contract_id,
+            "required_reference_contract_id": (
+                self.required_reference_contract_id
+            ),
+            "required_condition_ids": list(
+                self.required_condition_ids
+            ),
+            "satisfied_condition_ids": list(
+                self.satisfied_condition_ids
+            ),
+            "unmet_condition_ids": list(
+                self.unmet_condition_ids
+            ),
+            "forbidden_predecessor_condition_ids": list(
+                self.forbidden_predecessor_condition_ids
+            ),
+            "required_carrier_relation_ids": list(
+                self.required_carrier_relation_ids
+            ),
+            "required_boundary_ids": list(
+                self.required_boundary_ids
+            ),
+            "required_evaluator_ids": list(
+                self.required_evaluator_ids
+            ),
+            "required_release_path_ids": list(
+                self.required_release_path_ids
+            ),
+            "required_rollback_mechanism_ids": list(
+                self.required_rollback_mechanism_ids
+            ),
+            "uncertainty": self.uncertainty.to_dict(),
+            "backward_consistent": self.backward_consistent,
+        }
+
+
+@dataclass(frozen=True)
+class BidirectionalConsistencyRecord:
+    consistency_record_id: str
+    forward_reachable_set_id: str
+    backward_predecessor_set_id: str
+    shared_corridor_ids: tuple[str, ...]
+    excluded_trajectory_ids: tuple[str, ...]
+    consistency_evidence_ids: tuple[str, ...]
+    consistency_failure_ids: tuple[str, ...]
+    terminal_class_agreement: bool
+    intermediate_boundary_compliance: bool
+    future_freedom_compliance: bool
+    release_compliance: bool
+    gate_nominated: bool
+    gate_admissible: bool
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "consistency_record_id",
+            "forward_reachable_set_id",
+            "backward_predecessor_set_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        for field_name in (
+            "shared_corridor_ids",
+            "excluded_trajectory_ids",
+            "consistency_evidence_ids",
+            "consistency_failure_ids",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _normalize_identifiers(
+                    field_name,
+                    getattr(self, field_name),
+                    require_nonempty=(
+                        field_name
+                        in {
+                            "shared_corridor_ids",
+                            "consistency_evidence_ids",
+                        }
+                    ),
+                ),
+            )
+
+        for field_name in (
+            "terminal_class_agreement",
+            "intermediate_boundary_compliance",
+            "future_freedom_compliance",
+            "release_compliance",
+            "gate_nominated",
+            "gate_admissible",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_boolean(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        if self.gate_admissible:
+            required = (
+                self.terminal_class_agreement
+                and self.intermediate_boundary_compliance
+                and self.future_freedom_compliance
+                and self.release_compliance
+                and self.gate_nominated
+                and not self.consistency_failure_ids
+            )
+
+            if not required:
+                raise FutureAuthorityLedgerError(
+                    "gate_admissible requires complete bidirectional "
+                    "consistency and no consistency failures"
+                )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "consistency_record_id": self.consistency_record_id,
+            "forward_reachable_set_id": (
+                self.forward_reachable_set_id
+            ),
+            "backward_predecessor_set_id": (
+                self.backward_predecessor_set_id
+            ),
+            "shared_corridor_ids": list(
+                self.shared_corridor_ids
+            ),
+            "excluded_trajectory_ids": list(
+                self.excluded_trajectory_ids
+            ),
+            "consistency_evidence_ids": list(
+                self.consistency_evidence_ids
+            ),
+            "consistency_failure_ids": list(
+                self.consistency_failure_ids
+            ),
+            "terminal_class_agreement": (
+                self.terminal_class_agreement
+            ),
+            "intermediate_boundary_compliance": (
+                self.intermediate_boundary_compliance
+            ),
+            "future_freedom_compliance": (
+                self.future_freedom_compliance
+            ),
+            "release_compliance": self.release_compliance,
+            "gate_nominated": self.gate_nominated,
+            "gate_admissible": self.gate_admissible,
+        }
+
+
+@dataclass(frozen=True)
+class MatchedCausalBranch:
+    branch_id: str
+    branch_role: str
+    shared_initial_state_contract_id: str
+    intervention_id: str
+    context_id: str
+    boundary_relation: str
+    terminal_class_id: str
+    evaluator_id: str
+    support_present: bool
+    execution_performed: bool
+    verification_state: str
+    benefit: MetricVector
+    harm: MetricVector
+    containment: MetricVector
+    future_freedom: MetricVector
+    absorption: MetricVector
+    persistence: MetricVector
+    release: MetricVector
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "branch_id",
+            "shared_initial_state_contract_id",
+            "intervention_id",
+            "context_id",
+            "terminal_class_id",
+            "evaluator_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        object.__setattr__(
+            self,
+            "branch_role",
+            _require_choice(
+                "branch_role",
+                self.branch_role,
+                MATCHED_CAUSAL_BRANCH_ROLES,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "boundary_relation",
+            _require_choice(
+                "boundary_relation",
+                self.boundary_relation,
+                BOUNDARY_RELATIONS,
+            ),
+        )
+
+        for field_name in (
+            "support_present",
+            "execution_performed",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_boolean(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        object.__setattr__(
+            self,
+            "verification_state",
+            _require_choice(
+                "verification_state",
+                self.verification_state,
+                VERIFICATION_STATES,
+            ),
+        )
+
+        for field_name in (
+            "benefit",
+            "harm",
+            "containment",
+            "future_freedom",
+            "absorption",
+            "persistence",
+            "release",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_vector(
+                    field_name,
+                    getattr(self, field_name),
+                    nonempty=True,
+                ),
+            )
+
+        if (
+            self.branch_role
+            == "A5_support_withdrawal"
+            and self.support_present
+        ):
+            raise FutureAuthorityLedgerError(
+                "support-withdrawal branch cannot retain support"
+            )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "branch_id": self.branch_id,
+            "branch_role": self.branch_role,
+            "shared_initial_state_contract_id": (
+                self.shared_initial_state_contract_id
+            ),
+            "intervention_id": self.intervention_id,
+            "context_id": self.context_id,
+            "boundary_relation": self.boundary_relation,
+            "terminal_class_id": self.terminal_class_id,
+            "evaluator_id": self.evaluator_id,
+            "support_present": self.support_present,
+            "execution_performed": self.execution_performed,
+            "verification_state": self.verification_state,
+            "benefit": self.benefit.to_dict(),
+            "harm": self.harm.to_dict(),
+            "containment": self.containment.to_dict(),
+            "future_freedom": self.future_freedom.to_dict(),
+            "absorption": self.absorption.to_dict(),
+            "persistence": self.persistence.to_dict(),
+            "release": self.release.to_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class MatchedCausalExperiment:
+    experiment_id: str
+    frozen_future_contract_id: str
+    frozen_acceptance_criteria_id: str
+    independent_evaluator_id: str
+    branches: tuple[MatchedCausalBranch, ...]
+    treatment_effects: MetricVector
+    control_separation: MetricVector
+    wrong_context_separation: MetricVector
+    over_boundary_failure: MetricVector
+    support_withdrawal_persistence: MetricVector
+    cross_seed_robustness: MetricVector
+    cross_carrier_robustness: MetricVector
+    evaluator_agreement: MetricVector
+    valid_treatment_preferential: bool
+    controls_weaker: bool
+    withdrawal_persistent: bool
+    independent_verification_passed: bool
+    causal_support_established: bool
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "experiment_id",
+            "frozen_future_contract_id",
+            "frozen_acceptance_criteria_id",
+            "independent_evaluator_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        branches = tuple(self.branches)
+
+        roles = [
+            branch.branch_role
+            for branch in branches
+        ]
+
+        if set(roles) != MATCHED_CAUSAL_BRANCH_ROLES:
+            raise FutureAuthorityLedgerError(
+                "matched experiment must contain exactly A0 through A5"
+            )
+
+        if len(roles) != len(MATCHED_CAUSAL_BRANCH_ROLES):
+            raise FutureAuthorityLedgerError(
+                "matched experiment contains duplicate branch roles"
+            )
+
+        initial_states = {
+            branch.shared_initial_state_contract_id
+            for branch in branches
+        }
+
+        if len(initial_states) != 1:
+            raise FutureAuthorityLedgerError(
+                "matched branches must share one initial-state contract"
+            )
+
+        object.__setattr__(
+            self,
+            "branches",
+            branches,
+        )
+
+        for field_name in (
+            "treatment_effects",
+            "control_separation",
+            "wrong_context_separation",
+            "over_boundary_failure",
+            "support_withdrawal_persistence",
+            "cross_seed_robustness",
+            "cross_carrier_robustness",
+            "evaluator_agreement",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_vector(
+                    field_name,
+                    getattr(self, field_name),
+                    nonempty=True,
+                ),
+            )
+
+        for field_name in (
+            "valid_treatment_preferential",
+            "controls_weaker",
+            "withdrawal_persistent",
+            "independent_verification_passed",
+            "causal_support_established",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_boolean(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        if self.causal_support_established:
+            if not (
+                self.valid_treatment_preferential
+                and self.controls_weaker
+                and self.withdrawal_persistent
+                and self.independent_verification_passed
+            ):
+                raise FutureAuthorityLedgerError(
+                    "causal support requires treatment preference, "
+                    "control separation, withdrawal persistence and "
+                    "independent verification"
+                )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "experiment_id": self.experiment_id,
+            "frozen_future_contract_id": (
+                self.frozen_future_contract_id
+            ),
+            "frozen_acceptance_criteria_id": (
+                self.frozen_acceptance_criteria_id
+            ),
+            "independent_evaluator_id": (
+                self.independent_evaluator_id
+            ),
+            "branches": [
+                branch.to_dict()
+                for branch in self.branches
+            ],
+            "treatment_effects": (
+                self.treatment_effects.to_dict()
+            ),
+            "control_separation": (
+                self.control_separation.to_dict()
+            ),
+            "wrong_context_separation": (
+                self.wrong_context_separation.to_dict()
+            ),
+            "over_boundary_failure": (
+                self.over_boundary_failure.to_dict()
+            ),
+            "support_withdrawal_persistence": (
+                self.support_withdrawal_persistence.to_dict()
+            ),
+            "cross_seed_robustness": (
+                self.cross_seed_robustness.to_dict()
+            ),
+            "cross_carrier_robustness": (
+                self.cross_carrier_robustness.to_dict()
+            ),
+            "evaluator_agreement": (
+                self.evaluator_agreement.to_dict()
+            ),
+            "valid_treatment_preferential": (
+                self.valid_treatment_preferential
+            ),
+            "controls_weaker": self.controls_weaker,
+            "withdrawal_persistent": (
+                self.withdrawal_persistent
+            ),
+            "independent_verification_passed": (
+                self.independent_verification_passed
+            ),
+            "causal_support_established": (
+                self.causal_support_established
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class AntiCoercionAuthorityCheck:
+    check_id: str
+    prediction_preceded_intervention: bool
+    terminal_contract_frozen: bool
+    acceptance_criteria_frozen: bool
+    evaluator_independent: bool
+    target_rewrite_prevented: bool
+    evidence_rewrite_prevented: bool
+    control_branches_preserved: bool
+    valid_treatment_preferential: bool
+    support_withdrawal_persistent: bool
+    passed: bool
+
+    def __post_init__(
+        self,
+    ) -> None:
+        object.__setattr__(
+            self,
+            "check_id",
+            _require_identifier(
+                "check_id",
+                self.check_id,
+            ),
+        )
+
+        condition_names = (
+            "prediction_preceded_intervention",
+            "terminal_contract_frozen",
+            "acceptance_criteria_frozen",
+            "evaluator_independent",
+            "target_rewrite_prevented",
+            "evidence_rewrite_prevented",
+            "control_branches_preserved",
+            "valid_treatment_preferential",
+            "support_withdrawal_persistent",
+        )
+
+        conditions = []
+
+        for field_name in condition_names:
+            value = _require_boolean(
+                field_name,
+                getattr(self, field_name),
+            )
+
+            object.__setattr__(
+                self,
+                field_name,
+                value,
+            )
+
+            conditions.append(value)
+
+        object.__setattr__(
+            self,
+            "passed",
+            _require_boolean(
+                "passed",
+                self.passed,
+            ),
+        )
+
+        if self.passed != all(conditions):
+            raise FutureAuthorityLedgerError(
+                "anti-coercion result must equal all safeguards"
+            )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            field_name: getattr(self, field_name)
+            for field_name in self.__dataclass_fields__
+        }
+
+
+@dataclass(frozen=True)
+class RetrospectivePrecursorAtlasRecord:
+    atlas_record_id: str
+    completed_trajectory_id: str
+    terminal_class_id: str
+    earliest_reliable_precursor_id: str
+    precursor_class_id: str
+    decisive_carrier_coalition_ids: tuple[str, ...]
+    boundary_crossing_event_id: str
+    alternative_future_collapse_event_id: str
+    absorption_likelihood_event_id: str
+    release_danger_event_id: str
+    inference_method_id: str
+    validation_population_id: str
+    replication_evidence_ids: tuple[str, ...]
+    replicated: bool
+    authority_granted: bool = False
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "atlas_record_id",
+            "completed_trajectory_id",
+            "terminal_class_id",
+            "earliest_reliable_precursor_id",
+            "precursor_class_id",
+            "boundary_crossing_event_id",
+            "alternative_future_collapse_event_id",
+            "absorption_likelihood_event_id",
+            "release_danger_event_id",
+            "inference_method_id",
+            "validation_population_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        for field_name in (
+            "decisive_carrier_coalition_ids",
+            "replication_evidence_ids",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _normalize_identifiers(
+                    field_name,
+                    getattr(self, field_name),
+                    require_nonempty=True,
+                ),
+            )
+
+        object.__setattr__(
+            self,
+            "replicated",
+            _require_boolean(
+                "replicated",
+                self.replicated,
+            ),
+        )
+
+        authority_granted = _require_boolean(
+            "authority_granted",
+            self.authority_granted,
+        )
+
+        if authority_granted:
+            raise FutureAuthorityLedgerError(
+                "retrospective atlas extraction cannot grant authority"
+            )
+
+        object.__setattr__(
+            self,
+            "authority_granted",
+            False,
+        )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "atlas_record_id": self.atlas_record_id,
+            "completed_trajectory_id": self.completed_trajectory_id,
+            "terminal_class_id": self.terminal_class_id,
+            "earliest_reliable_precursor_id": (
+                self.earliest_reliable_precursor_id
+            ),
+            "precursor_class_id": self.precursor_class_id,
+            "decisive_carrier_coalition_ids": list(
+                self.decisive_carrier_coalition_ids
+            ),
+            "boundary_crossing_event_id": (
+                self.boundary_crossing_event_id
+            ),
+            "alternative_future_collapse_event_id": (
+                self.alternative_future_collapse_event_id
+            ),
+            "absorption_likelihood_event_id": (
+                self.absorption_likelihood_event_id
+            ),
+            "release_danger_event_id": (
+                self.release_danger_event_id
+            ),
+            "inference_method_id": self.inference_method_id,
+            "validation_population_id": (
+                self.validation_population_id
+            ),
+            "replication_evidence_ids": list(
+                self.replication_evidence_ids
+            ),
+            "replicated": self.replicated,
+            "authority_granted": False,
+        }
+
+
+@dataclass(frozen=True)
+class ProspectiveGateNomination:
+    nomination_id: str
+    observed_precursor_class_id: str
+    matched_atlas_invariant_id: str
+    reference_contract_id: str
+    corridor_match_id: str
+    deviation_metrics: MetricVector
+    evidence_ids: tuple[str, ...]
+    recommendation: str
+    authority_withheld: bool = True
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "nomination_id",
+            "observed_precursor_class_id",
+            "matched_atlas_invariant_id",
+            "reference_contract_id",
+            "corridor_match_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        object.__setattr__(
+            self,
+            "deviation_metrics",
+            _require_vector(
+                "deviation_metrics",
+                self.deviation_metrics,
+                nonempty=True,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "evidence_ids",
+            _normalize_identifiers(
+                "evidence_ids",
+                self.evidence_ids,
+                require_nonempty=True,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "recommendation",
+            _require_choice(
+                "recommendation",
+                self.recommendation,
+                NOMINATION_RECOMMENDATIONS,
+            ),
+        )
+
+        authority_withheld = _require_boolean(
+            "authority_withheld",
+            self.authority_withheld,
+        )
+
+        if authority_withheld is not True:
+            raise FutureAuthorityLedgerError(
+                "prospective nomination must withhold authority"
+            )
+
+        object.__setattr__(
+            self,
+            "authority_withheld",
+            True,
+        )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "nomination_id": self.nomination_id,
+            "observed_precursor_class_id": (
+                self.observed_precursor_class_id
+            ),
+            "matched_atlas_invariant_id": (
+                self.matched_atlas_invariant_id
+            ),
+            "reference_contract_id": self.reference_contract_id,
+            "corridor_match_id": self.corridor_match_id,
+            "deviation_metrics": (
+                self.deviation_metrics.to_dict()
+            ),
+            "evidence_ids": list(self.evidence_ids),
+            "recommendation": self.recommendation,
+            "authority_withheld": True,
+        }
+
+
+@dataclass(frozen=True)
+class FutureGateCalibration:
+    calibration_id: str
+    status: str
+    future_class_confidence: float | None
+    future_basin_pull: str
+    sample_count: int
+    effective_sample_count: int
+    calibration_population_id: str
+    calibration_error: float | None
+    out_of_distribution: bool
+    scenario_tail_metrics: MetricVector
+    confidence_interval: MetricVector = field(
+        default_factory=MetricVector
+    )
+
+    def __post_init__(
+        self,
+    ) -> None:
+        object.__setattr__(
+            self,
+            "calibration_id",
+            _require_identifier(
+                "calibration_id",
+                self.calibration_id,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "status",
+            _require_choice(
+                "status",
+                self.status,
+                CALIBRATION_STATES,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "future_class_confidence",
+            _optional_probability(
+                "future_class_confidence",
+                self.future_class_confidence,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "future_basin_pull",
+            _require_choice(
+                "future_basin_pull",
+                self.future_basin_pull,
+                FUTURE_BASIN_PULL_STATES,
+            ),
+        )
+
+        for field_name in (
+            "sample_count",
+            "effective_sample_count",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_nonnegative_integer(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        if self.effective_sample_count > self.sample_count:
+            raise FutureAuthorityLedgerError(
+                "effective sample count cannot exceed sample count"
+            )
+
+        object.__setattr__(
+            self,
+            "calibration_population_id",
+            _require_identifier(
+                "calibration_population_id",
+                self.calibration_population_id,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "calibration_error",
+            _optional_probability(
+                "calibration_error",
+                self.calibration_error,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "out_of_distribution",
+            _require_boolean(
+                "out_of_distribution",
+                self.out_of_distribution,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "scenario_tail_metrics",
+            _require_vector(
+                "scenario_tail_metrics",
+                self.scenario_tail_metrics,
+                nonempty=True,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "confidence_interval",
+            _require_vector(
+                "confidence_interval",
+                self.confidence_interval,
+            ),
+        )
+
+        if self.status == "uncalibrated":
+            if (
+                self.future_class_confidence is not None
+                or self.calibration_error is not None
+                or self.confidence_interval.components
+            ):
+                raise FutureAuthorityLedgerError(
+                    "uncalibrated evidence cannot claim confidence, "
+                    "calibration error or confidence interval"
+                )
+
+        if self.status == "calibrated":
+            if (
+                self.future_class_confidence is None
+                or self.calibration_error is None
+                or not self.confidence_interval.components
+            ):
+                raise FutureAuthorityLedgerError(
+                    "calibrated evidence requires confidence, "
+                    "calibration error and confidence interval"
+                )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "calibration_id": self.calibration_id,
+            "status": self.status,
+            "future_class_confidence": (
+                self.future_class_confidence
+            ),
+            "future_basin_pull": self.future_basin_pull,
+            "sample_count": self.sample_count,
+            "effective_sample_count": (
+                self.effective_sample_count
+            ),
+            "calibration_population_id": (
+                self.calibration_population_id
+            ),
+            "calibration_error": self.calibration_error,
+            "out_of_distribution": self.out_of_distribution,
+            "scenario_tail_metrics": (
+                self.scenario_tail_metrics.to_dict()
+            ),
+            "confidence_interval": (
+                self.confidence_interval.to_dict()
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class FutureConditionedGateLifecycle:
+    lifecycle_id: str
+    evidence_maturity: str
+    authority_status: str
+    retrospective_atlas_record_id: str
+    prospective_nomination_id: str
+    causal_experiment_id: str
+    anti_coercion_check_id: str
+    calibration_id: str
+    no_auto_promotion: bool = True
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "lifecycle_id",
+            "retrospective_atlas_record_id",
+            "prospective_nomination_id",
+            "causal_experiment_id",
+            "anti_coercion_check_id",
+            "calibration_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        object.__setattr__(
+            self,
+            "evidence_maturity",
+            _require_choice(
+                "evidence_maturity",
+                self.evidence_maturity,
+                GATE_EVIDENCE_MATURITY_STATES,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "authority_status",
+            _require_choice(
+                "authority_status",
+                self.authority_status,
+                GATE_AUTHORITY_STATES,
+            ),
+        )
+
+        no_auto_promotion = _require_boolean(
+            "no_auto_promotion",
+            self.no_auto_promotion,
+        )
+
+        if no_auto_promotion is not True:
+            raise FutureAuthorityLedgerError(
+                "future-gate evidence cannot auto-promote authority"
+            )
+
+        object.__setattr__(
+            self,
+            "no_auto_promotion",
+            True,
+        )
+
+        if self.authority_status == "bounded_authorized":
+            if self.evidence_maturity not in {
+                "calibrated",
+                "prospectively_validated",
+            }:
+                raise FutureAuthorityLedgerError(
+                    "bounded authority requires calibrated or "
+                    "prospectively validated evidence"
+                )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "lifecycle_id": self.lifecycle_id,
+            "evidence_maturity": self.evidence_maturity,
+            "authority_status": self.authority_status,
+            "retrospective_atlas_record_id": (
+                self.retrospective_atlas_record_id
+            ),
+            "prospective_nomination_id": (
+                self.prospective_nomination_id
+            ),
+            "causal_experiment_id": self.causal_experiment_id,
+            "anti_coercion_check_id": (
+                self.anti_coercion_check_id
+            ),
+            "calibration_id": self.calibration_id,
+            "no_auto_promotion": True,
+        }
+
+
+@dataclass(frozen=True)
+class BidirectionalMetaFieldReference:
+    meta_field_record_id: str
+    forward_transition_map_id: str
+    backward_predecessor_map_id: str
+    evidence_structure_id: str
+    admissibility_authority_structure_id: str
+    consistency_relation_id: str
+    literal_retrocausality_claimed: bool = False
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "meta_field_record_id",
+            "forward_transition_map_id",
+            "backward_predecessor_map_id",
+            "evidence_structure_id",
+            "admissibility_authority_structure_id",
+            "consistency_relation_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        literal = _require_boolean(
+            "literal_retrocausality_claimed",
+            self.literal_retrocausality_claimed,
+        )
+
+        if literal:
+            raise FutureAuthorityLedgerError(
+                "RCAF does not claim literal backward causation"
+            )
+
+        object.__setattr__(
+            self,
+            "literal_retrocausality_claimed",
+            False,
+        )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "meta_field_record_id": self.meta_field_record_id,
+            "forward_transition_map_id": (
+                self.forward_transition_map_id
+            ),
+            "backward_predecessor_map_id": (
+                self.backward_predecessor_map_id
+            ),
+            "evidence_structure_id": self.evidence_structure_id,
+            "admissibility_authority_structure_id": (
+                self.admissibility_authority_structure_id
+            ),
+            "consistency_relation_id": (
+                self.consistency_relation_id
+            ),
+            "literal_retrocausality_claimed": False,
+        }
+
+
+@dataclass(frozen=True)
+class FutureConditionedAuthorityEvidenceBundle:
+    terminal_contract: TerminalOrganizationalContract
+    forward_evidence: ForwardReachabilityEvidence
+    backward_evidence: BackwardPredecessorEvidence
+    consistency: BidirectionalConsistencyRecord
+    causal_experiment: MatchedCausalExperiment
+    anti_coercion: AntiCoercionAuthorityCheck
+    retrospective_atlas: RetrospectivePrecursorAtlasRecord
+    prospective_nomination: ProspectiveGateNomination
+    calibration: FutureGateCalibration
+    lifecycle: FutureConditionedGateLifecycle
+    meta_field: BidirectionalMetaFieldReference
+    raw_content_stored: bool = False
+    content_fingerprint_stored: bool = False
+
+    def __post_init__(
+        self,
+    ) -> None:
+        if (
+            self.backward_evidence.future_contract_id
+            != self.terminal_contract.contract_id
+        ):
+            raise FutureAuthorityLedgerError(
+                "backward evidence must use the terminal contract"
+            )
+
+        if (
+            self.causal_experiment.frozen_future_contract_id
+            != self.terminal_contract.contract_id
+        ):
+            raise FutureAuthorityLedgerError(
+                "causal experiment must freeze the terminal contract"
+            )
+
+        if (
+            self.terminal_contract.terminal_class_id
+            not in self.forward_evidence.reachable_terminal_class_ids
+        ):
+            raise FutureAuthorityLedgerError(
+                "forward evidence must include the terminal class"
+            )
+
+        if (
+            self.consistency.forward_reachable_set_id
+            != self.forward_evidence.reachable_set_id
+        ):
+            raise FutureAuthorityLedgerError(
+                "consistency record forward-set linkage mismatch"
+            )
+
+        if (
+            self.consistency.backward_predecessor_set_id
+            != self.backward_evidence.predecessor_set_id
+        ):
+            raise FutureAuthorityLedgerError(
+                "consistency record predecessor-set linkage mismatch"
+            )
+
+        if (
+            self.meta_field.forward_transition_map_id
+            != self.forward_evidence.forward_map_id
+        ):
+            raise FutureAuthorityLedgerError(
+                "meta-field forward-map linkage mismatch"
+            )
+
+        if (
+            self.meta_field.backward_predecessor_map_id
+            != self.backward_evidence.backward_map_id
+        ):
+            raise FutureAuthorityLedgerError(
+                "meta-field backward-map linkage mismatch"
+            )
+
+        if (
+            self.meta_field.consistency_relation_id
+            != self.consistency.consistency_record_id
+        ):
+            raise FutureAuthorityLedgerError(
+                "meta-field consistency linkage mismatch"
+            )
+
+        if (
+            self.lifecycle.retrospective_atlas_record_id
+            != self.retrospective_atlas.atlas_record_id
+        ):
+            raise FutureAuthorityLedgerError(
+                "lifecycle retrospective-atlas linkage mismatch"
+            )
+
+        if (
+            self.lifecycle.prospective_nomination_id
+            != self.prospective_nomination.nomination_id
+        ):
+            raise FutureAuthorityLedgerError(
+                "lifecycle prospective-nomination linkage mismatch"
+            )
+
+        if (
+            self.lifecycle.causal_experiment_id
+            != self.causal_experiment.experiment_id
+        ):
+            raise FutureAuthorityLedgerError(
+                "lifecycle causal-experiment linkage mismatch"
+            )
+
+        if (
+            self.lifecycle.anti_coercion_check_id
+            != self.anti_coercion.check_id
+        ):
+            raise FutureAuthorityLedgerError(
+                "lifecycle anti-coercion linkage mismatch"
+            )
+
+        if (
+            self.lifecycle.calibration_id
+            != self.calibration.calibration_id
+        ):
+            raise FutureAuthorityLedgerError(
+                "lifecycle calibration linkage mismatch"
+            )
+
+        if (
+            self.prospective_nomination.observed_precursor_class_id
+            != self.retrospective_atlas.precursor_class_id
+        ):
+            raise FutureAuthorityLedgerError(
+                "prospective nomination must match the validated "
+                "retrospective precursor class"
+            )
+
+        if not set(
+            self.consistency.shared_corridor_ids
+        ).issubset(
+            set(
+                self.forward_evidence.safe_corridor_ids
+            )
+        ):
+            raise FutureAuthorityLedgerError(
+                "shared consistency corridors must occur in "
+                "the forward safe-corridor set"
+            )
+
+        if (
+            self.prospective_nomination.corridor_match_id
+            not in self.consistency.shared_corridor_ids
+        ):
+            raise FutureAuthorityLedgerError(
+                "prospective nomination corridor mismatch"
+            )
+
+        if (
+            self.retrospective_atlas.terminal_class_id
+            != self.terminal_contract.terminal_class_id
+        ):
+            raise FutureAuthorityLedgerError(
+                "retrospective terminal-class linkage mismatch"
+            )
+
+        if (
+            self.calibration.calibration_population_id
+            != self.retrospective_atlas.validation_population_id
+        ):
+            raise FutureAuthorityLedgerError(
+                "calibration population linkage mismatch"
+            )
+
+        if (
+            self.causal_experiment.independent_evaluator_id
+            not in self.backward_evidence.required_evaluator_ids
+        ):
+            raise FutureAuthorityLedgerError(
+                "independent evaluator is not a required predecessor"
+            )
+
+        branch_evaluators = {
+            branch.evaluator_id
+            for branch in self.causal_experiment.branches
+        }
+
+        if branch_evaluators != {
+            self.causal_experiment.independent_evaluator_id
+        }:
+            raise FutureAuthorityLedgerError(
+                "matched branches must use the frozen independent evaluator"
+            )
+
+        if (
+            self.anti_coercion.valid_treatment_preferential
+            != self.causal_experiment.valid_treatment_preferential
+            or self.anti_coercion.support_withdrawal_persistent
+            != self.causal_experiment.withdrawal_persistent
+            or self.anti_coercion.evaluator_independent
+            != self.causal_experiment.independent_verification_passed
+        ):
+            raise FutureAuthorityLedgerError(
+                "anti-coercion evidence disagrees with the "
+                "matched causal experiment"
+            )
+
+        if (
+            self.causal_experiment.causal_support_established
+            and not self.anti_coercion.passed
+        ):
+            raise FutureAuthorityLedgerError(
+                "causal support cannot survive a failed anti-coercion check"
+            )
+
+        for field_name in (
+            "raw_content_stored",
+            "content_fingerprint_stored",
+        ):
+            value = _require_boolean(
+                field_name,
+                getattr(self, field_name),
+            )
+
+            if value is not False:
+                raise FutureAuthorityLedgerError(
+                    f"{field_name} must remain False"
+                )
+
+    @property
+    def causal_authority_eligible(
+        self,
+    ) -> bool:
+        return bool(
+            self.consistency.gate_admissible
+            and self.causal_experiment.causal_support_established
+            and self.anti_coercion.passed
+            and self.calibration.status == "calibrated"
+            and self.lifecycle.evidence_maturity
+            in {
+                "calibrated",
+                "prospectively_validated",
+            }
+            and self.lifecycle.authority_status
+            in {
+                "sandbox_candidate",
+                "sandboxed",
+                "bounded_authorized",
+            }
+        )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "schema": RCAF_FUTURE_AUTHORITY_SCHEMA,
+            "terminal_contract": (
+                self.terminal_contract.to_dict()
+            ),
+            "forward_evidence": self.forward_evidence.to_dict(),
+            "backward_evidence": (
+                self.backward_evidence.to_dict()
+            ),
+            "consistency": self.consistency.to_dict(),
+            "causal_experiment": (
+                self.causal_experiment.to_dict()
+            ),
+            "anti_coercion": self.anti_coercion.to_dict(),
+            "retrospective_atlas": (
+                self.retrospective_atlas.to_dict()
+            ),
+            "prospective_nomination": (
+                self.prospective_nomination.to_dict()
+            ),
+            "calibration": self.calibration.to_dict(),
+            "lifecycle": self.lifecycle.to_dict(),
+            "meta_field": self.meta_field.to_dict(),
+            "causal_authority_eligible": (
+                self.causal_authority_eligible
+            ),
+            "raw_content_stored": False,
+            "content_fingerprint_stored": False,
+        }
+
+    def canonical_json(
+        self,
+    ) -> str:
+        return json.dumps(
+            self.to_dict(),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )

--- a/src/rcaf/organizational_ledger.py
+++ b/src/rcaf/organizational_ledger.py
@@ -1,0 +1,1200 @@
+# ============================================================
+# src/rcaf/organizational_ledger.py
+# ============================================================
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+
+RCAF_ORGANIZATIONAL_LEDGER_SCHEMA = (
+    "RCAF-ORGANIZATIONAL-LEDGER-0.1"
+)
+
+RCAF_ATLAS_TYPES = frozenset(
+    {
+        "State",
+        "Response",
+        "Transition",
+        "Reference",
+        "Boundary",
+        "Authority",
+        "TemporalAnchor",
+        "Interface",
+        "Coupling",
+        "PropagationInfluence",
+        "ScaleTransition",
+        "GlobalReferenceBackreaction",
+        "Persistence",
+        "Evidence",
+        "CausalFlow",
+        "FutureTopology",
+        "SymmetryMetaAtlas",
+    }
+)
+
+RCAF_RECORD_TYPES = frozenset(
+    {
+        "event_spine",
+        "state_transition",
+        "evidence",
+        "boundary",
+        "authority",
+        "realization_lifecycle",
+        "counterfactual",
+        "atlas_linkage",
+        "composite",
+    }
+)
+
+RCAF_STAGES = frozenset(
+    {
+        "possibility",
+        "proposal",
+        "verification",
+        "transition_qualification",
+        "edge_admissibility",
+        "geometry_coherence",
+        "transformation_geometry",
+        "active_participation_permission",
+        "realization",
+        "absorption",
+        "influence",
+        "persistence",
+        "release",
+        "modified_possibility",
+    }
+)
+
+EVIDENCE_STATUSES = frozenset(
+    {
+        "unknown",
+        "unverified",
+        "partial",
+        "verified",
+        "contradictory",
+        "insufficient",
+        "rejected",
+    }
+)
+
+BOUNDARY_STATES = frozenset(
+    {
+        "unknown",
+        "open",
+        "bounded",
+        "closed",
+        "violated",
+    }
+)
+
+ADMISSIBILITY_STATES = frozenset(
+    {
+        "unknown",
+        "pending",
+        "admissible",
+        "inadmissible",
+        "deferred",
+    }
+)
+
+AUTHORITY_STATES = frozenset(
+    {
+        "none",
+        "proposed",
+        "bounded_grant",
+        "active",
+        "denied",
+        "expired",
+        "released",
+        "revoked",
+    }
+)
+
+LIFECYCLE_STATUSES = frozenset(
+    {
+        "not_observed",
+        "possible",
+        "proposed",
+        "verified",
+        "qualified",
+        "admissible",
+        "authorized",
+        "executed",
+        "absorbed",
+        "influential",
+        "persistent",
+        "released",
+        "revoked",
+        "failed",
+        "deferred",
+        "rejected",
+    }
+)
+
+COUNTERFACTUAL_STATUSES = frozenset(
+    {
+        "not_evaluated",
+        "partial",
+        "complete",
+        "inconclusive",
+    }
+)
+
+AUTHORITY_POSTURES = frozenset(
+    {
+        "observe_only",
+        "sandboxed",
+        "bounded",
+        "active",
+    }
+)
+
+_IDENTIFIER_PATTERN = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,191}$"
+)
+
+
+class RCAFOrganizationalLedgerError(ValueError):
+    """Raised when a multidimensional RCAF record is invalid."""
+
+
+def _require_identifier(
+    field_name: str,
+    value: str,
+) -> str:
+    normalized = str(value).strip()
+
+    if not _IDENTIFIER_PATTERN.fullmatch(normalized):
+        raise RCAFOrganizationalLedgerError(
+            f"{field_name} must be a static structural identifier"
+        )
+
+    return normalized
+
+
+def _optional_identifier(
+    field_name: str,
+    value: str | None,
+) -> str | None:
+    if value is None:
+        return None
+
+    return _require_identifier(
+        field_name,
+        value,
+    )
+
+
+def _require_choice(
+    field_name: str,
+    value: str,
+    allowed: frozenset[str],
+) -> str:
+    normalized = str(value).strip()
+
+    if normalized not in allowed:
+        raise RCAFOrganizationalLedgerError(
+            f"{field_name} must be one of {sorted(allowed)!r}; "
+            f"received {normalized!r}"
+        )
+
+    return normalized
+
+
+def _require_boolean(
+    field_name: str,
+    value: bool,
+) -> bool:
+    if not isinstance(value, bool):
+        raise RCAFOrganizationalLedgerError(
+            f"{field_name} must be bool"
+        )
+
+    return value
+
+
+def _require_finite(
+    field_name: str,
+    value: float,
+) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(float(value))
+    ):
+        raise RCAFOrganizationalLedgerError(
+            f"{field_name} must be a finite number"
+        )
+
+    return float(value)
+
+
+def _optional_finite(
+    field_name: str,
+    value: float | None,
+) -> float | None:
+    if value is None:
+        return None
+
+    return _require_finite(
+        field_name,
+        value,
+    )
+
+
+def _require_unit_interval(
+    field_name: str,
+    value: float,
+) -> float:
+    normalized = _require_finite(
+        field_name,
+        value,
+    )
+
+    if not 0.0 <= normalized <= 1.0:
+        raise RCAFOrganizationalLedgerError(
+            f"{field_name} must be between 0 and 1"
+        )
+
+    return normalized
+
+
+def _require_nonnegative_integer(
+    field_name: str,
+    value: int,
+) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value < 0
+    ):
+        raise RCAFOrganizationalLedgerError(
+            f"{field_name} must be a non-negative integer"
+        )
+
+    return value
+
+
+def _require_utc_timestamp(
+    field_name: str,
+    value: str,
+) -> str:
+    normalized = str(value).strip()
+
+    try:
+        parsed = datetime.fromisoformat(
+            normalized.replace(
+                "Z",
+                "+00:00",
+            )
+        )
+    except ValueError as exc:
+        raise RCAFOrganizationalLedgerError(
+            f"{field_name} must be an ISO-8601 timestamp"
+        ) from exc
+
+    if (
+        parsed.tzinfo is None
+        or parsed.utcoffset()
+        != timezone.utc.utcoffset(parsed)
+    ):
+        raise RCAFOrganizationalLedgerError(
+            f"{field_name} must be UTC"
+        )
+
+    return normalized
+
+
+def _normalize_identifiers(
+    field_name: str,
+    values: tuple[str, ...],
+) -> tuple[str, ...]:
+    normalized = tuple(
+        _require_identifier(
+            field_name,
+            value,
+        )
+        for value in values
+    )
+
+    if len(set(normalized)) != len(normalized):
+        raise RCAFOrganizationalLedgerError(
+            f"{field_name} contains duplicate identifiers"
+        )
+
+    return normalized
+
+
+@dataclass(frozen=True)
+class MetricVector:
+    components: tuple[
+        tuple[str, float],
+        ...,
+    ] = ()
+
+    def __post_init__(
+        self,
+    ) -> None:
+        normalized = []
+        seen = set()
+
+        for name, value in self.components:
+            component_name = _require_identifier(
+                "metric component",
+                name,
+            )
+
+            if component_name in seen:
+                raise RCAFOrganizationalLedgerError(
+                    "metric vector contains duplicate components"
+                )
+
+            seen.add(component_name)
+
+            normalized.append(
+                (
+                    component_name,
+                    _require_finite(
+                        component_name,
+                        value,
+                    ),
+                )
+            )
+
+        object.__setattr__(
+            self,
+            "components",
+            tuple(sorted(normalized)),
+        )
+
+    def to_dict(
+        self,
+    ) -> dict[str, float]:
+        return {
+            name: value
+            for name, value in self.components
+        }
+
+
+@dataclass(frozen=True)
+class AtlasLink:
+    atlas_type: str
+    atlas_record_id: str
+
+    def __post_init__(
+        self,
+    ) -> None:
+        object.__setattr__(
+            self,
+            "atlas_type",
+            _require_choice(
+                "atlas_type",
+                self.atlas_type,
+                RCAF_ATLAS_TYPES,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "atlas_record_id",
+            _require_identifier(
+                "atlas_record_id",
+                self.atlas_record_id,
+            ),
+        )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "atlas_type": self.atlas_type,
+            "atlas_record_id": self.atlas_record_id,
+        }
+
+
+@dataclass(frozen=True)
+class ReferenceGeometry:
+    reference_id: str
+    reference_class_id: str
+    anchor_id: str | None = None
+    drift: MetricVector = field(
+        default_factory=MetricVector
+    )
+    deviation: MetricVector = field(
+        default_factory=MetricVector
+    )
+    future_freedom: MetricVector = field(
+        default_factory=MetricVector
+    )
+
+    def __post_init__(
+        self,
+    ) -> None:
+        object.__setattr__(
+            self,
+            "reference_id",
+            _require_identifier(
+                "reference_id",
+                self.reference_id,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "reference_class_id",
+            _require_identifier(
+                "reference_class_id",
+                self.reference_class_id,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "anchor_id",
+            _optional_identifier(
+                "anchor_id",
+                self.anchor_id,
+            ),
+        )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "reference_id": self.reference_id,
+            "reference_class_id": self.reference_class_id,
+            "anchor_id": self.anchor_id,
+            "drift": self.drift.to_dict(),
+            "deviation": self.deviation.to_dict(),
+            "future_freedom": self.future_freedom.to_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class ParticipationGeometry:
+    pi_i: float
+    pi_r: float
+    pi_a: float
+    strain: float
+
+    def __post_init__(
+        self,
+    ) -> None:
+        values = {
+            "pi_i": _require_unit_interval(
+                "pi_i",
+                self.pi_i,
+            ),
+            "pi_r": _require_unit_interval(
+                "pi_r",
+                self.pi_r,
+            ),
+            "pi_a": _require_unit_interval(
+                "pi_a",
+                self.pi_a,
+            ),
+            "strain": _require_unit_interval(
+                "strain",
+                self.strain,
+            ),
+        }
+
+        total = (
+            values["pi_i"]
+            + values["pi_r"]
+            + values["pi_a"]
+        )
+
+        if not math.isclose(
+            total,
+            1.0,
+            rel_tol=0.0,
+            abs_tol=1e-6,
+        ):
+            raise RCAFOrganizationalLedgerError(
+                "pi_i + pi_r + pi_a must equal 1"
+            )
+
+        for name, value in values.items():
+            object.__setattr__(
+                self,
+                name,
+                value,
+            )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "pi_i": self.pi_i,
+            "pi_r": self.pi_r,
+            "pi_a": self.pi_a,
+            "strain": self.strain,
+        }
+
+
+@dataclass(frozen=True)
+class CoherenceGeometry:
+    meta_field_id: str | None = None
+    psi: float | None = None
+    rho_a: float | None = None
+    rho_c: float | None = None
+    occupancy: float | None = None
+    geometry_coherence: float | None = None
+    realization_pressure: float | None = None
+    viability: float | None = None
+    realization_coupling: float | None = None
+
+    def __post_init__(
+        self,
+    ) -> None:
+        object.__setattr__(
+            self,
+            "meta_field_id",
+            _optional_identifier(
+                "meta_field_id",
+                self.meta_field_id,
+            ),
+        )
+
+        for field_name in (
+            "psi",
+            "rho_a",
+            "rho_c",
+            "occupancy",
+            "geometry_coherence",
+            "realization_pressure",
+            "viability",
+            "realization_coupling",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _optional_finite(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "meta_field_id": self.meta_field_id,
+            "psi": self.psi,
+            "rho_a": self.rho_a,
+            "rho_c": self.rho_c,
+            "occupancy": self.occupancy,
+            "geometry_coherence": self.geometry_coherence,
+            "realization_pressure": self.realization_pressure,
+            "viability": self.viability,
+            "realization_coupling": self.realization_coupling,
+        }
+
+
+@dataclass(frozen=True)
+class EvidenceGeometry:
+    status: str
+    evidence_ids: tuple[str, ...] = ()
+    benefit: MetricVector = field(
+        default_factory=MetricVector
+    )
+    harm: MetricVector = field(
+        default_factory=MetricVector
+    )
+    containment: MetricVector = field(
+        default_factory=MetricVector
+    )
+    reversibility: MetricVector = field(
+        default_factory=MetricVector
+    )
+    confidence: MetricVector = field(
+        default_factory=MetricVector
+    )
+    future_freedom_delta: MetricVector = field(
+        default_factory=MetricVector
+    )
+
+    def __post_init__(
+        self,
+    ) -> None:
+        object.__setattr__(
+            self,
+            "status",
+            _require_choice(
+                "evidence status",
+                self.status,
+                EVIDENCE_STATUSES,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "evidence_ids",
+            _normalize_identifiers(
+                "evidence_ids",
+                self.evidence_ids,
+            ),
+        )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "status": self.status,
+            "evidence_ids": list(self.evidence_ids),
+            "benefit": self.benefit.to_dict(),
+            "harm": self.harm.to_dict(),
+            "containment": self.containment.to_dict(),
+            "reversibility": self.reversibility.to_dict(),
+            "confidence": self.confidence.to_dict(),
+            "future_freedom_delta": (
+                self.future_freedom_delta.to_dict()
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class FutureConditioning:
+    horizon: int
+    terminal_contract_id: str
+    terminal_class_id: str
+    corridor_id: str
+    forward_reachable: bool
+    backward_consistent: bool
+    gate_admissible: bool
+
+    def __post_init__(
+        self,
+    ) -> None:
+        object.__setattr__(
+            self,
+            "horizon",
+            _require_nonnegative_integer(
+                "horizon",
+                self.horizon,
+            ),
+        )
+
+        for field_name in (
+            "terminal_contract_id",
+            "terminal_class_id",
+            "corridor_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        for field_name in (
+            "forward_reachable",
+            "backward_consistent",
+            "gate_admissible",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_boolean(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "horizon": self.horizon,
+            "terminal_contract_id": self.terminal_contract_id,
+            "terminal_class_id": self.terminal_class_id,
+            "corridor_id": self.corridor_id,
+            "forward_reachable": self.forward_reachable,
+            "backward_consistent": self.backward_consistent,
+            "gate_admissible": self.gate_admissible,
+        }
+
+
+@dataclass(frozen=True)
+class BoundaryAuthority:
+    boundary_state: str
+    admissibility_state: str
+    authority_state: str
+    authority_id: str | None = None
+    scope_ids: tuple[str, ...] = ()
+    release_condition_ids: tuple[str, ...] = ()
+    revocation_condition_ids: tuple[str, ...] = ()
+    realization_authorized: bool = False
+
+    def __post_init__(
+        self,
+    ) -> None:
+        object.__setattr__(
+            self,
+            "boundary_state",
+            _require_choice(
+                "boundary_state",
+                self.boundary_state,
+                BOUNDARY_STATES,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "admissibility_state",
+            _require_choice(
+                "admissibility_state",
+                self.admissibility_state,
+                ADMISSIBILITY_STATES,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "authority_state",
+            _require_choice(
+                "authority_state",
+                self.authority_state,
+                AUTHORITY_STATES,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "authority_id",
+            _optional_identifier(
+                "authority_id",
+                self.authority_id,
+            ),
+        )
+
+        for field_name in (
+            "scope_ids",
+            "release_condition_ids",
+            "revocation_condition_ids",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _normalize_identifiers(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        object.__setattr__(
+            self,
+            "realization_authorized",
+            _require_boolean(
+                "realization_authorized",
+                self.realization_authorized,
+            ),
+        )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "boundary_state": self.boundary_state,
+            "admissibility_state": self.admissibility_state,
+            "authority_state": self.authority_state,
+            "authority_id": self.authority_id,
+            "scope_ids": list(self.scope_ids),
+            "release_condition_ids": list(
+                self.release_condition_ids
+            ),
+            "revocation_condition_ids": list(
+                self.revocation_condition_ids
+            ),
+            "realization_authorized": (
+                self.realization_authorized
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class RealizationLifecycle:
+    possibility: str = "not_observed"
+    proposal: str = "not_observed"
+    verification: str = "not_observed"
+    transition_qualification: str = "not_observed"
+    edge_admissibility: str = "not_observed"
+    geometry_coherence: str = "not_observed"
+    active_participation_permission: str = "not_observed"
+    realization: str = "not_observed"
+    absorption: str = "not_observed"
+    influence: str = "not_observed"
+    persistence: str = "not_observed"
+    release: str = "not_observed"
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in self.__dataclass_fields__:
+            object.__setattr__(
+                self,
+                field_name,
+                _require_choice(
+                    field_name,
+                    getattr(self, field_name),
+                    LIFECYCLE_STATUSES,
+                ),
+            )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            field_name: getattr(
+                self,
+                field_name,
+            )
+            for field_name
+            in self.__dataclass_fields__
+        }
+
+
+@dataclass(frozen=True)
+class CausalFlow:
+    interface_id: str | None = None
+    coupling_id: str | None = None
+    propagation_path_id: str | None = None
+    scale_transition_id: str | None = None
+    global_influence_id: str | None = None
+    coupling_strength: MetricVector = field(
+        default_factory=MetricVector
+    )
+    propagation_strength: MetricVector = field(
+        default_factory=MetricVector
+    )
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "interface_id",
+            "coupling_id",
+            "propagation_path_id",
+            "scale_transition_id",
+            "global_influence_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _optional_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "interface_id": self.interface_id,
+            "coupling_id": self.coupling_id,
+            "propagation_path_id": (
+                self.propagation_path_id
+            ),
+            "scale_transition_id": (
+                self.scale_transition_id
+            ),
+            "global_influence_id": (
+                self.global_influence_id
+            ),
+            "coupling_strength": (
+                self.coupling_strength.to_dict()
+            ),
+            "propagation_strength": (
+                self.propagation_strength.to_dict()
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class CounterfactualComparison:
+    status: str
+    candidate_ids: tuple[str, ...]
+    selected_candidate_id: str | None = None
+    comparison_metrics: MetricVector = field(
+        default_factory=MetricVector
+    )
+
+    def __post_init__(
+        self,
+    ) -> None:
+        object.__setattr__(
+            self,
+            "status",
+            _require_choice(
+                "counterfactual status",
+                self.status,
+                COUNTERFACTUAL_STATUSES,
+            ),
+        )
+
+        candidates = _normalize_identifiers(
+            "candidate_ids",
+            self.candidate_ids,
+        )
+
+        object.__setattr__(
+            self,
+            "candidate_ids",
+            candidates,
+        )
+
+        selected = _optional_identifier(
+            "selected_candidate_id",
+            self.selected_candidate_id,
+        )
+
+        if (
+            selected is not None
+            and selected not in candidates
+        ):
+            raise RCAFOrganizationalLedgerError(
+                "selected_candidate_id must occur in candidate_ids"
+            )
+
+        object.__setattr__(
+            self,
+            "selected_candidate_id",
+            selected,
+        )
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "status": self.status,
+            "candidate_ids": list(self.candidate_ids),
+            "selected_candidate_id": self.selected_candidate_id,
+            "comparison_metrics": (
+                self.comparison_metrics.to_dict()
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class RCAFOrganizationalRecord:
+    record_id: str
+    event_id: str
+    lineage_id: str
+    occurred_at_utc: str
+    record_type: str
+    stage: str
+    atlas_links: tuple[AtlasLink, ...]
+    reference: ReferenceGeometry | None = None
+    participation: ParticipationGeometry | None = None
+    coherence_geometry: CoherenceGeometry | None = None
+    evidence: EvidenceGeometry | None = None
+    future_conditioning: FutureConditioning | None = None
+    boundary_authority: BoundaryAuthority | None = None
+    lifecycle: RealizationLifecycle | None = None
+    causal_flow: CausalFlow | None = None
+    counterfactual: CounterfactualComparison | None = None
+    authority_posture: str = "observe_only"
+    raw_content_stored: bool = False
+    content_fingerprint_stored: bool = False
+
+    def __post_init__(
+        self,
+    ) -> None:
+        for field_name in (
+            "record_id",
+            "event_id",
+            "lineage_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_identifier(
+                    field_name,
+                    getattr(self, field_name),
+                ),
+            )
+
+        object.__setattr__(
+            self,
+            "occurred_at_utc",
+            _require_utc_timestamp(
+                "occurred_at_utc",
+                self.occurred_at_utc,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "record_type",
+            _require_choice(
+                "record_type",
+                self.record_type,
+                RCAF_RECORD_TYPES,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "stage",
+            _require_choice(
+                "stage",
+                self.stage,
+                RCAF_STAGES,
+            ),
+        )
+
+        object.__setattr__(
+            self,
+            "authority_posture",
+            _require_choice(
+                "authority_posture",
+                self.authority_posture,
+                AUTHORITY_POSTURES,
+            ),
+        )
+
+        atlas_types = [
+            link.atlas_type
+            for link in self.atlas_links
+        ]
+
+        if not self.atlas_links:
+            raise RCAFOrganizationalLedgerError(
+                "atlas_links must not be empty"
+            )
+
+        if len(set(atlas_types)) != len(atlas_types):
+            raise RCAFOrganizationalLedgerError(
+                "atlas_links contains duplicate atlas types"
+            )
+
+        if self.raw_content_stored is not False:
+            raise RCAFOrganizationalLedgerError(
+                "raw_content_stored must remain False"
+            )
+
+        if self.content_fingerprint_stored is not False:
+            raise RCAFOrganizationalLedgerError(
+                "content_fingerprint_stored must remain False"
+            )
+
+    def structural_summary(
+        self,
+    ) -> dict:
+        sections = {
+            "reference": self.reference is not None,
+            "participation": self.participation is not None,
+            "coherence_geometry": (
+                self.coherence_geometry is not None
+            ),
+            "evidence": self.evidence is not None,
+            "future_conditioning": (
+                self.future_conditioning is not None
+            ),
+            "boundary_authority": (
+                self.boundary_authority is not None
+            ),
+            "lifecycle": self.lifecycle is not None,
+            "causal_flow": self.causal_flow is not None,
+            "counterfactual": (
+                self.counterfactual is not None
+            ),
+        }
+
+        return {
+            "atlas_count": len(self.atlas_links),
+            "atlas_types": sorted(
+                link.atlas_type
+                for link in self.atlas_links
+            ),
+            "section_count": sum(
+                sections.values()
+            ),
+            "sections": sections,
+            "authority_posture": self.authority_posture,
+        }
+
+    def to_dict(
+        self,
+    ) -> dict:
+        return {
+            "schema": RCAF_ORGANIZATIONAL_LEDGER_SCHEMA,
+            "record_id": self.record_id,
+            "event_id": self.event_id,
+            "lineage_id": self.lineage_id,
+            "occurred_at_utc": self.occurred_at_utc,
+            "record_type": self.record_type,
+            "stage": self.stage,
+            "atlas_links": [
+                link.to_dict()
+                for link in self.atlas_links
+            ],
+            "reference": (
+                self.reference.to_dict()
+                if self.reference is not None
+                else None
+            ),
+            "participation": (
+                self.participation.to_dict()
+                if self.participation is not None
+                else None
+            ),
+            "coherence_geometry": (
+                self.coherence_geometry.to_dict()
+                if self.coherence_geometry is not None
+                else None
+            ),
+            "evidence": (
+                self.evidence.to_dict()
+                if self.evidence is not None
+                else None
+            ),
+            "future_conditioning": (
+                self.future_conditioning.to_dict()
+                if self.future_conditioning is not None
+                else None
+            ),
+            "boundary_authority": (
+                self.boundary_authority.to_dict()
+                if self.boundary_authority is not None
+                else None
+            ),
+            "lifecycle": (
+                self.lifecycle.to_dict()
+                if self.lifecycle is not None
+                else None
+            ),
+            "causal_flow": (
+                self.causal_flow.to_dict()
+                if self.causal_flow is not None
+                else None
+            ),
+            "counterfactual": (
+                self.counterfactual.to_dict()
+                if self.counterfactual is not None
+                else None
+            ),
+            "authority_posture": self.authority_posture,
+            "raw_content_stored": False,
+            "content_fingerprint_stored": False,
+            "summary": self.structural_summary(),
+        }
+
+    def canonical_json(
+        self,
+    ) -> str:
+        return json.dumps(
+            self.to_dict(),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )

--- a/tests/test_rcaf_canonical_governance.py
+++ b/tests/test_rcaf_canonical_governance.py
@@ -1,0 +1,502 @@
+# ============================================================
+# tests/test_rcaf_canonical_governance.py
+# ============================================================
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import stat
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from src.rcaf.canonical_evolution import (
+    CURRENT_SCHEMA_BY_FAMILY,
+    CanonicalSchemaEvolutionError,
+    LosslessMigrationManifest,
+    evaluate_schema,
+    require_current_schema,
+    validate_canonical_record_schema_set,
+)
+
+from src.rcaf.canonical_store import (
+    CanonicalStoreIntegrityError,
+    CanonicalStoreQuarantinedError,
+    append_canonical_record,
+    quarantine_canonical_store,
+    validate_and_replay_canonical_store,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+STORE_FIXTURE_PATH = (
+    REPO_ROOT
+    / "tests"
+    / "test_rcaf_canonical_store.py"
+)
+
+
+def _load_store_fixture():
+    spec = importlib.util.spec_from_file_location(
+        "rcaf_governance_store_fixture",
+        STORE_FIXTURE_PATH,
+    )
+
+    if (
+        spec is None
+        or spec.loader is None
+    ):
+        raise RuntimeError(
+            "unable to load canonical-store fixture"
+        )
+
+    module = importlib.util.module_from_spec(
+        spec
+    )
+
+    spec.loader.exec_module(
+        module
+    )
+
+    return module
+
+
+def _record(
+    index: int,
+):
+    return _load_store_fixture()._record(
+        index
+    )
+
+
+def test_current_schema_set_is_explicitly_accepted():
+    validation = (
+        validate_canonical_record_schema_set(
+            _record(1).to_dict()
+        )
+    )
+
+    assert validation.current is True
+
+    assert validation.to_dict()[
+        "automatic_migration_allowed"
+    ] is False
+
+
+def test_previous_canonical_schema_requires_manifest():
+    evaluation = evaluate_schema(
+        "canonical_record",
+        "RCAF-CANONICAL-FRAMEWORK-LEDGER-0.2",
+    )
+
+    assert evaluation.disposition == (
+        "migration_required"
+    )
+
+    with pytest.raises(
+        CanonicalSchemaEvolutionError,
+        match="explicit lossless migration manifest",
+    ):
+        require_current_schema(
+            "canonical_record",
+            (
+                "RCAF-CANONICAL-"
+                "FRAMEWORK-LEDGER-0.2"
+            ),
+        )
+
+
+def test_unknown_schema_is_rejected():
+    evaluation = evaluate_schema(
+        "canonical_record",
+        "RCAF-CANONICAL-FRAMEWORK-LEDGER-9.9",
+    )
+
+    assert evaluation.disposition == (
+        "unsupported"
+    )
+
+    with pytest.raises(
+        CanonicalSchemaEvolutionError,
+        match="schema is unsupported",
+    ):
+        require_current_schema(
+            "canonical_record",
+            (
+                "RCAF-CANONICAL-"
+                "FRAMEWORK-LEDGER-9.9"
+            ),
+        )
+
+
+def _migration_manifest():
+    return LosslessMigrationManifest(
+        migration_id=(
+            "MIGRATION-CANONICAL-02-03"
+        ),
+        family="canonical_record",
+        source_schema=(
+            "RCAF-CANONICAL-FRAMEWORK-LEDGER-0.2"
+        ),
+        target_schema=(
+            CURRENT_SCHEMA_BY_FAMILY[
+                "canonical_record"
+            ]
+        ),
+        source_record_sha256="a" * 64,
+        target_record_sha256="b" * 64,
+        preserved_field_paths=(
+            "record_id",
+            "event_spine_id",
+            "authority_posture",
+            "organizational_record",
+        ),
+        added_explicit_field_paths=(
+            "future_authority_evidence",
+        ),
+    )
+
+
+def test_lossless_migration_manifest_is_deterministic():
+    first = (
+        _migration_manifest()
+        .canonical_json()
+    )
+
+    second = (
+        _migration_manifest()
+        .canonical_json()
+    )
+
+    assert first == second
+
+    data = json.loads(
+        first
+    )
+
+    assert data["lossless"] is True
+    assert data["automatic_migration"] is False
+    assert data["dropped_field_paths"] == []
+    assert data["inferred_field_paths"] == []
+
+
+def test_migration_cannot_drop_fields():
+    with pytest.raises(
+        CanonicalSchemaEvolutionError,
+        match="cannot drop fields",
+    ):
+        replace(
+            _migration_manifest(),
+            dropped_field_paths=(
+                "future_gate",
+            ),
+        )
+
+
+def test_migration_cannot_infer_missing_rcaf_fields():
+    with pytest.raises(
+        CanonicalSchemaEvolutionError,
+        match="cannot infer missing RCAF fields",
+    ):
+        replace(
+            _migration_manifest(),
+            inferred_field_paths=(
+                "future_authority_evidence",
+            ),
+        )
+
+
+def test_migration_cannot_change_authority_posture():
+    with pytest.raises(
+        CanonicalSchemaEvolutionError,
+        match="cannot change authority posture",
+    ):
+        replace(
+            _migration_manifest(),
+            authority_posture_after="bounded",
+        )
+
+
+def _tamper_store(
+    root: Path,
+) -> bytes:
+    append_canonical_record(
+        root,
+        ledger_id="QUARANTINE-LEDGER",
+        record=_record(1),
+    )
+
+    segment = (
+        root
+        / "segment-000000.jsonl"
+    )
+
+    entry = json.loads(
+        segment.read_text(
+            encoding="utf-8"
+        )
+    )
+
+    entry["record"]["record_id"] = (
+        "RCAF-FORENSIC-TAMPER"
+    )
+
+    segment.write_text(
+        json.dumps(
+            entry,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    return segment.read_bytes()
+
+
+def test_quarantine_preserves_exact_bytes_and_blocks_store(
+    tmp_path,
+):
+    root = tmp_path / "ledger"
+
+    tampered_bytes = _tamper_store(
+        root
+    )
+
+    with pytest.raises(
+        CanonicalStoreIntegrityError,
+        match="entry SHA-256 mismatch",
+    ):
+        validate_and_replay_canonical_store(
+            root,
+            ledger_id="QUARANTINE-LEDGER",
+        )
+
+    receipt = quarantine_canonical_store(
+        root,
+        ledger_id="QUARANTINE-LEDGER",
+        case_id="CASE-HASH-MISMATCH-0001",
+        reason_code="ENTRY-HASH-MISMATCH",
+    )
+
+    case_directory = Path(
+        receipt.case_directory
+    )
+
+    snapshot = (
+        case_directory
+        / "segment-000000.jsonl"
+    )
+
+    assert snapshot.read_bytes() == (
+        tampered_bytes
+    )
+
+    assert receipt.append_blocked is True
+    assert receipt.authority_posture == (
+        "observe_only"
+    )
+
+    with pytest.raises(
+        CanonicalStoreQuarantinedError,
+        match="canonical store is quarantined",
+    ):
+        append_canonical_record(
+            root,
+            ledger_id="QUARANTINE-LEDGER",
+            record=_record(2),
+        )
+
+    with pytest.raises(
+        CanonicalStoreQuarantinedError,
+        match="canonical store is quarantined",
+    ):
+        validate_and_replay_canonical_store(
+            root,
+            ledger_id="QUARANTINE-LEDGER",
+        )
+
+    with pytest.raises(
+        CanonicalStoreIntegrityError,
+        match="entry SHA-256 mismatch",
+    ):
+        validate_and_replay_canonical_store(
+            root,
+            ledger_id="QUARANTINE-LEDGER",
+            allow_quarantined=True,
+        )
+
+
+def test_quarantine_filesystem_is_private(
+    tmp_path,
+):
+    root = tmp_path / "ledger"
+
+    _tamper_store(
+        root
+    )
+
+    receipt = quarantine_canonical_store(
+        root,
+        ledger_id="QUARANTINE-LEDGER",
+        case_id="CASE-PRIVATE-0001",
+        reason_code="ENTRY-HASH-MISMATCH",
+    )
+
+    case_directory = Path(
+        receipt.case_directory
+    )
+
+    forensic_root = (
+        case_directory.parent
+    )
+
+    assert (
+        stat.S_IMODE(
+            os.stat(forensic_root).st_mode
+        )
+        == 0o700
+    )
+
+    assert (
+        stat.S_IMODE(
+            os.stat(case_directory).st_mode
+        )
+        == 0o700
+    )
+
+    for path in case_directory.iterdir():
+        assert (
+            stat.S_IMODE(
+                os.stat(path).st_mode
+            )
+            == 0o600
+        )
+
+    marker = (
+        root
+        / "quarantine.json"
+    )
+
+    assert (
+        stat.S_IMODE(
+            os.stat(marker).st_mode
+        )
+        == 0o600
+    )
+
+
+def test_quarantine_does_not_follow_symlinks(
+    tmp_path,
+):
+    root = tmp_path / "ledger"
+
+    _tamper_store(
+        root
+    )
+
+    outside = (
+        tmp_path
+        / "outside-secret"
+    )
+
+    outside.write_text(
+        "must-not-be-copied",
+        encoding="utf-8",
+    )
+
+    (
+        root
+        / "unexpected-link"
+    ).symlink_to(
+        outside
+    )
+
+    receipt = quarantine_canonical_store(
+        root,
+        ledger_id="QUARANTINE-LEDGER",
+        case_id="CASE-SYMLINK-0001",
+        reason_code="UNSAFE-ENTRY",
+    )
+
+    case_directory = Path(
+        receipt.case_directory
+    )
+
+    manifest = json.loads(
+        (
+            case_directory
+            / "forensic_manifest.json"
+        ).read_text(
+            encoding="utf-8"
+        )
+    )
+
+    symlink_entries = [
+        entry
+        for entry in manifest["entries"]
+        if entry["name"]
+        == "unexpected-link"
+    ]
+
+    assert len(
+        symlink_entries
+    ) == 1
+
+    assert (
+        symlink_entries[0][
+            "entry_type"
+        ]
+        == "symlink"
+    )
+
+    assert (
+        symlink_entries[0][
+            "copied"
+        ]
+        is False
+    )
+
+    assert (
+        symlink_entries[0][
+            "target_followed"
+        ]
+        is False
+    )
+
+    assert not (
+        case_directory
+        / "unexpected-link"
+    ).exists()
+
+
+def test_existing_quarantine_cannot_be_overwritten(
+    tmp_path,
+):
+    root = tmp_path / "ledger"
+
+    _tamper_store(
+        root
+    )
+
+    quarantine_canonical_store(
+        root,
+        ledger_id="QUARANTINE-LEDGER",
+        case_id="CASE-IMMUTABLE-0001",
+        reason_code="ENTRY-HASH-MISMATCH",
+    )
+
+    with pytest.raises(
+        CanonicalStoreQuarantinedError,
+        match="canonical store is quarantined",
+    ):
+        quarantine_canonical_store(
+            root,
+            ledger_id="QUARANTINE-LEDGER",
+            case_id="CASE-IMMUTABLE-0002",
+            reason_code="SECOND-QUARANTINE",
+        )

--- a/tests/test_rcaf_canonical_ledger.py
+++ b/tests/test_rcaf_canonical_ledger.py
@@ -1,0 +1,1351 @@
+# ============================================================
+# tests/test_rcaf_canonical_ledger.py
+# ============================================================
+
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import json
+import math
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from src.rcaf.canonical_ledger import (
+    RCAF_BROAD_ORGANIZATIONAL_CHAIN,
+    RCAF_CANONICAL_CAPABILITIES,
+    RCAF_CANONICAL_LEDGER_SCHEMA,
+    RCAF_EVENT_COORDINATE_AXES,
+    RCAF_INTERFACE_PROPAGATION_CHAIN,
+    RCAF_REALIZATION_GOVERNANCE_CHAIN,
+    AuthorityLifecycleContract,
+    CausalConeReference,
+    CommitmentHysteresisRecord,
+    ConditionedDecisionTrace,
+    DerivedDiagnosticRecord,
+    E8LocalHarmonicReference,
+    FutureConditionedAuthorityGate,
+    GeometricReferenceBundle,
+    HorizonMetric,
+    InterfacePropagationChain,
+    InterfaceStageObservation,
+    LeechGlobalCompatibilityReference,
+    MinimalEventCoordinate,
+    MonsterMetaAtlasReference,
+    OperatorFlowReference,
+    ParticipationCorridor,
+    PrimitiveObservableBundle,
+    ProcessChainObservation,
+    ProposalGainDiscovery,
+    RCAFCanonicalLedgerError,
+    RCAFFullFrameworkRecord,
+    ReferenceConditioning,
+    StageObservation,
+    TransformationGeometryRecord,
+    canonical_completeness_report,
+)
+
+from src.rcaf.organizational_ledger import (
+    RCAF_ATLAS_TYPES,
+    AtlasLink,
+    BoundaryAuthority,
+    CausalFlow,
+    CoherenceGeometry,
+    CounterfactualComparison,
+    EvidenceGeometry,
+    FutureConditioning,
+    MetricVector,
+    ParticipationGeometry,
+    RCAFOrganizationalRecord,
+    RealizationLifecycle,
+    ReferenceGeometry,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+FUTURE_AUTHORITY_FIXTURE_PATH = (
+    REPO_ROOT
+    / "tests/test_rcaf_future_authority_ledger.py"
+)
+
+
+def _future_authority_bundle():
+    spec = importlib.util.spec_from_file_location(
+        "rcaf_future_authority_test_fixture",
+        FUTURE_AUTHORITY_FIXTURE_PATH,
+    )
+
+    if (
+        spec is None
+        or spec.loader is None
+    ):
+        raise RuntimeError(
+            "unable to load future-authority fixture"
+        )
+
+    module = importlib.util.module_from_spec(
+        spec
+    )
+
+    spec.loader.exec_module(module)
+
+    return module._bundle()
+
+
+def _vector(
+    name: str,
+    value: float = 0.5,
+) -> MetricVector:
+    return MetricVector(
+        (
+            (name, value),
+        )
+    )
+
+
+def _atlas_links():
+    return tuple(
+        AtlasLink(
+            atlas_type=atlas_type,
+            atlas_record_id=(
+                f"ATLAS-{index:02d}"
+            ),
+        )
+        for index, atlas_type in enumerate(
+            sorted(RCAF_ATLAS_TYPES),
+            start=1,
+        )
+    )
+
+
+def _organizational_record():
+    return RCAFOrganizationalRecord(
+        record_id="ORG-0001",
+        event_id="EVENT-0001",
+        lineage_id="LINEAGE-0001",
+        occurred_at_utc="2026-07-31T22:00:00Z",
+        record_type="composite",
+        stage="edge_admissibility",
+        atlas_links=_atlas_links(),
+        reference=ReferenceGeometry(
+            reference_id="REF-0001",
+            reference_class_id="REFCLASS-0001",
+            anchor_id="ANCHOR-0001",
+            drift=_vector("drift", 0.1),
+            deviation=_vector("deviation", 0.2),
+            future_freedom=_vector(
+                "future_freedom",
+                0.8,
+            ),
+        ),
+        participation=ParticipationGeometry(
+            pi_i=0.6,
+            pi_r=0.3,
+            pi_a=0.1,
+            strain=0.4,
+        ),
+        coherence_geometry=CoherenceGeometry(
+            meta_field_id="META-0001",
+            psi=0.7,
+            rho_a=0.2,
+            rho_c=0.6,
+            occupancy=0.5,
+            geometry_coherence=0.8,
+            realization_pressure=0.3,
+            viability=0.9,
+            realization_coupling=0.4,
+        ),
+        evidence=EvidenceGeometry(
+            status="verified",
+            evidence_ids=("EVIDENCE-0001",),
+            benefit=_vector("benefit", 0.4),
+            harm=_vector("harm", 0.0),
+            containment=_vector(
+                "containment",
+                1.0,
+            ),
+            reversibility=_vector(
+                "reversibility",
+                1.0,
+            ),
+            confidence=_vector(
+                "confidence",
+                0.9,
+            ),
+            future_freedom_delta=_vector(
+                "future_freedom_delta",
+                0.1,
+            ),
+        ),
+        future_conditioning=FutureConditioning(
+            horizon=8,
+            terminal_contract_id="FUTURE-CONTRACT-0001",
+            terminal_class_id="TERMINAL-CLASS-0001",
+            corridor_id="ADMISSIBLE-CORRIDOR-0001",
+            forward_reachable=True,
+            backward_consistent=True,
+            gate_admissible=True,
+        ),
+        boundary_authority=BoundaryAuthority(
+            boundary_state="bounded",
+            admissibility_state="admissible",
+            authority_state="none",
+            scope_ids=("SCOPE-OBSERVE",),
+            release_condition_ids=(
+                "RELEASE-COMPLETE",
+            ),
+            revocation_condition_ids=(
+                "REVOKE-BREACH",
+            ),
+            realization_authorized=False,
+        ),
+        lifecycle=RealizationLifecycle(
+            possibility="possible",
+            proposal="proposed",
+            verification="verified",
+            transition_qualification="qualified",
+            edge_admissibility="admissible",
+            geometry_coherence="verified",
+            active_participation_permission=(
+                "not_observed"
+            ),
+            realization="not_observed",
+            absorption="not_observed",
+            influence="not_observed",
+            persistence="not_observed",
+            release="not_observed",
+        ),
+        causal_flow=CausalFlow(
+            interface_id="INTERFACE-0001",
+            coupling_id="COUPLING-0001",
+            propagation_path_id="PATH-0001",
+            scale_transition_id="SCALE-0001",
+            global_influence_id="GLOBAL-0001",
+            coupling_strength=_vector(
+                "coupling",
+                0.4,
+            ),
+            propagation_strength=_vector(
+                "propagation",
+                0.2,
+            ),
+        ),
+        counterfactual=CounterfactualComparison(
+            status="complete",
+            candidate_ids=(
+                "CANDIDATE-A",
+                "CANDIDATE-B",
+            ),
+            selected_candidate_id="CANDIDATE-A",
+            comparison_metrics=_vector(
+                "comparison",
+                0.2,
+            ),
+        ),
+    )
+
+
+def _process_chains():
+    return ProcessChainObservation(
+        broad_chain=tuple(
+            StageObservation(
+                stage=stage,
+                status="observed",
+                evidence_ids=(
+                    f"EVIDENCE-BROAD-{index:02d}",
+                ),
+            )
+            for index, stage in enumerate(
+                RCAF_BROAD_ORGANIZATIONAL_CHAIN,
+                start=1,
+            )
+        ),
+        realization_governance_chain=tuple(
+            StageObservation(
+                stage=stage,
+                status="observed",
+                evidence_ids=(
+                    f"EVIDENCE-GOV-{index:02d}",
+                ),
+            )
+            for index, stage in enumerate(
+                RCAF_REALIZATION_GOVERNANCE_CHAIN,
+                start=1,
+            )
+        ),
+    )
+
+
+def _carrier_coalition_bundle(
+    *,
+    reference_contract_id: str,
+    terminal_organizational_class_id: str,
+):
+    path = (
+        Path(__file__).resolve().parent
+        / "test_rcaf_carrier_coalition.py"
+    )
+
+    spec = importlib.util.spec_from_file_location(
+        "rcaf_carrier_coalition_fixture",
+        path,
+    )
+
+    if (
+        spec is None
+        or spec.loader is None
+    ):
+        raise RuntimeError(
+            "unable to load carrier-coalition fixture"
+        )
+
+    module = importlib.util.module_from_spec(
+        spec
+    )
+
+    spec.loader.exec_module(
+        module
+    )
+
+    bundle = module._bundle()
+
+    coalition = replace(
+        bundle.coalition,
+        reference_contract_id=(
+            reference_contract_id
+        ),
+        terminal_organizational_class_id=(
+            terminal_organizational_class_id
+        ),
+    )
+
+    validity_relations = tuple(
+        replace(
+            relation,
+            reference_contract_id=(
+                reference_contract_id
+            ),
+        )
+        for relation
+        in bundle.validity_relations
+    )
+
+    role_evidence = tuple(
+        replace(
+            evidence,
+            reference_contract_id=(
+                reference_contract_id
+            ),
+        )
+        for evidence
+        in bundle.role_evidence
+    )
+
+    scaffold_dependence = replace(
+        bundle.scaffold_dependence,
+        reference_contract_id=(
+            reference_contract_id
+        ),
+    )
+
+    scaffold_release = replace(
+        bundle.scaffold_release,
+        reference_contract_id=(
+            reference_contract_id
+        ),
+    )
+
+    turbulence_channels = tuple(
+        replace(
+            channel,
+            reference_contract_id=(
+                reference_contract_id
+            ),
+        )
+        for channel
+        in bundle.turbulence_channels
+    )
+
+    future_freedom = replace(
+        bundle.future_freedom,
+        reference_contract_id=(
+            reference_contract_id
+        ),
+    )
+
+    equivalence_class = replace(
+        bundle.equivalence_class,
+        terminal_organizational_class_id=(
+            terminal_organizational_class_id
+        ),
+    )
+
+    return replace(
+        bundle,
+        coalition=coalition,
+        validity_relations=validity_relations,
+        role_evidence=role_evidence,
+        scaffold_dependence=(
+            scaffold_dependence
+        ),
+        scaffold_release=scaffold_release,
+        turbulence_channels=(
+            turbulence_channels
+        ),
+        future_freedom=future_freedom,
+        equivalence_class=equivalence_class,
+    )
+
+
+def _full_record():
+    reference_id = "REFERENCE-CONTRACT-0001"
+
+    return RCAFFullFrameworkRecord(
+        record_id="RCAF-FULL-0001",
+        event_spine_id="SPINE-0001",
+        lineage_id="LINEAGE-0001",
+        occurred_at_utc="2026-07-31T22:00:00Z",
+        observer_lineage_id="SYN-OBSERVER-LINEAGE",
+        observer_role_id="ROLE-STRUCTURAL-OBSERVER",
+        observer_effects_record_id="EFFECTS-0001",
+        organizational_record=_organizational_record(),
+        reference_conditioning=ReferenceConditioning(
+            reference_contract_id=reference_id,
+            reference_point_id="REFERENCE-POINT-0001",
+            reference_class_id="REFERENCE-CLASS-0001",
+            anchor_id="ANCHOR-0001",
+            validity_state="valid",
+            reference_age_steps=3,
+            observable_ids=tuple(
+                sorted(
+                    f"OBS-{name}"
+                    for name in (
+                        "PSI",
+                        "META",
+                        "RHO-A",
+                        "RHO-C",
+                        "SALIENCE",
+                        "PRESSURE",
+                        "CURIOSITY",
+                        "VIABILITY",
+                        "OCCUPANCY",
+                        "FUTURE-FREEDOM",
+                        "COUPLING",
+                        "ABSORPTION",
+                        "MEDIATION",
+                        "FEEDBACK",
+                    )
+                )
+            ),
+            drift=_vector("drift", 0.1),
+            deviation=_vector("deviation", 0.2),
+            uncertainty=_vector(
+                "uncertainty",
+                0.1,
+            ),
+            future_freedom=_vector(
+                "future_freedom",
+                0.8,
+            ),
+            replacement_condition_ids=(
+                "REPLACE-REFERENCE-DRIFT",
+            ),
+            release_condition_ids=(
+                "RELEASE-REFERENCE-INVALID",
+            ),
+        ),
+        primitives=PrimitiveObservableBundle(
+            reference_contract_id=reference_id,
+            coherence_psi=_vector("psi", 0.7),
+            coherence_meta_field=_vector(
+                "meta_field",
+                0.8,
+            ),
+            activity_density_rho_a=_vector(
+                "rho_a",
+                0.2,
+            ),
+            coherence_density_rho_c=_vector(
+                "rho_c",
+                0.6,
+            ),
+            salience=_vector("salience", 0.5),
+            realization_pressure_lambda=_vector(
+                "lambda",
+                0.3,
+            ),
+            curiosity=_vector("curiosity", 0.4),
+            viability_omega=_vector("omega", 0.9),
+            occupancy_xi=_vector("xi", 0.5),
+            future_freedom_f_xi=_vector(
+                "future_freedom",
+                0.8,
+            ),
+            realization_coupling_kappa_r=_vector(
+                "kappa_r",
+                0.4,
+            ),
+            absorption_a_r_h=(
+                HorizonMetric(
+                    horizon=1,
+                    values=_vector("absorption", 0.2),
+                ),
+                HorizonMetric(
+                    horizon=8,
+                    values=_vector("absorption", 0.6),
+                ),
+            ),
+            mediation=_vector("mediation", 0.4),
+            feedback=_vector("feedback", 0.3),
+        ),
+        participation=ParticipationCorridor(
+            participation=ParticipationGeometry(
+                pi_i=0.6,
+                pi_r=0.3,
+                pi_a=0.1,
+                strain=0.4,
+            ),
+            selected_structure_ids=(
+                "STRUCTURE-LOCAL-0001",
+            ),
+            selected_direction_ids=(
+                "DIRECTION-BOUNDED-0001",
+            ),
+            corridor_id="PARTICIPATION-CORRIDOR-0001",
+            triadic_deferral_state="resolved",
+            goldilocks_regime="bounded_explorative",
+            polarity_regime="ordinary",
+            harmonics_retention_state="retained",
+            transition_evidence_ids=(
+                "EVIDENCE-PARTICIPATION-0001",
+            ),
+        ),
+        process_chains=_process_chains(),
+        proposal_gain=ProposalGainDiscovery(
+            candidate_ids=(
+                "CANDIDATE-A",
+                "CANDIDATE-B",
+            ),
+            selected_candidate_id="CANDIDATE-A",
+            gain_components=_vector("gain", 0.3),
+            discovery_components=_vector(
+                "discovery",
+                0.5,
+            ),
+            evidence_ids=("EVIDENCE-GAIN-0001",),
+            assumption_ids=("ASSUMPTION-0001",),
+            limitation_ids=("LIMITATION-0001",),
+        ),
+        transformation_geometry=(
+            TransformationGeometryRecord(
+                event_state_space_id="SPACE-EVENT",
+                reference_space_id="SPACE-REFERENCE",
+                proposal_tangent_space_id="SPACE-PROPOSAL",
+                causal_cone_space_id="SPACE-CAUSAL-CONE",
+                response_parameter_space_id="SPACE-RESPONSE",
+                outcome_composition_space_id="SPACE-OUTCOME",
+                invariant_quotient_space_id="SPACE-INVARIANT",
+                interface_coupling_space_id="SPACE-INTERFACE",
+                propagation_path_space_id="SPACE-PROPAGATION",
+                operator_semigroup_space_id="SPACE-OPERATOR",
+                evidence_status_space_id="SPACE-EVIDENCE",
+                meta_atlas_space_id="SPACE-META-ATLAS",
+                geometry_components=_vector(
+                    "geometry",
+                    0.8,
+                ),
+            )
+        ),
+        interface_propagation=InterfacePropagationChain(
+            observations=tuple(
+                InterfaceStageObservation(
+                    stage=stage,
+                    status="observed",
+                    evidence_ids=(
+                        f"EVIDENCE-INTERFACE-{index:02d}",
+                    ),
+                )
+                for index, stage in enumerate(
+                    RCAF_INTERFACE_PROPAGATION_CHAIN,
+                    start=1,
+                )
+            )
+        ),
+        future_gate=FutureConditionedAuthorityGate(
+            current_state_id="STATE-CURRENT-0001",
+            horizon=8,
+            future_contract_id="FUTURE-CONTRACT-0001",
+            terminal_organizational_class_id=(
+                "TERMINAL-CLASS-0001"
+            ),
+            forward_reachable_set_id=(
+                "REACHABLE-SET-0001"
+            ),
+            backward_predecessor_set_id=(
+                "PREDECESSOR-SET-0001"
+            ),
+            admissible_corridor_id=(
+                "ADMISSIBLE-CORRIDOR-0001"
+            ),
+            trajectory_ids=(
+                "TRAJECTORY-A",
+                "TRAJECTORY-B",
+            ),
+            failure_mode_ids=(
+                "FAILURE-MODE-BOUNDARY",
+            ),
+            forward_reachable=True,
+            backward_consistent=True,
+            gate_admissible=True,
+            uncertainty=_vector("uncertainty", 0.1),
+            future_freedom_cost=_vector(
+                "future_freedom_cost",
+                0.1,
+            ),
+            reversibility=_vector(
+                "reversibility",
+                0.9,
+            ),
+        ),
+        future_authority_evidence=(
+            _future_authority_bundle()
+        ),
+        carrier_coalition=(
+            _carrier_coalition_bundle(
+                reference_contract_id=reference_id,
+                terminal_organizational_class_id=(
+                    "TERMINAL-CLASS-0001"
+                ),
+            )
+        ),
+        authority_lifecycle=AuthorityLifecycleContract(
+            status="proposed",
+            recipient_id="RECIPIENT-CARRIER-0001",
+            operation_id="OPERATION-OBSERVE-0001",
+            proposal_id="PROPOSAL-0001",
+            scope_ids=("SCOPE-OBSERVE",),
+            boundary_ids=("BOUNDARY-0001",),
+            evidence_ids=("EVIDENCE-AUTHORITY-0001",),
+            future_corridor_id=(
+                "ADMISSIBLE-CORRIDOR-0001"
+            ),
+            containment_requirement_ids=(
+                "CONTAINMENT-READ-ONLY",
+            ),
+            rollback_mechanism_id=(
+                "ROLLBACK-DISCARD-0001"
+            ),
+            release_condition_ids=(
+                "RELEASE-ON-COMPLETE",
+            ),
+            revocation_condition_ids=(
+                "REVOKE-ON-BREACH",
+            ),
+            duration_steps=1,
+            activated=False,
+            execution_performed=False,
+            verified_success=False,
+            persistence_observed=False,
+            residual_effects=_vector(
+                "residual_effects",
+                0.0,
+            ),
+        ),
+        geometric_references=GeometricReferenceBundle(
+            e8=E8LocalHarmonicReference(
+                chart_id="E8-CHART-0001",
+                nearest_root_basin_id=(
+                    "E8-ROOT-BASIN-0001"
+                ),
+                root_margin=_vector(
+                    "root_margin",
+                    0.4,
+                ),
+                root_decisiveness=_vector(
+                    "root_decisiveness",
+                    0.7,
+                ),
+                harmonics_retention=_vector(
+                    "harmonics_retention",
+                    0.9,
+                ),
+            ),
+            leech=LeechGlobalCompatibilityReference(
+                atlas_id="LEECH-ATLAS-0001",
+                compatibility=_vector(
+                    "compatibility",
+                    0.8,
+                ),
+                packing=_vector("packing", 0.7),
+                gluing=_vector("gluing", 0.8),
+                rootless_silence=_vector(
+                    "rootless_silence",
+                    0.2,
+                ),
+            ),
+            monster=MonsterMetaAtlasReference(
+                meta_atlas_id="MONSTER-META-0001",
+                transition_flow_atlas_ids=(
+                    "TRANSITION-FLOW-ATLAS-0001",
+                ),
+                symmetry_relation_ids=(
+                    "SYMMETRY-RELATION-0001",
+                ),
+            ),
+            causal_cone=CausalConeReference(
+                causal_cone_id="CAUSAL-CONE-0001",
+                admissible_direction_ids=(
+                    "CAUSAL-DIRECTION-0001",
+                ),
+                interval_geometry=_vector(
+                    "interval",
+                    0.8,
+                ),
+            ),
+            operator_flow=OperatorFlowReference(
+                operator_id="OPERATOR-0001",
+                semigroup_id="SEMIGROUP-0001",
+                generator_id="GENERATOR-0001",
+                flow_metrics=_vector("flow", 0.7),
+            ),
+        ),
+        commitment=CommitmentHysteresisRecord(
+            corridor_id="COMMIT-CORRIDOR-0001",
+            reference_contract_id=reference_id,
+            state="committed",
+            entry_threshold=_vector(
+                "entry_threshold",
+                0.6,
+            ),
+            retention_threshold=_vector(
+                "retention_threshold",
+                0.5,
+            ),
+            release_threshold=_vector(
+                "release_threshold",
+                0.3,
+            ),
+            future_freedom_remaining=_vector(
+                "future_freedom",
+                0.8,
+            ),
+            indecision_avoidance_active=True,
+        ),
+        event_coordinate=MinimalEventCoordinate(
+            T="COORD-T-0001",
+            O="COORD-O-0001",
+            X="COORD-X-0001",
+            Ref="COORD-REF-0001",
+            Pi="COORD-PI-0001",
+            Gamma="COORD-GAMMA-0001",
+            J="COORD-J-0001",
+            Q="COORD-Q-0001",
+            B="COORD-B-0001",
+            H="COORD-H-0001",
+            E="COORD-E-0001",
+        ),
+        decision_trace=ConditionedDecisionTrace(
+            component_observable_ids=(
+                "OBS-PSI",
+                "OBS-RHO-A",
+                "OBS-RHO-C",
+            ),
+            intermediate_geometry_ids=(
+                "GEOMETRY-PARTICIPATION",
+                "GEOMETRY-TRANSFORMATION",
+            ),
+            conditioned_decision_ids=(
+                "DECISION-ADMISSIBILITY",
+            ),
+        ),
+        derived_diagnostics=(
+            DerivedDiagnosticRecord(
+                diagnostic_name=(
+                    "organizational_potential"
+                ),
+                values=_vector(
+                    "organizational_potential",
+                    0.6,
+                ),
+                derived_from_component_ids=(
+                    "OBS-PSI",
+                    "OBS-RHO-A",
+                    "OBS-RHO-C",
+                ),
+            ),
+            DerivedDiagnosticRecord(
+                diagnostic_name=(
+                    "composite_admissibility"
+                ),
+                values=_vector(
+                    "composite_admissibility",
+                    0.7,
+                ),
+                derived_from_component_ids=(
+                    "DECISION-ADMISSIBILITY",
+                    "EVIDENCE-AUTHORITY-0001",
+                ),
+            ),
+        ),
+        authority_posture="observe_only",
+    )
+
+
+def test_full_canonical_completeness_report_passes():
+    report = canonical_completeness_report(
+        _full_record()
+    )
+
+    assert report["complete"] is True
+    assert report["missing_capabilities"] == []
+    assert (
+        report["satisfied_capability_count"]
+        == len(RCAF_CANONICAL_CAPABILITIES)
+    )
+
+
+def test_both_canonical_process_chains_are_exact():
+    record = _full_record()
+
+    assert tuple(
+        item.stage
+        for item in record.process_chains.broad_chain
+    ) == RCAF_BROAD_ORGANIZATIONAL_CHAIN
+
+    assert tuple(
+        item.stage
+        for item
+        in record.process_chains.realization_governance_chain
+    ) == RCAF_REALIZATION_GOVERNANCE_CHAIN
+
+
+def test_interface_distinction_chain_is_exact():
+    record = _full_record()
+
+    assert tuple(
+        item.stage
+        for item
+        in record.interface_propagation.observations
+    ) == RCAF_INTERFACE_PROPAGATION_CHAIN
+
+
+def test_all_canonical_atlases_are_linked():
+    record = _full_record()
+
+    assert {
+        link.atlas_type
+        for link
+        in record.organizational_record.atlas_links
+    } == RCAF_ATLAS_TYPES
+
+
+def test_primitives_are_reference_conditioned():
+    record = _full_record()
+
+    assert (
+        record.primitives.reference_contract_id
+        == record.reference_conditioning.reference_contract_id
+    )
+
+    assert record.reference_conditioning.observable_ids
+
+
+def test_participation_remains_triadic_and_directional():
+    record = _full_record()
+    participation = record.participation
+
+    assert math.isclose(
+        participation.participation.pi_i
+        + participation.participation.pi_r
+        + participation.participation.pi_a,
+        1.0,
+        rel_tol=0.0,
+        abs_tol=1e-6,
+    )
+    assert participation.selected_structure_ids
+    assert participation.selected_direction_ids
+    assert participation.goldilocks_regime == (
+        "bounded_explorative"
+    )
+    assert participation.harmonics_retention_state == (
+        "retained"
+    )
+
+
+def test_future_gate_preserves_both_trajectory_tests():
+    gate = _full_record().future_gate
+
+    assert gate.forward_reachable is True
+    assert gate.backward_consistent is True
+    assert gate.gate_admissible is True
+    assert gate.forward_reachable_set_id
+    assert gate.backward_predecessor_set_id
+    assert gate.admissible_corridor_id
+
+
+def test_authority_lifecycle_preserves_distinctions():
+    authority = _full_record().authority_lifecycle
+
+    assert authority.proposal_id
+    assert authority.permission_id is None
+    assert authority.grant_id is None
+    assert authority.activated is False
+    assert authority.execution_performed is False
+    assert authority.verified_success is False
+    assert authority.persistence_observed is False
+    assert authority.release_condition_ids
+    assert authority.revocation_condition_ids
+
+
+def test_reference_geometries_are_not_governing_gates():
+    references = _full_record().geometric_references.to_dict()
+
+    for value in references.values():
+        assert value["governing_gate"] is False
+
+
+def test_minimal_event_coordinate_preserves_all_axes():
+    coordinate = _full_record().event_coordinate.to_dict()
+
+    assert tuple(coordinate) == RCAF_EVENT_COORDINATE_AXES
+    assert len(coordinate) == 11
+
+
+def test_organizational_potential_is_derived_not_primitive():
+    primitive_fields = {
+        field_name
+        for field_name
+        in PrimitiveObservableBundle.__dataclass_fields__
+    }
+
+    assert (
+        "organizational_potential"
+        not in primitive_fields
+    )
+
+    assert any(
+        item.diagnostic_name
+        == "organizational_potential"
+        for item in _full_record().derived_diagnostics
+    )
+
+
+def test_observer_lineage_does_not_claim_identity():
+    record = _full_record()
+
+    assert record.observer_lineage_id
+    assert record.identity_proof_established is False
+    assert record.semantic_memory_authority is False
+    assert record.realization_authorized is False
+    assert record.external_causal_authority is False
+    assert record.self_modification_authority is False
+
+
+def test_canonical_serialization_is_private_and_deterministic():
+    marker = (
+        "RCAF-PRIVATE-MARKER-"
+        "9dc30ed873174033bc8cd343580bd95a"
+    )
+
+    first = _full_record().canonical_json()
+    second = _full_record().canonical_json()
+
+    assert first == second
+    assert marker not in first
+    assert '"raw_content_stored":false' in first
+    assert (
+        '"content_fingerprint_stored":false'
+        in first
+    )
+    assert json.loads(first)["completeness"][
+        "complete"
+    ] is True
+
+
+def test_canonical_record_api_accepts_no_content():
+    signature = inspect.signature(
+        RCAFFullFrameworkRecord
+    )
+
+    forbidden = {
+        "prompt",
+        "response",
+        "message",
+        "content",
+        "reasoning",
+        "embedding",
+        "content_sha256",
+    }
+
+    assert forbidden.isdisjoint(
+        signature.parameters
+    )
+
+
+def test_missing_process_stage_is_rejected():
+    valid = _process_chains()
+
+    with pytest.raises(
+        RCAFCanonicalLedgerError,
+        match="canonical order",
+    ):
+        ProcessChainObservation(
+            broad_chain=valid.broad_chain[:-1],
+            realization_governance_chain=(
+                valid.realization_governance_chain
+            ),
+        )
+
+
+def test_future_gate_cannot_admit_inconsistent_path():
+    with pytest.raises(
+        RCAFCanonicalLedgerError,
+        match="requires forward reachability",
+    ):
+        replace(
+            _full_record().future_gate,
+            forward_reachable=False,
+            gate_admissible=True,
+        )
+
+
+def test_reference_geometry_cannot_be_promoted_to_gate():
+    with pytest.raises(
+        RCAFCanonicalLedgerError,
+        match="cannot be a governing gate",
+    ):
+        replace(
+            _full_record().geometric_references.e8,
+            governing_gate=True,
+        )
+
+
+def test_observe_only_rejects_authority_expansion():
+    with pytest.raises(
+        RCAFCanonicalLedgerError,
+        match="observe_only posture forbids",
+    ):
+        replace(
+            _full_record(),
+            semantic_memory_authority=True,
+        )
+
+
+def test_derived_diagnostics_require_component_lineage():
+    with pytest.raises(
+        RCAFCanonicalLedgerError,
+        match="must not be empty",
+    ):
+        DerivedDiagnosticRecord(
+            diagnostic_name="aggregate_score",
+            values=_vector("aggregate", 0.5),
+            derived_from_component_ids=(),
+        )
+
+
+
+def test_future_authority_bundle_is_linked_to_existing_gate():
+    record = _full_record()
+    bundle = record.future_authority_evidence
+    gate = record.future_gate
+
+    assert (
+        bundle.terminal_contract.contract_id
+        == gate.future_contract_id
+    )
+    assert (
+        bundle.terminal_contract.terminal_class_id
+        == gate.terminal_organizational_class_id
+    )
+    assert (
+        bundle.forward_evidence.reachable_set_id
+        == gate.forward_reachable_set_id
+    )
+    assert (
+        bundle.backward_evidence.predecessor_set_id
+        == gate.backward_predecessor_set_id
+    )
+    assert (
+        gate.admissible_corridor_id
+        in bundle.consistency.shared_corridor_ids
+    )
+
+
+def test_expanded_completeness_contains_future_authority_contracts():
+    report = canonical_completeness_report(
+        _full_record()
+    )
+
+    expected = {
+        "terminal_organizational_class_contract",
+        "forward_transition_map",
+        "backward_predecessor_map",
+        "bidirectional_corridor_consistency",
+        "matched_causal_branching",
+        "support_withdrawal_validation",
+        "anti_self_fulfilling_authority",
+        "frozen_acceptance_criteria",
+        "independent_evaluator",
+        "retrospective_atlas_extraction",
+        "prospective_gate_nomination",
+        "calibration_status",
+        "scenario_tail_evidence",
+        "gate_maturity_lifecycle",
+        "authority_evidence_separation",
+        "bidirectional_meta_field",
+        "no_literal_retrocausality",
+    }
+
+    assert report["complete"] is True
+    assert expected.issubset(
+        set(
+            report["satisfied_capabilities"]
+        )
+    )
+
+
+def test_future_contract_link_mismatch_is_rejected():
+    record = _full_record()
+
+    with pytest.raises(
+        RCAFCanonicalLedgerError,
+        match="future contract mismatch",
+    ):
+        replace(
+            record,
+            future_gate=replace(
+                record.future_gate,
+                future_contract_id=(
+                    "FUTURE-CONTRACT-MISMATCH"
+                ),
+            ),
+        )
+
+
+def test_observe_only_rejects_future_authority_status_drift():
+    record = _full_record()
+
+    drifted_lifecycle = replace(
+        record.future_authority_evidence.lifecycle,
+        authority_status="nominated",
+    )
+
+    drifted_bundle = replace(
+        record.future_authority_evidence,
+        lifecycle=drifted_lifecycle,
+    )
+
+    with pytest.raises(
+        RCAFCanonicalLedgerError,
+        match="observe-only future-gate authority status",
+    ):
+        replace(
+            record,
+            future_authority_evidence=drifted_bundle,
+        )
+
+R1B_CARRIER_CAPABILITIES = {
+    "trajectory_admissible_carrier_coalition",
+    "carrier_validity_relations",
+    "multidimensional_component_roles",
+    "scaffold_dependence",
+    "scaffold_release_evidence",
+    "support_withdrawal_as_causal_intervention",
+    "multiscale_turbulence_channels",
+    "component_preserving_turbulence",
+    "turbulent_debt_observation",
+    "compression_future_freedom",
+    "topology_initialization_context_counterfactuals",
+    "dynamic_topology_counterfactual",
+    "microscopic_ticket_equivalence",
+    "prospective_coalition_nomination",
+    "reversible_pruning_contract",
+}
+
+
+def test_r1b_canonical_schema_is_0_4():
+    assert RCAF_CANONICAL_LEDGER_SCHEMA == (
+        "RCAF-CANONICAL-FRAMEWORK-LEDGER-0.4"
+    )
+
+
+def test_r1b_capability_matrix_contains_63_capabilities():
+    assert len(
+        RCAF_CANONICAL_CAPABILITIES
+    ) == 63
+
+    assert R1B_CARRIER_CAPABILITIES.issubset(
+        RCAF_CANONICAL_CAPABILITIES
+    )
+
+
+def test_r1b_full_record_is_complete_with_carrier_bundle():
+    record = _full_record()
+    report = canonical_completeness_report(
+        record
+    )
+
+    assert report[
+        "required_capability_count"
+    ] == 63
+
+    assert report[
+        "satisfied_capability_count"
+    ] == 63
+
+    assert report[
+        "missing_capabilities"
+    ] == []
+
+    assert report["complete"] is True
+
+
+def test_r1b_serialization_contains_private_observer_only_carrier_bundle():
+    data = _full_record().to_dict()
+
+    carrier = data[
+        "carrier_coalition"
+    ]
+
+    assert carrier["raw_content_stored"] is False
+
+    assert (
+        carrier["content_fingerprint_stored"]
+        is False
+    )
+
+    assert (
+        carrier["coalition"][
+            "observer_only"
+        ]
+        is True
+    )
+
+    assert (
+        carrier["coalition"][
+            "authority_eligible"
+        ]
+        is False
+    )
+
+    assert (
+        carrier["authority_contract"][
+            "authority_status"
+        ]
+        == "observe_only"
+    )
+
+
+def test_r1b_rejects_carrier_reference_mismatch():
+    record = _full_record()
+    bundle = record.carrier_coalition
+
+    drifted_coalition = replace(
+        bundle.coalition,
+        reference_contract_id=(
+            "REFERENCE-CONTRACT-WRONG"
+        ),
+    )
+
+    drifted_bundle = replace(
+        bundle,
+        coalition=drifted_coalition,
+    )
+
+    with pytest.raises(
+        RCAFCanonicalLedgerError,
+        match="wrong reference contract",
+    ):
+        replace(
+            record,
+            carrier_coalition=drifted_bundle,
+        )
+
+
+def test_r1b_rejects_carrier_terminal_class_mismatch():
+    record = _full_record()
+    bundle = record.carrier_coalition
+
+    drifted_coalition = replace(
+        bundle.coalition,
+        terminal_organizational_class_id=(
+            "TERMINAL-CLASS-WRONG"
+        ),
+    )
+
+    drifted_bundle = replace(
+        bundle,
+        coalition=drifted_coalition,
+    )
+
+    with pytest.raises(
+        RCAFCanonicalLedgerError,
+        match="terminal organizational class mismatch",
+    ):
+        replace(
+            record,
+            carrier_coalition=drifted_bundle,
+        )
+
+
+def test_r1b_rejects_carrier_pruning_authority_expansion():
+    record = _full_record()
+    bundle = record.carrier_coalition
+
+    drifted_contract = object.__new__(
+        type(bundle.authority_contract)
+    )
+
+    for field_name, value in vars(
+        bundle.authority_contract
+    ).items():
+        object.__setattr__(
+            drifted_contract,
+            field_name,
+            value,
+        )
+
+    object.__setattr__(
+        drifted_contract,
+        "authority_status",
+        "bounded",
+    )
+
+    drifted_bundle = replace(
+        bundle,
+        authority_contract=drifted_contract,
+    )
+
+    with pytest.raises(
+        RCAFCanonicalLedgerError,
+        match="observe-only authority",
+    ):
+        replace(
+            record,
+            carrier_coalition=drifted_bundle,
+        )
+
+
+def test_r1b_canonical_json_is_deterministic_with_carrier_bundle():
+    first = _full_record().canonical_json()
+    second = _full_record().canonical_json()
+
+    assert first == second
+
+    data = json.loads(
+        first
+    )
+
+    assert data["schema"] == (
+        "RCAF-CANONICAL-FRAMEWORK-LEDGER-0.4"
+    )
+
+    assert data["completeness"]["complete"] is True
+
+    assert (
+        data["carrier_coalition"]["schema"]
+        == "RCAF-CARRIER-COALITION-0.1"
+    )

--- a/tests/test_rcaf_canonical_migration_integrity.py
+++ b/tests/test_rcaf_canonical_migration_integrity.py
@@ -1,0 +1,208 @@
+from dataclasses import replace
+import json
+
+import pytest
+
+from src.rcaf.canonical_evolution import (
+    CURRENT_SCHEMA_BY_FAMILY,
+    KNOWN_PREVIOUS_SCHEMAS_BY_FAMILY,
+    RCAF_CANONICAL_0_3_TO_0_4_REQUIRED_EXPLICIT_PATHS,
+    RCAF_SCHEMA_EVOLUTION_SCHEMA,
+    CanonicalSchemaEvolutionError,
+    LosslessMigrationManifest,
+    evaluate_schema,
+)
+
+
+CANONICAL_0_2 = (
+    "RCAF-CANONICAL-FRAMEWORK-LEDGER-0.2"
+)
+
+CANONICAL_0_3 = (
+    "RCAF-CANONICAL-FRAMEWORK-LEDGER-0.3"
+)
+
+
+def _manifest(
+    *,
+    source_schema: str,
+    added_paths: tuple[str, ...],
+) -> LosslessMigrationManifest:
+    return LosslessMigrationManifest(
+        migration_id=(
+            "MIGRATION-CANONICAL-INTEGRITY"
+        ),
+        family="canonical_record",
+        source_schema=source_schema,
+        target_schema=(
+            CURRENT_SCHEMA_BY_FAMILY[
+                "canonical_record"
+            ]
+        ),
+        source_record_sha256="a" * 64,
+        target_record_sha256="b" * 64,
+        preserved_field_paths=(
+            "record_id",
+            "event_spine_id",
+            "authority_posture",
+            "organizational_record",
+        ),
+        added_explicit_field_paths=added_paths,
+    )
+
+
+def test_evolution_registry_is_exact():
+    assert RCAF_SCHEMA_EVOLUTION_SCHEMA == (
+        "RCAF-SCHEMA-EVOLUTION-0.2"
+    )
+
+    assert set(CURRENT_SCHEMA_BY_FAMILY) == {
+        "canonical_record",
+        "carrier_coalition",
+        "future_authority",
+        "organizational_record",
+    }
+
+    assert KNOWN_PREVIOUS_SCHEMAS_BY_FAMILY[
+        "canonical_record"
+    ] == frozenset(
+        {
+            CANONICAL_0_2,
+            CANONICAL_0_3,
+        }
+    )
+
+    assert KNOWN_PREVIOUS_SCHEMAS_BY_FAMILY[
+        "carrier_coalition"
+    ] == frozenset()
+
+
+def test_canonical_0_3_requires_explicit_migration():
+    evaluation = evaluate_schema(
+        "canonical_record",
+        CANONICAL_0_3,
+    )
+
+    assert evaluation.disposition == (
+        "migration_required"
+    )
+
+    assert (
+        evaluation.automatic_migration_allowed
+        is False
+    )
+
+
+def test_0_3_to_0_4_carrier_paths_are_exact():
+    assert (
+        RCAF_CANONICAL_0_3_TO_0_4_REQUIRED_EXPLICIT_PATHS
+        == (
+            "carrier_coalition",
+            "carrier_coalition.coalition",
+            "carrier_coalition.validity_relations",
+            "carrier_coalition.role_evidence",
+            "carrier_coalition.scaffold_dependence",
+            "carrier_coalition.scaffold_release",
+            "carrier_coalition.turbulence_channels",
+            "carrier_coalition.future_freedom",
+            "carrier_coalition.matched_experiment",
+            "carrier_coalition.equivalence_class",
+            "carrier_coalition.nomination",
+            "carrier_coalition.authority_contract",
+        )
+    )
+
+
+def test_0_3_migration_rejects_missing_carrier_path():
+    incomplete = (
+        RCAF_CANONICAL_0_3_TO_0_4_REQUIRED_EXPLICIT_PATHS[
+            :-1
+        ]
+    )
+
+    with pytest.raises(
+        CanonicalSchemaEvolutionError,
+    ):
+        _manifest(
+            source_schema=CANONICAL_0_3,
+            added_paths=incomplete,
+        )
+
+
+def test_0_3_migration_accepts_full_carrier_path_set():
+    manifest = _manifest(
+        source_schema=CANONICAL_0_3,
+        added_paths=(
+            RCAF_CANONICAL_0_3_TO_0_4_REQUIRED_EXPLICIT_PATHS
+        ),
+    )
+
+    data = manifest.to_dict()
+
+    assert tuple(
+        data["added_explicit_field_paths"]
+    ) == (
+        RCAF_CANONICAL_0_3_TO_0_4_REQUIRED_EXPLICIT_PATHS
+    )
+
+    assert data["lossless"] is True
+    assert data["automatic_migration"] is False
+    assert data["dropped_field_paths"] == []
+    assert data["inferred_field_paths"] == []
+
+    first = manifest.canonical_json()
+    second = manifest.canonical_json()
+
+    assert first == second
+    assert json.loads(first) == data
+
+
+def test_registered_0_2_migration_remains_accepted():
+    manifest = _manifest(
+        source_schema=CANONICAL_0_2,
+        added_paths=(
+            "future_authority_evidence",
+        ),
+    )
+
+    assert manifest.source_schema == CANONICAL_0_2
+    assert manifest.lossless is True
+    assert manifest.automatic_migration is False
+
+
+def test_0_3_migration_cannot_infer_carrier_evidence():
+    manifest = _manifest(
+        source_schema=CANONICAL_0_3,
+        added_paths=(
+            RCAF_CANONICAL_0_3_TO_0_4_REQUIRED_EXPLICIT_PATHS
+        ),
+    )
+
+    with pytest.raises(
+        CanonicalSchemaEvolutionError,
+        match="cannot infer missing RCAF fields",
+    ):
+        replace(
+            manifest,
+            inferred_field_paths=(
+                "carrier_coalition.future_freedom",
+            ),
+        )
+
+
+def test_0_3_migration_cannot_change_authority():
+    manifest = _manifest(
+        source_schema=CANONICAL_0_3,
+        added_paths=(
+            RCAF_CANONICAL_0_3_TO_0_4_REQUIRED_EXPLICIT_PATHS
+        ),
+    )
+
+    with pytest.raises(
+        CanonicalSchemaEvolutionError,
+        match="cannot change authority posture",
+    ):
+        replace(
+            manifest,
+            authority_posture_after="bounded",
+        )

--- a/tests/test_rcaf_canonical_store.py
+++ b/tests/test_rcaf_canonical_store.py
@@ -1,0 +1,524 @@
+# ============================================================
+# tests/test_rcaf_canonical_store.py
+# ============================================================
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import multiprocessing
+import os
+import stat
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from src.rcaf.canonical_store import (
+    CanonicalStoreIntegrityError,
+    CanonicalStoreSecurityError,
+    _validate_framework_record_dict,
+    append_canonical_record,
+    validate_and_replay_canonical_store,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_PATH = (
+    REPO_ROOT
+    / "tests/test_rcaf_canonical_ledger.py"
+)
+
+
+def _load_full_record():
+    spec = importlib.util.spec_from_file_location(
+        "rcaf_canonical_test_fixture",
+        FIXTURE_PATH,
+    )
+
+    if (
+        spec is None
+        or spec.loader is None
+    ):
+        raise RuntimeError(
+            "unable to load canonical fixture"
+        )
+
+    module = importlib.util.module_from_spec(
+        spec
+    )
+
+    spec.loader.exec_module(module)
+
+    return module._full_record()
+
+
+def _record(
+    index: int,
+):
+    return replace(
+        _load_full_record(),
+        record_id=(
+            f"RCAF-FULL-{index:04d}"
+        ),
+        event_spine_id=(
+            f"SPINE-{index:04d}"
+        ),
+    )
+
+
+def _append_worker(
+    root: str,
+    index: int,
+) -> None:
+    append_canonical_record(
+        root,
+        ledger_id="TEST-LEDGER",
+        record=_record(index),
+        max_records_per_segment=2,
+    )
+
+
+def _segment_paths(
+    root: Path,
+) -> list[Path]:
+    return sorted(
+        root.glob(
+            "segment-*.jsonl"
+        )
+    )
+
+
+def test_append_rotate_validate_and_permissions(
+    tmp_path,
+):
+    root = tmp_path / "ledger"
+
+    receipts = [
+        append_canonical_record(
+            root,
+            ledger_id="TEST-LEDGER",
+            record=_record(index),
+            max_records_per_segment=2,
+        )
+        for index in range(1, 6)
+    ]
+
+    assert [
+        receipt.sequence_index
+        for receipt in receipts
+    ] == [0, 1, 2, 3, 4]
+
+    assert [
+        receipt.segment_index
+        for receipt in receipts
+    ] == [0, 0, 1, 1, 2]
+
+    replay = (
+        validate_and_replay_canonical_store(
+            root,
+            ledger_id="TEST-LEDGER",
+        )
+    )
+
+    assert replay.record_count == 5
+    assert replay.segment_count == 3
+    assert replay.last_sequence_index == 4
+    assert replay.integrity_verified is True
+    assert (
+        replay.deterministic_replay_verified
+        is True
+    )
+
+    assert (
+        stat.S_IMODE(
+            os.stat(root).st_mode
+        )
+        == 0o700
+    )
+
+    for path in (
+        _segment_paths(root)
+        + [
+            root / "manifest.json",
+            root / ".lock",
+        ]
+    ):
+        assert (
+            stat.S_IMODE(
+                os.stat(path).st_mode
+            )
+            == 0o600
+        )
+
+
+def test_hash_chain_crosses_segment_boundary(
+    tmp_path,
+):
+    root = tmp_path / "ledger"
+
+    for index in range(1, 4):
+        append_canonical_record(
+            root,
+            ledger_id="TEST-LEDGER",
+            record=_record(index),
+            max_records_per_segment=2,
+        )
+
+    first_segment = [
+        json.loads(line)
+        for line in (
+            root
+            / "segment-000000.jsonl"
+        ).read_text().splitlines()
+    ]
+
+    second_segment = [
+        json.loads(line)
+        for line in (
+            root
+            / "segment-000001.jsonl"
+        ).read_text().splitlines()
+    ]
+
+    assert (
+        second_segment[0][
+            "previous_entry_sha256"
+        ]
+        == first_segment[-1][
+            "entry_sha256"
+        ]
+    )
+
+
+def test_trailing_partial_write_is_recovered(
+    tmp_path,
+):
+    root = tmp_path / "ledger"
+
+    append_canonical_record(
+        root,
+        ledger_id="TEST-LEDGER",
+        record=_record(1),
+    )
+
+    segment = (
+        root / "segment-000000.jsonl"
+    )
+
+    with segment.open("ab") as handle:
+        handle.write(
+            b'{"schema":"interrupted'
+        )
+        handle.flush()
+        os.fsync(handle.fileno())
+
+    replay = (
+        validate_and_replay_canonical_store(
+            root,
+            ledger_id="TEST-LEDGER",
+            recover_trailing=True,
+        )
+    )
+
+    assert replay.record_count == 1
+    assert (
+        replay.recovered_trailing_bytes
+        > 0
+    )
+
+    receipt = append_canonical_record(
+        root,
+        ledger_id="TEST-LEDGER",
+        record=_record(2),
+    )
+
+    assert receipt.sequence_index == 1
+
+    final = (
+        validate_and_replay_canonical_store(
+            root,
+            ledger_id="TEST-LEDGER",
+        )
+    )
+
+    assert final.record_count == 2
+
+
+def test_valid_terminal_record_without_newline_is_repaired(
+    tmp_path,
+):
+    root = tmp_path / "ledger"
+
+    append_canonical_record(
+        root,
+        ledger_id="TEST-LEDGER",
+        record=_record(1),
+    )
+
+    segment = (
+        root / "segment-000000.jsonl"
+    )
+
+    data = segment.read_bytes()
+
+    assert data.endswith(b"\n")
+
+    segment.write_bytes(
+        data[:-1]
+    )
+
+    replay = (
+        validate_and_replay_canonical_store(
+            root,
+            ledger_id="TEST-LEDGER",
+            recover_trailing=True,
+        )
+    )
+
+    assert (
+        replay.repaired_terminal_newline
+        is True
+    )
+    assert segment.read_bytes().endswith(
+        b"\n"
+    )
+
+
+def test_interior_corruption_is_rejected(
+    tmp_path,
+):
+    root = tmp_path / "ledger"
+
+    for index in range(1, 3):
+        append_canonical_record(
+            root,
+            ledger_id="TEST-LEDGER",
+            record=_record(index),
+        )
+
+    segment = (
+        root / "segment-000000.jsonl"
+    )
+
+    lines = segment.read_bytes().splitlines(
+        keepends=True
+    )
+
+    lines[0] = lines[0].replace(
+        b'"sequence_index":0',
+        b'"sequence_index":9',
+        1,
+    )
+
+    segment.write_bytes(
+        b"".join(lines)
+    )
+
+    with pytest.raises(
+        CanonicalStoreIntegrityError,
+    ):
+        validate_and_replay_canonical_store(
+            root,
+            ledger_id="TEST-LEDGER",
+            recover_trailing=True,
+        )
+
+
+def test_manifest_is_reconstructed_from_segments(
+    tmp_path,
+):
+    root = tmp_path / "ledger"
+
+    for index in range(1, 4):
+        append_canonical_record(
+            root,
+            ledger_id="TEST-LEDGER",
+            record=_record(index),
+            max_records_per_segment=2,
+        )
+
+    manifest = root / "manifest.json"
+
+    manifest.unlink()
+
+    replay = (
+        validate_and_replay_canonical_store(
+            root,
+            ledger_id="TEST-LEDGER",
+            rebuild_manifest=True,
+        )
+    )
+
+    assert replay.record_count == 3
+    assert manifest.exists()
+
+    rebuilt = json.loads(
+        manifest.read_text()
+    )
+
+    assert rebuilt["record_count"] == 3
+    assert rebuilt["segment_count"] == 2
+    assert (
+        rebuilt["last_entry_sha256"]
+        == replay.last_entry_sha256
+    )
+
+
+def test_concurrent_process_writers_are_serialized(
+    tmp_path,
+):
+    root = tmp_path / "ledger"
+
+    processes = [
+        multiprocessing.Process(
+            target=_append_worker,
+            args=(
+                str(root),
+                index,
+            ),
+        )
+        for index in range(1, 7)
+    ]
+
+    for process in processes:
+        process.start()
+
+    for process in processes:
+        process.join(timeout=20)
+
+        assert process.exitcode == 0
+
+    replay = (
+        validate_and_replay_canonical_store(
+            root,
+            ledger_id="TEST-LEDGER",
+        )
+    )
+
+    assert replay.record_count == 6
+    assert replay.segment_count == 3
+
+    record_ids = {
+        record["record_id"]
+        for record in replay.records
+    }
+
+    assert len(record_ids) == 6
+
+
+def test_duplicate_record_id_is_rejected(
+    tmp_path,
+):
+    root = tmp_path / "ledger"
+
+    record = _record(1)
+
+    append_canonical_record(
+        root,
+        ledger_id="TEST-LEDGER",
+        record=record,
+    )
+
+    with pytest.raises(
+        CanonicalStoreIntegrityError,
+        match="duplicate canonical record_id",
+    ):
+        append_canonical_record(
+            root,
+            ledger_id="TEST-LEDGER",
+            record=record,
+        )
+
+
+def test_symlink_segment_is_rejected(
+    tmp_path,
+):
+    root = tmp_path / "ledger"
+    root.mkdir(mode=0o700)
+
+    target = tmp_path / "target"
+    target.write_text("unsafe")
+
+    (
+        root / "segment-000000.jsonl"
+    ).symlink_to(target)
+
+    with pytest.raises(
+        CanonicalStoreSecurityError,
+    ):
+        validate_and_replay_canonical_store(
+            root,
+            ledger_id="TEST-LEDGER",
+        )
+
+
+def test_store_contains_no_private_marker(
+    tmp_path,
+):
+    marker = (
+        "PRIVATE-RCAF-MARKER-"
+        "8af7e5a47ad14cbd9a4e4df3f952f06c"
+    )
+
+    root = tmp_path / "ledger"
+
+    append_canonical_record(
+        root,
+        ledger_id="TEST-LEDGER",
+        record=_record(1),
+    )
+
+    combined = b"".join(
+        path.read_bytes()
+        for path in root.iterdir()
+        if path.is_file()
+    )
+
+    assert marker.encode() not in combined
+
+    replay = (
+        validate_and_replay_canonical_store(
+            root,
+            ledger_id="TEST-LEDGER",
+        )
+    )
+
+    assert replay.authority_posture == (
+        "observe_only"
+    )
+
+
+
+def test_store_rejects_missing_future_authority_bundle():
+    record = _record(1).to_dict()
+
+    record.pop(
+        "future_authority_evidence"
+    )
+
+    with pytest.raises(
+        CanonicalStoreIntegrityError,
+        match="lacks the required future-authority",
+    ):
+        _validate_framework_record_dict(
+            record
+        )
+
+
+def test_store_rejects_observe_only_future_authority_eligibility():
+    record = _record(1).to_dict()
+
+    record[
+        "future_authority_evidence"
+    ][
+        "causal_authority_eligible"
+    ] = True
+
+    with pytest.raises(
+        CanonicalStoreIntegrityError,
+        match="cannot be future-authority eligible",
+    ):
+        _validate_framework_record_dict(
+            record
+        )

--- a/tests/test_rcaf_canonical_store_fault_injection.py
+++ b/tests/test_rcaf_canonical_store_fault_injection.py
@@ -1,0 +1,521 @@
+# ============================================================
+# tests/test_rcaf_canonical_store_fault_injection.py
+# ============================================================
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from src.rcaf.canonical_store import (
+    CanonicalStoreIntegrityError,
+    CanonicalStoreSecurityError,
+    _validate_framework_record_dict,
+    append_canonical_record,
+    validate_and_replay_canonical_store,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+STORE_FIXTURE_PATH = (
+    REPO_ROOT
+    / "tests/test_rcaf_canonical_store.py"
+)
+
+
+def _load_store_fixture_module():
+    spec = importlib.util.spec_from_file_location(
+        "rcaf_canonical_store_test_fixture",
+        STORE_FIXTURE_PATH,
+    )
+
+    if (
+        spec is None
+        or spec.loader is None
+    ):
+        raise RuntimeError(
+            "unable to load canonical-store fixture"
+        )
+
+    module = importlib.util.module_from_spec(
+        spec
+    )
+
+    spec.loader.exec_module(module)
+
+    return module
+
+
+def _record(
+    index: int,
+):
+    return _load_store_fixture_module()._record(
+        index
+    )
+
+
+def _append(
+    root: Path,
+    index: int,
+    *,
+    max_records_per_segment: int = 2,
+):
+    return append_canonical_record(
+        root,
+        ledger_id="FAULT-LEDGER",
+        record=_record(index),
+        max_records_per_segment=(
+            max_records_per_segment
+        ),
+    )
+
+
+def test_root_symlink_is_rejected(
+    tmp_path,
+):
+    target = tmp_path / "real-ledger"
+    target.mkdir(mode=0o700)
+
+    root = tmp_path / "ledger-link"
+    root.symlink_to(
+        target,
+        target_is_directory=True,
+    )
+
+    with pytest.raises(
+        CanonicalStoreSecurityError,
+        match="must not be a symbolic link",
+    ):
+        validate_and_replay_canonical_store(
+            root,
+            ledger_id="FAULT-LEDGER",
+        )
+
+
+def test_hard_linked_segment_is_rejected(
+    tmp_path,
+):
+    root = tmp_path / "ledger"
+
+    _append(root, 1)
+
+    segment = (
+        root / "segment-000000.jsonl"
+    )
+
+    os.link(
+        segment,
+        tmp_path / "segment-hard-link",
+    )
+
+    with pytest.raises(
+        CanonicalStoreSecurityError,
+        match="exactly one link",
+    ):
+        validate_and_replay_canonical_store(
+            root,
+            ledger_id="FAULT-LEDGER",
+        )
+
+
+def test_non_contiguous_segments_are_rejected(
+    tmp_path,
+):
+    root = tmp_path / "ledger"
+    root.mkdir(mode=0o700)
+
+    (
+        root / "segment-000001.jsonl"
+    ).write_bytes(b"")
+
+    with pytest.raises(
+        CanonicalStoreIntegrityError,
+        match="contiguous from zero",
+    ):
+        validate_and_replay_canonical_store(
+            root,
+            ledger_id="FAULT-LEDGER",
+        )
+
+
+def test_nonterminal_partial_write_is_not_recovered(
+    tmp_path,
+):
+    root = tmp_path / "ledger"
+
+    for index in range(1, 4):
+        _append(
+            root,
+            index,
+            max_records_per_segment=2,
+        )
+
+    first_segment = (
+        root / "segment-000000.jsonl"
+    )
+
+    with first_segment.open("ab") as handle:
+        handle.write(
+            b'{"schema":"interrupted'
+        )
+        handle.flush()
+        os.fsync(handle.fileno())
+
+    with pytest.raises(
+        CanonicalStoreIntegrityError,
+        match="invalid trailing partial record",
+    ):
+        validate_and_replay_canonical_store(
+            root,
+            ledger_id="FAULT-LEDGER",
+            recover_trailing=True,
+        )
+
+
+def test_stale_manifest_is_reconstructed(
+    tmp_path,
+):
+    root = tmp_path / "ledger"
+
+    _append(root, 1)
+    _append(root, 2)
+
+    manifest = root / "manifest.json"
+
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema": "STALE-MANIFEST",
+                "ledger_id": "WRONG",
+                "record_count": 999,
+                "segment_count": 999,
+                "last_entry_sha256": "f" * 64,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    manifest.chmod(0o600)
+
+    replay = (
+        validate_and_replay_canonical_store(
+            root,
+            ledger_id="FAULT-LEDGER",
+            rebuild_manifest=True,
+        )
+    )
+
+    rebuilt = json.loads(
+        manifest.read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert replay.record_count == 2
+    assert rebuilt["ledger_id"] == (
+        "FAULT-LEDGER"
+    )
+    assert rebuilt["record_count"] == 2
+    assert rebuilt["segment_count"] == 1
+    assert (
+        rebuilt["last_entry_sha256"]
+        == replay.last_entry_sha256
+    )
+
+
+def test_empty_terminal_segment_after_rotation_crash_is_reused(
+    tmp_path,
+):
+    root = tmp_path / "ledger"
+
+    _append(
+        root,
+        1,
+        max_records_per_segment=2,
+    )
+
+    _append(
+        root,
+        2,
+        max_records_per_segment=2,
+    )
+
+    empty_segment = (
+        root / "segment-000001.jsonl"
+    )
+
+    empty_segment.write_bytes(b"")
+    empty_segment.chmod(0o600)
+
+    interrupted = (
+        validate_and_replay_canonical_store(
+            root,
+            ledger_id="FAULT-LEDGER",
+            rebuild_manifest=True,
+        )
+    )
+
+    assert interrupted.record_count == 2
+    assert interrupted.segment_count == 2
+
+    receipt = _append(
+        root,
+        3,
+        max_records_per_segment=2,
+    )
+
+    assert receipt.sequence_index == 2
+    assert receipt.segment_index == 1
+
+    final = (
+        validate_and_replay_canonical_store(
+            root,
+            ledger_id="FAULT-LEDGER",
+        )
+    )
+
+    assert final.record_count == 3
+    assert final.segment_count == 2
+
+
+def test_record_payload_hash_tampering_is_rejected(
+    tmp_path,
+):
+    root = tmp_path / "ledger"
+
+    _append(root, 1)
+
+    segment = (
+        root / "segment-000000.jsonl"
+    )
+
+    entries = [
+        json.loads(line)
+        for line in segment.read_text(
+            encoding="utf-8"
+        ).splitlines()
+    ]
+
+    entries[0]["record"]["record_id"] = (
+        "RCAF-TAMPERED-RECORD"
+    )
+
+    segment.write_text(
+        "\n".join(
+            json.dumps(
+                entry,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            for entry in entries
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        CanonicalStoreIntegrityError,
+        match="entry SHA-256 mismatch",
+    ):
+        validate_and_replay_canonical_store(
+            root,
+            ledger_id="FAULT-LEDGER",
+        )
+
+
+def test_previous_hash_tampering_is_rejected(
+    tmp_path,
+):
+    root = tmp_path / "ledger"
+
+    _append(root, 1)
+    _append(root, 2)
+
+    segment = (
+        root / "segment-000000.jsonl"
+    )
+
+    entries = [
+        json.loads(line)
+        for line in segment.read_text(
+            encoding="utf-8"
+        ).splitlines()
+    ]
+
+    entries[1][
+        "previous_entry_sha256"
+    ] = "0" * 64
+
+    segment.write_text(
+        "\n".join(
+            json.dumps(
+                entry,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            for entry in entries
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        CanonicalStoreIntegrityError,
+        match="hash-chain continuity failure",
+    ):
+        validate_and_replay_canonical_store(
+            root,
+            ledger_id="FAULT-LEDGER",
+        )
+
+
+def test_ledger_id_mismatch_is_rejected(
+    tmp_path,
+):
+    root = tmp_path / "ledger"
+
+    _append(root, 1)
+
+    with pytest.raises(
+        CanonicalStoreIntegrityError,
+        match="entry ledger_id mismatch",
+    ):
+        validate_and_replay_canonical_store(
+            root,
+            ledger_id="OTHER-LEDGER",
+        )
+
+
+def test_validation_repairs_private_permissions(
+    tmp_path,
+):
+    root = tmp_path / "ledger"
+
+    _append(root, 1)
+
+    root.chmod(0o777)
+
+    for path in (
+        root / "segment-000000.jsonl",
+        root / "manifest.json",
+        root / ".lock",
+    ):
+        path.chmod(0o666)
+
+    validate_and_replay_canonical_store(
+        root,
+        ledger_id="FAULT-LEDGER",
+        rebuild_manifest=True,
+    )
+
+    assert (
+        stat.S_IMODE(
+            os.stat(root).st_mode
+        )
+        == 0o700
+    )
+
+    for path in (
+        root / "segment-000000.jsonl",
+        root / "manifest.json",
+        root / ".lock",
+    ):
+        assert (
+            stat.S_IMODE(
+                os.stat(path).st_mode
+            )
+            == 0o600
+        )
+
+
+def test_unsupported_canonical_schema_is_rejected():
+    record = _record(1).to_dict()
+
+    record["schema"] = (
+        "RCAF-CANONICAL-FRAMEWORK-LEDGER-0.2"
+    )
+
+    with pytest.raises(
+        CanonicalStoreIntegrityError,
+        match="record schema mismatch",
+    ):
+        _validate_framework_record_dict(
+            record
+        )
+
+
+def test_unsupported_future_authority_schema_is_rejected():
+    record = _record(1).to_dict()
+
+    record[
+        "future_authority_evidence"
+    ][
+        "schema"
+    ] = (
+        "RCAF-FUTURE-CONDITIONED-AUTHORITY-UNKNOWN"
+    )
+
+    with pytest.raises(
+        CanonicalStoreIntegrityError,
+        match="lacks the required future-authority",
+    ):
+        _validate_framework_record_dict(
+            record
+        )
+
+
+def test_incomplete_canonical_record_is_rejected():
+    record = _record(1).to_dict()
+
+    record["completeness"][
+        "complete"
+    ] = False
+
+    record["completeness"][
+        "missing_capabilities"
+    ] = [
+        "matched_causal_branching"
+    ]
+
+    with pytest.raises(
+        CanonicalStoreIntegrityError,
+        match="canonical record is not complete",
+    ):
+        _validate_framework_record_dict(
+            record
+        )
+
+
+def test_unsafe_manifest_symlink_is_rejected(
+    tmp_path,
+):
+    root = tmp_path / "ledger"
+
+    _append(root, 1)
+
+    manifest = root / "manifest.json"
+    manifest.unlink()
+
+    target = tmp_path / "outside-manifest"
+    target.write_text(
+        "{}",
+        encoding="utf-8",
+    )
+
+    manifest.symlink_to(target)
+
+    with pytest.raises(
+        CanonicalStoreSecurityError,
+        match="existing manifest is unsafe",
+    ):
+        validate_and_replay_canonical_store(
+            root,
+            ledger_id="FAULT-LEDGER",
+            rebuild_manifest=True,
+        )

--- a/tests/test_rcaf_canonical_store_semantic_integrity.py
+++ b/tests/test_rcaf_canonical_store_semantic_integrity.py
@@ -1,0 +1,334 @@
+import copy
+import json
+import runpy
+from pathlib import Path
+
+import pytest
+
+from src.rcaf.canonical_store import (
+    CanonicalStoreIntegrityError,
+    _canonical_bytes,
+    _entry_body,
+    _sha256,
+    _validate_framework_record_dict,
+    append_canonical_record,
+    validate_and_replay_canonical_store,
+)
+from src.rcaf.carrier_coalition import (
+    COMPONENT_ROLE_NAMES,
+    FUTURE_FREEDOM_COMPONENT_NAMES,
+    ScaffoldDependenceEvidence,
+    TURBULENCE_COMPONENT_NAMES,
+)
+
+
+_RECORD_FACTORY = runpy.run_path(
+    "tests/test_rcaf_canonical_store.py"
+)["_record"]
+
+
+def _record_dict() -> dict:
+    return _RECORD_FACTORY(1).to_dict()
+
+
+def _replace_reference_ids(
+    value,
+    original: str,
+    replacement: str,
+) -> None:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if (
+                key == "reference_contract_id"
+                and item == original
+            ):
+                value[key] = replacement
+            else:
+                _replace_reference_ids(
+                    item,
+                    original,
+                    replacement,
+                )
+
+    elif isinstance(value, list):
+        for item in value:
+            _replace_reference_ids(
+                item,
+                original,
+                replacement,
+            )
+
+
+def test_sorted_json_round_trip_preserves_carrier_semantics():
+    record = _record_dict()
+
+    replayed = json.loads(
+        json.dumps(
+            record,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    )
+
+    assert _validate_framework_record_dict(
+        replayed
+    ) is replayed
+
+    carrier = replayed["carrier_coalition"]
+
+    assert set(
+        carrier["role_evidence"][0]["role_vector"]
+    ) == set(COMPONENT_ROLE_NAMES)
+
+    assert set(
+        carrier[
+            "turbulence_channels"
+        ][0]["component_vector"]
+    ) == set(TURBULENCE_COMPONENT_NAMES)
+
+    assert set(
+        carrier[
+            "scaffold_dependence"
+        ]["dependence_vector"]
+    ) == set(
+        ScaffoldDependenceEvidence
+        .DEPENDENCE_COMPONENT_NAMES
+    )
+
+    future_freedom = carrier["future_freedom"]
+
+    for field_name in (
+        "baseline_vector",
+        "candidate_vector",
+        "retention_by_component",
+    ):
+        assert set(
+            future_freedom[field_name]
+        ) == set(
+            FUTURE_FREEDOM_COMPONENT_NAMES
+        )
+
+
+def test_missing_role_component_is_rejected():
+    record = _record_dict()
+
+    role_vector = record[
+        "carrier_coalition"
+    ]["role_evidence"][0]["role_vector"]
+
+    role_vector.pop(
+        COMPONENT_ROLE_NAMES[0]
+    )
+
+    with pytest.raises(
+        CanonicalStoreIntegrityError,
+        match=(
+            "carrier role vectors must preserve "
+            "all components"
+        ),
+    ):
+        _validate_framework_record_dict(record)
+
+
+def test_exact_completeness_rejects_count_drift():
+    record = _record_dict()
+
+    record["completeness"][
+        "required_capability_count"
+    ] -= 1
+
+    with pytest.raises(
+        CanonicalStoreIntegrityError,
+        match="canonical record is not complete",
+    ):
+        _validate_framework_record_dict(record)
+
+
+def test_exact_completeness_rejects_capability_omission():
+    record = _record_dict()
+
+    record["completeness"][
+        "satisfied_capabilities"
+    ] = record["completeness"][
+        "satisfied_capabilities"
+    ][:-1]
+
+    with pytest.raises(
+        CanonicalStoreIntegrityError,
+        match="canonical record is not complete",
+    ):
+        _validate_framework_record_dict(record)
+
+
+def test_coordinated_carrier_reference_drift_is_rejected():
+    record = _record_dict()
+    carrier = record["carrier_coalition"]
+
+    original = carrier[
+        "coalition"
+    ]["reference_contract_id"]
+
+    _replace_reference_ids(
+        carrier,
+        original,
+        "REFERENCE-DRIFTED",
+    )
+
+    with pytest.raises(
+        CanonicalStoreIntegrityError,
+        match=(
+            "carrier reference contract does not "
+            "match canonical reference conditioning"
+        ),
+    ):
+        _validate_framework_record_dict(record)
+
+
+def test_carrier_terminal_class_drift_is_rejected():
+    record = _record_dict()
+    carrier = record["carrier_coalition"]
+    drifted = "TERMINAL-DRIFTED"
+
+    carrier["coalition"][
+        "terminal_organizational_class_id"
+    ] = drifted
+
+    carrier["equivalence_class"][
+        "terminal_organizational_class_id"
+    ] = drifted
+
+    with pytest.raises(
+        CanonicalStoreIntegrityError,
+        match=(
+            "carrier terminal class does not "
+            "match canonical future gate"
+        ),
+    ):
+        _validate_framework_record_dict(record)
+
+
+def test_framework_boundary_rejects_carrier_authority():
+    record = _record_dict()
+
+    record["carrier_coalition"][
+        "coalition"
+    ]["authority_eligible"] = True
+
+    with pytest.raises(
+        CanonicalStoreIntegrityError,
+        match=(
+            "carrier coalition violates "
+            "observer-only authority"
+        ),
+    ):
+        _validate_framework_record_dict(record)
+
+
+def test_governed_carrier_survives_append_and_replay(
+    tmp_path: Path,
+):
+    root = tmp_path / "valid-ledger"
+
+    receipt = append_canonical_record(
+        root,
+        ledger_id="R1C-G1-VALID",
+        record=_RECORD_FACTORY(1),
+    )
+
+    replay = validate_and_replay_canonical_store(
+        root,
+        ledger_id="R1C-G1-VALID",
+    )
+
+    assert receipt.durable_storage_write is True
+    assert receipt.authority_posture == "observe_only"
+    assert replay.integrity_verified is True
+    assert replay.deterministic_replay_verified is True
+    assert replay.authority_posture == "observe_only"
+    assert replay.record_count == 1
+
+    carrier = replay.records[0][
+        "carrier_coalition"
+    ]
+
+    assert carrier["coalition"][
+        "observer_only"
+    ] is True
+
+    assert carrier["coalition"][
+        "authority_eligible"
+    ] is False
+
+    assert carrier["coalition"][
+        "no_auto_promotion"
+    ] is True
+
+    authority = carrier[
+        "authority_contract"
+    ]
+
+    assert authority[
+        "authority_status"
+    ] == "observe_only"
+
+    assert authority[
+        "external_causal_authority"
+    ] is False
+
+    assert authority[
+        "self_modification_authority"
+    ] is False
+
+
+def test_replay_rejects_hash_valid_semantic_carrier_tamper(
+    tmp_path: Path,
+):
+    root = tmp_path / "tampered-ledger"
+
+    append_canonical_record(
+        root,
+        ledger_id="R1C-G1-TAMPER",
+        record=_RECORD_FACTORY(1),
+    )
+
+    segment = root / "segment-000000.jsonl"
+
+    entries = [
+        json.loads(line)
+        for line in segment.read_text(
+            encoding="utf-8"
+        ).splitlines()
+    ]
+
+    assert len(entries) == 1
+
+    entry = entries[0]
+
+    entry["record"][
+        "carrier_coalition"
+    ]["coalition"][
+        "authority_eligible"
+    ] = True
+
+    entry["entry_sha256"] = _sha256(
+        _canonical_bytes(
+            _entry_body(entry)
+        )
+    )
+
+    segment.write_bytes(
+        _canonical_bytes(entry) + b"\n"
+    )
+
+    with pytest.raises(
+        CanonicalStoreIntegrityError,
+        match=(
+            "carrier coalition violates "
+            "observer-only authority"
+        ),
+    ):
+        validate_and_replay_canonical_store(
+            root,
+            ledger_id="R1C-G1-TAMPER",
+            rebuild_manifest=False,
+        )

--- a/tests/test_rcaf_carrier_coalition.py
+++ b/tests/test_rcaf_carrier_coalition.py
@@ -1,0 +1,581 @@
+# ============================================================
+# tests/test_rcaf_carrier_coalition.py
+# ============================================================
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import pytest
+
+from src.rcaf.carrier_coalition import (
+    COMPONENT_ROLE_NAMES,
+    COUNTERFACTUAL_ARMS,
+    RCAF_CARRIER_COALITION_SCHEMA,
+    TURBULENCE_COMPONENT_NAMES,
+    CarrierCoalitionContractError,
+    CarrierValidityRelation,
+    CoalitionCounterfactualBranch,
+    CoalitionMatchedExperiment,
+    ComponentRoleEvidence,
+    CompressionFutureFreedom,
+    MicroscopicTicketEquivalenceClass,
+    MultiscaleTurbulenceChannel,
+    ProspectiveCoalitionNomination,
+    RCAFCarrierCoalitionBundle,
+    ReversiblePruningAuthorityContract,
+    ScaffoldDependenceEvidence,
+    ScaffoldReleaseEvidence,
+    TrajectoryAdmissibleCarrierCoalition,
+)
+
+
+def _branches(
+    coalition_id: str = "coalition-main",
+) -> tuple[CoalitionCounterfactualBranch, ...]:
+    return tuple(
+        CoalitionCounterfactualBranch(
+            branch_id=f"branch-{arm}",
+            arm=arm,
+            coalition_id=coalition_id,
+            topology_relation=f"topology-{arm}",
+            initialization_relation=f"initialization-{arm}",
+            context_relation=f"context-{arm}",
+            support_relation=f"support-{arm}",
+            dynamic_topology=(
+                arm == "A8"
+            ),
+            outcome_record_ids=(
+                f"outcome-{arm}",
+            ),
+        )
+        for arm in COUNTERFACTUAL_ARMS
+    )
+
+
+def _bundle() -> RCAFCarrierCoalitionBundle:
+    coalition = TrajectoryAdmissibleCarrierCoalition(
+        coalition_id="coalition-main",
+        member_ids=(
+            "member-payload",
+            "member-router",
+            "member-scaffold",
+        ),
+        initialization_state_id="initialization-001",
+        optimizer_state_id="optimizer-001",
+        data_contract_id="data-contract-001",
+        reference_contract_id="reference-contract-001",
+        participation_geometry_id="participation-001",
+        transformation_geometry_id="transformation-001",
+        boundary_contract_id="boundary-001",
+        terminal_organizational_class_id="terminal-class-001",
+        scaffold_relation_ids=(
+            "relation-scaffold",
+        ),
+        turbulence_channel_ids=(
+            "turbulence-001",
+        ),
+        role_evidence_ids=(
+            "role-payload",
+            "role-scaffold",
+        ),
+        future_freedom_record_id="future-freedom-001",
+        horizon_steps=128,
+        forward_reachable=True,
+        backward_consistent=True,
+        self_supporting=True,
+        support_withdrawal_verified=True,
+        context_specific=True,
+    )
+
+    validity_relations = (
+        CarrierValidityRelation(
+            relation_id="relation-scaffold",
+            source_member_id="member-scaffold",
+            target_member_id="member-payload",
+            relation_kind="scaffold",
+            reference_contract_id="reference-contract-001",
+            evidence_record_ids=(
+                "evidence-validity-001",
+            ),
+            context_validated=True,
+            phase_compatible=True,
+            boundary_compatible=True,
+            future_consistent=True,
+        ),
+        CarrierValidityRelation(
+            relation_id="relation-route",
+            source_member_id="member-router",
+            target_member_id="member-payload",
+            relation_kind="route",
+            reference_contract_id="reference-contract-001",
+            evidence_record_ids=(
+                "evidence-validity-002",
+            ),
+            context_validated=True,
+            phase_compatible=True,
+            boundary_compatible=True,
+            future_consistent=True,
+        ),
+    )
+
+    role_evidence = (
+        ComponentRoleEvidence(
+            evidence_id="role-payload",
+            member_id="member-payload",
+            reference_contract_id="reference-contract-001",
+            horizon_steps=128,
+            role_values=(
+                0.95,
+                0.15,
+                0.40,
+                0.20,
+                0.30,
+                0.10,
+                0.25,
+                0.05,
+            ),
+            evidence_record_ids=(
+                "evidence-role-001",
+            ),
+        ),
+        ComponentRoleEvidence(
+            evidence_id="role-scaffold",
+            member_id="member-scaffold",
+            reference_contract_id="reference-contract-001",
+            horizon_steps=128,
+            role_values=(
+                0.20,
+                0.92,
+                0.35,
+                0.70,
+                0.40,
+                0.15,
+                0.30,
+                0.10,
+            ),
+            evidence_record_ids=(
+                "evidence-role-002",
+            ),
+        ),
+    )
+
+    scaffold_dependence = ScaffoldDependenceEvidence(
+        dependence_id="dependence-001",
+        coalition_id="coalition-main",
+        scaffold_member_ids=(
+            "member-scaffold",
+        ),
+        reference_contract_id="reference-contract-001",
+        observation_horizon=64,
+        dependence_values=(
+            0.10,
+            0.12,
+            0.08,
+            0.20,
+            0.06,
+            0.10,
+            0.08,
+        ),
+        support_required_now=False,
+        evidence_record_ids=(
+            "evidence-dependence-001",
+        ),
+    )
+
+    scaffold_release = ScaffoldReleaseEvidence(
+        release_id="release-001",
+        coalition_id="coalition-main",
+        scaffold_member_ids=(
+            "member-scaffold",
+        ),
+        reference_contract_id="reference-contract-001",
+        withdrawal_horizon=64,
+        immediate_performance_preserved=True,
+        far_horizon_performance_preserved=True,
+        calibration_preserved=True,
+        robustness_preserved=True,
+        optimizer_stable=True,
+        activation_geometry_stable=True,
+        persistence_verified=True,
+        recovery_available=True,
+        transfer_preserved=True,
+        future_freedom_preserved=True,
+        turbulent_debt_admissible=True,
+        evidence_record_ids=(
+            "evidence-release-001",
+        ),
+    )
+
+    turbulence = MultiscaleTurbulenceChannel(
+        channel_id="turbulence-001",
+        source_organization_id="member-scaffold",
+        target_organization_id="coalition-main",
+        reference_contract_id="reference-contract-001",
+        horizon_steps=128,
+        component_values=(
+            0.10,
+            0.12,
+            0.08,
+            0.06,
+            0.11,
+            0.07,
+            0.05,
+            0.03,
+            0.06,
+            0.08,
+        ),
+        turbulence_classes=(
+            "productive_transition",
+        ),
+        evidence_record_ids=(
+            "evidence-turbulence-001",
+        ),
+    )
+
+    future_freedom = CompressionFutureFreedom(
+        record_id="future-freedom-001",
+        coalition_id="coalition-main",
+        reference_contract_id="reference-contract-001",
+        baseline_values=(
+            0.90,
+            0.80,
+            0.85,
+            0.75,
+            0.88,
+            0.82,
+        ),
+        candidate_values=(
+            0.86,
+            0.76,
+            0.82,
+            0.72,
+            0.84,
+            0.78,
+        ),
+        minimum_retention_ratio=0.90,
+        evidence_record_ids=(
+            "evidence-future-freedom-001",
+        ),
+    )
+
+    matched_experiment = CoalitionMatchedExperiment(
+        experiment_id="experiment-001",
+        branches=_branches(),
+        acceptance_contract_id="acceptance-001",
+        independent_evaluator=True,
+        frozen_acceptance_criteria=True,
+        matched_compute_budget=True,
+        multiple_seeds=True,
+    )
+
+    equivalence_class = (
+        MicroscopicTicketEquivalenceClass(
+            class_id="ticket-class-001",
+            coalition_ids=(
+                "coalition-main",
+                "coalition-alternative",
+            ),
+            terminal_organizational_class_id="terminal-class-001",
+            invariant_function_record_ids=(
+                "invariant-001",
+            ),
+            admissible_corridor_ids=(
+                "corridor-001",
+                "corridor-002",
+            ),
+            evidence_record_ids=(
+                "evidence-equivalence-001",
+            ),
+        )
+    )
+
+    nomination = ProspectiveCoalitionNomination(
+        nomination_id="nomination-001",
+        coalition_id="coalition-main",
+        retrospective_atlas_id="atlas-001",
+        matched_experiment_id="experiment-001",
+        acceptance_contract_id="acceptance-001",
+        evidence_record_ids=(
+            "evidence-nomination-001",
+        ),
+    )
+
+    authority_contract = (
+        ReversiblePruningAuthorityContract(
+            contract_id="pruning-contract-001",
+            coalition_id="coalition-main",
+            rollback_checkpoint_id="rollback-001",
+            release_criteria_ids=(
+                "release-criteria-001",
+            ),
+            maximum_sparsity=0.80,
+            maximum_step_removal=0.10,
+            recovery_budget_steps=32,
+        )
+    )
+
+    return RCAFCarrierCoalitionBundle(
+        bundle_id="bundle-001",
+        coalition=coalition,
+        validity_relations=validity_relations,
+        role_evidence=role_evidence,
+        scaffold_dependence=scaffold_dependence,
+        scaffold_release=scaffold_release,
+        turbulence_channels=(
+            turbulence,
+        ),
+        future_freedom=future_freedom,
+        matched_experiment=matched_experiment,
+        equivalence_class=equivalence_class,
+        nomination=nomination,
+        authority_contract=authority_contract,
+    )
+
+
+def test_schema_is_explicit():
+    assert RCAF_CARRIER_COALITION_SCHEMA == (
+        "RCAF-CARRIER-COALITION-0.1"
+    )
+
+
+def test_component_roles_are_named_and_nonexclusive():
+    evidence = _bundle().role_evidence[0]
+
+    assert tuple(
+        evidence.role_vector
+    ) == COMPONENT_ROLE_NAMES
+
+    assert evidence.role_vector[
+        "payload"
+    ] == 0.95
+
+    assert evidence.role_vector[
+        "routing"
+    ] == 0.40
+
+    assert evidence.role_assignment_nonexclusive is True
+
+
+def test_turbulence_preserves_all_components():
+    channel = _bundle().turbulence_channels[0]
+
+    assert tuple(
+        channel.component_vector
+    ) == TURBULENCE_COMPONENT_NAMES
+
+    assert len(
+        channel.component_vector
+    ) == 10
+
+    assert (
+        channel.collapsed_score_authoritative
+        is False
+    )
+
+
+def test_validity_requires_all_relational_conditions():
+    relation = _bundle().validity_relations[0]
+
+    assert relation.valid is True
+
+    altered = replace(
+        relation,
+        phase_compatible=False,
+    )
+
+    assert altered.valid is False
+
+
+def test_release_admissibility_requires_every_dimension():
+    release = _bundle().scaffold_release
+
+    assert release.release_admissible is True
+
+    altered = replace(
+        release,
+        transfer_preserved=False,
+    )
+
+    assert altered.release_admissible is False
+
+
+def test_future_freedom_is_componentwise():
+    record = _bundle().future_freedom
+
+    assert record.preserved is True
+
+    assert set(
+        record.retention_by_component
+    ) == {
+        "task_adaptability",
+        "routing_reserve",
+        "recovery_capacity",
+        "transfer_capacity",
+        "perturbation_tolerance",
+        "alternative_path_capacity",
+    }
+
+
+def test_coalition_can_be_nomination_ready_without_authority():
+    coalition = _bundle().coalition
+
+    assert coalition.nomination_ready is True
+    assert coalition.authority_eligible is False
+    assert coalition.observer_only is True
+
+
+def test_matched_experiment_requires_a0_through_a8():
+    experiment = _bundle().matched_experiment
+
+    assert {
+        branch.arm
+        for branch in experiment.branches
+    } == set(
+        COUNTERFACTUAL_ARMS
+    )
+
+    with pytest.raises(
+        CarrierCoalitionContractError,
+        match="A0 through A8",
+    ):
+        replace(
+            experiment,
+            branches=experiment.branches[:-1],
+        )
+
+
+def test_ticket_equivalence_does_not_require_same_microstate():
+    ticket_class = _bundle().equivalence_class
+
+    assert (
+        ticket_class.equivalent_terminal_organization
+        is True
+    )
+
+    assert (
+        ticket_class.identical_microstate_required
+        is False
+    )
+
+
+def test_bundle_is_deterministic_and_private():
+    first = _bundle().canonical_json()
+    second = _bundle().canonical_json()
+
+    assert first == second
+
+    data = json.loads(
+        first
+    )
+
+    assert data["schema"] == (
+        RCAF_CARRIER_COALITION_SCHEMA
+    )
+
+    assert data["raw_content_stored"] is False
+
+    assert (
+        data["content_fingerprint_stored"]
+        is False
+    )
+
+    assert (
+        data["authority_contract"][
+            "authority_status"
+        ]
+        == "observe_only"
+    )
+
+
+def test_bundle_rejects_nonmember_relation():
+    bundle = _bundle()
+
+    invalid_relation = replace(
+        bundle.validity_relations[0],
+        source_member_id="member-outside",
+    )
+
+    with pytest.raises(
+        CarrierCoalitionContractError,
+        match="non-member",
+    ):
+        replace(
+            bundle,
+            validity_relations=(
+                invalid_relation,
+            )
+            + bundle.validity_relations[1:],
+        )
+
+
+def test_authority_contract_rejects_nonobserver_status():
+    contract = _bundle().authority_contract
+
+    with pytest.raises(
+        CarrierCoalitionContractError,
+        match="observe_only",
+    ):
+        replace(
+            contract,
+            authority_status="bounded",
+        )
+
+
+def test_nomination_cannot_release_authority():
+    nomination = _bundle().nomination
+
+    with pytest.raises(
+        CarrierCoalitionContractError,
+        match="safeguards failed",
+    ):
+        replace(
+            nomination,
+            authority_withheld=False,
+        )
+
+
+def test_raw_content_storage_is_rejected():
+    bundle = _bundle()
+
+    with pytest.raises(
+        CarrierCoalitionContractError,
+        match="raw content",
+    ):
+        replace(
+            bundle,
+            raw_content_stored=True,
+        )
+
+
+def test_duplicate_coalition_members_are_rejected():
+    coalition = _bundle().coalition
+
+    with pytest.raises(
+        CarrierCoalitionContractError,
+        match="duplicates",
+    ):
+        replace(
+            coalition,
+            member_ids=(
+                "member-payload",
+                "member-payload",
+            ),
+        )
+
+
+def test_role_vector_must_preserve_every_component():
+    evidence = _bundle().role_evidence[0]
+
+    with pytest.raises(
+        CarrierCoalitionContractError,
+        match="8 components",
+    ):
+        replace(
+            evidence,
+            role_values=(
+                0.5,
+                0.5,
+            ),
+        )

--- a/tests/test_rcaf_future_authority_ledger.py
+++ b/tests/test_rcaf_future_authority_ledger.py
@@ -1,0 +1,622 @@
+# ============================================================
+# tests/test_rcaf_future_authority_ledger.py
+# ============================================================
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import replace
+
+import pytest
+
+from src.rcaf.future_authority_ledger import (
+    MATCHED_CAUSAL_BRANCH_ROLES,
+    AntiCoercionAuthorityCheck,
+    BackwardPredecessorEvidence,
+    BidirectionalConsistencyRecord,
+    BidirectionalMetaFieldReference,
+    ForwardReachabilityEvidence,
+    ForwardTrajectoryBranch,
+    FutureAuthorityLedgerError,
+    FutureConditionedAuthorityEvidenceBundle,
+    FutureConditionedGateLifecycle,
+    FutureGateCalibration,
+    MatchedCausalBranch,
+    MatchedCausalExperiment,
+    ProspectiveGateNomination,
+    RetrospectivePrecursorAtlasRecord,
+    TerminalOrganizationalContract,
+)
+
+from src.rcaf.organizational_ledger import (
+    MetricVector,
+)
+
+
+def _vector(
+    name: str,
+    value: float = 0.5,
+) -> MetricVector:
+    return MetricVector(
+        (
+            (name, value),
+        )
+    )
+
+
+def _matched_branch(
+    role: str,
+) -> MatchedCausalBranch:
+    relation_by_role = {
+        "A0_base_preserve": "within_boundary",
+        "A1_valid_candidate": "within_boundary",
+        "A2_sham": "sham",
+        "A3_wrong_context": "wrong_context",
+        "A4_over_boundary": "over_boundary",
+        "A5_support_withdrawal": "support_withdrawal",
+    }
+
+    return MatchedCausalBranch(
+        branch_id=f"BRANCH-{role}",
+        branch_role=role,
+        shared_initial_state_contract_id="INITIAL-STATE-0001",
+        intervention_id=f"INTERVENTION-{role}",
+        context_id=f"CONTEXT-{role}",
+        boundary_relation=relation_by_role[role],
+        terminal_class_id=(
+            "TERMINAL-CLASS-0001"
+            if role
+            in {
+                "A1_valid_candidate",
+                "A5_support_withdrawal",
+            }
+            else "TERMINAL-CLASS-CONTROL"
+        ),
+        evaluator_id="EVALUATOR-INDEPENDENT-0001",
+        support_present=(
+            role != "A5_support_withdrawal"
+        ),
+        execution_performed=True,
+        verification_state="verified",
+        benefit=_vector("benefit"),
+        harm=_vector("harm", 0.0),
+        containment=_vector("containment", 1.0),
+        future_freedom=_vector("future_freedom", 0.8),
+        absorption=_vector("absorption", 0.7),
+        persistence=_vector("persistence", 0.7),
+        release=_vector("release", 0.9),
+    )
+
+
+def _bundle() -> FutureConditionedAuthorityEvidenceBundle:
+    terminal_contract = TerminalOrganizationalContract(
+        contract_id="FUTURE-CONTRACT-0001",
+        terminal_class_id="TERMINAL-CLASS-0001",
+        benefit_requirements=_vector("benefit_minimum"),
+        persistence_requirements=_vector(
+            "persistence_minimum"
+        ),
+        harm_bounds=_vector("harm_maximum", 0.1),
+        containment_requirements=_vector(
+            "containment_minimum",
+            0.9,
+        ),
+        absorption_requirements=_vector(
+            "absorption_minimum",
+            0.6,
+        ),
+        future_freedom_minima=_vector(
+            "future_freedom_minimum",
+            0.7,
+        ),
+        continuity_constraint_ids=(
+            "CONTINUITY-ORGANIZATIONAL",
+        ),
+        release_condition_ids=(
+            "RELEASE-AVAILABLE",
+        ),
+        rollback_mechanism_ids=(
+            "ROLLBACK-AVAILABLE",
+        ),
+        allowed_variation_ids=(
+            "VARIATION-MICROSTATE",
+        ),
+        forbidden_condition_ids=(
+            "FORBID-AUTHORITY-EXPANSION",
+        ),
+    )
+
+    forward_evidence = ForwardReachabilityEvidence(
+        forward_map_id="META-T-PLUS-0001",
+        reachable_set_id="REACHABLE-SET-0001",
+        current_state_id="STATE-CURRENT-0001",
+        candidate_action_id="ACTION-CANDIDATE-0001",
+        branches=(
+            ForwardTrajectoryBranch(
+                branch_id="FORWARD-BRANCH-0001",
+                seed_id="SEED-0001",
+                carrier_state_id="CARRIER-STATE-0001",
+                hidden_context_class_id="HIDDEN-CONTEXT-0001",
+                disturbance_class_id="DISTURBANCE-0001",
+                terminal_class_id="TERMINAL-CLASS-0001",
+                corridor_id="ADMISSIBLE-CORRIDOR-0001",
+                safe_corridor_occupied=True,
+                boundary_compliant=True,
+                release_available=True,
+                future_freedom=_vector(
+                    "future_freedom",
+                    0.8,
+                ),
+                outcome_metrics=_vector("outcome", 0.7),
+            ),
+            ForwardTrajectoryBranch(
+                branch_id="FORWARD-BRANCH-0002",
+                seed_id="SEED-0002",
+                carrier_state_id="CARRIER-STATE-0002",
+                hidden_context_class_id="HIDDEN-CONTEXT-0002",
+                disturbance_class_id="DISTURBANCE-0002",
+                terminal_class_id="TERMINAL-CLASS-0001",
+                corridor_id="ADMISSIBLE-CORRIDOR-0001",
+                safe_corridor_occupied=True,
+                boundary_compliant=True,
+                release_available=True,
+                future_freedom=_vector(
+                    "future_freedom",
+                    0.75,
+                ),
+                outcome_metrics=_vector("outcome", 0.65),
+            ),
+        ),
+        reachable_terminal_class_ids=(
+            "TERMINAL-CLASS-0001",
+        ),
+        safe_corridor_ids=("ADMISSIBLE-CORRIDOR-0001",),
+        evidence_ids=("EVIDENCE-FORWARD-0001",),
+        forward_reachable=True,
+    )
+
+    required_conditions = (
+        "CONDITION-REFERENCE-VALID",
+        "CONDITION-EVALUATOR-INDEPENDENT",
+        "CONDITION-ROLLBACK-AVAILABLE",
+        "CONDITION-RELEASE-AVAILABLE",
+    )
+
+    backward_evidence = BackwardPredecessorEvidence(
+        backward_map_id="META-T-MINUS-0001",
+        predecessor_set_id="PREDECESSOR-SET-0001",
+        future_contract_id=terminal_contract.contract_id,
+        required_reference_contract_id=(
+            "REFERENCE-CONTRACT-0001"
+        ),
+        required_condition_ids=required_conditions,
+        satisfied_condition_ids=required_conditions,
+        unmet_condition_ids=(),
+        forbidden_predecessor_condition_ids=(
+            "FORBID-EVALUATOR-REWRITE",
+        ),
+        required_carrier_relation_ids=(
+            "CARRIER-RELATION-BOUNDED",
+        ),
+        required_boundary_ids=("BOUNDARY-0001",),
+        required_evaluator_ids=(
+            "EVALUATOR-INDEPENDENT-0001",
+        ),
+        required_release_path_ids=(
+            "RELEASE-PATH-0001",
+        ),
+        required_rollback_mechanism_ids=(
+            "ROLLBACK-AVAILABLE",
+        ),
+        uncertainty=_vector("uncertainty", 0.1),
+        backward_consistent=True,
+    )
+
+    consistency = BidirectionalConsistencyRecord(
+        consistency_record_id="CONSISTENCY-0001",
+        forward_reachable_set_id=(
+            forward_evidence.reachable_set_id
+        ),
+        backward_predecessor_set_id=(
+            backward_evidence.predecessor_set_id
+        ),
+        shared_corridor_ids=("ADMISSIBLE-CORRIDOR-0001",),
+        excluded_trajectory_ids=(
+            "TRAJECTORY-OVER-BOUNDARY",
+        ),
+        consistency_evidence_ids=(
+            "EVIDENCE-CONSISTENCY-0001",
+        ),
+        consistency_failure_ids=(),
+        terminal_class_agreement=True,
+        intermediate_boundary_compliance=True,
+        future_freedom_compliance=True,
+        release_compliance=True,
+        gate_nominated=True,
+        gate_admissible=True,
+    )
+
+    causal_experiment = MatchedCausalExperiment(
+        experiment_id="CAUSAL-EXPERIMENT-0001",
+        frozen_future_contract_id=terminal_contract.contract_id,
+        frozen_acceptance_criteria_id=(
+            "ACCEPTANCE-CRITERIA-0001"
+        ),
+        independent_evaluator_id=(
+            "EVALUATOR-INDEPENDENT-0001"
+        ),
+        branches=tuple(
+            _matched_branch(role)
+            for role in sorted(
+                MATCHED_CAUSAL_BRANCH_ROLES
+            )
+        ),
+        treatment_effects=_vector("treatment_effect", 0.3),
+        control_separation=_vector(
+            "control_separation",
+            0.3,
+        ),
+        wrong_context_separation=_vector(
+            "wrong_context_separation",
+            0.4,
+        ),
+        over_boundary_failure=_vector(
+            "over_boundary_failure",
+            1.0,
+        ),
+        support_withdrawal_persistence=_vector(
+            "withdrawal_persistence",
+            0.8,
+        ),
+        cross_seed_robustness=_vector(
+            "cross_seed",
+            0.8,
+        ),
+        cross_carrier_robustness=_vector(
+            "cross_carrier",
+            0.7,
+        ),
+        evaluator_agreement=_vector(
+            "evaluator_agreement",
+            0.9,
+        ),
+        valid_treatment_preferential=True,
+        controls_weaker=True,
+        withdrawal_persistent=True,
+        independent_verification_passed=True,
+        causal_support_established=True,
+    )
+
+    anti_coercion = AntiCoercionAuthorityCheck(
+        check_id="ANTI-COERCION-0001",
+        prediction_preceded_intervention=True,
+        terminal_contract_frozen=True,
+        acceptance_criteria_frozen=True,
+        evaluator_independent=True,
+        target_rewrite_prevented=True,
+        evidence_rewrite_prevented=True,
+        control_branches_preserved=True,
+        valid_treatment_preferential=True,
+        support_withdrawal_persistent=True,
+        passed=True,
+    )
+
+    retrospective = RetrospectivePrecursorAtlasRecord(
+        atlas_record_id="RETROSPECTIVE-ATLAS-0001",
+        completed_trajectory_id="TRAJECTORY-COMPLETE-0001",
+        terminal_class_id="TERMINAL-CLASS-0001",
+        earliest_reliable_precursor_id="PRECURSOR-0001",
+        precursor_class_id="PRECURSOR-CLASS-0001",
+        decisive_carrier_coalition_ids=(
+            "CARRIER-COALITION-0001",
+        ),
+        boundary_crossing_event_id="EVENT-BOUNDARY-0001",
+        alternative_future_collapse_event_id=(
+            "EVENT-FUTURE-COLLAPSE-0001"
+        ),
+        absorption_likelihood_event_id=(
+            "EVENT-ABSORPTION-0001"
+        ),
+        release_danger_event_id="EVENT-RELEASE-DANGER-0001",
+        inference_method_id="METHOD-SMOOTHING-0001",
+        validation_population_id="POPULATION-0001",
+        replication_evidence_ids=(
+            "EVIDENCE-REPLICATION-0001",
+        ),
+        replicated=True,
+    )
+
+    prospective = ProspectiveGateNomination(
+        nomination_id="NOMINATION-0001",
+        observed_precursor_class_id=(
+            retrospective.precursor_class_id
+        ),
+        matched_atlas_invariant_id=(
+            "ATLAS-INVARIANT-0001"
+        ),
+        reference_contract_id="REFERENCE-CONTRACT-0001",
+        corridor_match_id="ADMISSIBLE-CORRIDOR-0001",
+        deviation_metrics=_vector("deviation", 0.1),
+        evidence_ids=("EVIDENCE-NOMINATION-0001",),
+        recommendation="sandbox_candidate",
+    )
+
+    calibration = FutureGateCalibration(
+        calibration_id="CALIBRATION-0001",
+        status="uncalibrated",
+        future_class_confidence=None,
+        future_basin_pull="observed",
+        sample_count=12,
+        effective_sample_count=8,
+        calibration_population_id="POPULATION-0001",
+        calibration_error=None,
+        out_of_distribution=False,
+        scenario_tail_metrics=_vector(
+            "tail_risk",
+            0.2,
+        ),
+    )
+
+    lifecycle = FutureConditionedGateLifecycle(
+        lifecycle_id="GATE-LIFECYCLE-0001",
+        evidence_maturity="causally_supported",
+        authority_status="observe_only",
+        retrospective_atlas_record_id=(
+            retrospective.atlas_record_id
+        ),
+        prospective_nomination_id=(
+            prospective.nomination_id
+        ),
+        causal_experiment_id=causal_experiment.experiment_id,
+        anti_coercion_check_id=anti_coercion.check_id,
+        calibration_id=calibration.calibration_id,
+    )
+
+    meta_field = BidirectionalMetaFieldReference(
+        meta_field_record_id="META-FIELD-0001",
+        forward_transition_map_id=(
+            forward_evidence.forward_map_id
+        ),
+        backward_predecessor_map_id=(
+            backward_evidence.backward_map_id
+        ),
+        evidence_structure_id="EVIDENCE-STRUCTURE-0001",
+        admissibility_authority_structure_id=(
+            "AUTHORITY-STRUCTURE-0001"
+        ),
+        consistency_relation_id=(
+            consistency.consistency_record_id
+        ),
+    )
+
+    return FutureConditionedAuthorityEvidenceBundle(
+        terminal_contract=terminal_contract,
+        forward_evidence=forward_evidence,
+        backward_evidence=backward_evidence,
+        consistency=consistency,
+        causal_experiment=causal_experiment,
+        anti_coercion=anti_coercion,
+        retrospective_atlas=retrospective,
+        prospective_nomination=prospective,
+        calibration=calibration,
+        lifecycle=lifecycle,
+        meta_field=meta_field,
+    )
+
+
+def test_bundle_preserves_bidirectional_evidence_lifecycle():
+    bundle = _bundle()
+    data = bundle.to_dict()
+
+    assert data["terminal_contract"]["terminal_class_id"] == (
+        "TERMINAL-CLASS-0001"
+    )
+    assert data["forward_evidence"]["forward_reachable"] is True
+    assert data["backward_evidence"]["backward_consistent"] is True
+    assert data["consistency"]["gate_admissible"] is True
+    assert data["causal_experiment"][
+        "causal_support_established"
+    ] is True
+    assert data["anti_coercion"]["passed"] is True
+
+
+def test_matched_experiment_contains_exact_a0_through_a5():
+    roles = {
+        branch.branch_role
+        for branch in _bundle().causal_experiment.branches
+    }
+
+    assert roles == MATCHED_CAUSAL_BRANCH_ROLES
+
+
+def test_uncalibrated_evidence_does_not_claim_probability():
+    calibration = _bundle().calibration
+
+    assert calibration.status == "uncalibrated"
+    assert calibration.future_class_confidence is None
+    assert calibration.calibration_error is None
+    assert not calibration.confidence_interval.components
+    assert _bundle().causal_authority_eligible is False
+
+
+def test_uncalibrated_confidence_is_rejected():
+    with pytest.raises(
+        FutureAuthorityLedgerError,
+        match="uncalibrated evidence cannot claim confidence",
+    ):
+        replace(
+            _bundle().calibration,
+            future_class_confidence=0.8,
+        )
+
+
+def test_backward_consistency_rejects_unmet_condition():
+    evidence = _bundle().backward_evidence
+
+    with pytest.raises(
+        FutureAuthorityLedgerError,
+        match="cannot contain unmet conditions",
+    ):
+        replace(
+            evidence,
+            satisfied_condition_ids=(
+                evidence.required_condition_ids[:-1]
+            ),
+            unmet_condition_ids=(
+                evidence.required_condition_ids[-1],
+            ),
+            backward_consistent=True,
+        )
+
+
+def test_admissible_gate_rejects_consistency_failure():
+    with pytest.raises(
+        FutureAuthorityLedgerError,
+        match="requires complete bidirectional consistency",
+    ):
+        replace(
+            _bundle().consistency,
+            consistency_failure_ids=(
+                "FAILURE-CONSISTENCY-0001",
+            ),
+            gate_admissible=True,
+        )
+
+
+def test_causal_support_requires_all_controls():
+    with pytest.raises(
+        FutureAuthorityLedgerError,
+        match="causal support requires",
+    ):
+        replace(
+            _bundle().causal_experiment,
+            controls_weaker=False,
+            causal_support_established=True,
+        )
+
+
+def test_anti_coercion_result_cannot_be_self_declared():
+    with pytest.raises(
+        FutureAuthorityLedgerError,
+        match="must equal all safeguards",
+    ):
+        replace(
+            _bundle().anti_coercion,
+            evaluator_independent=False,
+            passed=True,
+        )
+
+
+def test_retrospective_atlas_cannot_grant_authority():
+    with pytest.raises(
+        FutureAuthorityLedgerError,
+        match="cannot grant authority",
+    ):
+        replace(
+            _bundle().retrospective_atlas,
+            authority_granted=True,
+        )
+
+
+def test_prospective_nomination_must_withhold_authority():
+    with pytest.raises(
+        FutureAuthorityLedgerError,
+        match="must withhold authority",
+    ):
+        replace(
+            _bundle().prospective_nomination,
+            authority_withheld=False,
+        )
+
+
+def test_meta_field_rejects_literal_retrocausality():
+    with pytest.raises(
+        FutureAuthorityLedgerError,
+        match="does not claim literal backward causation",
+    ):
+        replace(
+            _bundle().meta_field,
+            literal_retrocausality_claimed=True,
+        )
+
+
+def test_future_gate_evidence_cannot_auto_promote_authority():
+    with pytest.raises(
+        FutureAuthorityLedgerError,
+        match="cannot auto-promote authority",
+    ):
+        replace(
+            _bundle().lifecycle,
+            no_auto_promotion=False,
+        )
+
+
+def test_serialization_is_private_and_deterministic():
+    marker = (
+        "RCAF-FUTURE-PRIVATE-"
+        "027c0db83a924e3b8e11242068f13d91"
+    )
+
+    first = _bundle().canonical_json()
+    second = _bundle().canonical_json()
+
+    assert first == second
+    assert marker not in first
+    assert '"raw_content_stored":false' in first
+    assert '"content_fingerprint_stored":false' in first
+    assert '"causal_authority_eligible":false' in first
+
+
+def test_bundle_api_accepts_no_prompt_or_response_content():
+    signature = inspect.signature(
+        FutureConditionedAuthorityEvidenceBundle
+    )
+
+    forbidden = {
+        "prompt",
+        "response",
+        "message",
+        "content",
+        "reasoning",
+        "embedding",
+        "content_sha256",
+    }
+
+    assert forbidden.isdisjoint(
+        signature.parameters
+    )
+
+
+
+def test_bundle_rejects_prospective_corridor_mismatch():
+    bundle = _bundle()
+
+    with pytest.raises(
+        FutureAuthorityLedgerError,
+        match="prospective nomination corridor mismatch",
+    ):
+        replace(
+            bundle,
+            prospective_nomination=replace(
+                bundle.prospective_nomination,
+                corridor_match_id="CORRIDOR-MISMATCH",
+            ),
+        )
+
+
+def test_bundle_rejects_evaluator_linkage_mismatch():
+    bundle = _bundle()
+
+    with pytest.raises(
+        FutureAuthorityLedgerError,
+        match="independent evaluator is not a required predecessor",
+    ):
+        replace(
+            bundle,
+            causal_experiment=replace(
+                bundle.causal_experiment,
+                independent_evaluator_id=(
+                    "EVALUATOR-MISMATCH"
+                ),
+            ),
+        )

--- a/tests/test_rcaf_organizational_ledger.py
+++ b/tests/test_rcaf_organizational_ledger.py
@@ -1,0 +1,368 @@
+# ============================================================
+# tests/test_rcaf_organizational_ledger.py
+# ============================================================
+
+from __future__ import annotations
+
+import inspect
+import json
+
+import pytest
+
+from src.rcaf.organizational_ledger import (
+    RCAF_ATLAS_TYPES,
+    AtlasLink,
+    BoundaryAuthority,
+    CausalFlow,
+    CoherenceGeometry,
+    CounterfactualComparison,
+    EvidenceGeometry,
+    FutureConditioning,
+    MetricVector,
+    ParticipationGeometry,
+    RCAFOrganizationalLedgerError,
+    RCAFOrganizationalRecord,
+    RealizationLifecycle,
+    ReferenceGeometry,
+)
+
+
+def _links():
+    return tuple(
+        AtlasLink(
+            atlas_type=atlas_type,
+            atlas_record_id=(
+                f"ATLAS-{index:02d}"
+            ),
+        )
+        for index, atlas_type in enumerate(
+            sorted(RCAF_ATLAS_TYPES),
+            start=1,
+        )
+    )
+
+
+def _record():
+    return RCAFOrganizationalRecord(
+        record_id="RCAF-ORG-0001",
+        event_id="EVENT-0001",
+        lineage_id="LINEAGE-0001",
+        occurred_at_utc=(
+            "2026-07-31T22:00:00Z"
+        ),
+        record_type="composite",
+        stage="edge_admissibility",
+        atlas_links=_links(),
+        reference=ReferenceGeometry(
+            reference_id="REF-0001",
+            reference_class_id="REFCLASS-0001",
+            anchor_id="ANCHOR-0001",
+            drift=MetricVector(
+                (
+                    ("temporal", 0.1),
+                    ("structural", 0.2),
+                )
+            ),
+            deviation=MetricVector(
+                (
+                    ("local", 0.05),
+                )
+            ),
+            future_freedom=MetricVector(
+                (
+                    ("optionality", 0.8),
+                    ("reversibility", 0.9),
+                )
+            ),
+        ),
+        participation=ParticipationGeometry(
+            pi_i=0.6,
+            pi_r=0.3,
+            pi_a=0.1,
+            strain=0.4,
+        ),
+        coherence_geometry=CoherenceGeometry(
+            meta_field_id="META-0001",
+            psi=0.72,
+            rho_a=0.18,
+            rho_c=0.64,
+            occupancy=0.55,
+            geometry_coherence=0.81,
+            realization_pressure=0.35,
+            viability=0.88,
+            realization_coupling=0.42,
+        ),
+        evidence=EvidenceGeometry(
+            status="verified",
+            evidence_ids=(
+                "EVIDENCE-0001",
+                "EVIDENCE-0002",
+            ),
+            benefit=MetricVector(
+                (
+                    ("immediate", 0.4),
+                    ("far_field", 0.2),
+                )
+            ),
+            harm=MetricVector(
+                (
+                    ("observed", 0.0),
+                )
+            ),
+            containment=MetricVector(
+                (
+                    ("bounded", 1.0),
+                )
+            ),
+            reversibility=MetricVector(
+                (
+                    ("rollback", 1.0),
+                )
+            ),
+            confidence=MetricVector(
+                (
+                    ("structural", 0.9),
+                )
+            ),
+            future_freedom_delta=MetricVector(
+                (
+                    ("optionality", 0.05),
+                )
+            ),
+        ),
+        future_conditioning=FutureConditioning(
+            horizon=8,
+            terminal_contract_id=(
+                "TERMINAL-CONTRACT-0001"
+            ),
+            terminal_class_id=(
+                "TERMINAL-CLASS-0001"
+            ),
+            corridor_id="CORRIDOR-0001",
+            forward_reachable=True,
+            backward_consistent=True,
+            gate_admissible=True,
+        ),
+        boundary_authority=BoundaryAuthority(
+            boundary_state="bounded",
+            admissibility_state="admissible",
+            authority_state="none",
+            scope_ids=(
+                "SCOPE-OBSERVE",
+            ),
+            release_condition_ids=(
+                "RELEASE-ON-COMPLETE",
+            ),
+            revocation_condition_ids=(
+                "REVOKE-ON-BOUNDARY-BREACH",
+            ),
+            realization_authorized=False,
+        ),
+        lifecycle=RealizationLifecycle(
+            possibility="possible",
+            proposal="proposed",
+            verification="verified",
+            transition_qualification="qualified",
+            edge_admissibility="admissible",
+            geometry_coherence="verified",
+            active_participation_permission=(
+                "not_observed"
+            ),
+            realization="not_observed",
+            absorption="not_observed",
+            influence="not_observed",
+            persistence="not_observed",
+            release="not_observed",
+        ),
+        causal_flow=CausalFlow(
+            interface_id="INTERFACE-0001",
+            coupling_id="COUPLING-0001",
+            propagation_path_id=(
+                "PROPAGATION-0001"
+            ),
+            scale_transition_id=(
+                "SCALE-0001"
+            ),
+            global_influence_id=(
+                "GLOBAL-0001"
+            ),
+            coupling_strength=MetricVector(
+                (
+                    ("local", 0.4),
+                )
+            ),
+            propagation_strength=MetricVector(
+                (
+                    ("contained", 0.9),
+                )
+            ),
+        ),
+        counterfactual=CounterfactualComparison(
+            status="complete",
+            candidate_ids=(
+                "CANDIDATE-A",
+                "CANDIDATE-B",
+            ),
+            selected_candidate_id=(
+                "CANDIDATE-A"
+            ),
+            comparison_metrics=MetricVector(
+                (
+                    ("benefit_delta", 0.2),
+                    ("harm_delta", -0.1),
+                )
+            ),
+        ),
+        authority_posture="observe_only",
+    )
+
+
+def test_full_record_preserves_all_atlas_types():
+    record = _record()
+    summary = record.structural_summary()
+
+    assert summary["atlas_count"] == len(
+        RCAF_ATLAS_TYPES
+    )
+    assert set(
+        summary["atlas_types"]
+    ) == RCAF_ATLAS_TYPES
+    assert summary["section_count"] == 9
+
+
+def test_participation_remains_triadic():
+    record = _record()
+    participation = record.to_dict()[
+        "participation"
+    ]
+
+    assert participation == {
+        "pi_i": 0.6,
+        "pi_r": 0.3,
+        "pi_a": 0.1,
+        "strain": 0.4,
+    }
+
+
+def test_future_conditioned_gate_is_explicit():
+    future = _record().to_dict()[
+        "future_conditioning"
+    ]
+
+    assert future["forward_reachable"] is True
+    assert future["backward_consistent"] is True
+    assert future["gate_admissible"] is True
+    assert future["corridor_id"] == (
+        "CORRIDOR-0001"
+    )
+
+
+def test_authority_is_not_collapsed_into_success():
+    record = _record().to_dict()
+
+    assert record[
+        "boundary_authority"
+    ]["authority_state"] == "none"
+
+    assert record[
+        "boundary_authority"
+    ]["realization_authorized"] is False
+
+    assert record[
+        "lifecycle"
+    ]["verification"] == "verified"
+
+    assert record[
+        "lifecycle"
+    ]["realization"] == "not_observed"
+
+    assert record[
+        "lifecycle"
+    ]["persistence"] == "not_observed"
+
+
+def test_record_is_structural_and_private():
+    marker = (
+        "SR-PRIVATE-"
+        "7f875da157e5a4eb0d2f6489b34585bc"
+    )
+
+    serialized = _record().canonical_json()
+
+    assert marker not in serialized
+    assert '"raw_content_stored":false' in serialized
+    assert (
+        '"content_fingerprint_stored":false'
+        in serialized
+    )
+
+
+def test_canonical_serialization_is_deterministic():
+    first = _record().canonical_json()
+    second = _record().canonical_json()
+
+    assert first == second
+
+    parsed = json.loads(first)
+
+    assert parsed["record_id"] == "RCAF-ORG-0001"
+
+
+def test_invalid_participation_is_rejected():
+    with pytest.raises(
+        RCAFOrganizationalLedgerError,
+        match="must equal 1",
+    ):
+        ParticipationGeometry(
+            pi_i=0.7,
+            pi_r=0.4,
+            pi_a=0.1,
+            strain=0.2,
+        )
+
+
+def test_unknown_atlas_type_is_rejected():
+    with pytest.raises(
+        RCAFOrganizationalLedgerError,
+        match="atlas_type must be one of",
+    ):
+        AtlasLink(
+            atlas_type="InventedAtlas",
+            atlas_record_id="ATLAS-INVALID",
+        )
+
+
+def test_counterfactual_selection_must_be_candidate():
+    with pytest.raises(
+        RCAFOrganizationalLedgerError,
+        match="must occur in candidate_ids",
+    ):
+        CounterfactualComparison(
+            status="complete",
+            candidate_ids=(
+                "CANDIDATE-A",
+            ),
+            selected_candidate_id=(
+                "CANDIDATE-B"
+            ),
+        )
+
+
+def test_record_api_has_no_prompt_content_fields():
+    signature = inspect.signature(
+        RCAFOrganizationalRecord
+    )
+
+    forbidden = {
+        "prompt",
+        "response",
+        "message",
+        "content",
+        "reasoning",
+        "sha256",
+        "embedding",
+    }
+
+    assert forbidden.isdisjoint(
+        signature.parameters
+    )


### PR DESCRIPTION
## Summary

Introduces the durable RCAF carrier-coalition governance foundation as an observer-only canonical ledger layer.

## Included

- canonical framework ledger and deterministic canonical store
- carrier-coalition contracts and component-preserving validation
- future-conditioned authority ledger
- organizational ledger
- explicit schema-evolution and migration constraints
- append, replay, corruption, quarantine, concurrency, and filesystem defenses
- semantic-integrity and migration-integrity regression coverage

## Validation

- Full repository: 4709 passed, 3 skipped, 68 warnings
- Focused RCAF regression: passed
- Integration base: 25c9e735ef5ce605f47f8f666ac6689056d2c10c
- Integration commit: fb006a159211c52158891465fa7099684c98837a
- Changed paths: 15

## Authority posture

- observe-only
- no external causal authority
- no tool-execution authority
- no identity authority
- no semantic-memory authority
- no self-modification authority
- no automatic promotion
- no automatic pruning

## Provenance

The original accepted RCAF milestone was transplanted onto the current upstream dev history and fully retested before publication.
