### PR TITLE
fix(ci): add immutable X.Y.Z-<sha> tag for main docker publishes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,8 +1,8 @@
 name: ci / docker publish
 
 # Build the Odysseus image and publish to GHCR.
-#   push to main -> :latest, :X.Y.Z            (curated release; main is fast-forwarded at releases)
-#   push to dev  -> :dev,    :X.Y.Z-dev.<sha>  (rolling dev + an immutable, traceable pin)
+#   push to main -> :latest, :X.Y.Z, :X.Y.Z-<sha>  (curated release + immutable pin)
+#   push to dev  -> :dev,    :X.Y.Z-dev.<sha>      (rolling dev + an immutable, traceable pin)
 # Multi-arch (linux/amd64 + linux/arm64): each arch builds on its own native
 # runner and pushes by digest, then a merge job stitches the digests into one
 # manifest list and applies the tags (faster + cleaner than QEMU emulation).
@@ -118,6 +118,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=${{ steps.ver.outputs.version }},enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=${{ steps.ver.outputs.version }}-${{ steps.ver.outputs.short }},enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
             type=raw,value=${{ steps.ver.outputs.version }}-dev.${{ steps.ver.outputs.short }},enable=${{ github.ref == 'refs/heads/dev' }}
       - name: Create manifest list + push tags


### PR DESCRIPTION
## Summary
`main` docker publishes currently only tag `:latest` and `:X.Y.Z`. Both move on every main push, so a production deploy cannot pin one build. `dev` already gets an immutable `:X.Y.Z-dev.<sha>` pin. This change mirrors that for `main` by also publishing `:X.Y.Z-<shortsha>`.

This is the workflow half of #5728 only. Making the `odysseus-dev` GHCR package public still needs an org owner action and is out of scope here.

## Target branch
- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue
Fixes #5728

## Type of Change
- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] Infrastructure / CI only

## Checklist
- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app/test path with Docker-based project checks.
- [ ] For UI changes: I attached screenshots / a short clip of the running app (mobile too if relevant).
- [x] No Unicode emoji added to UI or code.

## How to Test
1. Inspect `.github/workflows/docker-publish.yml` — main tags now include `${version}-${shortsha}` next to `latest` and `${version}`.
2. On the next `main` publish, confirm GHCR gets an extra immutable tag like `1.0.2-abcdef0` while existing `latest` / `1.0.2` behavior is unchanged.
3. YAML parses cleanly (`python -c "import yaml; yaml.safe_load(open('.github/workflows/docker-publish.yml'))"`).

## Limitations
- Does not change GHCR package visibility for `odysseus-dev/odysseus` (owner setting).
- Does not add git tags / GitHub Releases (related #5629).
- Immutable pin only appears after the next successful `main` docker publish.

## Visual / UI changes — REQUIRED if you touched anything that renders
No visual/UI rendering changes.