### PR TITLE
fix(compose): move searxng off port 8080 to avoid conflict with external services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,7 +112,7 @@ services:
         fi
         exec /usr/local/searxng/entrypoint.sh
     ports:
-      - "127.0.0.1:8080:8080"
+      - "127.0.0.1:8180:8080"
     volumes:
       - searxng-data:/etc/searxng
       - ./config/searxng/settings.yml:/tmp/searxng-settings.yml.template:ro,z


### PR DESCRIPTION
## Summary

searxng's default host port mapping (`127.0.0.1:8080:8080`) collides with other common local services that also default to 8080 (e.g. self-hosted WhatsApp/Evolution API, various dev servers). Moves the host-side mapping to `127.0.0.1:8180:8080`; the container-internal port is untouched, so nothing inside the stack needs to change.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #5895

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Start another local service bound to `127.0.0.1:8080` (e.g. `docker run -p 8080:8080 <anything>`), simulating the collision.
2. On `dev` (pre-fix): `docker compose up -d` — searxng's port mapping collides with the other service.
3. Apply this PR, then `docker compose build odysseus && docker compose up -d`.
4. `docker ps` — confirm `odysseus-searxng-1` is now `127.0.0.1:8180->8080/tcp` and healthy, with no port conflict against the other service still on 8080.
5. Open Odysseus, run a search — confirm results come back via searxng as before.