### PR TITLE
fix(agent): make intent-without-tool-call detector work for non-English replies

### DIFF
--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -3853,14 +3853,43 @@ async def stream_agent_loop(
     # Match the common phrasings + an action verb that maps to an available
     # tool, so we don't nudge on harmless transitional text like "let me
     # know what you think".
+    #
+    # The detector is language-specific: a model replying in the user's own
+    # language announces the action in that language too, so an English-only
+    # pattern never fires and the turn ends silently instead of nudging.
+    # German is covered below; other languages can be added the same way.
+    _DE_FIN = (
+        r"rufe|pr\u00fcfe|schaue|sehe|lese|hole|frage|starte|suche|nutze|verwende|"
+        r"\u00fcberpr\u00fcfe|f\u00fchre|liste|ermittle|checke|greife|lade|\u00f6ffne|"
+        r"durchsuche|analysiere|kontrolliere"
+    )
+    _DE_INF = (
+        r"abrufen|pr\u00fcfen|schauen|nachsehen|lesen|holen|abfragen|starten|"
+        r"suchen|verwenden|nutzen|ausf\u00fchren|auflisten|ermitteln|checken|"
+        r"laden|\u00f6ffnen|durchsuchen|analysieren|kontrollieren"
+    )
+    _DE_MOD = (
+        r"werde|werden|muss|m\u00fcssen|sollte|sollten|kann|k\u00f6nnen|"
+        r"m\u00f6chte|will|wollen"
+    )
     _INTENT_RE = re.compile(
-        r"(?:^|\n)\s*(?:let me|i'?ll|i will|i need to|we need to|need to|"
+        r"(?:^|\n)\s*(?:"
+        # English: intent phrase + action verb
+        r"(?:let me|i'?ll|i will|i need to|we need to|need to|"
         r"i should|we should|i must|we must|going to|let's)\s+"
         r"(?:tail|check|investigate|look at|see|tail|read|fetch|inspect|"
         r"verify|diagnose|examine|debug|capture|grab|pull|view|run|call|"
         r"trigger|launch|start|kick off|stop|kill|restart|adopt|serve|"
         r"register|adopt|list|search|find|query|hit|ping|test|use|perform|do)"
-        r"\b[^.\n]{0,140}",
+        # German: "Ich rufe den Kalender ab", "Jetzt pr\u00fcfe ich ..."
+        rf"|(?:jetzt\s+)?(?:ich|wir)\s+(?:{_DE_FIN})"
+        # German: modal + trailing infinitive ("Ich werde den Kalender abrufen")
+        rf"|(?:ich|wir)\s+(?:{_DE_MOD})\b[^.\n]{{0,80}}?\b(?:{_DE_INF})"
+        # German: inversion ("Jetzt schaue ich ...")
+        rf"|(?:jetzt|nun|dann)\s+(?:{_DE_FIN})\s+(?:ich|wir)"
+        # German: "Lass mich ..." / "Lassen Sie uns ..."
+        r"|(?:lass|lassen)\s+(?:mich|uns)\s+"
+        r")\b[^.\n]{0,140}",
         re.IGNORECASE,
     )
     _awaiting_user = False  # set by ask_user → end the turn and wait for a choice


### PR DESCRIPTION
## Problem

`stream_agent_loop` has a supervisor for the "model announced an action but emitted no `tool_call`" case: `_INTENT_RE` (src/agent_loop.py) matches the announcement, and the loop injects a nudge so the model actually calls the tool.

The pattern is English-only (`let me`, `i'll`, `i need to`, …).

When a model replies in the user's language, it announces the action in that language too. The detector never matches, `_looks_like_promise` stays `False`, no nudge is injected — and the turn ends silently with no answer and no error. From the user's side the agent just stops mid-task, repeatedly.

Observed with a German-language chat (Ollama backend, several models — `llama3.1:8b`, `qwen3:8b`, `qwen3.5:9b`):

```
Ich rufe jetzt Ihren Kalender ab:      →  turn ends, no tool call, no error
```

The model itself was fine — verified that Ollama emits a correct structured `tool_calls` payload for the same prompt on both `/api/chat` and `/v1/chat/completions` (streaming and non-streaming). The stall is purely the missing nudge on the round where the call got dropped.

## Fix

Adds German phrasings to `_INTENT_RE`, covering the four common announcement shapes:

| Shape | Example |
|---|---|
| finite verb | `Ich rufe den Kalender ab` |
| modal + trailing infinitive | `Ich werde den Kalender abrufen` |
| inversion | `Jetzt schaue ich in den Kalender` |
| `lass mich` | `Lass mich das kurz prüfen` |

The English branch is unchanged — it's now one alternative in a top-level group rather than the whole pattern.

Umlauts are written as `\uXXXX` escapes so the pattern stays ASCII-safe in source.

## Verification

Extracted the compiled pattern from the patched file and ran it against positive and negative cases:

**Matches (was: silently ignored)**
- `Ich rufe jetzt Ihren Kalender ab:`
- `Ich rufe jetzt Ihren Kalender für den Zeitraum von heute bis Ende November 2026`
- `Ich prüfe deine Termine.`
- `Ich werde deinen Kalender abrufen`
- `Lass mich das kurz prüfen`
- `Jetzt schaue ich in den Kalender`
- `Ich suche passende Termine`

**Still matches (English regression guard)**
- `Let me check the calendar`
- `I'll fetch the events`
- `Let me tail the output to see the error`
- `I need to investigate the logs`

**Correctly ignored (no false nudges)**
- `Ich hoffe, das hilft dir weiter.`
- `Das Ergebnis ist 56.`
- `Ich freue mich, dass es geklappt hat.`
- `Hier sind deine drei Terminvorschläge:`
- `Der Termin am 12.08. ist bereits belegt.`
- `Wir sehen uns morgen.`
- `Ich danke dir für die Info.`
- `let me know what you think`

The negative cases matter as much as the positive ones — the existing comment notes the pattern deliberately avoids nudging on harmless transitional text, and the German branch keeps that property (`Ich hoffe…`, `Ich freue mich…`, `Wir sehen uns…` all stay unmatched because they aren't in the action-verb list).

Running patched in production on a self-hosted instance.

## Notes

- Only German is added here, since that's what I could actually test against real traffic. The structure makes additional languages a matter of adding one alternative each — happy to extend if maintainers want more in this PR.
- No behaviour change for English deployments.
