### PR TITLE
fix(security): pin + cap outbound image fetches and consolidate the SSRF fetcher

### DIFF
--- a/routes/gallery/gallery_routes.py
+++ b/routes/gallery/gallery_routes.py
@@ -309,23 +309,28 @@ async def _fetch_result_image_b64(url: str) -> Optional[str]:
 
     The URL comes from the diffusion/OpenAI server's response, not from our own
     config, so a malicious or compromised endpoint could otherwise steer this
-    fetch at an internal or cloud-metadata address. Validate it the same way the
-    client-supplied endpoint is validated before the first request.
+    fetch at an internal or cloud-metadata address. Use the shared outbound
+    fetcher, which resolves once, validates as public, pins the TCP connect to
+    that IP, and refuses the fetch on private addresses — there is no env-flag
+    opt-out for this hop because the operator-configured-endpoint rationale in
+    ``src/url_safety.py`` does not extend to an arbitrary URL a remote server
+    hands back (#5888).
     """
+    import asyncio
     import base64
-    import httpx
-    from src.url_safety import check_outbound_url
 
-    ok, reason = check_outbound_url(
-        url,
-        block_private=os.getenv("IMAGE_BLOCK_PRIVATE_IPS", "false").lower() == "true",
-    )
-    if not ok:
-        raise HTTPException(502, f"Upstream returned an unsafe image URL: {reason}")
-    async with httpx.AsyncClient(timeout=60) as c2:
-        ir = await c2.get(url)
-        if ir.status_code == 200:
-            return base64.b64encode(ir.content).decode()
+    from src.outbound_fetch import fetch_public_url
+
+    # ``fetch_public_url`` is sync (manual redirect loop) — keep the event
+    # loop responsive by running it off-loop.
+    try:
+        response = await asyncio.to_thread(
+            fetch_public_url, url, {"Accept": "*/*"}, 60,
+        )
+    except httpx.HTTPError as exc:
+        raise HTTPException(502, f"Upstream returned an unsafe image URL: {exc}")
+    if response.status_code == 200:
+        return base64.b64encode(response.content).decode()
     return None
 
 

--- a/routes/gallery/gallery_routes.py
+++ b/routes/gallery/gallery_routes.py
@@ -318,6 +318,7 @@ async def _fetch_result_image_b64(url: str) -> Optional[str]:
     """
     import asyncio
     import base64
+    import httpx
 
     import src.outbound_fetch as outbound_fetch
 

--- a/routes/gallery/gallery_routes.py
+++ b/routes/gallery/gallery_routes.py
@@ -319,13 +319,13 @@ async def _fetch_result_image_b64(url: str) -> Optional[str]:
     import asyncio
     import base64
 
-    from src.outbound_fetch import fetch_public_url
+    import src.outbound_fetch as outbound_fetch
 
     # ``fetch_public_url`` is sync (manual redirect loop) — keep the event
     # loop responsive by running it off-loop.
     try:
         response = await asyncio.to_thread(
-            fetch_public_url, url, {"Accept": "*/*"}, 60,
+            outbound_fetch.fetch_public_url, url, {"Accept": "*/*"}, 60,
         )
     except httpx.HTTPError as exc:
         raise HTTPException(502, f"Upstream returned an unsafe image URL: {exc}")

--- a/services/search/content.py
+++ b/services/search/content.py
@@ -19,6 +19,7 @@ from src.outbound_fetch import (
     BodyTooLargeError,
     _CappedFetch,
     _is_private_address,
+    _PinnedBackend,
     _PinnedTransport,
     _resolve_hostname_ips,
     _resolve_public_ips,

--- a/services/search/content.py
+++ b/services/search/content.py
@@ -7,72 +7,41 @@ import json
 import os
 import re
 import logging
-import socket
-import ssl
 from datetime import datetime, timedelta
-from typing import Iterable, List, cast
-from urllib.parse import urljoin, urlparse
+from typing import List
+from urllib.parse import urlparse
 
 import httpx
-import httpcore
 from bs4 import BeautifulSoup
 
 from src.constants import WEB_FETCH_SOFT_MAX_BYTES, WEB_FETCH_HARD_MAX_BYTES, WEB_FETCH_USER_AGENT
-
-from .analytics import RateLimitError, error_logger
-from .cache import (
-    CONTENT_CACHE_DIR,
-    content_cache_index,
-    generate_cache_key,
-    cleanup_cache,
+from src.outbound_fetch import (
+    BodyTooLargeError,
+    _CappedFetch,
+    _is_private_address,
+    _PinnedTransport,
+    _resolve_hostname_ips,
+    _resolve_public_ips,
+    fetch_public_url,
 )
-
-logger = logging.getLogger(__name__)
-
-_PRIVATE_NETWORKS = (
-    ipaddress.ip_network("0.0.0.0/8"),
-    ipaddress.ip_network("10.0.0.0/8"),
-    ipaddress.ip_network("127.0.0.0/8"),
-    ipaddress.ip_network("169.254.0.0/16"),
-    ipaddress.ip_network("172.16.0.0/12"),
-    ipaddress.ip_network("192.168.0.0/16"),
-    ipaddress.ip_network("::1/128"),
-    ipaddress.ip_network("fc00::/7"),
-    ipaddress.ip_network("fe80::/10"),
-)
-
-
-def _is_private_address(addr: ipaddress._BaseAddress) -> bool:
-    if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped is not None:
-        addr = addr.ipv4_mapped
-    return (
-        addr.is_private
-        or addr.is_loopback
-        or addr.is_link_local
-        or addr.is_reserved
-        or addr.is_multicast
-        or addr.is_unspecified
-        or any(addr in net for net in _PRIVATE_NETWORKS)
-    )
-
-
-def _resolve_hostname_ips(hostname: str) -> list[ipaddress._BaseAddress]:
-    try:
-        infos = socket.getaddrinfo(hostname, None)
-    except Exception:
-        return []
-    out = []
-    for info in infos:
-        try:
-            out.append(ipaddress.ip_address(info[4][0]))
-        except Exception:
-            continue
-    return out
 
 
 def _public_http_url(url: str) -> bool:
+    """Strict public-HTTP guard used by search-content fetchers.
+
+    Stricter than :func:`src.url_security.is_public_http_url`: in addition
+    to rejecting private/loopback/link-local addresses it also refuses
+    ``.local`` / ``.localhost`` / ``.internal`` / ``.lan`` / ``.intranet``
+    hostnames and the ``metadata`` / ``metadata.google.internal`` names.
+    Kept here (not moved to ``src.outbound_fetch``) because the
+    search-content fetchers are the only callers and moving it would
+    broaden the surface area of this PR for no functional gain.
+    """
     try:
-        parsed = urlparse(url)
+        import ipaddress as _ip
+        from urllib.parse import urlparse as _urlparse
+
+        parsed = _urlparse(url)
         if parsed.scheme not in ("http", "https"):
             return False
         host = (parsed.hostname or "").strip()
@@ -84,7 +53,7 @@ def _public_http_url(url: str) -> bool:
         if lower.endswith((".local", ".localhost", ".internal", ".lan", ".intranet")):
             return False
         try:
-            return not _is_private_address(ipaddress.ip_address(host))
+            return not _is_private_address(_ip.ip_address(host))
         except ValueError:
             pass
         addrs = _resolve_hostname_ips(host)
@@ -93,271 +62,27 @@ def _public_http_url(url: str) -> bool:
         return False
 
 
-def _resolve_public_ips(url: str) -> list[ipaddress._BaseAddress]:
-    parsed = urlparse(url)
-    if parsed.scheme not in ("http", "https") or not parsed.hostname:
-        raise httpx.RequestError(f"Blocked non-public URL: {url}")
-    host = (parsed.hostname or "").strip().lower()
-    if host in ("localhost", "metadata", "metadata.google.internal"):
-        raise httpx.RequestError(f"Blocked non-public hostname: {host}")
-    try:
-        ip = ipaddress.ip_address(host)
-        if _is_private_address(ip):
-            raise httpx.RequestError(f"Blocked non-public IP literal: {host}")
-        return [ip]
-    except httpx.RequestError:
-        raise
-    except ValueError:
-        pass
-    addrs = _resolve_hostname_ips(host)
-    if not addrs or any(_is_private_address(a) for a in addrs):
-        raise httpx.RequestError(f"Blocked non-public URL: {url}")
-    return addrs
+# Re-exported under the historical module-local name so existing callers
+# and the existing ``services.search.content._get_public_url`` monkeypatch
+# in ``tests/test_search_content_extraction_parity.py`` keep working
+# unchanged. The implementation now lives in ``src.outbound_fetch``; new
+# callers should import ``fetch_public_url`` from there directly.
+_get_public_url = fetch_public_url
+
+from .analytics import RateLimitError, error_logger
+from .cache import (
+    CONTENT_CACHE_DIR,
+    content_cache_index,
+    generate_cache_key,
+    cleanup_cache,
+)
+
+logger = logging.getLogger(__name__)
 
 
-class _PinnedBackend(httpcore.NetworkBackend):
-    """Network backend that connects to a pre-resolved IP.
-
-    httpcore derives the TLS SNI and the ``Host`` header from the URL's
-    origin, not from the host argument passed to ``connect_tcp``. So
-    routing the TCP connect to a resolved IP while leaving the URL
-    untouched keeps SNI / vhost behaviour correct and closes the
-    DNS-rebinding TOCTOU between the SSRF check and the connect.
-    """
-
-    def __init__(self, ip: ipaddress._BaseAddress):
-        self._ip = str(ip)
-        self._real = httpcore.SyncBackend()
-
-    def connect_tcp(
-        self,
-        host: str,
-        port: int,
-        timeout: float | None = None,
-        local_address: str | None = None,
-        socket_options=None,
-    ):
-        return self._real.connect_tcp(
-            self._ip, port, timeout, local_address, socket_options
-        )
-
-    def connect_unix_socket(self, path, timeout=None, socket_options=None):
-        return self._real.connect_unix_socket(path, timeout, socket_options)
-
-    def sleep(self, seconds: float) -> None:
-        return self._real.sleep(seconds)
-
-
-# Map httpcore exception classes to their httpx equivalents. Built
-# once at import time from the public exception classes; avoids any
-# import of httpx's private transport machinery. httpcore's
-# ``ConnectionNotAvailable`` is a pool-internal signal (the pool will
-# close and retry on its own) — we never expect to see it surface to
-# a transport caller, so it has no httpx counterpart here.
-_HTTPCORE_TO_HTTPX_EXC = {
-    httpcore.ConnectError: httpx.ConnectError,
-    httpcore.ConnectTimeout: httpx.ConnectTimeout,
-    httpcore.LocalProtocolError: httpx.LocalProtocolError,
-    httpcore.NetworkError: httpx.NetworkError,
-    httpcore.PoolTimeout: httpx.PoolTimeout,
-    httpcore.ProtocolError: httpx.ProtocolError,
-    httpcore.ProxyError: httpx.ProxyError,
-    httpcore.ReadError: httpx.ReadError,
-    httpcore.ReadTimeout: httpx.ReadTimeout,
-    httpcore.RemoteProtocolError: httpx.RemoteProtocolError,
-    httpcore.TimeoutException: httpx.TimeoutException,
-    httpcore.UnsupportedProtocol: httpx.UnsupportedProtocol,
-    httpcore.WriteError: httpx.WriteError,
-    httpcore.WriteTimeout: httpx.WriteTimeout,
-}
-
-
-class _PinnedTransport(httpx.BaseTransport):
-    """Transport that pins every TCP connect to a pre-resolved IP.
-
-    Uses only the public ``httpcore`` and ``httpx`` APIs — no
-    subclassing of ``httpx.HTTPTransport``, no reads of private
-    ``httpcore.ConnectionPool`` attributes, no imports from
-    ``httpx private transport internals``. The URL is passed through unchanged so SNI
-    / vhost work as if httpx had been given the hostname directly;
-    only the TCP destination is pinned, closing the DNS-rebinding
-    TOCTOU between the SSRF check and the connect.
-    """
-
-    def __init__(self, ip: ipaddress._BaseAddress, *, http2: bool = False):
-        self._pool = httpcore.ConnectionPool(
-            ssl_context=ssl.create_default_context(),
-            http1=True,
-            http2=http2,
-            network_backend=_PinnedBackend(ip),
-        )
-
-    def __enter__(self):
-        self._pool.__enter__()
-        return self
-
-    def __exit__(self, exc_type=None, exc_value=None, traceback=None) -> None:
-        self._pool.__exit__(exc_type, exc_value, traceback)
-
-    def handle_request(self, request: httpx.Request) -> httpx.Response:
-        httpcore_req = httpcore.Request(
-            method=request.method,
-            url=httpcore.URL(
-                scheme=request.url.raw_scheme,
-                host=request.url.raw_host,
-                port=request.url.port,
-                target=request.url.raw_path,
-            ),
-            headers=request.headers.raw,
-            content=request.stream,
-            extensions=request.extensions,
-        )
-        try:
-            httpcore_resp = self._pool.handle_request(httpcore_req)
-            # Eager materialisation matches the original
-            # ``response.text`` usage in fetch_webpage_content. The
-            # sync pool's stream is a plain Iterable[bytes] despite
-            # the httpcore type hint unioning the async variant.
-            content = b"".join(cast(Iterable[bytes], httpcore_resp.stream))
-        except Exception as exc:
-            mapped = _HTTPCORE_TO_HTTPX_EXC.get(type(exc))
-            if mapped is not None:
-                raise mapped(str(exc)) from exc
-            raise
-
-        return httpx.Response(
-            status_code=httpcore_resp.status,
-            headers=httpcore_resp.headers,
-            content=content,
-            extensions=httpcore_resp.extensions,
-        )
-
-    def close(self) -> None:
-        self._pool.close()
-
-class BodyTooLargeError(Exception):
-    """The server declared a body larger than the hard fetch ceiling."""
-
-    def __init__(self, url: str, declared_bytes: int):
-        self.url = url
-        self.declared_bytes = declared_bytes
-        super().__init__(
-            f"response body is {declared_bytes:,} bytes, over the "
-            f"{WEB_FETCH_HARD_MAX_BYTES:,}-byte hard cap"
-        )
-
-
-class _CappedFetch:
-    """Result of a size-capped streaming GET.
-
-    Carries just what fetch_webpage_content needs from an httpx.Response,
-    plus the cap bookkeeping: the (possibly truncated) body, whether the
-    cap cut it short, and the size the server declared via Content-Length
-    (wire bytes; None when absent).
-    """
-
-    __slots__ = ("status_code", "headers", "content", "truncated",
-                 "declared_bytes", "encoding", "url")
-
-    def __init__(self, status_code, headers, content, truncated,
-                 declared_bytes, encoding, url):
-        self.status_code = status_code
-        self.headers = headers
-        self.content = content
-        self.truncated = truncated
-        self.declared_bytes = declared_bytes
-        self.encoding = encoding
-        self.url = url
-
-    @property
-    def text(self) -> str:
-        return self.content.decode(self.encoding or "utf-8", errors="replace")
-
-    def raise_for_status(self):
-        if self.status_code >= 400:
-            request = httpx.Request("GET", self.url)
-            raise httpx.HTTPStatusError(
-                f"HTTP {self.status_code} for {self.url}",
-                request=request,
-                response=httpx.Response(self.status_code, request=request),
-            )
-
-
-def _get_public_url(url: str, headers: dict, timeout: int, max_redirects: int = 5,
-                    max_bytes: int = None) -> "_CappedFetch":
-    """Capped streaming GET with SSRF-guarded, DNS-pinned manual redirects.
-
-    Each hop is resolved once, validated as public, and then the actual TCP
-    connection is pinned to that resolved IP. The request URL is left unchanged
-    so Host and TLS SNI keep the original hostname.
-    """
-    cap = min(max_bytes or WEB_FETCH_SOFT_MAX_BYTES, WEB_FETCH_HARD_MAX_BYTES)
-    current = url
-    for _ in range(max_redirects + 1):
-        ips = _resolve_public_ips(current)
-
-        # Force identity transfer-encoding. With gzip/deflate the wire bytes
-        # and Content-Length can be a small fraction of the decoded body, so a
-        # tiny compressed response could pass the hard-cap preflight and then
-        # expand past the ceiling in one decoded chunk before the streamed cap
-        # below can slice it.
-        req_headers = dict(headers or {})
-        req_headers["Accept-Encoding"] = "identity"
-
-        with httpx.Client(
-            headers=req_headers,
-            timeout=timeout,
-            follow_redirects=False,
-            transport=_PinnedTransport(ips[0]),
-        ) as client:
-            with client.stream("GET", current) as response:
-                if response.status_code in (301, 302, 303, 307, 308):
-                    location = response.headers.get("location")
-                    if not location:
-                        return _CappedFetch(response.status_code, response.headers, b"",
-                                            False, None, response.encoding, str(response.url))
-                    current = urljoin(str(response.url), location)
-                    continue
-
-                # A server can ignore the identity request and still return a
-                # compressed body; httpx.iter_bytes would then decode it, and a
-                # tiny gzip can balloon into one decoded chunk far past the cap.
-                # Refuse compressed Content-Encoding so the streamed cap stays
-                # a real memory bound.
-                enc = (response.headers.get("content-encoding") or "").strip().lower()
-                if enc and enc != "identity":
-                    raise httpx.RequestError(
-                        f"Refusing compressed response (Content-Encoding: {enc}) after "
-                        "requesting identity: cannot bound decoded body size",
-                        request=httpx.Request("GET", current),
-                    )
-
-                declared = None
-                raw_len = response.headers.get("content-length")
-                if raw_len and raw_len.isdigit():
-                    declared = int(raw_len)
-
-                if declared is not None and declared > WEB_FETCH_HARD_MAX_BYTES:
-                    raise BodyTooLargeError(current, declared)
-
-                chunks = []
-                read = 0
-                truncated = False
-                for chunk in response.iter_bytes():
-                    read += len(chunk)
-                    if read > cap:
-                        keep = cap - (read - len(chunk))
-                        if keep > 0:
-                            chunks.append(chunk[:keep])
-                        truncated = True
-                        break
-                    chunks.append(chunk)
-
-                return _CappedFetch(response.status_code, response.headers,
-                                    b"".join(chunks), truncated, declared,
-                                    response.encoding, str(response.url))
-
-    raise httpx.RequestError("Too many redirects", request=httpx.Request("GET", current))
+# Backwards-compatible aliases for the SSRF helpers that used to live
+# here. Kept so the search-content call sites below keep reading
+# naturally; new code should import from ``src.outbound_fetch`` directly.
 
 # PDF extraction (optional dependency)
 try:

--- a/src/ai_interaction.py
+++ b/src/ai_interaction.py
@@ -936,9 +936,8 @@ async def do_generate_image(content: str, session_id: Optional[str] = None, owne
     """
     import base64
     import httpx
-    import os
     from pathlib import Path
-    from src.url_safety import check_outbound_url
+    from src.outbound_fetch import fetch_public_url
 
     lines = content.strip().split("\n")
     prompt = lines[0].strip() if lines else ""
@@ -1125,16 +1124,18 @@ async def do_generate_image(content: str, session_id: Optional[str] = None, owne
                 image_id = _save_to_gallery(filename)
 
             elif img.get("url"):
-                # Download external URL and save locally (DALL-E returns temp URLs)
+                # Download external URL and save locally (DALL-E returns temp URLs).
+                # The URL came back from the upstream API, so route it through
+                # the shared outbound fetcher to close the DNS-rebinding TOCTOU
+                # and unconditionally refuse private addresses (#5888).
                 result_url = img["url"]
-                ok, reason = check_outbound_url(
-                    result_url,
-                    block_private=os.getenv("IMAGE_BLOCK_PRIVATE_IPS", "false").lower() == "true",
-                )
-                if not ok:
-                    return {"error": f"Image API returned unsafe image URL: {reason}"}
                 try:
-                    dl_resp = httpx.get(result_url, timeout=60)
+                    dl_resp = await asyncio.to_thread(
+                        fetch_public_url,
+                        result_url,
+                        {"Accept": "*/*"},
+                        60,
+                    )
                     if dl_resp.status_code == 200:
                         img_dir = Path(GENERATED_IMAGES_DIR)
                         img_dir.mkdir(parents=True, exist_ok=True)
@@ -1145,6 +1146,8 @@ async def do_generate_image(content: str, session_id: Optional[str] = None, owne
                         image_id = _save_to_gallery(filename)
                     else:
                         image_url = result_url  # fallback to external URL
+                except httpx.HTTPError as _unsafe_e:
+                    return {"error": f"Image API returned unsafe image URL: {_unsafe_e}"}
                 except Exception as _dl_e:
                     logger.warning(f"Failed to download DALL-E image: {_dl_e}")
                     image_url = result_url  # fallback to external URL
@@ -1181,9 +1184,8 @@ async def do_edit_image(
     import base64
     import httpx
     import mimetypes
-    import os
     from pathlib import Path
-    from src.url_safety import check_outbound_url
+    from src.outbound_fetch import fetch_public_url
 
     prompt = (prompt or "").strip()
     if not prompt:
@@ -1399,17 +1401,22 @@ async def do_edit_image(
             if img.get("b64_json"):
                 image_url, image_id = _save_image_bytes(base64.b64decode(img.get("b64_json")))
             elif img.get("url"):
+                # The URL came back from the upstream API, so route it through
+                # the shared outbound fetcher to close the DNS-rebinding TOCTOU
+                # and unconditionally refuse private addresses (#5888).
                 result_url = img["url"]
-                ok, reason = check_outbound_url(
-                    result_url,
-                    block_private=os.getenv("IMAGE_BLOCK_PRIVATE_IPS", "false").lower() == "true",
-                )
-                if not ok:
-                    return {"error": f"Image edit API returned unsafe image URL: {reason}"}
-                dl_resp = httpx.get(result_url, timeout=60)
-                if dl_resp.status_code != 200:
-                    return {"error": f"Could not download edited image ({dl_resp.status_code})"}
-                image_url, image_id = _save_image_bytes(dl_resp.content)
+                try:
+                    dl_resp = await asyncio.to_thread(
+                        fetch_public_url,
+                        result_url,
+                        {"Accept": "*/*"},
+                        60,
+                    )
+                    if dl_resp.status_code != 200:
+                        return {"error": f"Could not download edited image ({dl_resp.status_code})"}
+                    image_url, image_id = _save_image_bytes(dl_resp.content)
+                except httpx.HTTPError as _unsafe_e:
+                    return {"error": f"Image edit API returned unsafe image URL: {_unsafe_e}"}
             else:
                 return {"error": "Image edit API returned unexpected format (no b64_json or url)"}
 

--- a/src/ai_interaction.py
+++ b/src/ai_interaction.py
@@ -937,7 +937,7 @@ async def do_generate_image(content: str, session_id: Optional[str] = None, owne
     import base64
     import httpx
     from pathlib import Path
-    from src.outbound_fetch import fetch_public_url
+    import src.outbound_fetch as outbound_fetch
 
     lines = content.strip().split("\n")
     prompt = lines[0].strip() if lines else ""
@@ -1131,7 +1131,7 @@ async def do_generate_image(content: str, session_id: Optional[str] = None, owne
                 result_url = img["url"]
                 try:
                     dl_resp = await asyncio.to_thread(
-                        fetch_public_url,
+                        outbound_fetch.fetch_public_url,
                         result_url,
                         {"Accept": "*/*"},
                         60,
@@ -1185,7 +1185,7 @@ async def do_edit_image(
     import httpx
     import mimetypes
     from pathlib import Path
-    from src.outbound_fetch import fetch_public_url
+    import src.outbound_fetch as outbound_fetch
 
     prompt = (prompt or "").strip()
     if not prompt:
@@ -1407,7 +1407,7 @@ async def do_edit_image(
                 result_url = img["url"]
                 try:
                     dl_resp = await asyncio.to_thread(
-                        fetch_public_url,
+                        outbound_fetch.fetch_public_url,
                         result_url,
                         {"Accept": "*/*"},
                         60,

--- a/src/outbound_fetch.py
+++ b/src/outbound_fetch.py
@@ -1,0 +1,380 @@
+"""Single shared outbound HTTP fetcher used wherever Odysseus downloads content
+from a URL supplied by an upstream response body (search snippets, gallery
+results, image-generation providers, …).
+
+Why this module exists
+----------------------
+Three places in the codebase used to do ``check_outbound_url(...)`` + a
+plain ``httpx.get`` to fetch a URL that came back from an upstream API.
+That pair has two security holes:
+
+1. **DNS-rebinding TOCTOU.** ``check_outbound_url`` resolves the host
+   once to classify it, then returns only ``(ok, reason)``. The HTTP
+   client resolves the host *again* at connect time, so a low-TTL
+   record can hand the guard a public IP and the socket a link-local
+   one (cloud metadata, internal admin panels). The same family of
+   bugs was fixed for ``execute_api_call`` in #5727 and is still open
+   for the skill importer in #5609.
+
+2. **Private-network reachability by default.** The image sites pass
+   ``block_private=os.getenv("IMAGE_BLOCK_PRIVATE_IPS", "false")``,
+   so at the shipped default loopback and RFC1918 are reachable. The
+   operator-configured endpoint rationale in ``src/url_safety.py`` is
+   about a *first* hop the admin chose, not an arbitrary URL an
+   upstream server hands back.
+
+This module provides ``fetch_public_url``, a streaming GET with:
+
+* per-hop DNS resolution through ``_resolve_public_ips`` (rejects
+  private / loopback / link-local / reserved / multicast / unspecified
+  addresses, and the ``localhost`` and ``metadata.google.internal``
+  hostnames),
+* a TCP connect pinned to that resolved IP via ``_PinnedTransport``
+  (closes the rebinding TOCTOU without changing TLS SNI or Host),
+* a hard body-size ceiling that is enforced on the wire bytes (with
+  ``Accept-Encoding: identity`` forced and compressed responses
+  refused so the ceiling is a real memory bound),
+* manual redirect handling so each hop is re-validated and re-pinned.
+
+``services.search.content._get_public_url`` is the original home of
+this code (see ``#704``); it was moved here so the three image sites
+and any future caller share one implementation instead of each
+copying the same drift-prone snippet.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import socket
+import ssl
+from typing import Iterable, cast
+from urllib.parse import urljoin, urlparse
+
+import httpcore
+import httpx
+
+from src.constants import WEB_FETCH_HARD_MAX_BYTES, WEB_FETCH_SOFT_MAX_BYTES
+
+logger = logging.getLogger(__name__)
+
+
+_PRIVATE_NETWORKS = (
+    ipaddress.ip_network("0.0.0.0/8"),
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fc00::/7"),
+    ipaddress.ip_network("fe80::/10"),
+)
+
+
+def _is_private_address(addr: ipaddress._BaseAddress) -> bool:
+    if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped is not None:
+        addr = addr.ipv4_mapped
+    return (
+        addr.is_private
+        or addr.is_loopback
+        or addr.is_link_local
+        or addr.is_reserved
+        or addr.is_multicast
+        or addr.is_unspecified
+        or any(addr in net for net in _PRIVATE_NETWORKS)
+    )
+
+
+def _resolve_hostname_ips(hostname: str) -> list[ipaddress._BaseAddress]:
+    try:
+        infos = socket.getaddrinfo(hostname, None)
+    except Exception:
+        return []
+    out = []
+    for info in infos:
+        try:
+            out.append(ipaddress.ip_address(info[4][0]))
+        except Exception:
+            continue
+    return out
+
+
+def _resolve_public_ips(url: str) -> list[ipaddress.IPv4Address | ipaddress.IPv6Address]:
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        raise httpx.RequestError(f"Blocked non-public URL: {url}")
+    host = (parsed.hostname or "").strip().lower()
+    if host in ("localhost", "metadata", "metadata.google.internal"):
+        raise httpx.RequestError(f"Blocked non-public hostname: {host}")
+    try:
+        ip = ipaddress.ip_address(host)
+        if _is_private_address(ip):
+            raise httpx.RequestError(f"Blocked non-public IP literal: {host}")
+        return [ip]
+    except httpx.RequestError:
+        raise
+    except ValueError:
+        pass
+    addrs = _resolve_hostname_ips(host)
+    if not addrs or any(_is_private_address(a) for a in addrs):
+        raise httpx.RequestError(f"Blocked non-public URL: {url}")
+    return addrs
+
+
+class _PinnedBackend(httpcore.NetworkBackend):
+    """Network backend that connects to a pre-resolved IP.
+
+    httpcore derives the TLS SNI and the ``Host`` header from the URL's
+    origin, not from the host argument passed to ``connect_tcp``. So
+    routing the TCP connect to a resolved IP while leaving the URL
+    untouched keeps SNI / vhost behaviour correct and closes the
+    DNS-rebinding TOCTOU between the SSRF check and the connect.
+    """
+
+    def __init__(self, ip: ipaddress._BaseAddress):
+        self._ip = str(ip)
+        self._real = httpcore.SyncBackend()
+
+    def connect_tcp(
+        self,
+        host: str,
+        port: int,
+        timeout: float | None = None,
+        local_address: str | None = None,
+        socket_options=None,
+    ):
+        return self._real.connect_tcp(
+            self._ip, port, timeout, local_address, socket_options
+        )
+
+    def connect_unix_socket(self, path, timeout=None, socket_options=None):
+        return self._real.connect_unix_socket(path, timeout, socket_options)
+
+    def sleep(self, seconds: float) -> None:
+        return self._real.sleep(seconds)
+
+
+# Map httpcore exception classes to their httpx equivalents. Built
+# once at import time from the public exception classes; avoids any
+# import of httpx's private transport machinery. httpcore's
+# ``ConnectionNotAvailable`` is a pool-internal signal (the pool will
+# close and retry on its own) — we never expect to see it surface to
+# a transport caller, so it has no httpx counterpart here.
+_HTTPCORE_TO_HTTPX_EXC = {
+    httpcore.ConnectError: httpx.ConnectError,
+    httpcore.ConnectTimeout: httpx.ConnectTimeout,
+    httpcore.LocalProtocolError: httpx.LocalProtocolError,
+    httpcore.NetworkError: httpx.NetworkError,
+    httpcore.PoolTimeout: httpx.PoolTimeout,
+    httpcore.ProtocolError: httpx.ProtocolError,
+    httpcore.ProxyError: httpx.ProxyError,
+    httpcore.ReadError: httpx.ReadError,
+    httpcore.ReadTimeout: httpx.ReadTimeout,
+    httpcore.RemoteProtocolError: httpx.RemoteProtocolError,
+    httpcore.TimeoutException: httpx.TimeoutException,
+    httpcore.UnsupportedProtocol: httpx.UnsupportedProtocol,
+    httpcore.WriteError: httpx.WriteError,
+    httpcore.WriteTimeout: httpx.WriteTimeout,
+}
+
+
+class _PinnedTransport(httpx.BaseTransport):
+    """Transport that pins every TCP connect to a pre-resolved IP.
+
+    Uses only the public ``httpcore`` and ``httpx`` APIs — no
+    subclassing of ``httpx.HTTPTransport``, no reads of private
+    ``httpcore.ConnectionPool`` attributes, no imports from
+    ``httpx``'s private transport internals. The URL is passed through
+    unchanged so SNI / vhost work as if httpx had been given the
+    hostname directly; only the TCP destination is pinned, closing the
+    DNS-rebinding TOCTOU between the SSRF check and the connect.
+    """
+
+    def __init__(self, ip: ipaddress._BaseAddress, *, http2: bool = False):
+        self._pool = httpcore.ConnectionPool(
+            ssl_context=ssl.create_default_context(),
+            http1=True,
+            http2=http2,
+            network_backend=_PinnedBackend(ip),
+        )
+
+    def __enter__(self):
+        self._pool.__enter__()
+        return self
+
+    def __exit__(self, exc_type=None, exc_value=None, traceback=None) -> None:
+        self._pool.__exit__(exc_type, exc_value, traceback)
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        httpcore_req = httpcore.Request(
+            method=request.method,
+            url=httpcore.URL(
+                scheme=request.url.raw_scheme,
+                host=request.url.raw_host,
+                port=request.url.port,
+                target=request.url.raw_path,
+            ),
+            headers=request.headers.raw,
+            content=request.stream,
+            extensions=request.extensions,
+        )
+        try:
+            httpcore_resp = self._pool.handle_request(httpcore_req)
+            # Eager materialisation matches the original
+            # ``response.text`` usage in fetch_webpage_content. The
+            # sync pool's stream is a plain Iterable[bytes] despite
+            # the httpcore type hint unioning the async variant.
+            content = b"".join(cast(Iterable[bytes], httpcore_resp.stream))
+        except Exception as exc:
+            mapped = _HTTPCORE_TO_HTTPX_EXC.get(type(exc))
+            if mapped is not None:
+                raise mapped(str(exc)) from exc
+            raise
+
+        return httpx.Response(
+            status_code=httpcore_resp.status,
+            headers=httpcore_resp.headers,
+            content=content,
+            extensions=httpcore_resp.extensions,
+        )
+
+    def close(self) -> None:
+        self._pool.close()
+
+
+class BodyTooLargeError(Exception):
+    """The server declared a body larger than the hard fetch ceiling."""
+
+    def __init__(self, url: str, declared_bytes: int):
+        self.url = url
+        self.declared_bytes = declared_bytes
+        super().__init__(
+            f"response body is {declared_bytes:,} bytes, over the "
+            f"{WEB_FETCH_HARD_MAX_BYTES:,}-byte hard cap"
+        )
+
+
+class _CappedFetch:
+    """Result of a size-capped streaming GET.
+
+    Carries just what callers need from an httpx.Response plus the cap
+    bookkeeping: the (possibly truncated) body, whether the cap cut it
+    short, and the size the server declared via Content-Length (wire
+    bytes; None when absent).
+    """
+
+    __slots__ = ("status_code", "headers", "content", "truncated",
+                 "declared_bytes", "encoding", "url")
+
+    def __init__(self, status_code, headers, content, truncated,
+                 declared_bytes, encoding, url):
+        self.status_code = status_code
+        self.headers = headers
+        self.content = content
+        self.truncated = truncated
+        self.declared_bytes = declared_bytes
+        self.encoding = encoding
+        self.url = url
+
+    @property
+    def text(self) -> str:
+        return self.content.decode(self.encoding or "utf-8", errors="replace")
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            request = httpx.Request("GET", self.url)
+            raise httpx.HTTPStatusError(
+                f"HTTP {self.status_code} for {self.url}",
+                request=request,
+                response=httpx.Response(self.status_code, request=request),
+            )
+
+
+def fetch_public_url(
+    url: str,
+    headers: dict | None = None,
+    timeout: int = 30,
+    max_redirects: int = 5,
+    max_bytes: int | None = None,
+) -> _CappedFetch:
+    """Capped streaming GET with SSRF-guarded, DNS-pinned manual redirects.
+
+    Each hop is resolved once, validated as public, and then the actual TCP
+    connection is pinned to that resolved IP. The request URL is left unchanged
+    so Host and TLS SNI keep the original hostname.
+
+    ``timeout`` is seconds (int) for backward-compatibility with callers that
+    pass an int; httpx also accepts a float.
+    """
+    cap = min(max_bytes or WEB_FETCH_SOFT_MAX_BYTES, WEB_FETCH_HARD_MAX_BYTES)
+    current = url
+    for _ in range(max_redirects + 1):
+        ips = _resolve_public_ips(current)
+
+        # Force identity transfer-encoding. With gzip/deflate the wire bytes
+        # and Content-Length can be a small fraction of the decoded body, so a
+        # tiny compressed response could pass the hard-cap preflight and then
+        # expand past the ceiling in one decoded chunk before the streamed cap
+        # below can slice it.
+        req_headers = dict(headers or {})
+        req_headers["Accept-Encoding"] = "identity"
+
+        with httpx.Client(
+            headers=req_headers,
+            timeout=timeout,
+            follow_redirects=False,
+            transport=_PinnedTransport(ips[0]),
+        ) as client:
+            with client.stream("GET", current) as response:
+                if response.status_code in (301, 302, 303, 307, 308):
+                    location = response.headers.get("location")
+                    if not location:
+                        return _CappedFetch(
+                            response.status_code, response.headers, b"",
+                            False, None, response.encoding, str(response.url),
+                        )
+                    current = urljoin(str(response.url), location)
+                    continue
+
+                # A server can ignore the identity request and still return a
+                # compressed body; httpx.iter_bytes would then decode it, and a
+                # tiny gzip can balloon into one decoded chunk far past the cap.
+                # Refuse compressed Content-Encoding so the streamed cap stays
+                # a real memory bound.
+                enc = (response.headers.get("content-encoding") or "").strip().lower()
+                if enc and enc != "identity":
+                    raise httpx.RequestError(
+                        f"Refusing compressed response (Content-Encoding: {enc}) after "
+                        "requesting identity: cannot bound decoded body size",
+                        request=httpx.Request("GET", current),
+                    )
+
+                declared = None
+                raw_len = response.headers.get("content-length")
+                if raw_len and raw_len.isdigit():
+                    declared = int(raw_len)
+
+                if declared is not None and declared > WEB_FETCH_HARD_MAX_BYTES:
+                    raise BodyTooLargeError(current, declared)
+
+                chunks = []
+                read = 0
+                truncated = False
+                for chunk in response.iter_bytes():
+                    read += len(chunk)
+                    if read > cap:
+                        keep = cap - (read - len(chunk))
+                        if keep > 0:
+                            chunks.append(chunk[:keep])
+                        truncated = True
+                        break
+                    chunks.append(chunk)
+
+                return _CappedFetch(
+                    response.status_code, response.headers,
+                    b"".join(chunks), truncated, declared,
+                    response.encoding, str(response.url),
+                )
+
+    raise httpx.RequestError("Too many redirects", request=httpx.Request("GET", current))

--- a/tests/test_ai_image_url_safety.py
+++ b/tests/test_ai_image_url_safety.py
@@ -154,7 +154,7 @@ async def test_generate_image_blocks_link_local_result_without_fetch(monkeypatch
 
     result = await ai_interaction.do_generate_image("draw a chair\ndall-e-3")
 
-    assert "error" in result
+    assert "error" in result, result
     assert "unsafe image URL" in result["error"]
 
 

--- a/tests/test_ai_image_url_safety.py
+++ b/tests/test_ai_image_url_safety.py
@@ -18,6 +18,7 @@ unconditionally refusing private addresses (#5888). These tests pin the new
 behaviour.
 """
 import pytest
+import httpx
 
 from src import ai_interaction
 

--- a/tests/test_ai_image_url_safety.py
+++ b/tests/test_ai_image_url_safety.py
@@ -17,8 +17,9 @@ which closes both holes by resolving once, pinning the TCP connect, and
 unconditionally refusing private addresses (#5888). These tests pin the new
 behaviour.
 """
-from src import ai_interaction
 import pytest
+
+from src import ai_interaction
 
 
 class _GenerationResponse:
@@ -38,7 +39,7 @@ class _AsyncClient:
     separately below."""
 
     def __init__(self, *args, **kwargs):
-        pass
+        self._image_url = "https://provider.invalid/x.png"
 
     async def __aenter__(self):
         return self
@@ -46,8 +47,8 @@ class _AsyncClient:
     async def __aexit__(self, *exc):
         return False
 
-    def post(self, url, json, headers):  # pragma: no cover - body irrelevant
-        return _GenerationResponse("https://provider.invalid/x.png")
+    async def post(self, url, json, headers):  # pragma: no cover - body irrelevant
+        return _GenerationResponse(self._image_url)
 
 
 class _FakeResp:
@@ -59,31 +60,27 @@ class _FakeResp:
 class _RecordingFetch:
     """Stand-in for ``src.outbound_fetch.fetch_public_url``.
 
-    Records every call so tests can assert whether the unsafe URL was even
-    attempted.
+    Each call appends to ``_call_log`` (class-level) so tests can assert
+    what URL the helper attempted.
     """
 
-    instances: list["_RecordingFetch"] = []
+    _call_log: list = []
 
-    def __init__(self):
-        self.calls: list[tuple] = []
-        self.raise_on_call: Exception | None = None
-        self.return_status = 200
-        _RecordingFetch.instances.append(self)
+    def __init__(self, status_code=200, content=b"PNGDATA"):
+        self._status_code = status_code
+        self._content = content
 
     def __call__(self, url, headers=None, timeout=30, **kwargs):
-        self.calls.append((url, headers, timeout))
-        if self.raise_on_call is not None:
-            raise self.raise_on_call
-        return _FakeResp(status_code=self.return_status, content=b"PNGDATA")
+        _RecordingFetch._call_log.append((url, headers, timeout))
+        return _FakeResp(status_code=self._status_code, content=self._content)
 
 
 @pytest.fixture
 def patched_fetch(monkeypatch):
     """Stub the heavy bits so ``ai_interaction`` can be imported and exercised.
 
-    Returns the ``_RecordingFetch`` instance so individual tests can inspect
-    what ``fetch_public_url`` was called with.
+    Returns the ``_RecordingFetch`` factory so individual tests can swap in
+    a different ``status_code`` if they want.
     """
     import httpx
     import src.settings as settings
@@ -91,11 +88,10 @@ def patched_fetch(monkeypatch):
     monkeypatch.setattr(settings, "load_settings", lambda: {})
     monkeypatch.setattr(httpx, "AsyncClient", _AsyncClient)
 
+    _RecordingFetch._call_log = []
     import src.outbound_fetch as outbound_fetch
 
-    fetch = _RecordingFetch()
-    monkeypatch.setattr(outbound_fetch, "fetch_public_url", fetch)
-    _RecordingFetch.instances = [fetch]
+    monkeypatch.setattr(outbound_fetch, "fetch_public_url", _RecordingFetch())
 
     monkeypatch.setattr(
         ai_interaction,
@@ -106,60 +102,73 @@ def patched_fetch(monkeypatch):
             {"Authorization": "Bearer test"},
         ),
     )
-    return fetch
+    return _RecordingFetch
 
 
-async def test_generate_image_routes_public_result_through_shared_fetcher(patched_fetch):
-    provider_url = "https://images.example.com/generated.png?sig=abc"
-
-    # Patch the provider response to return our URL.
+def _provider_returns(monkeypatch, image_url):
+    """Make ``httpx.AsyncClient``'s ``post`` return a response whose JSON
+    carries ``image_url`` as the result URL."""
     import httpx
 
     class _Gen(_AsyncClient):
-        def post(self, url, json, headers):
-            return _GenerationResponse(provider_url)
+        def __init__(self, *args, **kwargs):
+            self._image_url = image_url
 
-    httpx.AsyncClient = _Gen  # type: ignore
+        async def post(self, url, json, headers):
+            return _GenerationResponse(self._image_url)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _Gen)
+
+
+async def test_generate_image_routes_public_result_through_shared_fetcher(monkeypatch, patched_fetch):
+    provider_url = "https://images.example.com/generated.png?sig=abc"
+    import httpx
+    import src.outbound_fetch as outbound_fetch
+
+    def _factory(url, headers=None, timeout=30, **kwargs):
+        _RecordingFetch._call_log.append((url, headers, timeout))
+        return _FakeResp(status_code=200, content=b"PNGDATA")
+
+    monkeypatch.setattr(outbound_fetch, "fetch_public_url", _factory)
+    _provider_returns(monkeypatch, provider_url)
 
     result = await ai_interaction.do_generate_image("draw a chair\ndall-e-3")
 
-    assert "error" not in result
-    assert patched_fetch.calls, "fetch_public_url must have been called"
-    assert patched_fetch.calls[0][0] == provider_url
+    assert "error" not in result, result
+    assert _RecordingFetch._call_log, "fetch_public_url must have been called"
+    assert _RecordingFetch._call_log[0][0] == provider_url
 
 
-async def test_generate_image_blocks_link_local_result_without_fetch(patched_fetch):
+async def test_generate_image_blocks_link_local_result_without_fetch(monkeypatch, patched_fetch):
     unsafe_url = "http://169.254.169.254/latest/meta-data"
-    import httpx
+    import src.outbound_fetch as outbound_fetch
 
-    class _Gen(_AsyncClient):
-        def post(self, url, json, headers):
-            return _GenerationResponse(unsafe_url)
+    def _raise_unsafe(url, headers=None, timeout=30, **kwargs):
+        # Mirror the SSRF guard's behaviour: private IPs are rejected
+        # *before* any socket is opened, raising ``httpx.RequestError``.
+        raise httpx.RequestError(f"Blocked non-public URL: {url}")
 
-    httpx.AsyncClient = _Gen  # type: ignore
+    monkeypatch.setattr(outbound_fetch, "fetch_public_url", _raise_unsafe)
+    _provider_returns(monkeypatch, unsafe_url)
 
     result = await ai_interaction.do_generate_image("draw a chair\ndall-e-3")
 
     assert "error" in result
     assert "unsafe image URL" in result["error"]
-    # The unsafe URL was rejected by the shared fetcher's SSRF guard, so the
-    # helper must not have issued the fetch.
-    assert all(call[0] != unsafe_url for call in patched_fetch.calls), (
-        "fetch_public_url must reject the link-local URL before opening a socket"
-    )
 
 
-async def test_generate_image_blocks_loopback_result_unconditionally(patched_fetch):
+async def test_generate_image_blocks_loopback_result_unconditionally(monkeypatch, patched_fetch):
     # The previous version only blocked loopback when IMAGE_BLOCK_PRIVATE_IPS
     # was true. After #5888 it is unconditional on this hop.
     loopback_url = "http://127.0.0.1/diffusion/result.png"
     import httpx
+    import src.outbound_fetch as outbound_fetch
 
-    class _Gen(_AsyncClient):
-        def post(self, url, json, headers):
-            return _GenerationResponse(loopback_url)
+    def _raise_loopback(url, headers=None, timeout=30, **kwargs):
+        raise httpx.RequestError(f"Blocked non-public URL: {url}")
 
-    httpx.AsyncClient = _Gen  # type: ignore
+    monkeypatch.setattr(outbound_fetch, "fetch_public_url", _raise_loopback)
+    _provider_returns(monkeypatch, loopback_url)
 
     result = await ai_interaction.do_generate_image("draw a chair\ndall-e-3")
 
@@ -167,16 +176,15 @@ async def test_generate_image_blocks_loopback_result_unconditionally(patched_fet
     assert "unsafe image URL" in result["error"]
 
 
-async def test_generate_image_non_200_result_falls_back_to_url(patched_fetch):
+async def test_generate_image_non_200_result_falls_back_to_url(monkeypatch, patched_fetch):
     provider_url = "https://images.example.com/generated.png?sig=abc"
-    patched_fetch.return_status = 503
-    import httpx
+    import src.outbound_fetch as outbound_fetch
 
-    class _Gen(_AsyncClient):
-        def post(self, url, json, headers):
-            return _GenerationResponse(provider_url)
+    def _return_503(url, headers=None, timeout=30, **kwargs):
+        return _FakeResp(status_code=503, content=b"")
 
-    httpx.AsyncClient = _Gen  # type: ignore
+    monkeypatch.setattr(outbound_fetch, "fetch_public_url", _return_503)
+    _provider_returns(monkeypatch, provider_url)
 
     result = await ai_interaction.do_generate_image("draw a chair\ndall-e-3")
 

--- a/tests/test_ai_image_url_safety.py
+++ b/tests/test_ai_image_url_safety.py
@@ -1,4 +1,24 @@
+"""Tests for ``src.ai_interaction.do_generate_image`` and ``do_edit_image``
+result-URL safety.
+
+The image-generation and image-edit paths download the result file by URL
+when the upstream returns ``{"url": "..."}`` instead of ``{"b64_json": "..."}``.
+That URL came back in the upstream response body, so a malicious or
+compromised provider can return e.g. ``http://169.254.169.254/...`` and turn
+the result fetch into an SSRF primitive. The helper used to be a one-shot
+``check_outbound_url`` + ``httpx.get`` pair, which had two holes:
+
+1. DNS rebinding TOCTOU between the guard and the connect.
+2. ``IMAGE_BLOCK_PRIVATE_IPS`` defaulted to ``false``, so loopback / RFC1918
+   were reachable at the shipped default.
+
+Both sites now route through the shared ``src.outbound_fetch.fetch_public_url``,
+which closes both holes by resolving once, pinning the TCP connect, and
+unconditionally refusing private addresses (#5888). These tests pin the new
+behaviour.
+"""
 from src import ai_interaction
+import pytest
 
 
 class _GenerationResponse:
@@ -12,32 +32,71 @@ class _GenerationResponse:
         return {"data": [{"url": self._image_url}]}
 
 
-class _DownloadResponse:
-    status_code = 503
-    content = b""
+class _AsyncClient:
+    """Mock used for the *provider* (first hop) request — the result-URL
+    fetch is now offloaded to ``fetch_public_url`` and must be mocked
+    separately below."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def post(self, url, json, headers):  # pragma: no cover - body irrelevant
+        return _GenerationResponse("https://provider.invalid/x.png")
 
 
-def _patch_generation(monkeypatch, image_url):
-    async def _post(self, url, json, headers):
-        return _GenerationResponse(image_url)
+class _FakeResp:
+    def __init__(self, status_code=200, content=b"PNGDATA"):
+        self.status_code = status_code
+        self.content = content
 
-    class _AsyncClient:
-        def __init__(self, *args, **kwargs):
-            pass
 
-        async def __aenter__(self):
-            return self
+class _RecordingFetch:
+    """Stand-in for ``src.outbound_fetch.fetch_public_url``.
 
-        async def __aexit__(self, *exc):
-            return False
+    Records every call so tests can assert whether the unsafe URL was even
+    attempted.
+    """
 
-        post = _post
+    instances: list["_RecordingFetch"] = []
 
+    def __init__(self):
+        self.calls: list[tuple] = []
+        self.raise_on_call: Exception | None = None
+        self.return_status = 200
+        _RecordingFetch.instances.append(self)
+
+    def __call__(self, url, headers=None, timeout=30, **kwargs):
+        self.calls.append((url, headers, timeout))
+        if self.raise_on_call is not None:
+            raise self.raise_on_call
+        return _FakeResp(status_code=self.return_status, content=b"PNGDATA")
+
+
+@pytest.fixture
+def patched_fetch(monkeypatch):
+    """Stub the heavy bits so ``ai_interaction`` can be imported and exercised.
+
+    Returns the ``_RecordingFetch`` instance so individual tests can inspect
+    what ``fetch_public_url`` was called with.
+    """
     import httpx
     import src.settings as settings
 
     monkeypatch.setattr(settings, "load_settings", lambda: {})
     monkeypatch.setattr(httpx, "AsyncClient", _AsyncClient)
+
+    import src.outbound_fetch as outbound_fetch
+
+    fetch = _RecordingFetch()
+    monkeypatch.setattr(outbound_fetch, "fetch_public_url", fetch)
+    _RecordingFetch.instances = [fetch]
+
     monkeypatch.setattr(
         ai_interaction,
         "_resolve_model",
@@ -47,58 +106,81 @@ def _patch_generation(monkeypatch, image_url):
             {"Authorization": "Bearer test"},
         ),
     )
+    return fetch
 
 
-async def test_generate_image_validates_provider_url_before_download(monkeypatch):
-    import httpx
-    import src.url_safety as url_safety
-
+async def test_generate_image_routes_public_result_through_shared_fetcher(patched_fetch):
     provider_url = "https://images.example.com/generated.png?sig=abc"
-    events = []
-    _patch_generation(monkeypatch, provider_url)
 
-    def _check_outbound_url(url, *, block_private=False):
-        events.append(("check", url, block_private))
-        return True, "ok"
-
-    def _get(url, *, timeout):
-        events.append(("get", url, timeout))
-        return _DownloadResponse()
-
-    monkeypatch.setattr(url_safety, "check_outbound_url", _check_outbound_url)
-    monkeypatch.setattr(httpx, "get", _get)
-
-    result = await ai_interaction.do_generate_image("draw a chair\ndall-e-3")
-
-    assert result["image_url"] == provider_url
-    assert events == [
-        ("check", provider_url, False),
-        ("get", provider_url, 60),
-    ]
-
-
-async def test_generate_image_rejects_unsafe_provider_url_without_download(monkeypatch):
+    # Patch the provider response to return our URL.
     import httpx
-    import src.url_safety as url_safety
 
-    unsafe_url = "http://169.254.169.254/latest/meta-data"
-    events = []
-    _patch_generation(monkeypatch, unsafe_url)
+    class _Gen(_AsyncClient):
+        def post(self, url, json, headers):
+            return _GenerationResponse(provider_url)
 
-    def _check_outbound_url(url, *, block_private=False):
-        events.append(("check", url, block_private))
-        return False, "link-local address blocked (SSRF metadata risk): 169.254.169.254"
-
-    def _get(url, *, timeout):
-        raise AssertionError("unsafe provider image URL must not be downloaded")
-
-    monkeypatch.setattr(url_safety, "check_outbound_url", _check_outbound_url)
-    monkeypatch.setattr(httpx, "get", _get)
+    httpx.AsyncClient = _Gen  # type: ignore
 
     result = await ai_interaction.do_generate_image("draw a chair\ndall-e-3")
 
-    assert result["error"] == (
-        "Image API returned unsafe image URL: "
-        "link-local address blocked (SSRF metadata risk): 169.254.169.254"
+    assert "error" not in result
+    assert patched_fetch.calls, "fetch_public_url must have been called"
+    assert patched_fetch.calls[0][0] == provider_url
+
+
+async def test_generate_image_blocks_link_local_result_without_fetch(patched_fetch):
+    unsafe_url = "http://169.254.169.254/latest/meta-data"
+    import httpx
+
+    class _Gen(_AsyncClient):
+        def post(self, url, json, headers):
+            return _GenerationResponse(unsafe_url)
+
+    httpx.AsyncClient = _Gen  # type: ignore
+
+    result = await ai_interaction.do_generate_image("draw a chair\ndall-e-3")
+
+    assert "error" in result
+    assert "unsafe image URL" in result["error"]
+    # The unsafe URL was rejected by the shared fetcher's SSRF guard, so the
+    # helper must not have issued the fetch.
+    assert all(call[0] != unsafe_url for call in patched_fetch.calls), (
+        "fetch_public_url must reject the link-local URL before opening a socket"
     )
-    assert events == [("check", unsafe_url, False)]
+
+
+async def test_generate_image_blocks_loopback_result_unconditionally(patched_fetch):
+    # The previous version only blocked loopback when IMAGE_BLOCK_PRIVATE_IPS
+    # was true. After #5888 it is unconditional on this hop.
+    loopback_url = "http://127.0.0.1/diffusion/result.png"
+    import httpx
+
+    class _Gen(_AsyncClient):
+        def post(self, url, json, headers):
+            return _GenerationResponse(loopback_url)
+
+    httpx.AsyncClient = _Gen  # type: ignore
+
+    result = await ai_interaction.do_generate_image("draw a chair\ndall-e-3")
+
+    assert "error" in result
+    assert "unsafe image URL" in result["error"]
+
+
+async def test_generate_image_non_200_result_falls_back_to_url(patched_fetch):
+    provider_url = "https://images.example.com/generated.png?sig=abc"
+    patched_fetch.return_status = 503
+    import httpx
+
+    class _Gen(_AsyncClient):
+        def post(self, url, json, headers):
+            return _GenerationResponse(provider_url)
+
+    httpx.AsyncClient = _Gen  # type: ignore
+
+    result = await ai_interaction.do_generate_image("draw a chair\ndall-e-3")
+
+    # The upstream URL is reachable (we only stubbed fetch_public_url to
+    # return 503), so the helper falls back to the external URL instead of
+    # erroring out — the user still gets something.
+    assert result.get("image_url") == provider_url

--- a/tests/test_gallery_result_image_ssrf.py
+++ b/tests/test_gallery_result_image_ssrf.py
@@ -19,53 +19,59 @@ import base64
 import pytest
 from fastapi import HTTPException
 
-import routes.gallery_routes as gallery_routes
+import routes.gallery.gallery_routes as gallery_routes
 
 
 class _FakeResp:
-    def __init__(self, status_code: int, content: bytes = b""):
+    def __init__(self, status_code: int = 200, content: bytes = b"PNGDATA"):
         self.status_code = status_code
         self.content = content
 
 
-class _FakeFetch:
+class _RecordingFetch:
     """Stand-in for ``src.outbound_fetch.fetch_public_url``.
 
-    Records every call so tests can assert whether the helper tried to fetch
-    an unsafe URL.
+    Each call creates a new instance so ``_call_log`` (a class-level list of
+    call tuples) accumulates every fetch attempt. Tests assert against the log
+    to confirm whether the unsafe URL was even attempted.
     """
 
-    instances: list["_FakeFetch"] = []
+    _call_log: list = []
 
-    def __init__(self, *args, **kwargs):
-        self.calls: list[tuple] = []
-        _FakeFetch.instances.append(self)
+    def __init__(self, status_code: int = 200, content: bytes = b"PNGDATA"):
+        self._status_code = status_code
+        self._content = content
 
     def __call__(self, url, headers=None, timeout=30, **kwargs):
-        self.calls.append((url, headers, timeout))
-        return _FakeResp(200, b"PNGDATA")
+        _RecordingFetch._call_log.append((url, headers, timeout))
+        return _FakeResp(status_code=self._status_code, content=self._content)
 
 
 @pytest.fixture(autouse=True)
 def _fake_fetch(monkeypatch):
-    _FakeFetch.instances = []
+    _RecordingFetch._call_log = []
     import src.outbound_fetch as outbound_fetch
 
-    monkeypatch.setattr(outbound_fetch, "fetch_public_url", _FakeFetch())
-    yield
+    def _factory(url, headers=None, timeout=30, **kwargs):
+        _RecordingFetch._call_log.append((url, headers, timeout))
+        return _FakeResp()
+
+    monkeypatch.setattr(outbound_fetch, "fetch_public_url", _factory)
+    yield _RecordingFetch
 
 
 async def test_rejects_link_local_result_url():
     # A compromised upstream returns the cloud-metadata address as the image
-    # URL. The helper must refuse it and never issue the fetch.
+    # URL. The shared fetcher must refuse it before opening a socket, and the
+    # gallery helper must surface that as a 502 to the caller.
     with pytest.raises(HTTPException) as exc:
         await gallery_routes._fetch_result_image_b64(
             "http://169.254.169.254/latest/meta-data"
         )
     assert exc.value.status_code == 502
-    assert all(
-        not c.calls for c in _FakeFetch.instances
-    ), "the unsafe result URL must not be fetched"
+    assert _RecordingFetch._call_log == [], (
+        "the unsafe result URL must not reach fetch_public_url"
+    )
 
 
 async def test_rejects_loopback_result_url():
@@ -96,25 +102,18 @@ async def test_fetches_public_result_url_and_returns_base64():
     public_url = "http://93.184.216.34/img.png"
     out = await gallery_routes._fetch_result_image_b64(public_url)
     assert out == base64.b64encode(b"PNGDATA").decode()
-    assert _FakeFetch.instances, "fetch_public_url must have been called"
-    # Exactly one call, with our public URL.
-    assert _FakeFetch.instances[0].calls[0][0] == public_url
+    assert len(_RecordingFetch._call_log) == 1
+    assert _RecordingFetch._call_log[0][0] == public_url
 
 
-async def test_non_200_response_yields_none():
+async def test_non_200_response_yields_none(monkeypatch):
     # When the upstream returns a non-200, the gallery shows the external URL
     # as a fallback, so the helper must return None without raising.
     import src.outbound_fetch as outbound_fetch
 
-    class _OtherFetch(_FakeFetch):
-        def __init__(self):
-            super().__init__()
-            self.calls = []
+    def _non200(url, headers=None, timeout=30, **kwargs):
+        return _FakeResp(status_code=404, content=b"")
 
-        def __call__(self, url, headers=None, timeout=30, **kwargs):
-            self.calls.append((url, headers, timeout))
-            return _FakeResp(404, b"")
-
-    outbound_fetch.fetch_public_url = _OtherFetch()
+    monkeypatch.setattr(outbound_fetch, "fetch_public_url", _non200)
     out = await gallery_routes._fetch_result_image_b64("http://93.184.216.34/missing.png")
     assert out is None

--- a/tests/test_gallery_result_image_ssrf.py
+++ b/tests/test_gallery_result_image_ssrf.py
@@ -7,7 +7,12 @@ SSRF primitive (cloud-metadata credential exfil).
 
 The client-supplied ``_endpoint`` is already validated through
 ``check_outbound_url`` before the first request; this pins the same guard on the
-*result* URL pulled from the response body, which previously went unchecked.
+*result* URL pulled from the response body via the shared
+``src.outbound_fetch.fetch_public_url``, which resolves once, validates as
+public, pins the TCP connect to that resolved IP, and refuses the fetch on
+private addresses unconditionally — there is no env-flag opt-out for this hop
+because the operator-configured-endpoint rationale in ``src/url_safety.py`` does
+not extend to an arbitrary URL a remote server hands back (#5888).
 """
 import base64
 
@@ -23,30 +28,31 @@ class _FakeResp:
         self.content = content
 
 
-class _FakeAsyncClient:
-    instances: list["_FakeAsyncClient"] = []
+class _FakeFetch:
+    """Stand-in for ``src.outbound_fetch.fetch_public_url``.
+
+    Records every call so tests can assert whether the helper tried to fetch
+    an unsafe URL.
+    """
+
+    instances: list["_FakeFetch"] = []
 
     def __init__(self, *args, **kwargs):
-        self.gets: list[str] = []
-        _FakeAsyncClient.instances.append(self)
+        self.calls: list[tuple] = []
+        _FakeFetch.instances.append(self)
 
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, *exc):
-        return False
-
-    async def get(self, url, **kwargs):
-        self.gets.append(url)
+    def __call__(self, url, headers=None, timeout=30, **kwargs):
+        self.calls.append((url, headers, timeout))
         return _FakeResp(200, b"PNGDATA")
 
 
 @pytest.fixture(autouse=True)
-def _fake_httpx(monkeypatch):
-    import httpx
+def _fake_fetch(monkeypatch):
+    _FakeFetch.instances = []
+    import src.outbound_fetch as outbound_fetch
 
-    _FakeAsyncClient.instances = []
-    monkeypatch.setattr(httpx, "AsyncClient", _FakeAsyncClient)
+    monkeypatch.setattr(outbound_fetch, "fetch_public_url", _FakeFetch())
+    yield
 
 
 async def test_rejects_link_local_result_url():
@@ -57,13 +63,58 @@ async def test_rejects_link_local_result_url():
             "http://169.254.169.254/latest/meta-data"
         )
     assert exc.value.status_code == 502
-    assert all(c.gets == [] for c in _FakeAsyncClient.instances), (
-        "the unsafe result URL must not be fetched"
-    )
+    assert all(
+        not c.calls for c in _FakeFetch.instances
+    ), "the unsafe result URL must not be fetched"
 
 
-async def test_fetches_safe_result_url():
-    # A normal loopback/LAN diffusion server result URL is allowed (local-first)
-    # and returned base64-encoded, matching the prior inline behavior.
-    out = await gallery_routes._fetch_result_image_b64("http://127.0.0.1/img.png")
+async def test_rejects_loopback_result_url():
+    # The previous version allowed ``http://127.0.0.1/...`` here because the
+    # operator could opt into ``IMAGE_BLOCK_PRIVATE_IPS=true``. After #5888
+    # the second hop refuses private addresses unconditionally — a local
+    # diffusion server returns b64_json directly and never the URL branch, so
+    # this tightening costs no supported local setup.
+    with pytest.raises(HTTPException) as exc:
+        await gallery_routes._fetch_result_image_b64("http://127.0.0.1/img.png")
+    assert exc.value.status_code == 502
+
+
+async def test_rejects_metadata_hostname_result_url():
+    # The Google cloud-metadata hostname is rejected by name even before the
+    # resolver runs.
+    with pytest.raises(HTTPException) as exc:
+        await gallery_routes._fetch_result_image_b64(
+            "http://metadata.google.internal/computeMetadata/v1/"
+        )
+    assert exc.value.status_code == 502
+
+
+async def test_fetches_public_result_url_and_returns_base64():
+    # A public IP is allowed through, the response body is base64-encoded and
+    # returned, and the helper used the shared fetcher (single source of
+    # truth for SSRF pinning).
+    public_url = "http://93.184.216.34/img.png"
+    out = await gallery_routes._fetch_result_image_b64(public_url)
     assert out == base64.b64encode(b"PNGDATA").decode()
+    assert _FakeFetch.instances, "fetch_public_url must have been called"
+    # Exactly one call, with our public URL.
+    assert _FakeFetch.instances[0].calls[0][0] == public_url
+
+
+async def test_non_200_response_yields_none():
+    # When the upstream returns a non-200, the gallery shows the external URL
+    # as a fallback, so the helper must return None without raising.
+    import src.outbound_fetch as outbound_fetch
+
+    class _OtherFetch(_FakeFetch):
+        def __init__(self):
+            super().__init__()
+            self.calls = []
+
+        def __call__(self, url, headers=None, timeout=30, **kwargs):
+            self.calls.append((url, headers, timeout))
+            return _FakeResp(404, b"")
+
+    outbound_fetch.fetch_public_url = _OtherFetch()
+    out = await gallery_routes._fetch_result_image_b64("http://93.184.216.34/missing.png")
+    assert out is None

--- a/tests/test_gallery_result_image_ssrf.py
+++ b/tests/test_gallery_result_image_ssrf.py
@@ -16,6 +16,7 @@ not extend to an arbitrary URL a remote server hands back (#5888).
 """
 import base64
 
+import httpx
 import pytest
 from fastapi import HTTPException
 
@@ -28,23 +29,32 @@ class _FakeResp:
         self.content = content
 
 
+def _is_unsafe_url(url: str) -> bool:
+    """Mirror ``src.outbound_fetch._resolve_public_ips`` for the test fixtures
+    — private / loopback / link-local / metadata hostnames are rejected
+    *before* any socket is opened."""
+    lowered = url.lower()
+    if "metadata.google.internal" in lowered or "169.254." in lowered or "127.0.0.1" in lowered:
+        return True
+    return False
+
+
 class _RecordingFetch:
     """Stand-in for ``src.outbound_fetch.fetch_public_url``.
 
-    Each call creates a new instance so ``_call_log`` (a class-level list of
-    call tuples) accumulates every fetch attempt. Tests assert against the log
-    to confirm whether the unsafe URL was even attempted.
+    Records every call and mirrors the real helper's SSRF guard: private /
+    loopback / link-local / metadata hostnames raise ``httpx.RequestError``
+    *before* any socket is opened, and any other URL returns a 200 fake
+    response so tests can assert the safe path went through.
     """
 
     _call_log: list = []
 
-    def __init__(self, status_code: int = 200, content: bytes = b"PNGDATA"):
-        self._status_code = status_code
-        self._content = content
-
     def __call__(self, url, headers=None, timeout=30, **kwargs):
         _RecordingFetch._call_log.append((url, headers, timeout))
-        return _FakeResp(status_code=self._status_code, content=self._content)
+        if _is_unsafe_url(url):
+            raise httpx.RequestError(f"Blocked non-public URL: {url}")
+        return _FakeResp()
 
 
 @pytest.fixture(autouse=True)
@@ -52,11 +62,7 @@ def _fake_fetch(monkeypatch):
     _RecordingFetch._call_log = []
     import src.outbound_fetch as outbound_fetch
 
-    def _factory(url, headers=None, timeout=30, **kwargs):
-        _RecordingFetch._call_log.append((url, headers, timeout))
-        return _FakeResp()
-
-    monkeypatch.setattr(outbound_fetch, "fetch_public_url", _factory)
+    monkeypatch.setattr(outbound_fetch, "fetch_public_url", _RecordingFetch())
     yield _RecordingFetch
 
 

--- a/tests/test_gallery_result_image_ssrf.py
+++ b/tests/test_gallery_result_image_ssrf.py
@@ -69,15 +69,16 @@ def _fake_fetch(monkeypatch):
 async def test_rejects_link_local_result_url():
     # A compromised upstream returns the cloud-metadata address as the image
     # URL. The shared fetcher must refuse it before opening a socket, and the
-    # gallery helper must surface that as a 502 to the caller.
+    # gallery helper must surface that as a 502 to the caller. The helper
+    # *does* see the URL (that's where the guard runs); what matters is that
+    # it raises and the gallery surfaces that as a 502.
     with pytest.raises(HTTPException) as exc:
         await gallery_routes._fetch_result_image_b64(
             "http://169.254.169.254/latest/meta-data"
         )
     assert exc.value.status_code == 502
-    assert _RecordingFetch._call_log == [], (
-        "the unsafe result URL must not reach fetch_public_url"
-    )
+    assert len(_RecordingFetch._call_log) == 1
+    assert _RecordingFetch._call_log[0][0] == "http://169.254.169.254/latest/meta-data"
 
 
 async def test_rejects_loopback_result_url():

--- a/tests/test_outbound_fetch.py
+++ b/tests/test_outbound_fetch.py
@@ -11,6 +11,8 @@ These tests pin its public contract independently of any caller:
 * it raises on a Content-Encoding that would defeat the size cap,
 * it raises BodyTooLargeError on a server that declared an oversize body.
 """
+import ipaddress
+
 import pytest
 
 import src.outbound_fetch as outbound_fetch
@@ -43,8 +45,6 @@ class TestIsPrivateAddress:
         ],
     )
     def test_rejects_private_addresses(self, addr):
-        import ipaddress
-
         assert _is_private_address(ipaddress.ip_address(addr)) is True, addr
 
     @pytest.mark.parametrize(
@@ -57,15 +57,11 @@ class TestIsPrivateAddress:
         ],
     )
     def test_allows_public_addresses(self, addr):
-        import ipaddress
-
         assert _is_private_address(ipaddress.ip_address(addr)) is False, addr
 
     def test_ipv4_mapped_ipv6_is_classified_by_v4(self):
         # An IPv4-mapped IPv6 address like ``::ffff:127.0.0.1`` must be
         # classified as loopback, not as public IPv6.
-        import ipaddress
-
         addr = ipaddress.ip_address("::ffff:127.0.0.1")
         assert _is_private_address(addr) is True
 
@@ -102,8 +98,6 @@ class TestResolvePublicIps:
         # An IP literal that is not private resolves to itself.
         ips = _resolve_public_ips("http://93.184.216.34/example.com")
         assert len(ips) == 1
-        import ipaddress
-
         assert ips[0] == ipaddress.ip_address("93.184.216.34")
 
 
@@ -115,6 +109,10 @@ class TestResolvePublicIps:
 
 
 class _FakeStream:
+    """Mimics the streaming response context manager returned by
+    ``httpx.Client.stream(...)``. Must support ``iter_bytes`` because the
+    shared fetcher reads the body through it."""
+
     def __init__(self, status_code, headers, body):
         self.status_code = status_code
         self.headers = headers
@@ -126,44 +124,30 @@ class _FakeStream:
     def __exit__(self, *exc):
         return False
 
-    def iter_bytes(self):
+    def iter_bytes(self, chunk_size=None):
         yield self._body
-
-
-class _FakeResponse:
-    def __init__(self, status_code, headers, body):
-        self.status_code = status_code
-        self.headers = headers
-        self._body = body
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *exc):
-        return False
-
-    def stream(self, method, url):
-        return _FakeStream(self.status_code, self.headers, self._body)
 
 
 class _FakeClient:
     """Records every ``stream("GET", url)`` call so tests can assert the
-    helper refused the URL *before* opening the socket."""
+    helper refused the URL *before* opening the socket.
 
-    instances: list["_FakeClient"] = []
+    The transport is inspected here purely for the pin assertion — the
+    fetcher's ``_PinnedTransport`` exposes its pinned IP via
+    ``transport._pool._network_backend._ip``.
+    """
+
+    instances: list = []
 
     def __init__(self, *args, **kwargs):
-        self.calls: list[tuple] = []
-        # Inspect the transport argument to read which IP the helper pinned.
-        self.pinned_ip = None
+        self.calls: list = []
+        self.pinned_ip: str | None = None
         transport = kwargs.get("transport")
-        if transport is not None and hasattr(transport, "_PinnedBackend__dict"):
-            pass
-        # The transport exposes its pinned backend as ``_pool._network_backend``.
-        pool = getattr(transport, "_pool", None) if transport else None
-        backend = getattr(pool, "_network_backend", None) if pool else None
-        if backend is not None and hasattr(backend, "_ip"):
-            self.pinned_ip = backend._ip
+        if transport is not None:
+            pool = getattr(transport, "_pool", None)
+            backend = getattr(pool, "_network_backend", None) if pool else None
+            if backend is not None and hasattr(backend, "_ip"):
+                self.pinned_ip = backend._ip
         _FakeClient.instances.append(self)
 
     def __enter__(self):
@@ -174,7 +158,7 @@ class _FakeClient:
 
     def stream(self, method, url):
         self.calls.append((method, url))
-        return _FakeResponse(200, {}, b"PNG")
+        return _FakeStream(200, {}, b"PNGDATA")
 
 
 @pytest.fixture
@@ -184,19 +168,16 @@ def stub_httpx(monkeypatch):
     yield _FakeClient
 
 
-def test_public_url_is_pinned_to_first_resolved_ip(stub_httpx):
+def test_public_url_is_pinned_to_first_resolved_ip(stub_httpx, monkeypatch):
     # The helper must call httpx.Client with a ``transport`` whose pinned IP
     # equals the first address returned by the resolver. A monkeypatched
     # resolver returning a single public IP gives us a deterministic target.
-    import ipaddress
-
-    monkeypatch_resolver = lambda url: [ipaddress.ip_address("93.184.216.34")]
-    original_resolve = outbound_fetch._resolve_public_ips
-    outbound_fetch._resolve_public_ips = monkeypatch_resolver  # type: ignore
-    try:
-        fetch_public_url("http://example.com/x.png", headers=None, timeout=10)
-    finally:
-        outbound_fetch._resolve_public_ips = original_resolve
+    monkeypatch.setattr(
+        outbound_fetch,
+        "_resolve_public_ips",
+        lambda url: [ipaddress.ip_address("93.184.216.34")],
+    )
+    fetch_public_url("http://example.com/x.png", headers=None, timeout=10)
 
     assert stub_httpx.calls == [("GET", "http://example.com/x.png")]
     assert stub_httpx.pinned_ip == "93.184.216.34"
@@ -230,46 +211,47 @@ def test_compressed_body_is_refused(stub_httpx):
     # A gzip body would defeat the size cap (a tiny compressed payload can
     # balloon into one decoded chunk far past the cap). The helper must
     # reject it instead of decoding.
-    class _CompressedResponse(_FakeResponse):
-        def stream(self, method, url):
-            return _FakeStream(
+
+    class _CompressedStream(_FakeStream):
+        def __init__(self):
+            super().__init__(
                 200,
                 {"content-encoding": "gzip"},
                 b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03",
             )
 
     class _CompressedClient(_FakeClient):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
         def stream(self, method, url):
             self.calls.append((method, url))
-            return _CompressedResponse(200, {"content-encoding": "gzip"}, b"")
+            return _CompressedStream()
 
-    stub_httpx.__class__  # quiet linter
-    outbound_fetch.httpx.Client = _CompressedClient  # type: ignore
     _CompressedClient.instances = []
+    outbound_fetch.httpx.Client = _CompressedClient  # type: ignore
 
     with pytest.raises(Exception) as exc:
         fetch_public_url("http://example.com/x", headers=None, timeout=10)
     assert "encoding" in str(exc.value).lower() or "compress" in str(exc.value).lower()
 
 
-def test_oversize_declared_body_raises_body_too_large(stub_httpx):
+def test_oversize_declared_body_raises_body_too_large(stub_httpx, monkeypatch):
     # A server that declares a Content-Length above the hard cap must be
     # refused up-front rather than streamed. We exercise that branch by
     # monkeypatching the cap to a tiny number and feeding in a response
     # whose declared size sits above it.
     class _OversizeClient(_FakeClient):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
         def stream(self, method, url):
             self.calls.append((method, url))
             return _FakeStream(200, {"content-length": "99999999"}, b"")
 
-    outbound_fetch.httpx.Client = _OversizeClient  # type: ignore
     _OversizeClient.instances = []
-    import src.outbound_fetch as m
+    outbound_fetch.httpx.Client = _OversizeClient  # type: ignore
+    monkeypatch.setattr(outbound_fetch, "WEB_FETCH_HARD_MAX_BYTES", 1000)
 
-    original_hard = m.WEB_FETCH_HARD_MAX_BYTES
-    m.WEB_FETCH_HARD_MAX_BYTES = 1000
-    try:
-        with pytest.raises(BodyTooLargeError):
-            fetch_public_url("http://example.com/x", headers=None, timeout=10)
-    finally:
-        m.WEB_FETCH_HARD_MAX_BYTES = original_hard
+    with pytest.raises(BodyTooLargeError):
+        fetch_public_url("http://example.com/x", headers=None, timeout=10)

--- a/tests/test_outbound_fetch.py
+++ b/tests/test_outbound_fetch.py
@@ -111,14 +111,15 @@ class TestResolvePublicIps:
 class _FakeStream:
     """Mimics the streaming response context manager returned by
     ``httpx.Client.stream(...)``. Must support ``iter_bytes`` because the
-    shared fetcher reads the body through it, plus an ``encoding`` attribute
-    that the fetcher copies onto the returned ``_CappedFetch``."""
+    shared fetcher reads the body through it, plus ``encoding`` and ``url``
+    attributes that the fetcher copies onto the returned ``_CappedFetch``."""
 
     def __init__(self, status_code, headers, body):
         self.status_code = status_code
         self.headers = headers
         self._body = body
         self.encoding = headers.get("content-encoding") or "utf-8"
+        self.url = "http://example.com/fake"
 
     def __enter__(self):
         return self

--- a/tests/test_outbound_fetch.py
+++ b/tests/test_outbound_fetch.py
@@ -1,0 +1,275 @@
+"""Tests for the shared outbound fetcher in ``src.outbound_fetch``.
+
+The fetcher is the single SSRF-guarded, DNS-pinned HTTP downloader that the
+gallery, image-generation and image-edit paths now route through (#5888).
+These tests pin its public contract independently of any caller:
+
+* it rejects URLs whose host is private / loopback / link-local / reserved
+  / unspecified before opening a socket,
+* it rejects the cloud-metadata hostnames by name even before the resolver
+  runs,
+* it raises on a Content-Encoding that would defeat the size cap,
+* it raises BodyTooLargeError on a server that declared an oversize body.
+"""
+import pytest
+
+import src.outbound_fetch as outbound_fetch
+from src.outbound_fetch import (
+    BodyTooLargeError,
+    _is_private_address,
+    _resolve_public_ips,
+    fetch_public_url,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure unit tests — no HTTP, no resolver.
+# ---------------------------------------------------------------------------
+
+
+class TestIsPrivateAddress:
+    @pytest.mark.parametrize(
+        "addr",
+        [
+            "127.0.0.1",
+            "10.0.0.1",
+            "172.16.0.1",
+            "192.168.1.1",
+            "169.254.169.254",  # cloud metadata
+            "0.0.0.0",
+            "::1",
+            "fc00::1",
+            "fe80::1",
+        ],
+    )
+    def test_rejects_private_addresses(self, addr):
+        import ipaddress
+
+        assert _is_private_address(ipaddress.ip_address(addr)) is True, addr
+
+    @pytest.mark.parametrize(
+        "addr",
+        [
+            "8.8.8.8",
+            "1.1.1.1",
+            "93.184.216.34",
+            "2606:4700:4700::1111",
+        ],
+    )
+    def test_allows_public_addresses(self, addr):
+        import ipaddress
+
+        assert _is_private_address(ipaddress.ip_address(addr)) is False, addr
+
+    def test_ipv4_mapped_ipv6_is_classified_by_v4(self):
+        # An IPv4-mapped IPv6 address like ``::ffff:127.0.0.1`` must be
+        # classified as loopback, not as public IPv6.
+        import ipaddress
+
+        addr = ipaddress.ip_address("::ffff:127.0.0.1")
+        assert _is_private_address(addr) is True
+
+
+class TestResolvePublicIps:
+    def test_rejects_metadata_hostname_without_resolver(self):
+        # The hostname check fires before DNS, so the resolver does not even
+        # need to be running. No patch needed — the function raises before
+        # touching socket.getaddrinfo.
+        with pytest.raises(Exception) as exc:
+            _resolve_public_ips("http://metadata.google.internal/")
+        assert "metadata" in str(exc.value).lower() or "public" in str(exc.value).lower()
+
+    def test_rejects_localhost_without_resolver(self):
+        with pytest.raises(Exception):
+            _resolve_public_ips("http://localhost/secret")
+
+    def test_rejects_non_http_scheme(self):
+        with pytest.raises(Exception):
+            _resolve_public_ips("file:///etc/passwd")
+
+        with pytest.raises(Exception):
+            _resolve_public_ips("ftp://example.com/x")
+
+    def test_rejects_link_local_ip_literal(self):
+        with pytest.raises(Exception):
+            _resolve_public_ips("http://169.254.169.254/latest/meta-data")
+
+    def test_rejects_loopback_ip_literal(self):
+        with pytest.raises(Exception):
+            _resolve_public_ips("http://127.0.0.1/admin")
+
+    def test_accepts_public_ip_literal(self):
+        # An IP literal that is not private resolves to itself.
+        ips = _resolve_public_ips("http://93.184.216.34/example.com")
+        assert len(ips) == 1
+        import ipaddress
+
+        assert ips[0] == ipaddress.ip_address("93.184.216.34")
+
+
+# ---------------------------------------------------------------------------
+# HTTP-level tests — monkeypatch the underlying httpx.Client to avoid real
+# network calls and assert how the shared fetcher actually behaves at the
+# socket boundary.
+# ---------------------------------------------------------------------------
+
+
+class _FakeStream:
+    def __init__(self, status_code, headers, body):
+        self.status_code = status_code
+        self.headers = headers
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def iter_bytes(self):
+        yield self._body
+
+
+class _FakeResponse:
+    def __init__(self, status_code, headers, body):
+        self.status_code = status_code
+        self.headers = headers
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def stream(self, method, url):
+        return _FakeStream(self.status_code, self.headers, self._body)
+
+
+class _FakeClient:
+    """Records every ``stream("GET", url)`` call so tests can assert the
+    helper refused the URL *before* opening the socket."""
+
+    instances: list["_FakeClient"] = []
+
+    def __init__(self, *args, **kwargs):
+        self.calls: list[tuple] = []
+        # Inspect the transport argument to read which IP the helper pinned.
+        self.pinned_ip = None
+        transport = kwargs.get("transport")
+        if transport is not None and hasattr(transport, "_PinnedBackend__dict"):
+            pass
+        # The transport exposes its pinned backend as ``_pool._network_backend``.
+        pool = getattr(transport, "_pool", None) if transport else None
+        backend = getattr(pool, "_network_backend", None) if pool else None
+        if backend is not None and hasattr(backend, "_ip"):
+            self.pinned_ip = backend._ip
+        _FakeClient.instances.append(self)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def stream(self, method, url):
+        self.calls.append((method, url))
+        return _FakeResponse(200, {}, b"PNG")
+
+
+@pytest.fixture
+def stub_httpx(monkeypatch):
+    _FakeClient.instances = []
+    monkeypatch.setattr(outbound_fetch.httpx, "Client", _FakeClient)
+    yield _FakeClient
+
+
+def test_public_url_is_pinned_to_first_resolved_ip(stub_httpx):
+    # The helper must call httpx.Client with a ``transport`` whose pinned IP
+    # equals the first address returned by the resolver. A monkeypatched
+    # resolver returning a single public IP gives us a deterministic target.
+    import ipaddress
+
+    monkeypatch_resolver = lambda url: [ipaddress.ip_address("93.184.216.34")]
+    original_resolve = outbound_fetch._resolve_public_ips
+    outbound_fetch._resolve_public_ips = monkeypatch_resolver  # type: ignore
+    try:
+        fetch_public_url("http://example.com/x.png", headers=None, timeout=10)
+    finally:
+        outbound_fetch._resolve_public_ips = original_resolve
+
+    assert stub_httpx.calls == [("GET", "http://example.com/x.png")]
+    assert stub_httpx.pinned_ip == "93.184.216.34"
+
+
+def test_loopback_url_never_opens_a_socket(stub_httpx):
+    # The whole point of #5888: a URL pointing at loopback must be refused
+    # before httpx.Client is constructed at all.
+    with pytest.raises(Exception):
+        fetch_public_url("http://127.0.0.1/diffusion/result.png", headers=None, timeout=10)
+    assert stub_httpx.calls == [], "loopback URL must not reach httpx.Client"
+
+
+def test_link_local_url_never_opens_a_socket(stub_httpx):
+    with pytest.raises(Exception):
+        fetch_public_url("http://169.254.169.254/latest/meta-data", headers=None, timeout=10)
+    assert stub_httpx.calls == []
+
+
+def test_metadata_hostname_never_opens_a_socket(stub_httpx):
+    with pytest.raises(Exception):
+        fetch_public_url(
+            "http://metadata.google.internal/computeMetadata/v1/",
+            headers=None,
+            timeout=10,
+        )
+    assert stub_httpx.calls == []
+
+
+def test_compressed_body_is_refused(stub_httpx):
+    # A gzip body would defeat the size cap (a tiny compressed payload can
+    # balloon into one decoded chunk far past the cap). The helper must
+    # reject it instead of decoding.
+    class _CompressedResponse(_FakeResponse):
+        def stream(self, method, url):
+            return _FakeStream(
+                200,
+                {"content-encoding": "gzip"},
+                b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03",
+            )
+
+    class _CompressedClient(_FakeClient):
+        def stream(self, method, url):
+            self.calls.append((method, url))
+            return _CompressedResponse(200, {"content-encoding": "gzip"}, b"")
+
+    stub_httpx.__class__  # quiet linter
+    outbound_fetch.httpx.Client = _CompressedClient  # type: ignore
+    _CompressedClient.instances = []
+
+    with pytest.raises(Exception) as exc:
+        fetch_public_url("http://example.com/x", headers=None, timeout=10)
+    assert "encoding" in str(exc.value).lower() or "compress" in str(exc.value).lower()
+
+
+def test_oversize_declared_body_raises_body_too_large(stub_httpx):
+    # A server that declares a Content-Length above the hard cap must be
+    # refused up-front rather than streamed. We exercise that branch by
+    # monkeypatching the cap to a tiny number and feeding in a response
+    # whose declared size sits above it.
+    class _OversizeClient(_FakeClient):
+        def stream(self, method, url):
+            self.calls.append((method, url))
+            return _FakeStream(200, {"content-length": "99999999"}, b"")
+
+    outbound_fetch.httpx.Client = _OversizeClient  # type: ignore
+    _OversizeClient.instances = []
+    import src.outbound_fetch as m
+
+    original_hard = m.WEB_FETCH_HARD_MAX_BYTES
+    m.WEB_FETCH_HARD_MAX_BYTES = 1000
+    try:
+        with pytest.raises(BodyTooLargeError):
+            fetch_public_url("http://example.com/x", headers=None, timeout=10)
+    finally:
+        m.WEB_FETCH_HARD_MAX_BYTES = original_hard

--- a/tests/test_outbound_fetch.py
+++ b/tests/test_outbound_fetch.py
@@ -111,12 +111,14 @@ class TestResolvePublicIps:
 class _FakeStream:
     """Mimics the streaming response context manager returned by
     ``httpx.Client.stream(...)``. Must support ``iter_bytes`` because the
-    shared fetcher reads the body through it."""
+    shared fetcher reads the body through it, plus an ``encoding`` attribute
+    that the fetcher copies onto the returned ``_CappedFetch``."""
 
     def __init__(self, status_code, headers, body):
         self.status_code = status_code
         self.headers = headers
         self._body = body
+        self.encoding = headers.get("content-encoding") or "utf-8"
 
     def __enter__(self):
         return self
@@ -165,7 +167,7 @@ class _FakeClient:
 def stub_httpx(monkeypatch):
     _FakeClient.instances = []
     monkeypatch.setattr(outbound_fetch.httpx, "Client", _FakeClient)
-    yield _FakeClient
+    return _FakeClient
 
 
 def test_public_url_is_pinned_to_first_resolved_ip(stub_httpx, monkeypatch):
@@ -179,8 +181,11 @@ def test_public_url_is_pinned_to_first_resolved_ip(stub_httpx, monkeypatch):
     )
     fetch_public_url("http://example.com/x.png", headers=None, timeout=10)
 
-    assert stub_httpx.calls == [("GET", "http://example.com/x.png")]
-    assert stub_httpx.pinned_ip == "93.184.216.34"
+    # The fetcher creates a new _FakeClient instance per call.
+    assert len(stub_httpx.instances) == 1
+    instance = stub_httpx.instances[0]
+    assert instance.calls == [("GET", "http://example.com/x.png")]
+    assert instance.pinned_ip == "93.184.216.34"
 
 
 def test_loopback_url_never_opens_a_socket(stub_httpx):
@@ -188,13 +193,13 @@ def test_loopback_url_never_opens_a_socket(stub_httpx):
     # before httpx.Client is constructed at all.
     with pytest.raises(Exception):
         fetch_public_url("http://127.0.0.1/diffusion/result.png", headers=None, timeout=10)
-    assert stub_httpx.calls == [], "loopback URL must not reach httpx.Client"
+    assert stub_httpx.instances == [], "loopback URL must not reach httpx.Client"
 
 
 def test_link_local_url_never_opens_a_socket(stub_httpx):
     with pytest.raises(Exception):
         fetch_public_url("http://169.254.169.254/latest/meta-data", headers=None, timeout=10)
-    assert stub_httpx.calls == []
+    assert stub_httpx.instances == []
 
 
 def test_metadata_hostname_never_opens_a_socket(stub_httpx):
@@ -204,7 +209,7 @@ def test_metadata_hostname_never_opens_a_socket(stub_httpx):
             headers=None,
             timeout=10,
         )
-    assert stub_httpx.calls == []
+    assert stub_httpx.instances == []
 
 
 def test_compressed_body_is_refused(stub_httpx):

--- a/tests/test_security_regressions.py
+++ b/tests/test_security_regressions.py
@@ -1416,6 +1416,7 @@ def test_dns_rebinding_redirect_re_resolves_per_hop(monkeypatch):
     first hop was public.
     """
     from src.search import content
+    import src.outbound_fetch as outbound_fetch
 
     seen = []
 
@@ -1425,7 +1426,10 @@ def test_dns_rebinding_redirect_re_resolves_per_hop(monkeypatch):
             raise _httpx.RequestError(f"Blocked non-public URL: {url}")
         return [_ipaddr.ip_address("93.184.216.34")]
 
-    monkeypatch.setattr(content, "_resolve_public_ips", fake_resolve)
+    # The implementation lives in ``src.outbound_fetch`` since #5888;
+    # ``services.search.content._get_public_url`` is now a re-export of
+    # ``fetch_public_url`` so the call below still works.
+    monkeypatch.setattr(outbound_fetch, "_resolve_public_ips", fake_resolve)
 
     class _Resp:
         status_code = 302


### PR DESCRIPTION
## Summary

Move the SSRF-guarded, DNS-pinned HTTP fetcher from `services/search/content.py` into a neutral `src/outbound_fetch.py` module, then route the three call sites that fetch response-supplied image URLs (gallery `_fetch_result_image_b64`, `do_generate_image`, `do_edit_image`) through it.

The previous helper pair at each site — `check_outbound_url(url, block_private=os.getenv("IMAGE_BLOCK_PRIVATE_IPS", "false") == "true")` followed by `httpx.get(url, timeout=60)` — had two holes that the same-family bugs #5513 / #5609 already exposed elsewhere:

1. **DNS-rebinding TOCTOU.** `check_outbound_url` resolves the host once to classify it and returns only `(ok, reason)`. The HTTP client resolved the host *again* at connect time, so a low-TTL record could pass the guard as a public IP and the socket as a link-local one — which defeats `src/url_safety.py:47-49`'s link-local block regardless of configuration. PR #5727 closed the same hole for `execute_api_call`; the image-fetch sites had no analogue.
2. **`block_private` defaults to `false`** on this hop, so at the shipped default loopback and RFC1918 are reachable. The operator-configured-endpoint rationale in `src/url_safety.py` is about a *first* hop the admin chose, not an arbitrary URL a remote server hands back. Odysseus's own diffusion server only emits `b64_json` and never takes the URL branch, so tightening this hop costs no supported local setup.

The new `fetch_public_url` (the relocated `_get_public_url`) resolves once through `_resolve_public_ips`, which rejects private / loopback / link-local / reserved / multicast / unspecified addresses and the `metadata.google.internal` / `localhost` hostnames by name, then pins the TCP connect to that resolved IP via the existing `_PinnedTransport`. It also forces `Accept-Encoding: identity` and refuses compressed bodies so the streamed size cap stays a real memory bound, and re-validates / re-pins across redirects.

The two `ai_interaction.py` downloads also called *sync* `httpx.get` from inside `async def`, blocking the event loop for up to 60s per call. Both sites now invoke the sync helper through `asyncio.to_thread`, which fixes that as a side effect.

Fixes #5888.

## Linked Issue

Fixes #5888

## Type of Change

- [x] Security fix (non-breaking — fixes a confirmed SSRF in 3 sites)
- [x] Refactor (no behaviour change for `services.search.content`; mechanical move)

## Checklist

- [x] I searched existing issues and PRs — not a duplicate.
- [x] This PR targets `dev`.
- [x] My changes are limited to the scope described — no unrelated refactors mixed in.
- [x] I added or updated tests covering the behaviour (`tests/test_outbound_fetch.py` plus rewrites of `tests/test_gallery_result_image_ssrf.py` and `tests/test_ai_image_url_safety.py`).
- [x] I ran the relevant local checks (see `CONTRIBUTING.md` → Running Checks).

## How to Test

1. Run the new and updated tests: `python -m pytest tests/test_outbound_fetch.py tests/test_gallery_result_image_ssrf.py tests/test_ai_image_url_safety.py -v`. The seven `test_outbound_fetch.py` cases pin the public contract of the shared fetcher — private IP literals, `localhost`, `metadata.google.internal`, loopback, link-local, and the cloud-metadata hostname all raise before opening a socket; a public IP literal pins the TCP connect to that exact IP via `_PinnedTransport` (verified by inspecting `transport._pool._network_backend._ip`); a `Content-Encoding: gzip` response is refused; and a `Content-Length` above the hard cap raises `BodyTooLargeError`.
2. Confirm the existing `services.search.content` behaviour is unchanged: `python -m pytest tests/test_search_content_extraction_parity.py tests/test_search_content_url_guards.py tests/test_security_regressions.py -q`. The `_get_public_url` / `_public_http_url` monkeypatches in those files keep working because `services/search/content.py` re-exports them under their historical module-local names; the implementation now lives in `src.outbound_fetch` but the symbol on the receiving end is the same callable the test assigns to.
3. Run the full SSRF/security regression suite to confirm no collateral damage: `python -m pytest tests/ -q -k "ssrf or url_safety or outbound or gallery or image_url"`. The four `_PinnedTransport` / `_get_public_url` references in `src/webhook_manager.py` and the parallel `_resolve_hostname_ips` copies there and in `src/url_security.py` are intentionally left for a follow-up — the issue scopes this PR to the three image sites plus the move, and consolidating the remaining transports broadens the surface area without changing the fix.