### PR TITLE
fix(llm): send reasoning_effort=none on Ollama /v1 thinking models

### DIFF
--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -2119,8 +2119,12 @@ async def llm_call_async(
             tok_key = "max_completion_tokens" if _uses_max_completion_tokens(model) else "max_tokens"
             payload[tok_key] = max_tokens
         # Suppress thinking for qwen3/gemma4 on Ollama /v1 — same as stream_llm.
+        # Current Ollama ignores top-level "think" on /v1 and only honors
+        # OpenAI-standard reasoning_effort; send both so older and newer
+        # Ollama builds both turn thinking off.
         if _is_ollama_openai_compat_url(url) and _supports_thinking(model):
             payload["think"] = False
+            payload["reasoning_effort"] = "none"
         if provider == "mistral" and _supports_thinking(model):
             payload["reasoning_effort"] = _MISTRAL_REASONING_EFFORT
         _apply_local_cache_affinity(payload, url, session_id)
@@ -2298,9 +2302,12 @@ async def _stream_llm_inner(url: str, model: str, messages: List[Dict], temperat
             payload["reasoning_effort"] = _MISTRAL_REASONING_EFFORT
         # For Ollama's OpenAI-compat /v1 endpoint with thinking models (qwen3,
         # gemma4, etc.), suppress thinking so tool calls aren't swallowed inside
-        # <think> blocks. Ollama /v1 accepts "think": false as a top-level param.
+        # <think> blocks. Keep "think": false for older Ollama builds, and also
+        # send reasoning_effort:"none" because current Ollama /v1 ignores
+        # top-level "think" and only honors the OpenAI-standard field.
         if _is_ollama_openai_compat_url(url) and _supports_thinking(model):
             payload["think"] = False
+            payload["reasoning_effort"] = "none"
         _apply_local_cache_affinity(payload, url, session_id)
         _apply_local_generation_stability(payload, target_url, model)
         _scrub_openai_chat_tool_reasoning(payload, target_url, model)

--- a/tests/test_llm_core_ollama_thinking.py
+++ b/tests/test_llm_core_ollama_thinking.py
@@ -2,8 +2,8 @@
 
 Covers:
 - _is_ollama_openai_compat_url: URL classification (local host + /v1 path)
-- think: false is injected into the payload for Ollama /v1 thinking models
-- think: false is NOT injected for non-thinking models or non-Ollama /v1 endpoints
+- think: false and reasoning_effort: none are injected for Ollama /v1 thinking models
+- those fields are NOT injected for non-thinking models or non-Ollama /v1 endpoints
 """
 import asyncio
 import json
@@ -131,21 +131,23 @@ class TestIsOllamaOpenAICompatUrl:
 # ---------------------------------------------------------------------------
 
 class TestThinkSuppression:
-    """Assert think:false is present/absent in the outgoing HTTP payload."""
+    """Assert think:false + reasoning_effort:none are present/absent in the payload."""
 
     def test_think_false_for_ollama_v1_thinking_model(self, monkeypatch):
-        """think:false must be set for qwen3 on Ollama /v1."""
+        """think:false and reasoning_effort:none must be set for qwen3 on Ollama /v1."""
         payload = _capture_payload(
             monkeypatch, "http://127.0.0.1:11434/v1/chat/completions", "qwen3:14b"
         )
         assert payload.get("think") is False
+        assert payload.get("reasoning_effort") == "none"
 
     def test_no_think_for_ollama_v1_non_thinking_model(self, monkeypatch):
-        """think must NOT be set for a plain (non-thinking) model on Ollama /v1."""
+        """think/reasoning_effort must NOT be set for a plain model on Ollama /v1."""
         payload = _capture_payload(
             monkeypatch, "http://127.0.0.1:11434/v1/chat/completions", "llama3.2:3b"
         )
         assert "think" not in payload
+        assert "reasoning_effort" not in payload
 
     def test_no_think_for_openai_endpoint_with_thinking_model_name(self, monkeypatch):
         """think must NOT leak to a real OpenAI endpoint even if the model name
@@ -154,12 +156,15 @@ class TestThinkSuppression:
             monkeypatch, "https://api.openai.com/v1/chat/completions", "qwen3:14b"
         )
         assert "think" not in payload
+        # Do not force reasoning_effort on real OpenAI just because the model
+        # name looks like a local thinking model.
+        assert "reasoning_effort" not in payload
 
     def test_think_false_for_non_default_port_thinking_model(self, monkeypatch):
         """Custom-port localhost Ollama (e.g. OLLAMA_HOST=0.0.0.0:11435) must
-        also receive think:false — this is the regression guarded by the
-        host-set check added in this fix."""
+        also receive think:false + reasoning_effort:none."""
         payload = _capture_payload(
             monkeypatch, "http://127.0.0.1:11435/v1/chat/completions", "qwen3:14b"
         )
         assert payload.get("think") is False
+        assert payload.get("reasoning_effort") == "none"


### PR DESCRIPTION
## Summary
Ollama's OpenAI-compatible `/v1` path ignores top-level `think` and only honors `reasoning_effort`. Keep `think: false` for older builds, and also set `reasoning_effort` to `none` on stream and non-stream paths so Qwen3/Gemma thinking is actually suppressed when the user turns thinking off.

## Target branch
- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue
Fixes #5707

## Type of Change
- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist
- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test
```bash
python -m pytest tests/test_llm_core_ollama_thinking.py -q --noconftest
# 19 passed
```
Also re-read the Ollama `/v1` request body construction for the thinking-off path and confirm both stream and non-stream payloads include `reasoning_effort: "none"` while still sending `think: false` for older builds. No UI changes. Full app e2e against a live Ollama Qwen3/Gemma model was not run on this box.
