### PR TITLE
Integrate PDV governed provider boundary (reconciled)

### DIFF
--- a/PDV_INTEGRATION_BOUNDARY.md
+++ b/PDV_INTEGRATION_BOUNDARY.md
@@ -1,0 +1,74 @@
+# PDV integration boundary
+
+This checkout is an isolated, modified copy of Odysseus for native-Windows
+evaluation. It must remain outside PDV repositories. The pinned upstream state
+is recorded in `PDV_UPSTREAM_SNAPSHOT.json`.
+
+## License boundary
+
+Odysseus is licensed `AGPL-3.0-or-later`. Preserve `LICENSE`,
+`ACKNOWLEDGMENTS.md`, copyright notices, Git history, and the canonical upstream
+URL. If this modified service is conveyed or made available for remote network
+interaction, provide the complete corresponding source for the exact running
+version, including these integration changes and build/run scripts. An API
+metadata response or upstream URL alone is not a substitute for corresponding
+source availability.
+
+The source builder inventories every tracked file plus an explicit integration
+file list, records per-file and license hashes, fails on excluded tracked files
+or high-confidence credential/private-key content, and excludes exact
+runtime/secret paths. Arbitrary untracked source-like notes are not admitted by
+extension; an intentional additional file requires `--include` and receives the
+same path and secret screening.
+
+Do not copy Odysseus source into PDV. Connect over the authenticated loopback
+HTTP boundary. If PDV needs a concept implemented natively, perform a separate
+license review and clean-room design from a permissively licensed original
+source where available.
+
+## Runtime boundary
+
+- Native Windows only for this baseline; Docker and GPU paths are excluded.
+- Bind only `127.0.0.1`; selected port is `7000`.
+- Ports `11435` and `11436` are reserved and rejected by the lifecycle wrapper.
+- Keep `AUTH_ENABLED=true` and `LOCALHOST_BYPASS=false`.
+- Existing Odysseus admin authorization remains authoritative. No adapter
+  bypass, shared-secret header, or anonymous health route is added.
+- `ODYSSEUS_PDV_ADAPTER_KEY_FILE` references a pre-provisioned, ACL-restricted,
+  non-empty key file. Neither its path nor contents are returned by PDV routes.
+- Runtime data is isolated under ignored `data/pdv-integration-v1/`.
+- No paid provider, model-provider credential, GPU fallback, or external model
+  endpoint is required by the baseline.
+
+## Adapter contract
+
+Use an authenticated admin session or `Authorization: Bearer <ody_...>` token
+owned by an Odysseus admin.
+
+- `GET /api/pdv/health` wraps native readiness and fails closed with HTTP 503
+  unless database/data readiness, loopback binding, adapter-key reference,
+  source metadata, a live governed Execution OS `health.status` round-trip, and
+  a connected seven-tool `pdv_control` MCP child are all valid.
+- `GET /api/pdv/source` returns canonical repository, pinned upstream commit,
+  branch, and license metadata. It never returns local filesystem paths.
+
+Run a non-mutating preflight:
+
+```powershell
+pwsh -NoProfile -File .\scripts\pdv_verify_native_windows_baseline.ps1 `
+  -RepositoryRoot . `
+  -ExpectedUpstreamCommit 25c9e735ef5ce605f47f8f666ac6689056d2c10c `
+  -Json
+
+pwsh -NoProfile -File .\scripts\pdv_windows_lifecycle.ps1 `
+  -Action Check `
+  -RepositoryRoot . `
+  -AdapterKeyFile $env:ODYSSEUS_PDV_ADAPTER_KEY_FILE `
+  -ExecutionOsUrl http://127.0.0.1:4310 `
+  -Port 7000 `
+  -Json
+```
+
+`Start` launches a hidden Uvicorn process and records its PID. `Stop` terminates
+only a PID whose executable and command line match this checkout's Uvicorn
+instance.

--- a/PDV_INTEGRATION_BOUNDARY.md
+++ b/PDV_INTEGRATION_BOUNDARY.md
@@ -40,6 +40,23 @@ source where available.
 - No paid provider, model-provider credential, GPU fallback, or external model
   endpoint is required by the baseline.
 
+## Provider-routing boundary
+
+When `PDV_PROVIDER_GUARD_REQUIRED=true`, Odysseus fallback chains are ranked by
+the authenticated Execution OS adapter before any model request. The governed
+order is approved local capacity, configured free hosted routes, NVIDIA NIM,
+other explicitly authorized OpenAI-compatible routes, then paid routes only
+when the PDV paid-route policy is already enabled. Ranking fails closed.
+
+Only endpoint and model identifiers cross this boundary. Provider headers and
+keys remain attached to the original Odysseus candidate tuple and are never
+serialized to PDV. The returned candidate indexes, endpoint/model correlation,
+timeout, and retry limits are validated before use. Odysseus applies those
+limits, then obtains a separate per-request authorization receipt. Completion,
+failure, timeout, cancellation, available token usage, and available cost are
+reported against that exact authorization. PDV owns resource health and circuit
+state; Odysseus remains the credential-owning HTTP client.
+
 ## Adapter contract
 
 Use an authenticated admin session or `Authorization: Bearer <ody_...>` token

--- a/PDV_NATIVE_FEATURE_PROOF.md
+++ b/PDV_NATIVE_FEATURE_PROOF.md
@@ -1,0 +1,58 @@
+# PDV native feature proof
+
+Validation date: 2026-08-01
+
+This proof stays inside an isolated temporary Odysseus data directory. It does
+not enter the application lifespan, start background jobs, contact an LLM, or
+probe any provider endpoint.
+
+## Production bearer path
+
+`tests/test_pdv_native_integration_proof.py` imports the production `app.py` in
+a child interpreter, creates bcrypt-hashed API-token rows in the real SQLite
+schema, and sends requests through the real ASGI authentication middleware to
+`/api/pdv/source` from a non-loopback client address.
+
+Observed contract:
+
+| Caller | Expected/observed status |
+|---|---:|
+| No credential | 401 |
+| Invalid bearer | 401 |
+| Admin-owned token, wrong scope | 403 |
+| Non-admin-owned token, `pdv:read` | 403 |
+| Admin-owned token, `pdv:read` | 200 |
+
+The authorized response exposes canonical repository, upstream commit, and
+AGPL license metadata. It does not contain token values or local data paths.
+
+The same process generated production OpenAPI and confirmed 425 paths,
+including chat, agents, research, documents, notes, tasks, scheduler,
+providers, history, email, and calendar surfaces.
+
+## Commands and results
+
+```text
+.venv\Scripts\python.exe -m pytest -q tests\test_pdv_native_integration_proof.py
+1 passed, 1 warning in 12.31s
+
+.venv\Scripts\python.exe -m pytest -q tests\test_api_chat_security.py tests\test_ai_interaction_owner_scope.py tests\test_research_owner_scope_routes.py tests\test_document_session_owner_scope.py tests\test_document_tool_owner_scope.py tests\test_manage_notes_owner_gate.py tests\test_notes_fail_closed_auth.py tests\test_manage_tasks_owner_scope.py tests\test_task_scheduler_cancel.py tests\test_scheduler_restart_doublefire.py tests\test_model_helper_owner_scope.py tests\test_provider_endpoints_normalization.py tests\test_history_topics_owner_scope.py tests\test_email_owner_scope.py tests\test_calendar_owner_scope.py tests\test_session_manager_persist_guard.py
+110 passed, 15 warnings in 13.26s
+
+.venv\Scripts\python.exe -m pytest -q tests\test_pdv_routes.py tests\test_api_token_routes.py tests\test_pdv_native_integration_proof.py
+25 passed, 1 warning in 14.02s
+```
+
+The 110-test lane exercises owner isolation and persisted state for chat/agent
+resolution, research, documents, notes, tasks and scheduler restart/cancel,
+provider configuration, history, email SQLite indexes/scheduled rows, calendar,
+and session messages. Tests use local stores and mocks; no model inference is a
+condition of passing.
+
+## Credential-dependent capabilities
+
+Local calendar storage and routes are available without a remote CalDAV
+account. CalDAV synchronization requires owner-supplied remote credentials.
+Email routes and owner isolation are implemented and tested, but live IMAP,
+SMTP, and OAuth operations remain `AUTH_REQUIRED` until the owner configures an
+email account. No credential was invented or persisted by this proof.

--- a/PDV_UPSTREAM_SNAPSHOT.json
+++ b/PDV_UPSTREAM_SNAPSHOT.json
@@ -1,0 +1,33 @@
+{
+  "capturedAtUtc": "2026-08-01T11:52:31.8989675Z",
+  "canonicalRepository": "https://github.com/odysseus-dev/odysseus",
+  "cloneUrl": "https://github.com/odysseus-dev/odysseus.git",
+  "upstreamBranch": "dev",
+  "upstreamCommit": "25c9e735ef5ce605f47f8f666ac6689056d2c10c",
+  "upstreamAuthorDate": "2026-07-30T13:57:07Z",
+  "upstreamSubject": "fix(email): open settings after OAuth callback (#5803)",
+  "integrationBranch": "codex/pdv-integration-v1",
+  "fullClone": true,
+  "upstreamCommitCount": 1973,
+  "submodules": [],
+  "tags": [],
+  "releases": [],
+  "license": "AGPL-3.0-or-later",
+  "licenseSha256": "79735a75d0274d2a5dcc240d11a0f81e34cfc3533939b7fce8e84e35a150a238",
+  "dependencyManifests": {
+    "requirements.txt": "6d9e118376ee8da3834896f36b036d5b6b21dc64f9b20f878826fb83623f2047",
+    "requirements-optional.txt": "b572b633270f7c24b3d1e568e7738bca0ac9a0dbfe3139c2f1637d1d7c3a327c",
+    "pyproject.toml": "1f90da0a25470dafb5027c29a29cf198dbb019152646cf6311adccf24c329334",
+    "package.json": "63717150ec227586083dd990877ece21701591abd3a277008909616033391c11",
+    "package-lock.json": "d766341fdc5599f52c31cf015b8ebb212a3722f94f08b069a191a83f48b425ea",
+    "setup.py": "a5763ce4316df2aeda11002200cfe2ed582f2462aeff544282e94a856471c9e3"
+  },
+  "lockfiles": {
+    "npm": {
+      "path": "package-lock.json",
+      "lockfileVersion": 3
+    },
+    "python": null
+  },
+  "attributionSha256": "a0733b4b19ef0820c4b75e4d12348ec9e05c8d977b778ed2445eac1c850b7861"
+}

--- a/PDV_WINDOWS_NATIVE_BASELINE.md
+++ b/PDV_WINDOWS_NATIVE_BASELINE.md
@@ -1,0 +1,43 @@
+# Native Windows baseline
+
+## Scope
+
+Captured against upstream `dev` commit
+`25c9e735ef5ce605f47f8f666ac6689056d2c10c` on branch
+`codex/pdv-integration-v1`. This baseline does not start the application,
+Docker, model servers, providers, GPU probes, or network listeners.
+
+## Host and dependency state
+
+- Windows `10.0.26200.0`; PowerShell `7.6.3`; Git `2.52.0.windows.1`.
+- CPython `3.12.10` in ignored `.venv`; pip `26.2`.
+- Git Bash available at the standard Git for Windows installation.
+- Core `requirements.txt` installed successfully into `.venv`.
+- `python -m pip check`: `No broken requirements found.`
+- Python dependencies are unpinned; no Python lockfile exists. The npm
+  `package-lock.json` is lockfile version 3.
+- Optional dependencies from `requirements-optional.txt` were not installed.
+
+## Guardrails
+
+- Native bind contract: `127.0.0.1:7000`.
+- Reserved model ports untouched: `11435`, `11436`.
+- No key contents, paid APIs, provider credentials, Docker, or GPUs used.
+- First-time `setup.py` was not run because it creates auth/data state and may
+  emit a generated admin password. Runtime route/import tests use isolated test
+  state instead.
+
+## Reproduction commands
+
+```powershell
+git clone https://github.com/odysseus-dev/odysseus.git C:\Users\User\Desktop\PDV_APPS\_external\odysseus-pdv-integration-v1
+git -C C:\Users\User\Desktop\PDV_APPS\_external\odysseus-pdv-integration-v1 fetch --all --tags --prune
+git -C C:\Users\User\Desktop\PDV_APPS\_external\odysseus-pdv-integration-v1 switch -c codex/pdv-integration-v1
+py -3.12 -m venv .venv
+.\.venv\Scripts\python.exe -m pip install --upgrade pip
+.\.venv\Scripts\python.exe -m pip install -r requirements.txt
+.\.venv\Scripts\python.exe -m pip check
+```
+
+Validation results and any upstream failures are appended after the bounded test
+run; no failure is hidden or converted to an expected failure.

--- a/app.py
+++ b/app.py
@@ -703,6 +703,10 @@ app.include_router(setup_preset_routes(preset_manager))
 from routes.diagnostics_routes import setup_diagnostics_routes
 app.include_router(setup_diagnostics_routes(rag_manager, rag_available, research_handler, memory_vector))
 
+# PDV local adapter boundary (existing admin auth; metadata/readiness only)
+from routes.pdv_routes import setup_pdv_routes
+app.include_router(setup_pdv_routes())
+
 # Cleanup
 from routes.cleanup.cleanup_routes import setup_cleanup_routes
 app.include_router(setup_cleanup_routes(session_manager))

--- a/mcp_servers/image_gen_server.py
+++ b/mcp_servers/image_gen_server.py
@@ -104,6 +104,8 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
         if is_gpt_image:
             payload["quality"] = quality if quality in ("low", "medium", "high", "auto") else "medium"
 
+        from src.pdv_provider_guard import authorize_provider
+        await authorize_provider(images_url, model_id)
         async with httpx.AsyncClient(timeout=httpx.Timeout(connect=30.0, read=300.0, write=30.0, pool=30.0)) as client:
             resp = await client.post(images_url, json=payload, headers=headers)
 

--- a/mcp_servers/pdv_control_server.py
+++ b/mcp_servers/pdv_control_server.py
@@ -1,0 +1,96 @@
+"""Bounded MCP client bridge to the independent PDV Execution OS service."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from urllib.parse import urlparse
+
+import httpx
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import TextContent, Tool
+
+
+server = Server("pdv-control")
+_TOOL_MAP = {
+    "pdv_health_status": "health.status",
+    "pdv_memory_read": "memory.read",
+    "pdv_memory_write": "memory.write",
+    "pdv_memory_delete": "memory.delete",
+    "pdv_dispatch_submit": "dispatch.submit",
+    "pdv_dispatch_status": "dispatch.status",
+    "pdv_dispatch_cancel": "dispatch.cancel",
+}
+
+
+def _boundary() -> tuple[str, str]:
+    base = os.environ.get("PDV_EXECUTION_OS_URL", "").strip().rstrip("/")
+    parsed = urlparse(base)
+    if parsed.scheme != "http" or parsed.hostname not in {"127.0.0.1", "localhost", "::1"} or not parsed.port:
+        raise RuntimeError("PDV Execution OS requires an explicit loopback HTTP URL and port")
+    key_path = Path(os.environ.get("ODYSSEUS_PDV_ADAPTER_KEY_FILE", "").strip())
+    try:
+        key = key_path.read_text(encoding="ascii").strip()
+    except OSError as error:
+        raise RuntimeError("PDV adapter credential reference is unavailable") from error
+    if len(key) != 64 or any(character not in "0123456789abcdef" for character in key):
+        raise RuntimeError("PDV adapter credential format is invalid")
+    return base, key
+
+
+async def _invoke(tool_name: str, arguments: dict) -> dict:
+    base, key = _boundary()
+    async with httpx.AsyncClient(timeout=httpx.Timeout(15.0, connect=3.0)) as client:
+        response = await client.post(
+            f"{base}/v1/integrations/odysseus/mcp/invoke",
+            headers={"X-PDV-Odysseus-Key": key},
+            json={"server_id": "pdv-control", "tool_name": tool_name, "arguments": arguments},
+        )
+    try:
+        payload = response.json()
+    except ValueError:
+        payload = {}
+    if response.status_code >= 400:
+        reason = payload.get("reason_code") if isinstance(payload, dict) else None
+        raise RuntimeError(f"PDV MCP invocation refused ({response.status_code}, {reason or 'UNAVAILABLE'})")
+    if not isinstance(payload, dict) or payload.get("allowed") is not True or "provenance" not in payload:
+        raise RuntimeError("PDV MCP response failed provenance validation")
+    return payload
+
+
+@server.list_tools()
+async def list_tools() -> list[Tool]:
+    source = {
+        "source": {"type": "object"},
+        "retention": {"type": "object"},
+    }
+    return [
+        Tool(name="pdv_health_status", description="Read governed PDV Execution OS health and kill-switch status.", inputSchema={"type": "object", "properties": {}, "additionalProperties": False}),
+        Tool(name="pdv_memory_read", description="Read one provenance-tracked Odysseus memory record from PDV.", inputSchema={"type": "object", "properties": {"memory_id": {"type": "string"}}, "required": ["memory_id"], "additionalProperties": False}),
+        Tool(name="pdv_memory_write", description="Write one provenance-tracked Odysseus memory record when PDV policy authorizes mutation.", inputSchema={"type": "object", "properties": {"memory_id": {"type": "string"}, "owner": {"type": "string"}, "materialization": {"type": "string"}, "content": {"type": "string"}, **source}, "required": ["memory_id", "owner", "materialization", "content", "source", "retention"], "additionalProperties": False}),
+        Tool(name="pdv_memory_delete", description="Delete one Odysseus-owned memory record when PDV policy authorizes mutation.", inputSchema={"type": "object", "properties": {"memory_id": {"type": "string"}}, "required": ["memory_id"], "additionalProperties": False}),
+        Tool(name="pdv_dispatch_submit", description="Submit bounded work to the governed PDV Execution OS. Recursive dispatch is denied.", inputSchema={"type": "object", "properties": {"project_id": {"type": "string"}, "idempotency_key": {"type": "string"}, "pdv_request_id": {"type": "string"}, "odysseus_agent_run_id": {"type": "string"}, "objective": {"type": "string"}, "timeout_ms": {"type": "integer"}, "dispatch_depth": {"type": "integer", "const": 0}}, "required": ["project_id", "idempotency_key", "pdv_request_id", "odysseus_agent_run_id", "objective", "timeout_ms", "dispatch_depth"], "additionalProperties": False}),
+        Tool(name="pdv_dispatch_status", description="Read a correlated Execution OS dispatch state.", inputSchema={"type": "object", "properties": {"dispatch_id": {"type": "string"}}, "required": ["dispatch_id"], "additionalProperties": False}),
+        Tool(name="pdv_dispatch_cancel", description="Cancel a correlated Execution OS dispatch when PDV policy authorizes mutation.", inputSchema={"type": "object", "properties": {"dispatch_id": {"type": "string"}, "final_receipt_id": {"type": "string"}, "reason": {"type": "string"}}, "required": ["dispatch_id", "final_receipt_id", "reason"], "additionalProperties": False}),
+    ]
+
+
+@server.call_tool()
+async def call_tool(name: str, arguments: dict) -> list[TextContent]:
+    mapped = _TOOL_MAP.get(name)
+    if not mapped:
+        raise ValueError(f"Unknown PDV tool: {name}")
+    payload = await _invoke(mapped, arguments if isinstance(arguments, dict) else {})
+    return [TextContent(type="text", text=json.dumps(payload, sort_keys=True))]
+
+
+async def main() -> None:
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(read_stream, write_stream, server.create_initialization_options())
+
+
+if __name__ == "__main__":
+    import asyncio
+    asyncio.run(main())

--- a/routes/api_token_routes.py
+++ b/routes/api_token_routes.py
@@ -27,12 +27,14 @@ ALLOWED_SCOPES = {
     "memory:write",
     "cookbook:read",
     "cookbook:launch",
+    "pdv:read",
 }
 TOKEN_PROFILES = {
     "chat": ["chat"],
     "codex_todos": ["todos:read", "todos:write"],
     "codex_documents": ["documents:read", "documents:write"],
     "codex_email_drafts": ["email:read", "email:draft", "documents:read", "documents:write"],
+    "pdv_control": ["pdv:read"],
 }
 
 

--- a/routes/embedding_routes.py
+++ b/routes/embedding_routes.py
@@ -274,6 +274,8 @@ def setup_embedding_routes():
         # Quick health check
         try:
             import httpx
+            from src.pdv_provider_guard import authorize_provider_sync
+            authorize_provider_sync(url, model or "embedding-endpoint")
             resp = httpx.post(
                 url,
                 json={"input": ["test"], "model": model or "test"},

--- a/routes/gallery/gallery_routes.py
+++ b/routes/gallery/gallery_routes.py
@@ -571,6 +571,8 @@ def setup_gallery_routes() -> APIRouter:
 
         # Use img2img endpoint if available, otherwise upscale via canvas on client
         try:
+            from src.pdv_provider_guard import authorize_provider
+            await authorize_provider(f"{base_url}/images/upscale", getattr(ep, "model", None) or "image-endpoint")
             async with httpx.AsyncClient(timeout=120) as client:
                 resp = await client.post(f"{base_url}/images/upscale", json={
                     "image": b64, "scale": scale,
@@ -614,6 +616,8 @@ def setup_gallery_routes() -> APIRouter:
             base_url += "/v1"
 
         try:
+            from src.pdv_provider_guard import authorize_provider
+            await authorize_provider(f"{base_url}/images/generations", getattr(ep, "model", None) or "image-endpoint")
             async with httpx.AsyncClient(timeout=180) as client:
                 resp = await client.post(f"{base_url}/images/generations", json={
                     "prompt": prompt,
@@ -1357,6 +1361,8 @@ def setup_gallery_routes() -> APIRouter:
             }
             headers = {"Authorization": f"Bearer {api_key}"}
             try:
+                from src.pdv_provider_guard import authorize_provider
+                await authorize_provider(_join_checked_gallery_endpoint(base, "/images/edits"), oa_model)
                 async with httpx.AsyncClient(timeout=120) as client:
                     r = await client.post(_join_checked_gallery_endpoint(base, "/images/edits"), headers=headers, data=data, files=files)
                     if r.status_code != 200:
@@ -1411,6 +1417,8 @@ def setup_gallery_routes() -> APIRouter:
             # supports multiple models per process. Harmless if ignored.
             if chosen_model:
                 body["model"] = chosen_model
+            from src.pdv_provider_guard import authorize_provider
+            await authorize_provider(_join_checked_gallery_endpoint(base, "/images/edits"), chosen_model or body.get("model") or "image-endpoint")
             async with httpx.AsyncClient(timeout=240) as client:
                 try:
                     import base64, io
@@ -1477,7 +1485,9 @@ def setup_gallery_routes() -> APIRouter:
                     logger.exception("inpaint_proxy: failed to prepare self-hosted edit request")
                     raise HTTPException(400, "Failed to prepare inpaint request")
 
-                r = await client.post(_join_checked_gallery_endpoint(base, "/images/inpaint"), json=body)
+                inpaint_target = _join_checked_gallery_endpoint(base, "/images/inpaint")
+                await authorize_provider(inpaint_target, chosen_model or body.get("model") or "image-endpoint")
+                r = await client.post(inpaint_target, json=body)
                 if r.status_code != 200:
                     logger.error("inpaint_proxy diffusion: status %s", r.status_code)
                     raise HTTPException(r.status_code, "Inpaint request failed")
@@ -1649,6 +1659,8 @@ def setup_gallery_routes() -> APIRouter:
                 _effective_base = base_root if path.startswith("/sdapi") else base
                 target = _join_checked_gallery_endpoint(_effective_base, path)
                 try:
+                    from src.pdv_provider_guard import authorize_provider
+                    await authorize_provider(target, model or "image-endpoint")
                     r = await client.post(target, json=payload, headers=headers)
                     if r.status_code == 404:
                         last_err = f"{path}: 404"
@@ -2297,6 +2309,8 @@ def setup_gallery_routes() -> APIRouter:
                 h.update(headers)
 
             async with httpx.AsyncClient(timeout=60) as client:
+                from src.pdv_provider_guard import authorize_provider
+                await authorize_provider(chat_url, model_name)
                 resp = await client.post(chat_url, json=payload, headers=h)
                 if resp.status_code != 200:
                     logger.error("ai_tag vision model: status %s: %s", resp.status_code, resp.text[:500])

--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -733,6 +733,8 @@ def _probe_single_model(base: str, api_key: str, model_id: str, timeout: int = 1
             payload["tools"] = _test_tools
 
     try:
+        from src.pdv_provider_guard import authorize_provider_sync
+        authorize_provider_sync(target_url, model_id)
         t0 = _time.time()
         r = httpx.post(target_url, headers=h, json=payload, timeout=timeout, verify=llm_verify())
         latency = round((_time.time() - t0) * 1000)

--- a/routes/pdv_routes.py
+++ b/routes/pdv_routes.py
@@ -124,6 +124,13 @@ def _default_runtime_state() -> Dict[str, object]:
     run or correlation ID. Reporting UNKNOWN/null is more truthful than choosing
     an unrelated task run.
     """
+    try:
+        from src.pdv_provider_guard import get_provider_runtime_observation
+        observation = get_provider_runtime_observation()
+        if observation:
+            return observation
+    except Exception:
+        pass
     provider = None
     model = None
     try:
@@ -146,6 +153,13 @@ def _default_runtime_state() -> Dict[str, object]:
 
 def _default_capability_state(request: Request, ready: bool) -> Dict[str, str]:
     core_state = "AVAILABLE" if ready else "DEGRADED"
+    provider_observation = {}
+    try:
+        from src.pdv_provider_guard import get_provider_runtime_observation
+        provider_observation = get_provider_runtime_observation()
+    except Exception:
+        pass
+    provider_state = "AVAILABLE" if ready and provider_observation.get("currentRunStatus") == "SUCCEEDED" else "DEGRADED"
     email_state = "AUTH_REQUIRED"
     try:
         from core.database import EmailAccount, get_db_session
@@ -160,11 +174,11 @@ def _default_capability_state(request: Request, ready: bool) -> Dict[str, str]:
     except Exception:
         pass
     return {
-        "chat": core_state,
-        "agents": core_state,
+        "chat": provider_state,
+        "agents": provider_state,
         "mcp": core_state,
         "memory": core_state,
-        "research": core_state,
+        "research": provider_state,
         "documents": core_state,
         "notes": core_state,
         "tasks": core_state,

--- a/routes/pdv_routes.py
+++ b/routes/pdv_routes.py
@@ -1,0 +1,297 @@
+"""Authenticated, metadata-only boundary for a local PDV adapter."""
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Awaitable, Callable, Dict, Optional
+from urllib.parse import urlparse
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import FileResponse, JSONResponse
+import httpx
+
+from core.middleware import require_admin
+from src.runtime_paths import get_app_root
+
+
+SNAPSHOT_NAME = "PDV_UPSTREAM_SNAPSHOT.json"
+SOURCE_ARCHIVE_RELATIVE = Path("data/pdv-integration-v1/source/odysseus-corresponding-source.zip")
+_LOOPBACK_HOSTS = {"127.0.0.1", "::1", "localhost"}
+
+
+async def _default_integration_probe(execution_os_url: str, adapter_key: str) -> Dict[str, bool]:
+    """Prove both the live governed bridge and its registered MCP child."""
+    from src.tool_utils import get_mcp_manager
+
+    manager = get_mcp_manager()
+    status = manager.get_server_status("pdv_control") if manager is not None else {}
+    mcp_connected = status.get("status") == "connected" and int(status.get("tool_count") or 0) >= 7
+    async with httpx.AsyncClient(timeout=httpx.Timeout(3.0, connect=1.0)) as client:
+        response = await client.post(
+            f"{execution_os_url.rstrip('/')}/v1/integrations/odysseus/mcp/invoke",
+            headers={"X-PDV-Odysseus-Key": adapter_key},
+            json={"server_id": "pdv-control", "tool_name": "health.status", "arguments": {}},
+        )
+    try:
+        payload = response.json()
+    except ValueError:
+        payload = {}
+    provenance = payload.get("provenance") if isinstance(payload, dict) else None
+    bridge_verified = bool(
+        response.status_code == 200
+        and payload.get("allowed") is True
+        and isinstance(provenance, dict)
+        and provenance.get("source_system") == "pdv-execution-os"
+        and provenance.get("tool_name") == "health.status"
+    )
+    return {
+        "executionOsReachable": bridge_verified,
+        "pdvControlMcpConnected": mcp_connected,
+        "pdvControlBridgeVerified": bridge_verified,
+    }
+
+
+def _require_pdv_reader(request: Request) -> None:
+    """Require an admin session or a narrowly scoped, admin-owned API token."""
+    if not getattr(request.state, "api_token", False):
+        require_admin(request)
+        return
+    owner = getattr(request.state, "api_token_owner", None)
+    scopes = set(getattr(request.state, "api_token_scopes", ()) or ())
+    auth_manager = getattr(request.app.state, "auth_manager", None)
+    if not owner or "pdv:read" not in scopes or not auth_manager or not auth_manager.is_admin(owner):
+        raise HTTPException(403, "PDV owner token with pdv:read scope required")
+
+
+def _source_archive(root: Path) -> tuple[Path, Dict[str, object]]:
+    archive = (root / SOURCE_ARCHIVE_RELATIVE).resolve()
+    archive.relative_to(root)
+    receipt_path = archive.with_suffix(archive.suffix + ".json")
+    try:
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+        expected = receipt["archiveSha256"]
+        actual = hashlib.sha256(archive.read_bytes()).hexdigest()
+    except (OSError, json.JSONDecodeError, KeyError, TypeError):
+        raise HTTPException(503, "Corresponding source archive unavailable")
+    if not isinstance(expected, str) or expected != actual:
+        raise HTTPException(503, "Corresponding source archive verification failed")
+    return archive, receipt
+
+
+def _load_source_metadata(repository_root: Path) -> Dict[str, object]:
+    path = repository_root / SNAPSHOT_NAME
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    allowed = {
+        "canonicalRepository",
+        "upstreamCommit",
+        "upstreamBranch",
+        "integrationBranch",
+        "license",
+    }
+    return {key: value for key, value in payload.items() if key in allowed}
+
+
+def _default_runtime_state() -> Dict[str, object]:
+    """Return non-secret configured model metadata; run fields stay unknown.
+
+    Odysseus has task-specific run records, but no single process-wide current
+    run or correlation ID. Reporting UNKNOWN/null is more truthful than choosing
+    an unrelated task run.
+    """
+    provider = None
+    model = None
+    try:
+        from src.endpoint_resolver import resolve_endpoint
+        from src.llm_core import _detect_provider
+
+        endpoint, model, _headers = resolve_endpoint("default")
+        if endpoint:
+            provider = _detect_provider(endpoint) or None
+    except Exception:
+        pass
+    return {
+        "provider": provider,
+        "model": model,
+        "currentRunStatus": "UNKNOWN",
+        "taskCorrelationId": None,
+        "failureMessage": None,
+    }
+
+
+def _default_capability_state(request: Request, ready: bool) -> Dict[str, str]:
+    core_state = "AVAILABLE" if ready else "DEGRADED"
+    email_state = "AUTH_REQUIRED"
+    try:
+        from core.database import EmailAccount, get_db_session
+
+        owner = getattr(request.state, "api_token_owner", None) or getattr(request.state, "current_user", None)
+        with get_db_session() as db:
+            query = db.query(EmailAccount)
+            if owner:
+                query = query.filter(EmailAccount.owner == owner)
+            if query.first() is not None:
+                email_state = core_state
+    except Exception:
+        pass
+    return {
+        "chat": core_state,
+        "agents": core_state,
+        "mcp": core_state,
+        "memory": core_state,
+        "research": core_state,
+        "documents": core_state,
+        "notes": core_state,
+        "tasks": core_state,
+        "scheduler": core_state,
+        "providers": core_state,
+        "history": core_state,
+        "calendar": core_state,
+        "email": email_state,
+    }
+
+
+def setup_pdv_routes(
+    repository_root: Optional[Path] = None,
+    readiness_checker: Optional[Callable[[], Dict[str, object]]] = None,
+    runtime_state_provider: Optional[Callable[[], Dict[str, object]]] = None,
+    capability_state_provider: Optional[Callable[[Request, bool], Dict[str, str]]] = None,
+    integration_probe: Optional[Callable[[str, str], Awaitable[Dict[str, bool]]]] = None,
+) -> APIRouter:
+    """Create the PDV adapter router without adding an authentication bypass."""
+    router = APIRouter(prefix="/api/pdv", tags=["pdv"])
+    root = Path(repository_root or get_app_root()).resolve()
+
+    if readiness_checker is None:
+        from src.readiness import check_readiness
+
+        readiness_checker = check_readiness
+    runtime_state_provider = runtime_state_provider or _default_runtime_state
+    capability_state_provider = capability_state_provider or _default_capability_state
+    integration_probe = integration_probe or _default_integration_probe
+
+    @router.get("/health")
+    async def pdv_health(request: Request):
+        _require_pdv_reader(request)
+        readiness = readiness_checker()
+        bind_host = (os.getenv("APP_BIND") or os.getenv("ODYSSEUS_HOST") or "127.0.0.1").strip().lower()
+        loopback = bind_host in _LOOPBACK_HOSTS
+        key_ref = (os.getenv("ODYSSEUS_PDV_ADAPTER_KEY_FILE") or "").strip()
+        key_readable = False
+        key_text = ""
+        if key_ref and Path(key_ref).is_file():
+            try:
+                key_text = Path(key_ref).read_text(encoding="ascii").strip()
+                key_readable = len(key_text) == 64 and all(character in "0123456789abcdef" for character in key_text)
+            except (OSError, UnicodeError):
+                key_readable = False
+        source_metadata = _load_source_metadata(root)
+        source_ok = bool(source_metadata.get("upstreamCommit") and source_metadata.get("license"))
+        source_archive_ok = True
+        source_archive_sha256 = None
+        try:
+            _archive, source_receipt = _source_archive(root)
+            source_archive_sha256 = source_receipt.get("archiveSha256")
+        except HTTPException:
+            source_archive_ok = False
+        try:
+            raw_runtime = runtime_state_provider() or {}
+        except Exception:
+            raw_runtime = {}
+        runtime = {
+            "provider": raw_runtime.get("provider"),
+            "model": raw_runtime.get("model"),
+            "currentRunStatus": raw_runtime.get("currentRunStatus") or "UNKNOWN",
+            "taskCorrelationId": raw_runtime.get("taskCorrelationId"),
+            "failureMessage": raw_runtime.get("failureMessage"),
+        }
+        execution_os_url = (os.getenv("PDV_EXECUTION_OS_URL") or "").strip()
+        parsed_execution_os = urlparse(execution_os_url)
+        execution_os_configured = (
+            parsed_execution_os.scheme == "http"
+            and parsed_execution_os.hostname in _LOOPBACK_HOSTS
+            and parsed_execution_os.port is not None
+            and not parsed_execution_os.username
+            and not parsed_execution_os.password
+        )
+        integration_state = {
+            "executionOsReachable": False,
+            "pdvControlMcpConnected": False,
+            "pdvControlBridgeVerified": False,
+        }
+        if execution_os_configured and key_readable:
+            try:
+                observed = await integration_probe(execution_os_url, key_text)
+                integration_state = {
+                    name: observed.get(name) is True for name in integration_state
+                }
+            except Exception:
+                pass
+        provider_guard_required = os.getenv("PDV_PROVIDER_GUARD_REQUIRED", "false").lower() == "true"
+        key_acl_restricted = os.getenv("PDV_ADAPTER_KEY_ACL_VERIFIED", "false").lower() == "true"
+        ready = bool(readiness.get("ready")) and loopback and key_readable and key_acl_restricted and execution_os_configured and all(integration_state.values()) and provider_guard_required and source_ok and source_archive_ok
+        capabilities = capability_state_provider(request, ready)
+        payload = {
+            **readiness,
+            "ready": ready,
+            "boundary": {
+                "loopback": loopback,
+                "adapterKeyReferenceConfigured": bool(key_ref),
+                "adapterKeyReadable": key_readable,
+                "adapterKeyAclRestricted": key_acl_restricted,
+                "executionOsConfigured": execution_os_configured,
+                **integration_state,
+                "providerGuardRequired": provider_guard_required,
+            },
+            "sourceMetadataAvailable": source_ok,
+            "sourceArchiveAvailable": source_archive_ok,
+            "sourceArchiveSha256": source_archive_sha256,
+            "runtime": runtime,
+            "capabilities": capabilities,
+        }
+        return JSONResponse(status_code=200 if ready else 503, content=payload)
+
+    @router.get("/source")
+    async def pdv_source(request: Request):
+        _require_pdv_reader(request)
+        metadata = _load_source_metadata(root)
+        if not metadata:
+            return JSONResponse(
+                status_code=503,
+                content={"available": False, "correspondingSourceRequired": True},
+            )
+        archive_available = True
+        archive_sha256 = None
+        try:
+            _archive, receipt = _source_archive(root)
+            archive_sha256 = receipt.get("archiveSha256")
+        except HTTPException:
+            archive_available = False
+        return {
+            **metadata,
+            "available": True,
+            "modifiedSource": True,
+            "correspondingSourceRequired": True,
+            "sourceEndpoint": "/api/pdv/source",
+            "sourceArchiveEndpoint": "/api/pdv/source/archive",
+            "sourceArchiveAvailable": archive_available,
+            "sourceArchiveSha256": archive_sha256,
+        }
+
+    @router.get("/source/archive")
+    async def pdv_source_archive(request: Request):
+        _require_pdv_reader(request)
+        archive, receipt = _source_archive(root)
+        return FileResponse(
+            archive,
+            media_type="application/zip",
+            filename="odysseus-corresponding-source.zip",
+            headers={"Digest": f"sha-256={receipt['archiveSha256']}"},
+        )
+
+    return router

--- a/routes/pdv_routes.py
+++ b/routes/pdv_routes.py
@@ -3,6 +3,7 @@
 import hashlib
 import json
 import os
+import zipfile
 from pathlib import Path
 from typing import Awaitable, Callable, Dict, Optional
 from urllib.parse import urlparse
@@ -71,8 +72,27 @@ def _source_archive(root: Path) -> tuple[Path, Dict[str, object]]:
     try:
         receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
         expected = receipt["archiveSha256"]
-        actual = hashlib.sha256(archive.read_bytes()).hexdigest()
-    except (OSError, json.JSONDecodeError, KeyError, TypeError):
+        archive_bytes = archive.read_bytes()
+        actual = hashlib.sha256(archive_bytes).hexdigest()
+        with zipfile.ZipFile(archive) as source_zip:
+            manifest = json.loads(source_zip.read("CORRESPONDING_SOURCE_MANIFEST.json"))
+        expected_files = manifest["files"]
+        explicit_includes = receipt["explicitIncludes"]
+        expected_tree = receipt["sourceTreeSha256"]
+        if not isinstance(expected_files, dict) or not isinstance(explicit_includes, list) or manifest.get("sourceTreeSha256") != expected_tree:
+            raise ValueError("invalid source inventory receipt")
+        from scripts.pdv_build_source_archive import INTEGRATION_FILES, _git_paths, _safe_relative, _source_tree_sha256
+        candidates = set(_git_paths(root, "--cached"))
+        candidates.update(path for path in (*INTEGRATION_FILES, *explicit_includes) if (root / path).is_file())
+        live_hashes = {}
+        for candidate in sorted(candidates):
+            relative, absolute = _safe_relative(root, candidate)
+            if not absolute.is_file():
+                raise ValueError("source inventory contains a non-file")
+            live_hashes[relative] = hashlib.sha256(absolute.read_bytes()).hexdigest()
+        if live_hashes != expected_files or _source_tree_sha256(live_hashes) != expected_tree:
+            raise ValueError("corresponding source is stale")
+    except (OSError, ValueError, zipfile.BadZipFile, json.JSONDecodeError, KeyError, TypeError):
         raise HTTPException(503, "Corresponding source archive unavailable")
     if not isinstance(expected, str) or expected != actual:
         raise HTTPException(503, "Corresponding source archive verification failed")

--- a/scripts/pdv_build_source_archive.py
+++ b/scripts/pdv_build_source_archive.py
@@ -100,6 +100,14 @@ def _is_untracked_source_candidate(root: Path, value: str) -> bool:
     return path.suffix.lower() in SOURCE_SUFFIXES or name in SOURCE_NAMES or (not path.suffix and path.is_file() and path.read_bytes()[:2] == b"#!")
 
 
+def _source_tree_sha256(file_hashes: dict[str, str]) -> str:
+    canonical = b"".join(
+        name.encode("utf-8") + b"\0" + digest.encode("ascii") + b"\n"
+        for name, digest in sorted(file_hashes.items())
+    )
+    return hashlib.sha256(canonical).hexdigest()
+
+
 def build(repository_root: Path, output: Path, includes: list[str]) -> dict[str, object]:
     root = repository_root.resolve()
     output = output.resolve()
@@ -149,6 +157,8 @@ def build(repository_root: Path, output: Path, includes: list[str]) -> dict[str,
         text=True,
     ).stdout.strip()
     license_sha256 = hashlib.sha256(files["LICENSE"]).hexdigest()
+    file_hashes = {name: hashlib.sha256(content).hexdigest() for name, content in sorted(files.items())}
+    source_tree_sha256 = _source_tree_sha256(file_hashes)
     manifest = {
         "schemaVersion": 2,
         "canonicalRepository": "https://github.com/odysseus-dev/odysseus",
@@ -159,7 +169,9 @@ def build(repository_root: Path, output: Path, includes: list[str]) -> dict[str,
         "sourceInventoryMode": "tracked-plus-explicit-integration-files",
         "excludedUntrackedCount": len(excluded_untracked),
         "excludedUntrackedPathsSha256": hashlib.sha256("\n".join(sorted(excluded_untracked)).encode("utf-8")).hexdigest(),
-        "files": {name: hashlib.sha256(content).hexdigest() for name, content in sorted(files.items())},
+        "explicitIncludes": sorted(explicit_includes),
+        "sourceTreeSha256": source_tree_sha256,
+        "files": file_hashes,
     }
     files["CORRESPONDING_SOURCE_MANIFEST.json"] = (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode("utf-8")
     output.parent.mkdir(parents=True, exist_ok=True)
@@ -181,6 +193,8 @@ def build(repository_root: Path, output: Path, includes: list[str]) -> dict[str,
         "integrationBranch": branch,
         "licenseSha256": license_sha256,
         "sourceInventoryMode": "tracked-plus-explicit-integration-files",
+        "explicitIncludes": sorted(explicit_includes),
+        "sourceTreeSha256": source_tree_sha256,
         "excludedUntrackedCount": len(excluded_untracked),
         "excludedUntrackedPathsSha256": hashlib.sha256("\n".join(sorted(excluded_untracked)).encode("utf-8")).hexdigest(),
         "sourceEndpoint": "/api/pdv/source/archive",

--- a/scripts/pdv_build_source_archive.py
+++ b/scripts/pdv_build_source_archive.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Build a deterministic, credential-screened corresponding-source archive."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import sys
+import zipfile
+from pathlib import Path, PurePosixPath
+
+
+INTEGRATION_FILES = (
+    "PDV_INTEGRATION_BOUNDARY.md",
+    "PDV_UPSTREAM_SNAPSHOT.json",
+    "PDV_WINDOWS_NATIVE_BASELINE.md",
+    "PDV_NATIVE_FEATURE_PROOF.md",
+    "routes/pdv_routes.py",
+    "mcp_servers/pdv_control_server.py",
+    "src/pdv_provider_guard.py",
+    "scripts/pdv_verify_native_windows_baseline.ps1",
+    "scripts/pdv_windows_lifecycle.ps1",
+    "scripts/pdv_initialize_adapter_key.ps1",
+    "scripts/pdv_build_source_archive.py",
+    "scripts/pdv_runtime_provider_probe.py",
+    "tests/cli/test_pdv_windows_baseline.py",
+    "tests/cli/test_pdv_source_archive.py",
+    "tests/test_pdv_routes.py",
+    "tests/test_pdv_mcp_bridge.py",
+    "tests/test_pdv_provider_guard.py",
+    "tests/test_pdv_native_integration_proof.py",
+)
+PROHIBITED_PARTS = {".git", ".venv", "venv", "__pycache__", ".pytest_cache", "secrets"}
+PROHIBITED_RUNTIME_PREFIXES = {("data", "pdv-integration-v1"), ("logs", "pdv-integration-v1")}
+PROHIBITED_FILE_NAMES = {".env", "adapter.key", "id_ed25519", "id_rsa"}
+PROHIBITED_FILE_SUFFIXES = (".env", ".key", ".p12", ".pem", ".pfx")
+FIXED_TIME = (1980, 1, 1, 0, 0, 0)
+SECRET_PATTERNS = (
+    re.compile(rb"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"),
+    re.compile(rb"\b(?:sk-(?:proj-|live-)?[A-Za-z0-9_-]{24,}|gh[pousr]_[A-Za-z0-9]{30,}|AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z_-]{30,})\b"),
+    re.compile(rb"\body_[A-Za-z0-9_-]{24,}\b"),
+    re.compile(rb"(?i)\b(?:api[_-]?key|access[_-]?token|auth[_-]?token|client[_-]?secret|password)\b[\"']?\s*[:=]\s*[\"'][A-Za-z0-9+/_=-]{24,}[\"']"),
+)
+SOURCE_SUFFIXES = {
+    ".bat", ".c", ".cc", ".cfg", ".cjs", ".cpp", ".css", ".cts", ".go", ".h", ".hpp", ".html", ".ini",
+    ".java", ".js", ".json", ".jsx", ".lock", ".md", ".mjs", ".mts", ".ps1", ".py", ".rb", ".rs", ".sh",
+    ".sql", ".svelte", ".toml", ".ts", ".tsx", ".txt", ".vue", ".xml", ".yaml", ".yml",
+}
+SOURCE_NAMES = {"dockerfile", "gemfile", "license", "makefile", "procfile", "rakefile"}
+
+
+def _is_runtime_path(value: str) -> bool:
+    parts = tuple(part.lower() for part in PurePosixPath(value.replace("\\", "/")).parts)
+    return parts[:2] in PROHIBITED_RUNTIME_PREFIXES
+
+
+def _is_untracked_runtime_path(value: str) -> bool:
+    parts = tuple(part.lower() for part in PurePosixPath(value.replace("\\", "/")).parts)
+    return bool(parts and parts[0] in {"data", "logs"})
+
+
+def _safe_relative(root: Path, value: str) -> tuple[str, Path]:
+    posix = PurePosixPath(value.replace("\\", "/"))
+    lowered_parts = tuple(part.lower() for part in posix.parts)
+    file_name = lowered_parts[-1] if lowered_parts else ""
+    if (
+        posix.is_absolute()
+        or ".." in posix.parts
+        or any(part in PROHIBITED_PARTS for part in lowered_parts)
+        or _is_runtime_path(value)
+        or file_name in PROHIBITED_FILE_NAMES
+        or file_name.endswith(PROHIBITED_FILE_SUFFIXES)
+    ):
+        raise ValueError("source include escapes or enters a prohibited runtime directory")
+    absolute = (root / Path(*posix.parts)).resolve()
+    absolute.relative_to(root)
+    return posix.as_posix(), absolute
+
+
+def _git_paths(root: Path, *arguments: str) -> list[str]:
+    output = subprocess.run(
+        ["git", "-c", f"safe.directory={root.as_posix()}", "ls-files", *arguments, "-z"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+    ).stdout
+    return [item.decode("utf-8") for item in output.split(b"\0") if item]
+
+
+def _contains_high_confidence_secret(content: bytes) -> bool:
+    return any(pattern.search(content) for pattern in SECRET_PATTERNS)
+
+
+def _is_untracked_source_candidate(root: Path, value: str) -> bool:
+    path = root / Path(*PurePosixPath(value.replace("\\", "/")).parts)
+    name = path.name.lower()
+    return path.suffix.lower() in SOURCE_SUFFIXES or name in SOURCE_NAMES or (not path.suffix and path.is_file() and path.read_bytes()[:2] == b"#!")
+
+
+def build(repository_root: Path, output: Path, includes: list[str]) -> dict[str, object]:
+    root = repository_root.resolve()
+    output = output.resolve()
+    output.relative_to(root)
+    tracked = set(_git_paths(root, "--cached"))
+    untracked = set(_git_paths(root, "--others", "--exclude-standard"))
+    candidates = set(tracked)
+    candidates.update(path for path in (*INTEGRATION_FILES, *includes) if (root / path).is_file())
+    excluded_untracked = sorted(untracked - candidates)
+    explicit_includes = {value.replace("\\", "/") for value in includes}
+    files: dict[str, bytes] = {}
+    excluded_untracked = [candidate.replace("\\", "/") for candidate in excluded_untracked if not _is_runtime_path(candidate)]
+    protected_values: list[bytes] = []
+    adapter_key_path = root / "data" / "pdv-integration-v1" / "adapter.key"
+    if adapter_key_path.is_file():
+        adapter_key = adapter_key_path.read_bytes().strip()
+        if len(adapter_key) == 64 and re.fullmatch(rb"[a-f0-9]{64}", adapter_key):
+            protected_values.append(adapter_key)
+    for candidate in sorted(candidates):
+        try:
+            relative, absolute = _safe_relative(root, candidate)
+        except ValueError:
+            if candidate in tracked or candidate.replace("\\", "/") in explicit_includes:
+                raise
+            if not _is_runtime_path(candidate):
+                excluded_untracked.append(candidate.replace("\\", "/"))
+            continue
+        if absolute.is_file():
+            content = absolute.read_bytes()
+            if _contains_high_confidence_secret(content) or any(secret in content for secret in protected_values):
+                raise ValueError("source inventory contains high-confidence secret material")
+            files[relative] = content
+    if "LICENSE" not in files:
+        raise ValueError("LICENSE is required in corresponding source")
+    commit = subprocess.run(
+        ["git", "-c", f"safe.directory={root.as_posix()}", "rev-parse", "HEAD"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    branch = subprocess.run(
+        ["git", "-c", f"safe.directory={root.as_posix()}", "rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    license_sha256 = hashlib.sha256(files["LICENSE"]).hexdigest()
+    manifest = {
+        "schemaVersion": 2,
+        "canonicalRepository": "https://github.com/odysseus-dev/odysseus",
+        "upstreamCommit": commit,
+        "integrationBranch": branch,
+        "license": "AGPL-3.0-or-later",
+        "licenseSha256": license_sha256,
+        "sourceInventoryMode": "tracked-plus-explicit-integration-files",
+        "excludedUntrackedCount": len(excluded_untracked),
+        "excludedUntrackedPathsSha256": hashlib.sha256("\n".join(sorted(excluded_untracked)).encode("utf-8")).hexdigest(),
+        "files": {name: hashlib.sha256(content).hexdigest() for name, content in sorted(files.items())},
+    }
+    files["CORRESPONDING_SOURCE_MANIFEST.json"] = (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = output.with_suffix(output.suffix + ".tmp")
+    with zipfile.ZipFile(temporary, "w") as archive:
+        for name, content in sorted(files.items()):
+            info = zipfile.ZipInfo(name, FIXED_TIME)
+            info.compress_type = zipfile.ZIP_DEFLATED
+            info.external_attr = 0o100644 << 16
+            archive.writestr(info, content, compresslevel=9)
+    temporary.replace(output)
+    archive_bytes = output.read_bytes()
+    receipt = {
+        "schemaVersion": 2,
+        "archiveSha256": hashlib.sha256(archive_bytes).hexdigest(),
+        "archiveBytes": len(archive_bytes),
+        "fileCount": len(files),
+        "upstreamCommit": commit,
+        "integrationBranch": branch,
+        "licenseSha256": license_sha256,
+        "sourceInventoryMode": "tracked-plus-explicit-integration-files",
+        "excludedUntrackedCount": len(excluded_untracked),
+        "excludedUntrackedPathsSha256": hashlib.sha256("\n".join(sorted(excluded_untracked)).encode("utf-8")).hexdigest(),
+        "sourceEndpoint": "/api/pdv/source/archive",
+    }
+    output.with_suffix(output.suffix + ".json").write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return receipt
+
+
+def _invalidate_failed_output(repository_root: Path, output_path: Path) -> bool:
+    root = repository_root.resolve()
+    output = output_path.resolve()
+    try:
+        output.relative_to(root)
+    except ValueError:
+        return False
+    success = True
+    # Invalidate the small verification sidecar first. The archive itself may be
+    # locked by a Windows streaming response, but without the sidecar it cannot
+    # pass the authenticated route's integrity check.
+    for stale in (output.with_suffix(output.suffix + ".json"), output.with_suffix(output.suffix + ".tmp"), output):
+        try:
+            stale.unlink(missing_ok=True)
+        except OSError:
+            success = False
+    return success
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository-root", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--include", action="append", default=[])
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    try:
+        receipt = build(Path(args.repository_root), Path(args.output), args.include)
+    except Exception as error:
+        _invalidate_failed_output(Path(args.repository_root), Path(args.output))
+        if args.json:
+            print(json.dumps({"ok": False, "error": type(error).__name__}))
+        else:
+            print(f"source archive build failed: {type(error).__name__}", file=sys.stderr)
+        return 1
+    report = {"ok": True, **receipt}
+    print(json.dumps(report) if args.json else json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pdv_initialize_adapter_key.ps1
+++ b/scripts/pdv_initialize_adapter_key.ps1
@@ -1,0 +1,73 @@
+#Requires -Version 5.1
+param(
+    [string]$RepositoryRoot = (Split-Path -Parent $PSScriptRoot),
+    [Alias("Target")]
+    [string]$KeyFile = "",
+    [switch]$Json
+)
+
+$ErrorActionPreference = "Stop"
+$root = [System.IO.Path]::GetFullPath($RepositoryRoot)
+$allowedRoot = [System.IO.Path]::GetFullPath((Join-Path $root "data\pdv-integration-v1"))
+if (-not $KeyFile) { $KeyFile = Join-Path $allowedRoot "adapter.key" }
+$targetPath = [System.IO.Path]::GetFullPath($KeyFile)
+$prefix = $allowedRoot.TrimEnd([System.IO.Path]::DirectorySeparatorChar) + [System.IO.Path]::DirectorySeparatorChar
+if (-not $targetPath.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+    $failure = [ordered]@{ ok = $false; error = "key target must stay inside the PDV runtime directory" }
+    if ($Json) { $failure | ConvertTo-Json -Compress } else { $failure | Format-List }
+    exit 1
+}
+
+$created = $false
+if (-not (Test-Path -LiteralPath $targetPath -PathType Leaf)) {
+    New-Item -ItemType Directory -Path ([System.IO.Path]::GetDirectoryName($targetPath)) -Force | Out-Null
+    $bytes = [byte[]]::new(32)
+    [System.Security.Cryptography.RandomNumberGenerator]::Fill($bytes)
+    $keyText = [Convert]::ToHexString($bytes).ToLowerInvariant()
+    $encoded = [System.Text.Encoding]::ASCII.GetBytes($keyText)
+    $stream = [System.IO.File]::Open($targetPath, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
+    try { $stream.Write($encoded, 0, $encoded.Length) } finally { $stream.Dispose() }
+    $created = $true
+}
+
+function Test-KeyAclRestricted {
+    param([string]$Path)
+    try {
+        $identityName = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+        $candidate = Get-Acl -LiteralPath $Path -ErrorAction Stop
+        $rules = @($candidate.Access)
+        return $candidate.AreAccessRulesProtected -and $rules.Count -eq 1 -and
+            -not $rules[0].IsInherited -and $rules[0].AccessControlType -eq [System.Security.AccessControl.AccessControlType]::Allow -and
+            $rules[0].IdentityReference.Value -eq $identityName -and
+            (($rules[0].FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::FullControl) -eq [System.Security.AccessControl.FileSystemRights]::FullControl)
+    } catch { return $false }
+}
+
+$aclRestricted = Test-KeyAclRestricted $targetPath
+if (-not $aclRestricted) {
+    try {
+        $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+        $security = Get-Acl -LiteralPath $targetPath
+        $security.SetAccessRuleProtection($true, $false)
+        foreach ($existingRule in @($security.Access)) { [void]$security.RemoveAccessRuleAll($existingRule) }
+        $rule = [System.Security.AccessControl.FileSystemAccessRule]::new($identity.Name, [System.Security.AccessControl.FileSystemRights]::FullControl, [System.Security.AccessControl.AccessControlType]::Allow)
+        $security.AddAccessRule($rule)
+        $security.SetOwner($identity.User)
+        Set-Acl -LiteralPath $targetPath -AclObject $security
+        $aclRestricted = Test-KeyAclRestricted $targetPath
+    } catch { $aclRestricted = $false }
+}
+
+if (-not $aclRestricted) {
+    if ($created) { Remove-Item -LiteralPath $targetPath -Force -ErrorAction SilentlyContinue }
+    $failure = [ordered]@{ ok = $false; created = $created; aclRestricted = $false; error = "adapter key ACL restriction failed" }
+    if ($Json) { $failure | ConvertTo-Json -Compress } else { $failure | Format-List }
+    exit 1
+}
+
+$keyBytes = [System.IO.File]::ReadAllBytes($targetPath)
+$keyText = [System.Text.Encoding]::ASCII.GetString($keyBytes)
+if ($keyBytes.Length -ne 64 -or $keyText -notmatch '^[a-f0-9]{64}$') { throw "Existing adapter key is not a 32-byte hex credential" }
+$fingerprint = [Convert]::ToHexString([System.Security.Cryptography.SHA256]::HashData($keyBytes)).ToLowerInvariant()
+$report = [ordered]@{ ok = $true; created = $created; fingerprintSha256 = $fingerprint; aclRestricted = $aclRestricted; keyBytes = $keyBytes.Length }
+if ($Json) { $report | ConvertTo-Json -Compress } else { $report | Format-List }

--- a/scripts/pdv_runtime_provider_probe.py
+++ b/scripts/pdv_runtime_provider_probe.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Bounded provider proof: authorization guard plus one synthetic LLM request."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from src.llm_core import llm_call
+from src.pdv_provider_guard import get_last_authorization_receipt, record_provider_outcome_sync
+
+
+def main() -> int:
+    endpoint = os.environ.get("PDV_PROOF_ENDPOINT", "").strip()
+    model = os.environ.get("PDV_PROOF_MODEL", "").strip()
+    if endpoint != "http://127.0.0.1:11435/v1" or not model:
+        print(json.dumps({"ok": False, "reason": "invalid proof route"}))
+        return 2
+    started = time.monotonic()
+    try:
+        response = llm_call(
+            endpoint,
+            model,
+            [{"role": "user", "content": "Reply with exactly: PDV_ODYSSEUS_PROVIDER_OK"}],
+            temperature=0,
+            max_tokens=16,
+            timeout=60,
+        )
+    except Exception as error:
+        authorization = get_last_authorization_receipt() or {}
+        reason_code = "HERMES_REQUEST_TIMEOUT" if "timed out" in str(error).lower() else "HERMES_REQUEST_FAILED"
+        outcome_receipt = None
+        if authorization:
+            try:
+                outcome_receipt = record_provider_outcome_sync(
+                    authorization,
+                    "timed_out" if reason_code == "HERMES_REQUEST_TIMEOUT" else "failed",
+                    round((time.monotonic() - started) * 1000),
+                    cost_microusd=0,
+                )
+            except Exception:
+                outcome_receipt = None
+        print(json.dumps({
+            "ok": False,
+            "reason_code": reason_code,
+            "providerRequestId": authorization.get("provider_request_id"),
+            "authorizationReceiptId": authorization.get("authorization_receipt_id"),
+            "authorizationReasonCode": authorization.get("reason_code"),
+            "selectedEndpoint": authorization.get("selected_endpoint"),
+            "outcomeReceiptId": (outcome_receipt or {}).get("outcome_receipt_id"),
+            "outcomeRecorded": outcome_receipt is not None,
+            "responseContentPersisted": False,
+            "maxTokens": 16,
+        }))
+        return 1
+    authorization = get_last_authorization_receipt() or {}
+    outcome_receipt = record_provider_outcome_sync(
+        authorization,
+        "completed",
+        round((time.monotonic() - started) * 1000),
+        cost_microusd=0,
+    )
+    encoded = response.encode("utf-8")
+    print(json.dumps({
+        "ok": bool(response.strip()),
+        "endpoint": "http://127.0.0.1:11435/v1",
+        "model": model,
+        "responseChars": len(response),
+        "responseSha256": hashlib.sha256(encoded).hexdigest(),
+        "responseContentPersisted": False,
+        "maxTokens": 16,
+        "providerRequestId": authorization.get("provider_request_id"),
+        "authorizationReceiptId": authorization.get("authorization_receipt_id"),
+        "authorizationReasonCode": authorization.get("reason_code"),
+        "selectedEndpoint": authorization.get("selected_endpoint"),
+        "outcomeReceiptId": outcome_receipt.get("outcome_receipt_id"),
+        "outcomeRecorded": True,
+    }))
+    return 0 if response.strip() else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pdv_verify_native_windows_baseline.ps1
+++ b/scripts/pdv_verify_native_windows_baseline.ps1
@@ -1,0 +1,208 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  Read-only verifier for the PDV native-Windows Odysseus boundary.
+
+.DESCRIPTION
+  Inspects repository provenance, license/dependency manifests, and local
+  Windows prerequisites. It never starts Docker, model servers, or listeners.
+#>
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$RepositoryRoot,
+
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^[0-9a-fA-F]{40}$')]
+    [string]$ExpectedUpstreamCommit,
+
+    [switch]$Json
+)
+
+$ErrorActionPreference = "Stop"
+$canonicalOrigin = "https://github.com/odysseus-dev/odysseus.git"
+$requiredManifests = @(
+    "LICENSE",
+    "requirements.txt",
+    "requirements-optional.txt",
+    "pyproject.toml",
+    "package.json",
+    "package-lock.json",
+    "setup.py"
+)
+
+function Invoke-GitText {
+    param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Arguments)
+    $output = & git -C $script:root @Arguments 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        throw "git command failed: git -C $script:root $($Arguments -join ' ')"
+    }
+    return (($output | Out-String).Trim())
+}
+
+function Find-CompatiblePython {
+    $candidates = @()
+    $py = Get-Command py -ErrorAction SilentlyContinue
+    if ($py) {
+        foreach ($selector in @("-3.13", "-3.12", "-3.11")) {
+            $candidates += ,@($py.Source, $selector)
+        }
+    }
+    $python = Get-Command python -ErrorAction SilentlyContinue
+    if ($python) {
+        $candidates += ,@($python.Source)
+    }
+
+    foreach ($candidate in $candidates) {
+        $exe = $candidate[0]
+        $args = @($candidate | Select-Object -Skip 1)
+        try {
+            $raw = (& $exe @args -c "import json,sys; print(json.dumps({'version': list(sys.version_info[:3]), 'executable': sys.executable}))" 2>$null | Out-String).Trim()
+            if ($LASTEXITCODE -ne 0 -or -not $raw) { continue }
+            $probe = $raw | ConvertFrom-Json
+            if ([int]$probe.version[0] -gt 3 -or ([int]$probe.version[0] -eq 3 -and [int]$probe.version[1] -ge 11)) {
+                return [ordered]@{
+                    executable = [string]$probe.executable
+                    version = (($probe.version | ForEach-Object { [string]$_ }) -join ".")
+                    launcher = $exe
+                    launcherArgs = @($args)
+                }
+            }
+        } catch {
+            continue
+        }
+    }
+    return $null
+}
+
+function Find-GitBash {
+    $bash = Get-Command bash.exe -ErrorAction SilentlyContinue
+    if ($bash) {
+        $candidate = [string]$bash.Source
+        $lower = $candidate.ToLowerInvariant()
+        if (-not ($lower.Contains("\system32\bash.exe") -or $lower.Contains("\sysnative\bash.exe") -or $lower.Contains("\windowsapps\bash.exe"))) {
+            return $candidate
+        }
+    }
+    foreach ($candidate in @(
+        "C:\Program Files\Git\bin\bash.exe",
+        "C:\Program Files\Git\usr\bin\bash.exe",
+        "C:\Program Files (x86)\Git\bin\bash.exe"
+    )) {
+        if (Test-Path -LiteralPath $candidate -PathType Leaf) { return $candidate }
+    }
+    return $null
+}
+
+$errors = [System.Collections.Generic.List[string]]::new()
+$root = [System.IO.Path]::GetFullPath($RepositoryRoot)
+if (-not (Test-Path -LiteralPath $root -PathType Container)) {
+    $errors.Add("repository root exists")
+}
+
+$origin = ""
+$head = ""
+$branch = ""
+$expectedIsAncestor = $false
+$tags = @()
+$submodules = @()
+
+if ($errors.Count -eq 0) {
+    try {
+        $inside = Invoke-GitText rev-parse --is-inside-work-tree
+        if ($inside -ne "true") { $errors.Add("repository root is a Git worktree") }
+        $origin = Invoke-GitText remote get-url origin
+        $head = Invoke-GitText rev-parse HEAD
+        $branch = Invoke-GitText branch --show-current
+        & git -C $root merge-base --is-ancestor $ExpectedUpstreamCommit HEAD 2>$null
+        $expectedIsAncestor = $LASTEXITCODE -eq 0
+        $tagText = Invoke-GitText tag --list
+        if ($tagText) { $tags = @($tagText -split "`r?`n") }
+        if (Test-Path -LiteralPath (Join-Path $root ".gitmodules")) {
+            $submoduleText = Invoke-GitText submodule status
+            if ($submoduleText) { $submodules = @($submoduleText -split "`r?`n") }
+        }
+    } catch {
+        $errors.Add("repository metadata is readable")
+    }
+}
+
+if ($origin.TrimEnd('/') -ne $canonicalOrigin.TrimEnd('/')) {
+    $errors.Add("canonical origin")
+}
+if (-not $expectedIsAncestor) {
+    $errors.Add("expected upstream commit is present in checkout history")
+}
+
+$manifestStatus = [ordered]@{}
+foreach ($name in $requiredManifests) {
+    $present = Test-Path -LiteralPath (Join-Path $root $name) -PathType Leaf
+    $manifestStatus[$name] = $present
+    if (-not $present) { $errors.Add("required manifest: $name") }
+}
+
+$licensePath = Join-Path $root "LICENSE"
+$licenseHash = ""
+$licenseSpdx = "unknown"
+if (Test-Path -LiteralPath $licensePath -PathType Leaf) {
+    $licenseHash = (Get-FileHash -LiteralPath $licensePath -Algorithm SHA256).Hash.ToLowerInvariant()
+    $licenseText = Get-Content -LiteralPath $licensePath -Raw
+    if ($licenseText -match "GNU AFFERO GENERAL PUBLIC LICENSE" -and $licenseText -match "Version 3") {
+        $licenseSpdx = "AGPL-3.0-or-later"
+    } else {
+        $errors.Add("AGPL-3.0-or-later license text")
+    }
+}
+
+$python = Find-CompatiblePython
+if ($null -eq $python) { $errors.Add("Python 3.11 or newer") }
+$gitBash = Find-GitBash
+
+$report = [ordered]@{
+    ok = $errors.Count -eq 0
+    repository = [ordered]@{
+        root = $root
+        origin = $origin
+        head = $head
+        branch = $branch
+        expectedUpstreamCommit = $ExpectedUpstreamCommit.ToLowerInvariant()
+        expectedCommitIsAncestor = $expectedIsAncestor
+        tags = @($tags)
+        submodules = @($submodules)
+    }
+    license = [ordered]@{
+        spdx = $licenseSpdx
+        sha256 = $licenseHash
+        sourceAvailabilityRequired = $true
+    }
+    dependencies = [ordered]@{
+        manifests = $manifestStatus
+        pythonLockfilePresent = $false
+        npmLockfilePresent = [bool]$manifestStatus["package-lock.json"]
+    }
+    runtime = [ordered]@{
+        platform = [System.Environment]::OSVersion.VersionString
+        powershell = $PSVersionTable.PSVersion.ToString()
+        python = $python
+        git = ((& git --version 2>$null | Out-String).Trim())
+        gitBash = $gitBash
+        gitBashOptionalForCore = $true
+    }
+    guardrails = [ordered]@{
+        mode = "native-windows-read-only-preflight"
+        dockerInvoked = $false
+        providersContacted = @()
+        credentialsLoaded = $false
+        gpuProbed = $false
+        portsTouched = @()
+        reservedPorts = @(11435, 11436)
+    }
+    errors = @($errors)
+}
+
+if ($Json) {
+    $report | ConvertTo-Json -Depth 8
+} else {
+    $report | Format-List
+}
+
+if (-not $report.ok) { exit 1 }

--- a/scripts/pdv_windows_lifecycle.ps1
+++ b/scripts/pdv_windows_lifecycle.ps1
@@ -1,0 +1,261 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  Native Windows lifecycle wrapper for the loopback-only PDV adapter instance.
+
+.DESCRIPTION
+  Check validates configuration without opening a listener. Start launches a
+  hidden Uvicorn child and records its PID under the ignored data directory.
+  Stop terminates only a matching Uvicorn process started from this checkout.
+#>
+param(
+    [ValidateSet("Check", "Start", "Stop", "Restart")]
+    [string]$Action = "Check",
+    [string]$RepositoryRoot = (Split-Path -Parent $PSScriptRoot),
+    [string]$AdapterKeyFile = $env:ODYSSEUS_PDV_ADAPTER_KEY_FILE,
+    [string]$ExecutionOsUrl = $env:PDV_EXECUTION_OS_URL,
+    [string]$PythonExecutable = "",
+    [ValidateRange(1, 65535)]
+    [int]$Port = 7000,
+    [switch]$Json
+)
+
+$ErrorActionPreference = "Stop"
+$reservedPorts = @(11435, 11436)
+$root = [System.IO.Path]::GetFullPath($RepositoryRoot)
+$runtimeDir = Join-Path $root "data\pdv-integration-v1"
+$logDir = Join-Path $runtimeDir "logs"
+$pidFile = Join-Path $runtimeDir "odysseus.pid"
+$errors = [System.Collections.Generic.List[string]]::new()
+$processStarted = $false
+$processStopped = $false
+$processId = $null
+$executionOsConfigured = -not [string]::IsNullOrWhiteSpace($ExecutionOsUrl)
+
+if (-not (Test-Path -LiteralPath $root -PathType Container) -or
+    -not (Test-Path -LiteralPath (Join-Path $root "app.py") -PathType Leaf)) {
+    $errors.Add("Odysseus repository root")
+}
+if ($Port -in $reservedPorts) {
+    $errors.Add("reserved model port")
+}
+if ($executionOsConfigured) {
+    try {
+        $executionUri = [uri]$ExecutionOsUrl
+        if ($executionUri.Scheme -ne "http" -or $executionUri.Host -notin @("127.0.0.1", "localhost", "::1") -or $executionUri.Port -le 0) {
+            $errors.Add("loopback PDV Execution OS URL")
+        }
+    } catch { $errors.Add("loopback PDV Execution OS URL") }
+} else { $errors.Add("PDV Execution OS URL") }
+
+$keyConfigured = -not [string]::IsNullOrWhiteSpace($AdapterKeyFile)
+$keyReadable = $false
+$keyAclRestricted = $false
+if ($keyConfigured) {
+    try {
+        $keyInfo = Get-Item -LiteralPath $AdapterKeyFile -ErrorAction Stop
+        $keyText = if (-not $keyInfo.PSIsContainer) { (Get-Content -LiteralPath $AdapterKeyFile -Raw -Encoding ascii).Trim() } else { "" }
+        $keyReadable = -not $keyInfo.PSIsContainer -and $keyText -match '^[a-f0-9]{64}$'
+        $keyAcl = Get-Acl -LiteralPath $AdapterKeyFile -ErrorAction Stop
+        $currentIdentity = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+        $rules = @($keyAcl.Access)
+        $keyAclRestricted = $keyAcl.AreAccessRulesProtected -and $rules.Count -eq 1 -and
+            -not $rules[0].IsInherited -and $rules[0].AccessControlType -eq [System.Security.AccessControl.AccessControlType]::Allow -and
+            $rules[0].IdentityReference.Value -eq $currentIdentity -and
+            (($rules[0].FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::FullControl) -eq [System.Security.AccessControl.FileSystemRights]::FullControl)
+    } catch {
+        $keyReadable = $false
+        $keyAclRestricted = $false
+    }
+}
+if (-not $keyConfigured) { $errors.Add("adapter key-file reference") }
+elseif (-not $keyReadable) { $errors.Add("readable 32-byte hex adapter key file") }
+elseif (-not $keyAclRestricted) { $errors.Add("ACL-restricted adapter key file") }
+
+if (-not $PythonExecutable) {
+    foreach ($candidate in @(
+        (Join-Path $root ".venv\Scripts\python.exe"),
+        (Join-Path $root "venv\Scripts\python.exe")
+    )) {
+        if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+            $PythonExecutable = $candidate
+            break
+        }
+    }
+}
+if (-not $PythonExecutable) {
+    $pythonCommand = Get-Command python.exe -ErrorAction SilentlyContinue
+    if ($pythonCommand) { $PythonExecutable = $pythonCommand.Source }
+}
+if (-not $PythonExecutable -or -not (Test-Path -LiteralPath $PythonExecutable -PathType Leaf)) {
+    $errors.Add("Python executable")
+}
+
+function New-Report {
+    param([string]$RequestedAction)
+    return [ordered]@{
+        ok = $script:errors.Count -eq 0
+        action = $RequestedAction
+        bindHost = "127.0.0.1"
+        port = $script:Port
+        authEnabled = $true
+        localhostBypass = $false
+        adapterKeyReferenceConfigured = $script:keyConfigured
+        adapterKeyReadable = $script:keyReadable
+        adapterKeyAclRestricted = $script:keyAclRestricted
+        executionOsConfigured = $script:executionOsConfigured
+        reservedPorts = @($script:reservedPorts)
+        portsTouched = @($(if ($script:processStarted) { $script:Port }))
+        processStarted = $script:processStarted
+        processStopped = $script:processStopped
+        processId = $script:processId
+        errors = @($script:errors)
+    }
+}
+
+function Write-ReportAndExit {
+    param([int]$ExitCode)
+    $report = New-Report $Action
+    if ($Json) { $report | ConvertTo-Json -Depth 5 }
+    else { $report | Format-List }
+    exit $ExitCode
+}
+
+if ($Action -eq "Check") {
+    Write-ReportAndExit $(if ($errors.Count -eq 0) { 0 } else { 1 })
+}
+
+if ($Action -eq "Restart") {
+    $stopOutput = @(& $PSCommandPath -Action Stop -RepositoryRoot $root -AdapterKeyFile $AdapterKeyFile -ExecutionOsUrl $ExecutionOsUrl -PythonExecutable $PythonExecutable -Port $Port -Json)
+    $stopExitCode = $LASTEXITCODE
+    if ($stopExitCode -ne 0) { $errors.Add("existing PDV Odysseus process stopped for restart"); Write-ReportAndExit 1 }
+    try { $stopReport = ($stopOutput -join [Environment]::NewLine) | ConvertFrom-Json } catch { $stopReport = $null }
+    if (-not $stopReport -or -not $stopReport.processStopped) { $errors.Add("valid stop receipt for restart"); Write-ReportAndExit 1 }
+
+    $startOutput = @(& $PSCommandPath -Action Start -RepositoryRoot $root -AdapterKeyFile $AdapterKeyFile -ExecutionOsUrl $ExecutionOsUrl -PythonExecutable $PythonExecutable -Port $Port -Json)
+    $startExitCode = $LASTEXITCODE
+    if ($startExitCode -ne 0) { $errors.Add("PDV Odysseus process started after restart"); Write-ReportAndExit 1 }
+    try { $startReport = ($startOutput -join [Environment]::NewLine) | ConvertFrom-Json } catch { $startReport = $null }
+    if (-not $startReport -or -not $startReport.processStarted) { $errors.Add("valid start receipt for restart"); Write-ReportAndExit 1 }
+
+    $processStopped = $true
+    $processStarted = $true
+    $processId = [int]$startReport.processId
+    Write-ReportAndExit 0
+}
+
+if ($Action -eq "Start") {
+    if ($errors.Count -ne 0) { Write-ReportAndExit 1 }
+    New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+    if (Test-Path -LiteralPath $pidFile -PathType Leaf) {
+        try { $existingReceipt = Get-Content -LiteralPath $pidFile -Raw | ConvertFrom-Json } catch { $existingReceipt = $null }
+        $existingPid = if ($existingReceipt) { [int]$existingReceipt.pid } else { 0 }
+        if ($existingPid -gt 0 -and (Get-Process -Id $existingPid -ErrorAction SilentlyContinue)) {
+            $errors.Add("PDV Odysseus process is already running")
+            Write-ReportAndExit 1
+        }
+    }
+
+    $env:APP_BIND = "127.0.0.1"
+    $env:AUTH_ENABLED = "true"
+    $env:LOCALHOST_BYPASS = "false"
+    $env:ODYSSEUS_PDV_ADAPTER_KEY_FILE = [System.IO.Path]::GetFullPath($AdapterKeyFile)
+    $env:ODYSSEUS_DATA_DIR = $runtimeDir
+    $env:PDV_EXECUTION_OS_URL = $ExecutionOsUrl.TrimEnd("/")
+    $env:PDV_PROVIDER_GUARD_REQUIRED = "true"
+    $env:PDV_ADAPTER_KEY_ACL_VERIFIED = "true"
+    $stdout = Join-Path $logDir "stdout.log"
+    $stderr = Join-Path $logDir "stderr.log"
+    $arguments = @("-m", "uvicorn", "app:app", "--app-dir", $root, "--host", "127.0.0.1", "--port", [string]$Port)
+    $startParameters = @{
+        FilePath = $PythonExecutable
+        ArgumentList = $arguments
+        WorkingDirectory = $root
+        WindowStyle = "Hidden"
+        RedirectStandardOutput = $stdout
+        RedirectStandardError = $stderr
+        PassThru = $true
+    }
+    $process = Start-Process @startParameters
+    $pidReceipt = [ordered]@{
+        schemaVersion = 1
+        pid = $process.Id
+        startedAt = [DateTime]::UtcNow.ToString("o")
+        executable = [System.IO.Path]::GetFullPath($PythonExecutable)
+        repositoryRoot = $root
+        bindHost = "127.0.0.1"
+        port = $Port
+    }
+    $pidReceipt | ConvertTo-Json -Compress | Set-Content -LiteralPath $pidFile -Encoding utf8
+    $live = $false
+    foreach ($attempt in 1..40) {
+        if ($process.HasExited) { break }
+        try {
+            $probe = Invoke-WebRequest -UseBasicParsing -Uri "http://127.0.0.1:$Port/api/health" -TimeoutSec 1
+            if ($probe.StatusCode -eq 200) { $live = $true; break }
+        } catch {}
+        Start-Sleep -Milliseconds 250
+    }
+    if (-not $live) {
+        $failedChildren = @(Get-CimInstance Win32_Process -Filter "ParentProcessId = $($process.Id)" -ErrorAction SilentlyContinue | Where-Object {
+            [string]$_.CommandLine -match "uvicorn" -and [string]$_.CommandLine -match "app:app" -and
+            [string]$_.CommandLine -match ([regex]::Escape($root)) -and [string]$_.CommandLine -match ("(?:--port\s+|--port=)" + [regex]::Escape([string]$Port))
+        })
+        foreach ($failedChild in $failedChildren) { Stop-Process -Id ([int]$failedChild.ProcessId) -Force -ErrorAction SilentlyContinue }
+        if (-not $process.HasExited) { Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue }
+        Remove-Item -LiteralPath $pidFile -Force -ErrorAction SilentlyContinue
+        $errors.Add("PDV Odysseus liveness probe")
+        Write-ReportAndExit 1
+    }
+    $processStarted = $true
+    $processId = $process.Id
+    Write-ReportAndExit 0
+}
+
+if (-not (Test-Path -LiteralPath $pidFile -PathType Leaf)) {
+    $errors.Add("PDV Odysseus PID file")
+    Write-ReportAndExit 1
+}
+try { $pidReceipt = Get-Content -LiteralPath $pidFile -Raw | ConvertFrom-Json } catch { $pidReceipt = $null }
+$pidValue = if ($pidReceipt) { [int]$pidReceipt.pid } else { 0 }
+if (-not $pidReceipt -or $pidReceipt.schemaVersion -ne 1 -or $pidValue -le 0) {
+    $errors.Add("valid PDV Odysseus PID")
+    Write-ReportAndExit 1
+}
+$candidateProcess = Get-CimInstance Win32_Process -Filter "ProcessId = $pidValue" -ErrorAction SilentlyContinue
+if (-not $candidateProcess) {
+    Remove-Item -LiteralPath $pidFile -Force
+    $errors.Add("running PDV Odysseus process")
+    Write-ReportAndExit 1
+}
+$expectedPython = [System.IO.Path]::GetFullPath($PythonExecutable)
+$actualExecutable = [System.IO.Path]::GetFullPath([string]$candidateProcess.ExecutablePath)
+$commandLine = [string]$candidateProcess.CommandLine
+$receiptRoot = [System.IO.Path]::GetFullPath([string]$pidReceipt.repositoryRoot)
+$receiptExecutable = [System.IO.Path]::GetFullPath([string]$pidReceipt.executable)
+$appDirPattern = [regex]::Escape($root)
+$portPattern = "(?:--port\s+|--port=)" + [regex]::Escape([string]$Port) + "(?:\s|" + '"' + "|$)"
+if ($receiptRoot -ne $root -or [int]$pidReceipt.port -ne $Port -or $receiptExecutable -ne $expectedPython -or
+    $actualExecutable -ne $expectedPython -or $commandLine -notmatch "uvicorn" -or $commandLine -notmatch "app:app" -or
+    $commandLine -notmatch ("--app-dir\s+" + '"' + "?$appDirPattern") -or $commandLine -notmatch $portPattern) {
+    $errors.Add("PID belongs to this checkout's Uvicorn process")
+    Write-ReportAndExit 1
+}
+$childProcesses = @(Get-CimInstance Win32_Process -Filter "ParentProcessId = $pidValue" -ErrorAction SilentlyContinue)
+$serverChildren = @($childProcesses | Where-Object { [string]$_.CommandLine -match "uvicorn" -and [string]$_.CommandLine -match "app:app" })
+foreach ($childProcess in $serverChildren) {
+    $childCommandLine = [string]$childProcess.CommandLine
+    if ($childCommandLine -notmatch "uvicorn" -or $childCommandLine -notmatch "app:app" -or
+        $childCommandLine -notmatch ("--app-dir\s+" + '"' + "?$appDirPattern") -or $childCommandLine -notmatch $portPattern) {
+        $errors.Add("PID child belongs to this checkout's Uvicorn process")
+        Write-ReportAndExit 1
+    }
+}
+foreach ($childProcess in $serverChildren) {
+    Stop-Process -Id ([int]$childProcess.ProcessId) -Force -ErrorAction Stop
+}
+Stop-Process -Id $pidValue -ErrorAction Stop
+Remove-Item -LiteralPath $pidFile -Force
+$processStopped = $true
+$processId = $pidValue
+Write-ReportAndExit 0

--- a/src/ai_interaction.py
+++ b/src/ai_interaction.py
@@ -1078,6 +1078,8 @@ async def do_generate_image(content: str, session_id: Optional[str] = None, owne
     logger.info(f"Image generation: model={model_id}, size={size}, quality={quality}, prompt={prompt[:80]}")
 
     try:
+        from src.pdv_provider_guard import authorize_provider
+        await authorize_provider(images_url, model_id)
         # GPT image models can take 30-120s+ depending on quality
         async with httpx.AsyncClient(timeout=httpx.Timeout(connect=30.0, read=300.0, write=30.0, pool=30.0)) as client:
             resp = await client.post(images_url, json=payload, headers=headers)
@@ -1284,6 +1286,8 @@ async def do_edit_image(
         """
         harmonize_url = base_url + "/images/harmonize"
         try:
+            from src.pdv_provider_guard import authorize_provider
+            await authorize_provider(harmonize_url, model_id)
             image_bytes = path.read_bytes()
             image_b64 = base64.b64encode(image_bytes).decode()
             fallback_payload = {
@@ -1333,6 +1337,8 @@ async def do_edit_image(
             return {"error": f"Image edit fallback error: {fallback_error}"}
 
     try:
+        from src.pdv_provider_guard import authorize_provider
+        await authorize_provider(edits_url, model_id)
         async with httpx.AsyncClient(timeout=httpx.Timeout(connect=30.0, read=600.0, write=60.0, pool=30.0)) as client:
             progress_task = None
             if progress_callback:

--- a/src/builtin_mcp.py
+++ b/src/builtin_mcp.py
@@ -74,6 +74,7 @@ _BUILTIN_SERVERS = {
     "memory":     ("mcp_servers/memory_server.py",     "Built-in: Memory"),
     "rag":        ("mcp_servers/rag_server.py",        "Built-in: RAG"),
     "email":      ("mcp_servers/email_server.py",      "Built-in: Email"),
+    "pdv_control": ("mcp_servers/pdv_control_server.py", "PDV: Governed Execution OS"),
 }
 
 # NPX-based built-in servers (run via npx, not Python)
@@ -190,6 +191,12 @@ async def register_builtin_servers(mcp_manager):
             logger.warning(f"Built-in MCP server {name} error: {type(e).__name__}: {e}")
 
     for server_id, (script, name) in _BUILTIN_SERVERS.items():
+        if server_id == "pdv_control" and not (
+            os.environ.get("PDV_EXECUTION_OS_URL", "").strip()
+            and os.environ.get("ODYSSEUS_PDV_ADAPTER_KEY_FILE", "").strip()
+        ):
+            logger.info("PDV MCP bridge not configured; skipping")
+            continue
         script_path = os.path.join(base_dir, script)
         if not os.path.exists(script_path):
             logger.warning(f"Built-in MCP server script not found: {script_path}")

--- a/src/embeddings.py
+++ b/src/embeddings.py
@@ -115,6 +115,8 @@ class EmbeddingClient:
             raise
 
     def _post_embeddings(self, batch: List[str]) -> List[List[float]]:
+        from src.pdv_provider_guard import authorize_provider_sync
+        authorize_provider_sync(self.url, self.model)
         resp = self._client.post(
             self.url,
             headers={"Authorization": f"Bearer {self.api_key}"} if self.api_key else {},

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -1863,6 +1863,8 @@ def llm_call(url: str, model: str, messages: List[Dict], temperature: float = LL
         if provider == "mistral" and _supports_thinking(model):
             payload["reasoning_effort"] = _MISTRAL_REASONING_EFFORT
     try:
+        from src.pdv_provider_guard import authorize_provider_sync
+        authorize_provider_sync(target_url, model)
         note_model_activity(target_url, model)
         r = httpx_post_kimi_aware(target_url, h, json=payload, timeout=timeout)
     except Exception as e:
@@ -2078,6 +2080,8 @@ async def llm_call_async(
     if _is_host_dead(target_url):
         raise HTTPException(503, f"Upstream {_host_key(target_url)} marked unreachable (cooldown active)")
 
+    from src.pdv_provider_guard import authorize_provider
+    await authorize_provider(target_url, model)
     call_timeout = _call_timeout(timeout)
     attempt = 0
     while attempt < max_retries:
@@ -2146,6 +2150,8 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
                      tools: Optional[List[Dict]] = None, session_id: Optional[str] = None,
                      tool_choice_none: bool = False, workload: str = "foreground"):
     target_url = _stream_target_url(url)
+    from src.pdv_provider_guard import authorize_provider
+    await authorize_provider(target_url, model)
     async with _local_model_slot(target_url, model, workload):
         async for chunk in _stream_llm_inner(
             url,

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -1944,10 +1944,17 @@ def llm_call_with_fallback(candidates, messages, **kwargs) -> str:
     cands = _dedupe_candidates(candidates)
     if not cands:
         raise HTTPException(503, "No model endpoint configured")
+    from src.pdv_provider_guard import get_ranked_route_policy, rank_provider_candidates_sync
+    cands = rank_provider_candidates_sync(cands, kwargs.get("prompt_type") or "chat")
     last_err = None
     for i, (url, model, headers) in enumerate(cands):
         try:
-            return llm_call(url, model, messages, headers=headers, **kwargs)
+            candidate_kwargs = dict(kwargs)
+            policy = get_ranked_route_policy(url, model)
+            if policy:
+                policy_timeout = max(1, (policy["timeout_ms"] + 999) // 1000)
+                candidate_kwargs["timeout"] = min(candidate_kwargs.get("timeout", policy_timeout), policy_timeout)
+            return llm_call(url, model, messages, headers=headers, **candidate_kwargs)
         except Exception as e:
             last_err = e
             tag = "primary" if i == 0 else "candidate"
@@ -1961,10 +1968,18 @@ async def llm_call_async_with_fallback(candidates, messages, **kwargs) -> str:
     cands = _dedupe_candidates(candidates)
     if not cands:
         raise HTTPException(503, "No model endpoint configured")
+    from src.pdv_provider_guard import get_ranked_route_policy, rank_provider_candidates
+    cands = await rank_provider_candidates(cands, kwargs.get("prompt_type") or "chat")
     last_err = None
     for i, (url, model, headers) in enumerate(cands):
         try:
-            return await llm_call_async(url, model, messages, headers=headers, **kwargs)
+            candidate_kwargs = dict(kwargs)
+            policy = get_ranked_route_policy(url, model)
+            if policy:
+                policy_timeout = max(1, (policy["timeout_ms"] + 999) // 1000)
+                candidate_kwargs["timeout"] = min(candidate_kwargs.get("timeout", policy_timeout), policy_timeout)
+                candidate_kwargs["max_retries"] = min(candidate_kwargs.get("max_retries", policy["retry_limit"]), policy["retry_limit"])
+            return await llm_call_async(url, model, messages, headers=headers, **candidate_kwargs)
         except Exception as e:
             last_err = e
             tag = "primary" if i == 0 else "candidate"
@@ -2177,6 +2192,7 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
     from src.pdv_provider_guard import authorize_provider, record_provider_outcome
     authorization = await authorize_provider(target_url, model)
     provider_started = time.time()
+    stream_failed = False
     try:
         async with _local_model_slot(target_url, model, workload):
             async for chunk in _stream_llm_inner(
@@ -2192,6 +2208,8 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
                 session_id=session_id,
                 tool_choice_none=tool_choice_none,
             ):
+                if chunk.startswith("event: error"):
+                    stream_failed = True
                 yield chunk
     except (asyncio.CancelledError, GeneratorExit):
         await record_provider_outcome(authorization, "cancelled", round((time.time() - provider_started) * 1000))
@@ -2200,7 +2218,7 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
         await record_provider_outcome(authorization, "timed_out" if isinstance(error, httpx.TimeoutException) or "timed out" in str(error).lower() else "failed", round((time.time() - provider_started) * 1000))
         raise
     else:
-        await record_provider_outcome(authorization, "completed", round((time.time() - provider_started) * 1000))
+        await record_provider_outcome(authorization, "failed" if stream_failed else "completed", round((time.time() - provider_started) * 1000))
 
 
 async def _stream_llm_inner(url: str, model: str, messages: List[Dict], temperature: float = LLMConfig.DEFAULT_TEMPERATURE,
@@ -2862,6 +2880,9 @@ async def stream_llm_with_fallback(candidates, messages, **kwargs):
         yield f'event: error\ndata: {json.dumps({"error": "No model endpoint configured", "status": 503})}\n\n'
         return
 
+    from src.pdv_provider_guard import get_ranked_route_policy, rank_provider_candidates
+    cands = await rank_provider_candidates(cands, kwargs.get("prompt_type") or "chat")
+
     primary_model = cands[0][1]
     last_error = None
     for i, (url, model, headers) in enumerate(cands):
@@ -2869,7 +2890,12 @@ async def stream_llm_with_fallback(candidates, messages, **kwargs):
         emitted = False
         retried = False
         pending_metadata = []
-        async for chunk in stream_llm(url, model, messages, headers=headers, **kwargs):
+        candidate_kwargs = dict(kwargs)
+        policy = get_ranked_route_policy(url, model)
+        if policy:
+            policy_timeout = max(1, (policy["timeout_ms"] + 999) // 1000)
+            candidate_kwargs["timeout"] = min(candidate_kwargs.get("timeout", policy_timeout), policy_timeout)
+        async for chunk in stream_llm(url, model, messages, headers=headers, **candidate_kwargs):
             if chunk.startswith("event: error"):
                 if not emitted and not is_last:
                     # Pre-content failure with fallbacks left — swallow and

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -1978,7 +1978,8 @@ async def llm_call_async_with_fallback(candidates, messages, **kwargs) -> str:
             if policy:
                 policy_timeout = max(1, (policy["timeout_ms"] + 999) // 1000)
                 candidate_kwargs["timeout"] = min(candidate_kwargs.get("timeout", policy_timeout), policy_timeout)
-                candidate_kwargs["max_retries"] = min(candidate_kwargs.get("max_retries", policy["retry_limit"]), policy["retry_limit"])
+                policy_attempts = policy["retry_limit"] + 1
+                candidate_kwargs["max_retries"] = min(candidate_kwargs.get("max_retries", policy_attempts), policy_attempts)
             return await llm_call_async(url, model, messages, headers=headers, **candidate_kwargs)
         except Exception as e:
             last_err = e

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -1862,14 +1862,19 @@ def llm_call(url: str, model: str, messages: List[Dict], temperature: float = LL
         _apply_local_generation_stability(payload, target_url, model)
         if provider == "mistral" and _supports_thinking(model):
             payload["reasoning_effort"] = _MISTRAL_REASONING_EFFORT
+    authorization = None
+    provider_started = time.time()
     try:
-        from src.pdv_provider_guard import authorize_provider_sync
-        authorize_provider_sync(target_url, model)
+        from src.pdv_provider_guard import authorize_provider_sync, record_provider_outcome_sync
+        authorization = authorize_provider_sync(target_url, model)
         note_model_activity(target_url, model)
         r = httpx_post_kimi_aware(target_url, h, json=payload, timeout=timeout)
     except Exception as e:
+        if authorization is not None:
+            record_provider_outcome_sync(authorization, "timed_out" if "timed out" in str(e).lower() else "failed", round((time.time() - provider_started) * 1000))
         raise HTTPException(502, f"POST {target_url} failed: {e}")
     if not r.is_success:
+        record_provider_outcome_sync(authorization, "failed", round((time.time() - provider_started) * 1000))
         raise HTTPException(502, f"Upstream {target_url} -> {r.status_code}: {r.text}")
     data = r.json()
     try:
@@ -1889,9 +1894,17 @@ def llm_call(url: str, model: str, messages: List[Dict], temperature: float = LL
                     response = text_part or msg.get("reasoning_content") or ""
             else:
                 response = content or msg.get("reasoning_content") or ""
+        from src.pdv_provider_guard import provider_usage
+        input_tokens, output_tokens = provider_usage(data)
+        record_provider_outcome_sync(authorization, "completed", round((time.time() - provider_started) * 1000), input_tokens=input_tokens, output_tokens=output_tokens)
         _set_cached_response(cache_key, response)
         return response
     except Exception:
+        if authorization is not None:
+            try:
+                record_provider_outcome_sync(authorization, "failed", round((time.time() - provider_started) * 1000))
+            except Exception:
+                pass
         raise HTTPException(502, f"Unexpected schema from {target_url}: {str(data)[:400]}")
 
 
@@ -2080,8 +2093,9 @@ async def llm_call_async(
     if _is_host_dead(target_url):
         raise HTTPException(503, f"Upstream {_host_key(target_url)} marked unreachable (cooldown active)")
 
-    from src.pdv_provider_guard import authorize_provider
-    await authorize_provider(target_url, model)
+    from src.pdv_provider_guard import authorize_provider, provider_usage, record_provider_outcome
+    authorization = await authorize_provider(target_url, model)
+    provider_started = time.time()
     call_timeout = _call_timeout(timeout)
     attempt = 0
     while attempt < max_retries:
@@ -2102,6 +2116,7 @@ async def llm_call_async(
                 if r.status_code in (429, 502, 503, 504) and attempt < max_retries:
                     await asyncio.sleep(LLMConfig.RETRY_DELAY)
                     continue
+                await record_provider_outcome(authorization, "failed", round((time.time() - provider_started) * 1000))
                 raise HTTPException(r.status_code, friendly)
             logger.info(f"LLM async call to {target_url} succeeded in {duration:.2f}s (attempt {attempt})")
             _clear_host_dead(target_url)
@@ -2114,9 +2129,16 @@ async def llm_call_async(
                 else:
                     msg = data["choices"][0]["message"]
                     response = msg.get("content") or msg.get("reasoning_content") or ""
+                input_tokens, output_tokens = provider_usage(data)
+                await record_provider_outcome(authorization, "completed", round((time.time() - provider_started) * 1000), input_tokens=input_tokens, output_tokens=output_tokens)
                 _set_cached_response(cache_key, response)
                 return response
             except Exception:
+                if authorization is not None:
+                    try:
+                        await record_provider_outcome(authorization, "failed", round((time.time() - provider_started) * 1000))
+                    except Exception:
+                        pass
                 raise HTTPException(502, f"Unexpected schema from {target_url}: {str(data)[:400]}")
         except (httpx.ConnectError, httpx.ConnectTimeout) as e:
             _cooled = _mark_host_dead(target_url)
@@ -2124,12 +2146,14 @@ async def llm_call_async(
             _tail = f" — host cooled for {DEAD_HOST_COOLDOWN:.0f}s" if _cooled else " — transient, will retry"
             logger.warning(f"LLM async connect to {target_url} failed after {duration:.2f}s: {e}{_tail}")
             if _cooled or attempt >= max_retries:
+                await record_provider_outcome(authorization, "timed_out" if isinstance(e, httpx.ConnectTimeout) else "failed", round((time.time() - provider_started) * 1000))
                 raise HTTPException(503, f"Cannot reach {_host_key(target_url)}: {e}")
             await asyncio.sleep(LLMConfig.RETRY_DELAY)
         except (httpx.RequestError, httpx.HTTPStatusError) as e:
             duration = time.time() - start
             logger.warning(f"LLM async call attempt {attempt} failed after {duration:.2f}s: {e}")
             if attempt >= max_retries:
+                await record_provider_outcome(authorization, "timed_out" if isinstance(e, httpx.TimeoutException) else "failed", round((time.time() - provider_started) * 1000))
                 raise HTTPException(502, f"POST {target_url} failed after {max_retries} attempts: {e}")
             await asyncio.sleep(LLMConfig.RETRY_DELAY)
 
@@ -2150,23 +2174,33 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
                      tools: Optional[List[Dict]] = None, session_id: Optional[str] = None,
                      tool_choice_none: bool = False, workload: str = "foreground"):
     target_url = _stream_target_url(url)
-    from src.pdv_provider_guard import authorize_provider
-    await authorize_provider(target_url, model)
-    async with _local_model_slot(target_url, model, workload):
-        async for chunk in _stream_llm_inner(
-            url,
-            model,
-            messages,
-            temperature=temperature,
-            max_tokens=max_tokens,
-            headers=headers,
-            timeout=timeout,
-            prompt_type=prompt_type,
-            tools=tools,
-            session_id=session_id,
-            tool_choice_none=tool_choice_none,
-        ):
-            yield chunk
+    from src.pdv_provider_guard import authorize_provider, record_provider_outcome
+    authorization = await authorize_provider(target_url, model)
+    provider_started = time.time()
+    try:
+        async with _local_model_slot(target_url, model, workload):
+            async for chunk in _stream_llm_inner(
+                url,
+                model,
+                messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                headers=headers,
+                timeout=timeout,
+                prompt_type=prompt_type,
+                tools=tools,
+                session_id=session_id,
+                tool_choice_none=tool_choice_none,
+            ):
+                yield chunk
+    except (asyncio.CancelledError, GeneratorExit):
+        await record_provider_outcome(authorization, "cancelled", round((time.time() - provider_started) * 1000))
+        raise
+    except Exception as error:
+        await record_provider_outcome(authorization, "timed_out" if isinstance(error, httpx.TimeoutException) or "timed out" in str(error).lower() else "failed", round((time.time() - provider_started) * 1000))
+        raise
+    else:
+        await record_provider_outcome(authorization, "completed", round((time.time() - provider_started) * 1000))
 
 
 async def _stream_llm_inner(url: str, model: str, messages: List[Dict], temperature: float = LLMConfig.DEFAULT_TEMPERATURE,

--- a/src/pdv_provider_guard.py
+++ b/src/pdv_provider_guard.py
@@ -1,0 +1,127 @@
+"""Fail-closed PDV provider authorization preflight for integrated deployments."""
+
+from __future__ import annotations
+
+import os
+from contextvars import ContextVar
+from pathlib import Path
+from urllib.parse import urlparse
+from uuid import uuid4
+
+import httpx
+
+
+_last_authorization: ContextVar[dict | None] = ContextVar("pdv_last_provider_authorization", default=None)
+
+
+def get_last_authorization_receipt() -> dict | None:
+    receipt = _last_authorization.get()
+    return dict(receipt) if receipt is not None else None
+
+
+def record_provider_outcome_sync(
+    authorization: dict,
+    outcome: str,
+    duration_ms: int,
+    *,
+    input_tokens: int | None = None,
+    output_tokens: int | None = None,
+    cost_microusd: int | None = None,
+) -> dict | None:
+    if not required():
+        return None
+    if not isinstance(authorization, dict):
+        raise RuntimeError("PDV provider outcome requires an authorization receipt")
+    base, key = _boundary()
+    payload = {
+        "authorization_receipt_id": authorization.get("authorization_receipt_id"),
+        "provider_request_id": authorization.get("provider_request_id"),
+        "outcome": outcome,
+        "duration_ms": max(0, int(duration_ms)),
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "cost_microusd": cost_microusd,
+    }
+    response = httpx.post(
+        f"{base}/v1/integrations/odysseus/provider/outcome",
+        headers={"X-PDV-Odysseus-Key": key},
+        json=payload,
+        timeout=3.0,
+    )
+    try:
+        receipt = response.json()
+    except ValueError as error:
+        raise RuntimeError("PDV provider outcome returned malformed JSON") from error
+    if (response.status_code != 201 or not isinstance(receipt, dict)
+            or receipt.get("authorization_receipt_id") != payload["authorization_receipt_id"]
+            or receipt.get("provider_request_id") != payload["provider_request_id"]
+            or receipt.get("outcome") != outcome or not receipt.get("outcome_receipt_id")):
+        raise RuntimeError("PDV provider outcome receipt validation failed")
+    return receipt
+
+
+def required() -> bool:
+    return os.environ.get("PDV_PROVIDER_GUARD_REQUIRED", "false").lower() == "true"
+
+
+def _boundary() -> tuple[str, str]:
+    base = os.environ.get("PDV_EXECUTION_OS_URL", "").strip().rstrip("/")
+    parsed = urlparse(base)
+    if parsed.scheme != "http" or parsed.hostname not in {"127.0.0.1", "localhost", "::1"} or not parsed.port:
+        raise RuntimeError("PDV provider guard requires an explicit loopback Execution OS URL")
+    key_path = Path(os.environ.get("ODYSSEUS_PDV_ADAPTER_KEY_FILE", "").strip())
+    try:
+        key = key_path.read_text(encoding="ascii").strip()
+    except OSError as error:
+        raise RuntimeError("PDV provider guard credential reference is unavailable") from error
+    if len(key) != 64 or any(character not in "0123456789abcdef" for character in key):
+        raise RuntimeError("PDV provider guard credential format is invalid")
+    return base, key
+
+
+def _validate(response: httpx.Response, endpoint: str, model: str, provider_request_id: str) -> dict:
+    try:
+        payload = response.json()
+    except ValueError as error:
+        raise RuntimeError("PDV provider authorization returned malformed JSON") from error
+    if response.status_code != 200 or not isinstance(payload, dict) or payload.get("allowed") is not True:
+        reason = payload.get("reason_code") if isinstance(payload, dict) else "UNAVAILABLE"
+        raise RuntimeError(f"PDV provider authorization denied route ({reason or 'UNAVAILABLE'})")
+    if (payload.get("selected_model") != model or payload.get("selected_endpoint") != endpoint
+            or payload.get("provider_request_id") != provider_request_id or not payload.get("authorization_receipt_id")):
+        raise RuntimeError("PDV provider authorization correlation mismatch")
+    return payload
+
+
+def authorize_provider_sync(endpoint: str, model: str) -> dict | None:
+    _last_authorization.set(None)
+    if not required():
+        return None
+    base, key = _boundary()
+    provider_request_id = str(uuid4())
+    response = httpx.post(
+        f"{base}/v1/integrations/odysseus/provider/authorize",
+        headers={"X-PDV-Odysseus-Key": key},
+        json={"endpoint": endpoint, "model": model, "provider_request_id": provider_request_id},
+        timeout=3.0,
+    )
+    payload = _validate(response, endpoint, model, provider_request_id)
+    _last_authorization.set(payload)
+    return payload
+
+
+async def authorize_provider(endpoint: str, model: str) -> dict | None:
+    _last_authorization.set(None)
+    if not required():
+        return None
+    base, key = _boundary()
+    provider_request_id = str(uuid4())
+    async with httpx.AsyncClient(timeout=3.0) as client:
+        response = await client.post(
+            f"{base}/v1/integrations/odysseus/provider/authorize",
+            headers={"X-PDV-Odysseus-Key": key},
+            json={"endpoint": endpoint, "model": model, "provider_request_id": provider_request_id},
+        )
+    payload = _validate(response, endpoint, model, provider_request_id)
+    _last_authorization.set(payload)
+    return payload

--- a/src/pdv_provider_guard.py
+++ b/src/pdv_provider_guard.py
@@ -12,11 +12,27 @@ import httpx
 
 
 _last_authorization: ContextVar[dict | None] = ContextVar("pdv_last_provider_authorization", default=None)
+_last_routing: ContextVar[dict | None] = ContextVar("pdv_last_provider_routing", default=None)
 
 
 def get_last_authorization_receipt() -> dict | None:
     receipt = _last_authorization.get()
     return dict(receipt) if receipt is not None else None
+
+
+def get_last_routing_receipt() -> dict | None:
+    receipt = _last_routing.get()
+    return dict(receipt) if receipt is not None else None
+
+
+def get_ranked_route_policy(endpoint: str, model: str) -> dict | None:
+    receipt = _last_routing.get()
+    if not isinstance(receipt, dict):
+        return None
+    for item in receipt.get("ordered_candidates", []):
+        if isinstance(item, dict) and item.get("endpoint") == endpoint and item.get("model") == model:
+            return dict(item)
+    return None
 
 
 def record_provider_outcome_sync(
@@ -142,6 +158,70 @@ def _validate(response: httpx.Response, endpoint: str, model: str, provider_requ
             or payload.get("provider_request_id") != provider_request_id or not payload.get("authorization_receipt_id")):
         raise RuntimeError("PDV provider authorization correlation mismatch")
     return payload
+
+
+def _validate_ranking(response: httpx.Response, candidates: list, task_class: str) -> tuple[list, dict]:
+    try:
+        payload = response.json()
+    except ValueError as error:
+        raise RuntimeError("PDV provider ranking returned malformed JSON") from error
+    ordered = payload.get("ordered_candidates") if isinstance(payload, dict) else None
+    if (not isinstance(payload, dict) or response.status_code != 200 or payload.get("allowed") is not True
+            or payload.get("task_class") != task_class or not payload.get("routing_receipt_id")
+            or not isinstance(ordered, list) or not ordered or len(ordered) > len(candidates)):
+        reason = payload.get("reason_code") if isinstance(payload, dict) else "UNAVAILABLE"
+        raise RuntimeError(f"PDV provider ranking denied candidates ({reason or 'UNAVAILABLE'})")
+    seen = set()
+    ranked = []
+    for item in ordered:
+        index = item.get("candidate_index") if isinstance(item, dict) else None
+        if isinstance(index, bool) or not isinstance(index, int) or index < 0 or index >= len(candidates) or index in seen:
+            raise RuntimeError("PDV provider ranking correlation mismatch")
+        candidate = candidates[index]
+        if item.get("endpoint") != candidate[0] or item.get("model") != candidate[1]:
+            raise RuntimeError("PDV provider ranking correlation mismatch")
+        timeout_ms = item.get("timeout_ms")
+        retry_limit = item.get("retry_limit")
+        if (not isinstance(timeout_ms, int) or isinstance(timeout_ms, bool) or timeout_ms < 1
+                or not isinstance(retry_limit, int) or isinstance(retry_limit, bool) or retry_limit < 0):
+            raise RuntimeError("PDV provider ranking policy is invalid")
+        seen.add(index)
+        ranked.append(candidate)
+    if payload.get("selected_endpoint") != ranked[0][0] or payload.get("selected_model") != ranked[0][1]:
+        raise RuntimeError("PDV provider ranking correlation mismatch")
+    return ranked, payload
+
+
+def rank_provider_candidates_sync(candidates: list, task_class: str = "chat") -> list:
+    _last_routing.set(None)
+    if not required():
+        return list(candidates)
+    base, key = _boundary()
+    response = httpx.post(
+        f"{base}/v1/integrations/odysseus/provider/rank",
+        headers={"X-PDV-Odysseus-Key": key},
+        json={"task_class": task_class, "candidates": [{"endpoint": item[0], "model": item[1]} for item in candidates]},
+        timeout=3.0,
+    )
+    ranked, receipt = _validate_ranking(response, candidates, task_class)
+    _last_routing.set(receipt)
+    return ranked
+
+
+async def rank_provider_candidates(candidates: list, task_class: str = "chat") -> list:
+    _last_routing.set(None)
+    if not required():
+        return list(candidates)
+    base, key = _boundary()
+    async with httpx.AsyncClient(timeout=3.0) as client:
+        response = await client.post(
+            f"{base}/v1/integrations/odysseus/provider/rank",
+            headers={"X-PDV-Odysseus-Key": key},
+            json={"task_class": task_class, "candidates": [{"endpoint": item[0], "model": item[1]} for item in candidates]},
+        )
+    ranked, receipt = _validate_ranking(response, candidates, task_class)
+    _last_routing.set(receipt)
+    return ranked
 
 
 def authorize_provider_sync(endpoint: str, model: str) -> dict | None:

--- a/src/pdv_provider_guard.py
+++ b/src/pdv_provider_guard.py
@@ -60,6 +60,57 @@ def record_provider_outcome_sync(
     return receipt
 
 
+async def record_provider_outcome(
+    authorization: dict,
+    outcome: str,
+    duration_ms: int,
+    *,
+    input_tokens: int | None = None,
+    output_tokens: int | None = None,
+    cost_microusd: int | None = None,
+) -> dict | None:
+    if not required():
+        return None
+    if not isinstance(authorization, dict):
+        raise RuntimeError("PDV provider outcome requires an authorization receipt")
+    base, key = _boundary()
+    payload = {
+        "authorization_receipt_id": authorization.get("authorization_receipt_id"),
+        "provider_request_id": authorization.get("provider_request_id"),
+        "outcome": outcome,
+        "duration_ms": max(0, int(duration_ms)),
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "cost_microusd": cost_microusd,
+    }
+    async with httpx.AsyncClient(timeout=3.0) as client:
+        response = await client.post(
+            f"{base}/v1/integrations/odysseus/provider/outcome",
+            headers={"X-PDV-Odysseus-Key": key},
+            json=payload,
+        )
+    try:
+        receipt = response.json()
+    except ValueError as error:
+        raise RuntimeError("PDV provider outcome returned malformed JSON") from error
+    if (response.status_code != 201 or not isinstance(receipt, dict)
+            or receipt.get("authorization_receipt_id") != payload["authorization_receipt_id"]
+            or receipt.get("provider_request_id") != payload["provider_request_id"]
+            or receipt.get("outcome") != outcome or not receipt.get("outcome_receipt_id")):
+        raise RuntimeError("PDV provider outcome receipt validation failed")
+    return receipt
+
+
+def provider_usage(payload: object) -> tuple[int | None, int | None]:
+    if not isinstance(payload, dict):
+        return None, None
+    usage = payload.get("usage") if isinstance(payload.get("usage"), dict) else {}
+    input_value = usage.get("prompt_tokens", usage.get("input_tokens", payload.get("prompt_eval_count")))
+    output_value = usage.get("completion_tokens", usage.get("output_tokens", payload.get("eval_count")))
+    safe = lambda value: value if isinstance(value, int) and value >= 0 else None
+    return safe(input_value), safe(output_value)
+
+
 def required() -> bool:
     return os.environ.get("PDV_PROVIDER_GUARD_REQUIRED", "false").lower() == "true"
 

--- a/src/pdv_provider_guard.py
+++ b/src/pdv_provider_guard.py
@@ -7,12 +7,26 @@ from contextvars import ContextVar
 from pathlib import Path
 from urllib.parse import urlparse
 from uuid import uuid4
+from threading import Lock
 
 import httpx
 
 
 _last_authorization: ContextVar[dict | None] = ContextVar("pdv_last_provider_authorization", default=None)
 _last_routing: ContextVar[dict | None] = ContextVar("pdv_last_provider_routing", default=None)
+_last_outcome: ContextVar[dict | None] = ContextVar("pdv_last_provider_outcome", default=None)
+_runtime_lock = Lock()
+_runtime_observation: dict = {}
+
+
+def _observe_runtime(**values) -> None:
+    with _runtime_lock:
+        _runtime_observation.update(values)
+
+
+def get_provider_runtime_observation() -> dict:
+    with _runtime_lock:
+        return dict(_runtime_observation)
 
 
 def get_last_authorization_receipt() -> dict | None:
@@ -23,6 +37,37 @@ def get_last_authorization_receipt() -> dict | None:
 def get_last_routing_receipt() -> dict | None:
     receipt = _last_routing.get()
     return dict(receipt) if receipt is not None else None
+
+
+def get_last_outcome_receipt() -> dict | None:
+    receipt = _last_outcome.get()
+    return dict(receipt) if receipt is not None else None
+
+
+def _dispatch_id() -> str | None:
+    value = os.environ.get("PDV_EXECUTION_OS_DISPATCH_ID", "").strip()
+    return value if value.startswith("ody_dispatch_") and len(value) == 49 else None
+
+
+def _dispatch_transition_sync(base: str, key: str, state: str, authorization: dict, final_receipt_id: str | None = None) -> None:
+    dispatch_id = _dispatch_id()
+    if not dispatch_id:
+        return
+    payload = {"state": state, "provider_request_id": authorization.get("provider_request_id"), "final_receipt_id": final_receipt_id}
+    response = httpx.post(f"{base}/v1/integrations/odysseus/dispatch/{dispatch_id}/events", headers={"X-PDV-Odysseus-Key": key}, json=payload, timeout=3.0)
+    if response.status_code != 200:
+        raise RuntimeError("PDV dispatch correlation transition failed")
+
+
+async def _dispatch_transition(base: str, key: str, state: str, authorization: dict, final_receipt_id: str | None = None) -> None:
+    dispatch_id = _dispatch_id()
+    if not dispatch_id:
+        return
+    payload = {"state": state, "provider_request_id": authorization.get("provider_request_id"), "final_receipt_id": final_receipt_id}
+    async with httpx.AsyncClient(timeout=3.0) as client:
+        response = await client.post(f"{base}/v1/integrations/odysseus/dispatch/{dispatch_id}/events", headers={"X-PDV-Odysseus-Key": key}, json=payload)
+    if response.status_code != 200:
+        raise RuntimeError("PDV dispatch correlation transition failed")
 
 
 def get_ranked_route_policy(endpoint: str, model: str) -> dict | None:
@@ -44,6 +89,7 @@ def record_provider_outcome_sync(
     output_tokens: int | None = None,
     cost_microusd: int | None = None,
 ) -> dict | None:
+    _last_outcome.set(None)
     if not required():
         return None
     if not isinstance(authorization, dict):
@@ -73,6 +119,9 @@ def record_provider_outcome_sync(
             or receipt.get("provider_request_id") != payload["provider_request_id"]
             or receipt.get("outcome") != outcome or not receipt.get("outcome_receipt_id")):
         raise RuntimeError("PDV provider outcome receipt validation failed")
+    _last_outcome.set(receipt)
+    _dispatch_transition_sync(base, key, outcome, authorization, receipt["outcome_receipt_id"])
+    _observe_runtime(currentRunStatus="SUCCEEDED" if outcome == "completed" else "BLOCKED" if outcome == "cancelled" else "FAILED", failureMessage=None if outcome == "completed" else outcome)
     return receipt
 
 
@@ -85,6 +134,7 @@ async def record_provider_outcome(
     output_tokens: int | None = None,
     cost_microusd: int | None = None,
 ) -> dict | None:
+    _last_outcome.set(None)
     if not required():
         return None
     if not isinstance(authorization, dict):
@@ -114,6 +164,9 @@ async def record_provider_outcome(
             or receipt.get("provider_request_id") != payload["provider_request_id"]
             or receipt.get("outcome") != outcome or not receipt.get("outcome_receipt_id")):
         raise RuntimeError("PDV provider outcome receipt validation failed")
+    _last_outcome.set(receipt)
+    await _dispatch_transition(base, key, outcome, authorization, receipt["outcome_receipt_id"])
+    _observe_runtime(currentRunStatus="SUCCEEDED" if outcome == "completed" else "BLOCKED" if outcome == "cancelled" else "FAILED", failureMessage=None if outcome == "completed" else outcome)
     return receipt
 
 
@@ -146,18 +199,35 @@ def _boundary() -> tuple[str, str]:
     return base, key
 
 
-def _validate(response: httpx.Response, endpoint: str, model: str, provider_request_id: str) -> dict:
+def _validate(response: httpx.Response, endpoint: str, model: str, provider_request_id: str, routing_receipt_id: str, candidate_index: int) -> dict:
     try:
         payload = response.json()
     except ValueError as error:
         raise RuntimeError("PDV provider authorization returned malformed JSON") from error
     if response.status_code != 200 or not isinstance(payload, dict) or payload.get("allowed") is not True:
         reason = payload.get("reason_code") if isinstance(payload, dict) else "UNAVAILABLE"
+        _observe_runtime(model=model, currentRunStatus="BLOCKED", taskCorrelationId=provider_request_id, failureMessage=str(reason or "UNAVAILABLE"))
         raise RuntimeError(f"PDV provider authorization denied route ({reason or 'UNAVAILABLE'})")
     if (payload.get("selected_model") != model or payload.get("selected_endpoint") != endpoint
-            or payload.get("provider_request_id") != provider_request_id or not payload.get("authorization_receipt_id")):
+            or payload.get("provider_request_id") != provider_request_id or payload.get("routing_receipt_id") != routing_receipt_id
+            or payload.get("candidate_index") != candidate_index or not payload.get("authorization_receipt_id")):
         raise RuntimeError("PDV provider authorization correlation mismatch")
     return payload
+
+
+def _provider_target(value: str) -> str:
+    parsed = urlparse(value)
+    path = parsed.path.rstrip("/")
+    if path.endswith("/v1"):
+        path += "/chat/completions"
+    return parsed._replace(path=path).geturl()
+
+
+def _routing_candidate(receipt: dict | None, endpoint: str, model: str) -> dict | None:
+    for item in receipt.get("ordered_candidates", []) if isinstance(receipt, dict) else []:
+        if isinstance(item, dict) and _provider_target(str(item.get("endpoint", ""))) == _provider_target(endpoint) and item.get("model") == model:
+            return item
+    return None
 
 
 def _validate_ranking(response: httpx.Response, candidates: list, task_class: str) -> tuple[list, dict]:
@@ -205,6 +275,7 @@ def rank_provider_candidates_sync(candidates: list, task_class: str = "chat") ->
     )
     ranked, receipt = _validate_ranking(response, candidates, task_class)
     _last_routing.set(receipt)
+    _observe_runtime(provider=receipt.get("selected_provider"), model=receipt.get("selected_model"), currentRunStatus="IDLE", taskCorrelationId=None, failureMessage=None)
     return ranked
 
 
@@ -221,6 +292,7 @@ async def rank_provider_candidates(candidates: list, task_class: str = "chat") -
         )
     ranked, receipt = _validate_ranking(response, candidates, task_class)
     _last_routing.set(receipt)
+    _observe_runtime(provider=receipt.get("selected_provider"), model=receipt.get("selected_model"), currentRunStatus="IDLE", taskCorrelationId=None, failureMessage=None)
     return ranked
 
 
@@ -229,15 +301,25 @@ def authorize_provider_sync(endpoint: str, model: str) -> dict | None:
     if not required():
         return None
     base, key = _boundary()
+    routing = _last_routing.get()
+    candidate = _routing_candidate(routing, endpoint, model)
+    if candidate is None:
+        rank_provider_candidates_sync([(endpoint, model, {})])
+        routing = _last_routing.get()
+        candidate = _routing_candidate(routing, endpoint, model)
+    if candidate is None:
+        raise RuntimeError("PDV provider authorization lacks ranked candidate correlation")
     provider_request_id = str(uuid4())
     response = httpx.post(
         f"{base}/v1/integrations/odysseus/provider/authorize",
         headers={"X-PDV-Odysseus-Key": key},
-        json={"endpoint": endpoint, "model": model, "provider_request_id": provider_request_id},
+        json={"endpoint": endpoint, "model": model, "provider_request_id": provider_request_id, "routing_receipt_id": routing.get("routing_receipt_id"), "candidate_index": candidate.get("candidate_index")},
         timeout=3.0,
     )
-    payload = _validate(response, endpoint, model, provider_request_id)
+    payload = _validate(response, endpoint, model, provider_request_id, routing.get("routing_receipt_id"), candidate.get("candidate_index"))
+    _dispatch_transition_sync(base, key, "running", payload)
     _last_authorization.set(payload)
+    _observe_runtime(provider=payload.get("selected_provider"), model=model, currentRunStatus="RUNNING", taskCorrelationId=provider_request_id, failureMessage=None)
     return payload
 
 
@@ -246,13 +328,23 @@ async def authorize_provider(endpoint: str, model: str) -> dict | None:
     if not required():
         return None
     base, key = _boundary()
+    routing = _last_routing.get()
+    candidate = _routing_candidate(routing, endpoint, model)
+    if candidate is None:
+        await rank_provider_candidates([(endpoint, model, {})])
+        routing = _last_routing.get()
+        candidate = _routing_candidate(routing, endpoint, model)
+    if candidate is None:
+        raise RuntimeError("PDV provider authorization lacks ranked candidate correlation")
     provider_request_id = str(uuid4())
     async with httpx.AsyncClient(timeout=3.0) as client:
         response = await client.post(
             f"{base}/v1/integrations/odysseus/provider/authorize",
             headers={"X-PDV-Odysseus-Key": key},
-            json={"endpoint": endpoint, "model": model, "provider_request_id": provider_request_id},
+            json={"endpoint": endpoint, "model": model, "provider_request_id": provider_request_id, "routing_receipt_id": routing.get("routing_receipt_id"), "candidate_index": candidate.get("candidate_index")},
         )
-    payload = _validate(response, endpoint, model, provider_request_id)
+    payload = _validate(response, endpoint, model, provider_request_id, routing.get("routing_receipt_id"), candidate.get("candidate_index"))
+    await _dispatch_transition(base, key, "running", payload)
     _last_authorization.set(payload)
+    _observe_runtime(provider=payload.get("selected_provider"), model=model, currentRunStatus="RUNNING", taskCorrelationId=provider_request_id, failureMessage=None)
     return payload

--- a/tests/cli/test_pdv_source_archive.py
+++ b/tests/cli/test_pdv_source_archive.py
@@ -48,6 +48,7 @@ def test_corresponding_source_archive_is_deterministic_complete_and_secret_safe(
     first_receipt = json.loads(first.stdout)
     assert first_receipt["schemaVersion"] == 2
     assert first_receipt["sourceInventoryMode"] == "tracked-plus-explicit-integration-files"
+    assert len(first_receipt["sourceTreeSha256"]) == 64
     first_bytes = output.read_bytes()
     second = subprocess.run(command, capture_output=True, text=True, timeout=30, check=False)
     assert second.returncode == 0, second.stderr or second.stdout
@@ -65,6 +66,7 @@ def test_corresponding_source_archive_is_deterministic_complete_and_secret_safe(
       manifest = json.loads(archive.read("CORRESPONDING_SOURCE_MANIFEST.json"))
       assert manifest["schemaVersion"] == 2
       assert manifest["sourceInventoryMode"] == "tracked-plus-explicit-integration-files"
+      assert manifest["sourceTreeSha256"] == first_receipt["sourceTreeSha256"]
       assert manifest["excludedUntrackedCount"] == 6
       assert len(manifest["excludedUntrackedPathsSha256"]) == 64
       assert manifest["integrationBranch"] == "dev"

--- a/tests/cli/test_pdv_source_archive.py
+++ b/tests/cli/test_pdv_source_archive.py
@@ -1,0 +1,145 @@
+import hashlib
+import importlib.util
+import json
+import shutil
+import subprocess
+import zipfile
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).parents[2] / "scripts" / "pdv_build_source_archive.py"
+
+
+def _load_builder():
+    spec = importlib.util.spec_from_file_location("pdv_build_source_archive_test", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_corresponding_source_archive_is_deterministic_complete_and_secret_safe(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-b", "dev"], cwd=repo, check=True, capture_output=True)
+    (repo / "app.py").write_text("print('source')\n", encoding="utf-8")
+    (repo / "LICENSE").write_text("GNU AFFERO GENERAL PUBLIC LICENSE\n", encoding="utf-8")
+    (repo / "service" / "data").mkdir(parents=True)
+    (repo / "service" / "data" / "required.json").write_text("{}\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "-m", "fixture"], cwd=repo, check=True, capture_output=True)
+    (repo / "PDV_INTEGRATION_BOUNDARY.md").write_text("integration boundary\n", encoding="utf-8")
+    (repo / "new_integration_module.py").write_text("print('untracked integration source')\n", encoding="utf-8")
+    (repo / "confidential-notes.md").write_text("private but not secret-pattern-matching\n", encoding="utf-8")
+    (repo / "local.env").write_text("TOKEN=must-not-ship\n", encoding="utf-8")
+    (repo / "private.pem").write_text("must-not-ship\n", encoding="utf-8")
+    (repo / "unrelated.bin").write_bytes(b"unrelated local material")
+    (repo / "data" / "pdv-integration-v1").mkdir(parents=True)
+    (repo / "data" / "pdv-integration-v1" / "adapter.key").write_text("must-not-ship", encoding="utf-8")
+    (repo / ".venv").mkdir()
+    (repo / ".venv" / "secret.env").write_text("must-not-ship", encoding="utf-8")
+    output = repo / "data" / "pdv-integration-v1" / "source" / "source.zip"
+
+    command = [shutil.which("python") or "python", str(SCRIPT), "--repository-root", str(repo), "--output", str(output), "--include", "PDV_INTEGRATION_BOUNDARY.md", "--json"]
+    first = subprocess.run(command, capture_output=True, text=True, timeout=30, check=False)
+    assert first.returncode == 0, first.stderr or first.stdout
+    first_receipt = json.loads(first.stdout)
+    assert first_receipt["schemaVersion"] == 2
+    assert first_receipt["sourceInventoryMode"] == "tracked-plus-explicit-integration-files"
+    first_bytes = output.read_bytes()
+    second = subprocess.run(command, capture_output=True, text=True, timeout=30, check=False)
+    assert second.returncode == 0, second.stderr or second.stdout
+    assert output.read_bytes() == first_bytes
+    assert json.loads(second.stdout)["archiveSha256"] == hashlib.sha256(first_bytes).hexdigest() == first_receipt["archiveSha256"]
+
+    with zipfile.ZipFile(output) as archive:
+      names = archive.namelist()
+      assert names == sorted(names)
+      assert "app.py" in names and "LICENSE" in names and "PDV_INTEGRATION_BOUNDARY.md" in names
+      assert "new_integration_module.py" not in names
+      assert "confidential-notes.md" not in names
+      assert "service/data/required.json" in names
+      assert "CORRESPONDING_SOURCE_MANIFEST.json" in names
+      manifest = json.loads(archive.read("CORRESPONDING_SOURCE_MANIFEST.json"))
+      assert manifest["schemaVersion"] == 2
+      assert manifest["sourceInventoryMode"] == "tracked-plus-explicit-integration-files"
+      assert manifest["excludedUntrackedCount"] == 6
+      assert len(manifest["excludedUntrackedPathsSha256"]) == 64
+      assert manifest["integrationBranch"] == "dev"
+      assert manifest["licenseSha256"] == hashlib.sha256((repo / "LICENSE").read_bytes()).hexdigest()
+      assert "new_integration_module.py" not in manifest["files"]
+      assert all(".venv" not in name and not name.startswith("data/") and "adapter.key" not in name and not name.endswith((".env", ".pem")) for name in names)
+      assert b"must-not-ship" not in first_bytes
+      assert b"unrelated local material" not in first_bytes
+
+
+def test_corresponding_source_builder_rejects_include_outside_repository(tmp_path):
+    repo = tmp_path / "repo"; repo.mkdir(); subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    outside = tmp_path / "outside.py"; outside.write_text("secret", encoding="utf-8")
+    result = subprocess.run([shutil.which("python") or "python", str(SCRIPT), "--repository-root", str(repo), "--output", str(repo / "data" / "source.zip"), "--include", "../outside.py", "--json"], capture_output=True, text=True, timeout=30, check=False)
+    assert result.returncode != 0
+    assert not (repo / "data" / "source.zip").exists()
+
+
+def test_corresponding_source_builder_fails_closed_on_secret_content_in_innocent_path(tmp_path):
+    repo = tmp_path / "repo"; repo.mkdir(); subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    (repo / "LICENSE").write_text("GNU AFFERO GENERAL PUBLIC LICENSE\n", encoding="utf-8")
+    synthetic_secret = "sk-proj-" + "abcdefghijklmnopqrstuvwxyz0123456789"
+    (repo / "settings.json").write_text(json.dumps({"endpointCredential": synthetic_secret}) + "\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    output = repo / "data" / "pdv-integration-v1" / "source" / "source.zip"
+    result = subprocess.run([shutil.which("python") or "python", str(SCRIPT), "--repository-root", str(repo), "--output", str(output), "--json"], capture_output=True, text=True, timeout=30, check=False)
+    assert result.returncode != 0
+    assert json.loads(result.stdout) == {"ok": False, "error": "ValueError"}
+    assert not output.exists()
+
+
+def test_failed_rebuild_invalidates_old_archive_and_detects_integration_secrets(tmp_path):
+    repo = tmp_path / "repo"; repo.mkdir(); subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    (repo / "LICENSE").write_text("GNU AFFERO GENERAL PUBLIC LICENSE\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "-m", "fixture"], cwd=repo, check=True, capture_output=True)
+    key_dir = repo / "data" / "pdv-integration-v1"; key_dir.mkdir(parents=True)
+    adapter_key = ("a1" * 32).encode()
+    (key_dir / "adapter.key").write_bytes(adapter_key)
+    output = key_dir / "source" / "source.zip"
+    command = [shutil.which("python") or "python", str(SCRIPT), "--repository-root", str(repo), "--output", str(output), "--json"]
+    assert subprocess.run(command, capture_output=True, text=True, timeout=30, check=False).returncode == 0
+    assert output.exists() and output.with_suffix(".zip.json").exists()
+
+    innocent = repo / "innocent.txt"
+    innocent.write_text(adapter_key.decode() + "\n", encoding="utf-8")
+    failed = subprocess.run([*command[:-1], "--include", "innocent.txt", "--json"], capture_output=True, text=True, timeout=30, check=False)
+    assert failed.returncode != 0
+    assert not output.exists()
+    assert not output.with_suffix(".zip.json").exists()
+
+    innocent.unlink()
+    assert subprocess.run(command, capture_output=True, text=True, timeout=30, check=False).returncode == 0
+    owner_token = "ody_" + "Ab9x" * 8
+    innocent.write_text(owner_token + "\n", encoding="utf-8")
+    assert subprocess.run([*command[:-1], "--include", "innocent.txt", "--json"], capture_output=True, text=True, timeout=30, check=False).returncode != 0
+    assert not output.exists() and not output.with_suffix(".zip.json").exists()
+
+
+def test_failed_output_invalidation_removes_sidecar_and_temp_even_when_archive_is_locked(tmp_path, monkeypatch):
+    module = _load_builder()
+    output = tmp_path / "source.zip"
+    sidecar = output.with_suffix(".zip.json")
+    temporary = output.with_suffix(".zip.tmp")
+    for path in (output, sidecar, temporary):
+        path.write_bytes(b"stale")
+    original_unlink = Path.unlink
+
+    def locked_archive_unlink(path, *args, **kwargs):
+        if path == output:
+            raise PermissionError("synthetic archive lock")
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", locked_archive_unlink)
+    assert module._invalidate_failed_output(tmp_path, output) is False
+    assert output.exists()
+    assert not sidecar.exists()
+    assert not temporary.exists()

--- a/tests/cli/test_pdv_windows_baseline.py
+++ b/tests/cli/test_pdv_windows_baseline.py
@@ -1,0 +1,328 @@
+"""Behavioral tests for the PDV native-Windows boundary verifier."""
+
+import json
+import shutil
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).parents[2] / "scripts" / "pdv_verify_native_windows_baseline.ps1"
+LIFECYCLE_SCRIPT = Path(__file__).parents[2] / "scripts" / "pdv_windows_lifecycle.ps1"
+KEY_INIT_SCRIPT = Path(__file__).parents[2] / "scripts" / "pdv_initialize_adapter_key.ps1"
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    pwsh = shutil.which("pwsh")
+    if not pwsh:
+        pytest.skip("PowerShell 7 is required for the Windows boundary verifier")
+    return subprocess.run(
+        [pwsh, "-NoProfile", "-File", str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
+def _run_lifecycle(*args: str) -> subprocess.CompletedProcess[str]:
+    pwsh = shutil.which("pwsh")
+    if not pwsh:
+        pytest.skip("PowerShell 7 is required for the Windows lifecycle wrapper")
+    return subprocess.run(
+        [pwsh, "-NoProfile", "-File", str(LIFECYCLE_SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
+def _run_lifecycle_file_capture(output_root: Path, label: str, *args: str) -> subprocess.CompletedProcess[str]:
+    """Avoid Windows daemon descendants retaining pytest's capture pipe."""
+    pwsh = shutil.which("pwsh")
+    if not pwsh:
+        pytest.skip("PowerShell 7 is required for the Windows lifecycle wrapper")
+    stdout_path = output_root / f"{label}.stdout"
+    stderr_path = output_root / f"{label}.stderr"
+    with stdout_path.open("w", encoding="utf-8") as stdout, stderr_path.open("w", encoding="utf-8") as stderr:
+        result = subprocess.run(
+            [pwsh, "-NoProfile", "-File", str(LIFECYCLE_SCRIPT), *args],
+            stdout=stdout,
+            stderr=stderr,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    return subprocess.CompletedProcess(
+        result.args,
+        result.returncode,
+        stdout_path.read_text(encoding="utf-8-sig"),
+        stderr_path.read_text(encoding="utf-8-sig"),
+    )
+
+
+def _run_key_init(*args: str) -> subprocess.CompletedProcess[str]:
+    pwsh = shutil.which("pwsh")
+    if not pwsh:
+        pytest.skip("PowerShell 7 is required for adapter-key initialization")
+    return subprocess.run(
+        [pwsh, "-NoProfile", "-File", str(KEY_INIT_SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
+def _initialized_key(repo: Path) -> Path:
+    key_file = repo / "data" / "pdv-integration-v1" / "adapter.key"
+    result = _run_key_init("-RepositoryRoot", str(repo), "-KeyFile", str(key_file), "-Json")
+    assert result.returncode == 0, result.stderr or result.stdout
+    return key_file
+
+
+def _make_checkout(tmp_path: Path, origin: str) -> tuple[Path, str]:
+    repo = tmp_path / "checkout"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-b", "dev"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "remote", "add", "origin", origin], cwd=repo, check=True)
+    for name, content in {
+        "LICENSE": "GNU AFFERO GENERAL PUBLIC LICENSE\nVersion 3\n",
+        "requirements.txt": "fastapi\n",
+        "requirements-optional.txt": "markitdown\n",
+        "pyproject.toml": "[tool.pytest.ini_options]\n",
+        "package.json": "{}\n",
+        "package-lock.json": "{}\n",
+        "setup.py": "# setup marker\n",
+    }.items():
+        (repo / name).write_text(content, encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=PDV Baseline Test",
+            "-c",
+            "user.email=pdv-baseline@example.invalid",
+            "commit",
+            "-m",
+            "fixture",
+        ],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout.strip()
+    return repo, head
+
+
+def test_verifier_reports_safe_canonical_checkout(tmp_path):
+    repo, head = _make_checkout(tmp_path, "https://github.com/odysseus-dev/odysseus.git")
+
+    result = _run(
+        "-RepositoryRoot",
+        str(repo),
+        "-ExpectedUpstreamCommit",
+        head,
+        "-Json",
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    report = json.loads(result.stdout)
+    assert report["ok"] is True
+    assert report["repository"]["origin"] == "https://github.com/odysseus-dev/odysseus.git"
+    assert report["repository"]["expectedUpstreamCommit"] == head
+    assert report["repository"]["expectedCommitIsAncestor"] is True
+    assert report["license"]["spdx"] == "AGPL-3.0-or-later"
+    assert report["guardrails"]["dockerInvoked"] is False
+    assert report["guardrails"]["portsTouched"] == []
+
+
+def test_verifier_rejects_noncanonical_origin(tmp_path):
+    repo, head = _make_checkout(tmp_path, "https://example.invalid/not-odysseus.git")
+
+    result = _run(
+        "-RepositoryRoot",
+        str(repo),
+        "-ExpectedUpstreamCommit",
+        head,
+        "-Json",
+    )
+
+    assert result.returncode != 0
+    report = json.loads(result.stdout)
+    assert report["ok"] is False
+    assert "canonical origin" in report["errors"]
+
+
+def test_lifecycle_check_enforces_loopback_and_secret_reference(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "app.py").write_text("# app marker\n", encoding="utf-8")
+    key_file = _initialized_key(repo)
+
+    result = _run_lifecycle(
+        "-Action",
+        "Check",
+        "-RepositoryRoot",
+        str(repo),
+        "-AdapterKeyFile",
+        str(key_file),
+        "-PythonExecutable",
+        shutil.which("python") or "python",
+        "-ExecutionOsUrl",
+        "http://127.0.0.1:4310",
+        "-Port",
+        "7000",
+        "-Json",
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    report = json.loads(result.stdout)
+    assert report["ok"] is True
+    assert report["bindHost"] == "127.0.0.1"
+    assert report["adapterKeyReferenceConfigured"] is True
+    assert report["adapterKeyReadable"] is True
+    assert report["reservedPorts"] == [11435, 11436]
+    assert report["portsTouched"] == []
+    assert key_file.read_text(encoding="ascii") not in result.stdout
+    assert str(key_file) not in result.stdout
+    assert report["adapterKeyAclRestricted"] is True
+    assert report["executionOsConfigured"] is True
+
+
+def test_lifecycle_rejects_reserved_model_ports_without_starting(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "app.py").write_text("# app marker\n", encoding="utf-8")
+    key_file = _initialized_key(repo)
+
+    result = _run_lifecycle(
+        "-Action",
+        "Check",
+        "-RepositoryRoot",
+        str(repo),
+        "-AdapterKeyFile",
+        str(key_file),
+        "-PythonExecutable",
+        shutil.which("python") or "python",
+        "-ExecutionOsUrl",
+        "http://127.0.0.1:4310",
+        "-Port",
+        "11435",
+        "-Json",
+    )
+
+    assert result.returncode != 0
+    report = json.loads(result.stdout)
+    assert report["ok"] is False
+    assert "reserved model port" in report["errors"]
+    assert report["processStarted"] is False
+
+
+def test_adapter_key_initializer_creates_once_and_returns_fingerprint_only(tmp_path):
+    import hashlib
+
+    repo = tmp_path / "repo"
+    key_file = repo / "data" / "pdv-integration-v1" / "adapter.key"
+    repo.mkdir()
+
+    first = _run_key_init(
+        "-RepositoryRoot", str(repo), "-KeyFile", str(key_file), "-Json"
+    )
+
+    assert first.returncode == 0, first.stderr or first.stdout
+    first_report = json.loads(first.stdout)
+    key_bytes = key_file.read_bytes()
+    assert len(key_bytes) == 64
+    assert key_bytes.decode("ascii") == key_bytes.decode("ascii").lower()
+    assert len(bytes.fromhex(key_bytes.decode("ascii"))) == 32
+    assert first_report == {
+        "ok": True,
+        "created": True,
+        "fingerprintSha256": hashlib.sha256(key_bytes).hexdigest(),
+        "aclRestricted": True,
+        "keyBytes": 64,
+    }
+    assert str(key_file) not in first.stdout
+    assert key_bytes.hex() not in first.stdout
+
+    second = _run_key_init(
+        "-RepositoryRoot", str(repo), "-KeyFile", str(key_file), "-Json"
+    )
+
+    assert second.returncode == 0, second.stderr or second.stdout
+    second_report = json.loads(second.stdout)
+    assert second_report["created"] is False
+    assert second_report["fingerprintSha256"] == first_report["fingerprintSha256"]
+    assert key_file.read_bytes() == key_bytes
+
+
+def test_adapter_key_initializer_rejects_target_outside_runtime_boundary(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside.key"
+
+    result = _run_key_init(
+        "-RepositoryRoot", str(repo), "-KeyFile", str(outside), "-Json"
+    )
+
+    assert result.returncode != 0
+    assert not outside.exists()
+    report = json.loads(result.stdout)
+    assert report["ok"] is False
+    assert report["error"] == "key target must stay inside the PDV runtime directory"
+    assert str(outside) not in result.stdout
+
+
+def test_lifecycle_start_and_stop_verify_exact_process_receipt(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "app.py").write_text(
+        "from fastapi import FastAPI\napp = FastAPI()\n@app.get('/api/health')\ndef health(): return {'status': 'healthy'}\n",
+        encoding="utf-8",
+    )
+    key_file = _initialized_key(repo)
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+
+    start = _run_lifecycle_file_capture(
+        tmp_path, "start",
+        "-Action", "Start", "-RepositoryRoot", str(repo), "-AdapterKeyFile", str(key_file),
+        "-ExecutionOsUrl", "http://127.0.0.1:4310", "-PythonExecutable", sys.executable, "-Port", str(port), "-Json",
+    )
+    try:
+        assert start.returncode == 0, start.stderr or start.stdout
+        start_report = json.loads(start.stdout)
+        assert start_report["processStarted"] is True
+        receipt = json.loads((repo / "data" / "pdv-integration-v1" / "odysseus.pid").read_text(encoding="utf-8-sig"))
+        assert receipt["schemaVersion"] == 1
+        assert receipt["repositoryRoot"] == str(repo.resolve())
+        assert receipt["port"] == port
+        assert receipt["pid"] == start_report["processId"]
+        restart = _run_lifecycle_file_capture(
+            tmp_path, "restart",
+            "-Action", "Restart", "-RepositoryRoot", str(repo), "-AdapterKeyFile", str(key_file),
+            "-ExecutionOsUrl", "http://127.0.0.1:4310", "-PythonExecutable", sys.executable, "-Port", str(port), "-Json",
+        )
+        assert restart.returncode == 0, restart.stderr or restart.stdout
+        restart_report = json.loads(restart.stdout)
+        assert restart_report["action"] == "Restart"
+        assert restart_report["processStopped"] is True
+        assert restart_report["processStarted"] is True
+        assert restart_report["processId"] != start_report["processId"]
+    finally:
+        stop = _run_lifecycle_file_capture(
+            tmp_path, "stop",
+            "-Action", "Stop", "-RepositoryRoot", str(repo), "-AdapterKeyFile", str(key_file),
+            "-ExecutionOsUrl", "http://127.0.0.1:4310", "-PythonExecutable", sys.executable, "-Port", str(port), "-Json",
+        )
+    assert stop.returncode == 0, stop.stderr or stop.stdout
+    assert json.loads(stop.stdout)["processStopped"] is True

--- a/tests/test_llm_core_fallback.py
+++ b/tests/test_llm_core_fallback.py
@@ -224,6 +224,25 @@ def test_sync_fallback_consumes_pdv_ranked_order_and_policy(monkeypatch):
     assert calls == [("u-local", "local", {"headers": {}, "timeout": 2, "prompt_type": "chat"})]
 
 
+def test_async_retry_limit_zero_still_performs_one_attempt(monkeypatch):
+    from src import pdv_provider_guard
+
+    calls = []
+
+    async def rank(candidates, _task):
+        return candidates
+
+    async def call(url, model, messages, **kwargs):
+        calls.append(kwargs["max_retries"])
+        return "ok"
+
+    monkeypatch.setattr(pdv_provider_guard, "rank_provider_candidates", rank)
+    monkeypatch.setattr(pdv_provider_guard, "get_ranked_route_policy", lambda *_args: {"timeout_ms": 2000, "retry_limit": 0})
+    monkeypatch.setattr(llm_core, "llm_call_async", call)
+    assert asyncio.run(llm_core.llm_call_async_with_fallback([("u", "m", {})], [{"role": "user", "content": "hi"}])) == "ok"
+    assert calls == [1]
+
+
 def test_duplicate_route_is_attempted_only_once(monkeypatch):
     """A fallback that repeats the primary's (url, model) must NOT make the chain
     sail back into the same dead route — each distinct route is tried once."""

--- a/tests/test_llm_core_fallback.py
+++ b/tests/test_llm_core_fallback.py
@@ -212,6 +212,18 @@ def test_dedupe_candidates_keeps_first_of_each_route():
     assert llm_core._dedupe_candidates(None) == []
 
 
+def test_sync_fallback_consumes_pdv_ranked_order_and_policy(monkeypatch):
+    from src import pdv_provider_guard
+
+    candidates = [("u-paid", "paid", {"Authorization": "secret"}), ("u-local", "local", {})]
+    calls = []
+    monkeypatch.setattr(pdv_provider_guard, "rank_provider_candidates_sync", lambda cands, task: [cands[1], cands[0]])
+    monkeypatch.setattr(pdv_provider_guard, "get_ranked_route_policy", lambda url, _model: {"timeout_ms": 2000, "retry_limit": 0} if url == "u-local" else None)
+    monkeypatch.setattr(llm_core, "llm_call", lambda url, model, messages, **kwargs: calls.append((url, model, kwargs)) or "ok")
+    assert llm_core.llm_call_with_fallback(candidates, [{"role": "user", "content": "hi"}], timeout=30, prompt_type="chat") == "ok"
+    assert calls == [("u-local", "local", {"headers": {}, "timeout": 2, "prompt_type": "chat"})]
+
+
 def test_duplicate_route_is_attempted_only_once(monkeypatch):
     """A fallback that repeats the primary's (url, model) must NOT make the chain
     sail back into the same dead route — each distinct route is tried once."""

--- a/tests/test_pdv_mcp_bridge.py
+++ b/tests/test_pdv_mcp_bridge.py
@@ -1,0 +1,45 @@
+import json
+
+import pytest
+
+from mcp_servers import pdv_control_server
+
+
+def test_pdv_mcp_boundary_requires_loopback_and_hex_key(tmp_path, monkeypatch):
+    key = tmp_path / "adapter.key"
+    key.write_text("a" * 64, encoding="ascii")
+    monkeypatch.setenv("ODYSSEUS_PDV_ADAPTER_KEY_FILE", str(key))
+    monkeypatch.setenv("PDV_EXECUTION_OS_URL", "https://remote.invalid:4173")
+    with pytest.raises(RuntimeError, match="loopback"):
+        pdv_control_server._boundary()
+    monkeypatch.setenv("PDV_EXECUTION_OS_URL", "http://127.0.0.1:4173")
+    assert pdv_control_server._boundary() == ("http://127.0.0.1:4173", "a" * 64)
+
+
+@pytest.mark.asyncio
+async def test_pdv_mcp_allowed_result_preserves_provenance(monkeypatch):
+    async def approved(tool_name, arguments):
+        return {"allowed": True, "result": {"service": "pdv-execution-os"}, "provenance": {"source_system": "pdv-execution-os", "tool_name": tool_name}}
+    monkeypatch.setattr(pdv_control_server, "_invoke", approved)
+    result = await pdv_control_server.call_tool("pdv_health_status", {})
+    payload = json.loads(result[0].text)
+    assert payload["provenance"]["source_system"] == "pdv-execution-os"
+    assert payload["provenance"]["tool_name"] == "health.status"
+
+
+@pytest.mark.asyncio
+async def test_pdv_mcp_unknown_tool_never_reaches_transport(monkeypatch):
+    async def forbidden(*_args):
+        raise AssertionError("transport must not run")
+    monkeypatch.setattr(pdv_control_server, "_invoke", forbidden)
+    with pytest.raises(ValueError, match="Unknown PDV tool"):
+        await pdv_control_server.call_tool("shell_exec", {"command": "whoami"})
+
+
+@pytest.mark.asyncio
+async def test_pdv_mcp_transport_denial_is_protocol_failure(monkeypatch):
+    async def denied(*_args):
+        raise RuntimeError("PDV MCP invocation refused (403, TOOL_NOT_ALLOWLISTED)")
+    monkeypatch.setattr(pdv_control_server, "_invoke", denied)
+    with pytest.raises(RuntimeError, match="TOOL_NOT_ALLOWLISTED"):
+        await pdv_control_server.call_tool("pdv_health_status", {})

--- a/tests/test_pdv_native_integration_proof.py
+++ b/tests/test_pdv_native_integration_proof.py
@@ -1,0 +1,177 @@
+"""Integrated PDV proof against the real Odysseus ASGI application.
+
+This deliberately runs in a child interpreter.  ``app.py`` resolves its data
+root, authentication policy, database engine, and middleware at import time;
+an isolated process is the only reliable way to prove that complete production
+path without contaminating the developer's live data or pytest's module cache.
+No lifespan is entered, so background schedulers and provider probes never run.
+"""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+
+
+_PROOF_PROGRAM = r"""
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import bcrypt
+import httpx
+
+data_dir = Path(sys.argv[1]).resolve()
+data_dir.mkdir(parents=True, exist_ok=True)
+(data_dir / "auth.json").write_text(json.dumps({
+    "users": {
+        "owner": {"password_hash": "unused", "is_admin": True},
+        "member": {"password_hash": "unused", "is_admin": False},
+    }
+}), encoding="utf-8")
+
+import app as odysseus_app
+from core.database import ApiToken, SessionLocal
+
+tokens = {
+    "owner_read": "ody_" + "A" * 43,
+    "owner_chat": "ody_" + "B" * 43,
+    "member_read": "ody_" + "C" * 43,
+}
+
+with SessionLocal() as db:
+    for token_id, owner, scopes, raw in (
+        ("pdvown01", "owner", "pdv:read", tokens["owner_read"]),
+        ("pdvown02", "owner", "chat", tokens["owner_chat"]),
+        ("pdvmem01", "member", "pdv:read", tokens["member_read"]),
+    ):
+        db.add(ApiToken(
+            id=token_id,
+            owner=owner,
+            name=token_id,
+            token_hash=bcrypt.hashpw(raw.encode(), bcrypt.gensalt()).decode(),
+            token_prefix=raw[:8],
+            scopes=scopes,
+            is_active=True,
+        ))
+    db.commit()
+odysseus_app.app.state._token_cache_dirty = True
+
+expected_surfaces = {
+    "chat": "/api/chat",
+    "agents": "/api/assistant/run/{task_id}",
+    "research": "/api/research/start",
+    "documents": "/api/document",
+    "notes": "/api/notes",
+    "tasks": "/api/tasks",
+    "scheduler": "/api/tasks/{task_id}/run",
+    "providers": "/api/model-endpoints",
+    "history": "/api/history/{session_id}",
+    "email": "/api/email/accounts",
+    "calendar": "/api/calendar/events",
+}
+paths = set(odysseus_app.app.openapi()["paths"])
+missing = {name: path for name, path in expected_surfaces.items() if path not in paths}
+assert not missing, missing
+
+async def run():
+    transport = httpx.ASGITransport(
+        app=odysseus_app.app,
+        client=("203.0.113.10", 443),
+        raise_app_exceptions=True,
+    )
+    async with httpx.AsyncClient(transport=transport, base_url="http://odysseus.test") as client:
+        unauthenticated = await client.get("/api/pdv/source")
+        invalid = await client.get(
+            "/api/pdv/source", headers={"Authorization": "Bearer ody_invalid-value"}
+        )
+        wrong_scope = await client.get(
+            "/api/pdv/source",
+            headers={"Authorization": "Bearer " + tokens["owner_chat"]},
+        )
+        wrong_owner = await client.get(
+            "/api/pdv/source",
+            headers={"Authorization": "Bearer " + tokens["member_read"]},
+        )
+        authorized = await client.get(
+            "/api/pdv/source",
+            headers={"Authorization": "Bearer " + tokens["owner_read"]},
+        )
+        await asyncio.sleep(0.05)
+
+    assert unauthenticated.status_code == 401, unauthenticated.text
+    assert invalid.status_code == 401, invalid.text
+    assert wrong_scope.status_code == 403, wrong_scope.text
+    assert wrong_owner.status_code == 403, wrong_owner.text
+    assert authorized.status_code == 200, authorized.text
+    payload = authorized.json()
+    assert payload["canonicalRepository"] == "https://github.com/odysseus-dev/odysseus"
+    assert payload["license"] == "AGPL-3.0-or-later"
+    assert all(raw not in authorized.text for raw in tokens.values())
+    assert str(data_dir) not in authorized.text
+    return {
+        "routeCount": len(paths),
+        "nativeSurfaces": sorted(expected_surfaces),
+        "bearerStatuses": {
+            "unauthenticated": unauthenticated.status_code,
+            "invalid": invalid.status_code,
+            "wrongScope": wrong_scope.status_code,
+            "nonAdminOwner": wrong_owner.status_code,
+            "adminPdvRead": authorized.status_code,
+        },
+        "sourceCommit": payload["upstreamCommit"],
+    }
+
+print(json.dumps(asyncio.run(run()), sort_keys=True))
+"""
+
+
+def test_real_app_bearer_middleware_and_native_surface(tmp_path):
+    repository_root = Path(__file__).resolve().parents[1]
+    python = repository_root / ".venv" / "Scripts" / "python.exe"
+    if not python.is_file():
+        python = Path(sys.executable)
+
+    data_dir = tmp_path / "isolated-data"
+    key_file = tmp_path / "adapter.key"
+    key_file.write_text("a" * 64, encoding="ascii")
+    env = os.environ.copy()
+    env.update({
+        "AUTH_ENABLED": "true",
+        "LOCALHOST_BYPASS": "false",
+        "APP_BIND": "127.0.0.1",
+        "ODYSSEUS_DATA_DIR": str(data_dir),
+        "DATABASE_URL": "sqlite:///" + str(data_dir / "app.db"),
+        "ODYSSEUS_PDV_ADAPTER_KEY_FILE": str(key_file),
+        # The guard remains inert and cannot authorize an outbound provider call.
+        "PDV_PROVIDER_GUARD_REQUIRED": "false",
+    })
+
+    result = subprocess.run(
+        [str(python), "-c", textwrap.dedent(_PROOF_PROGRAM), str(data_dir)],
+        cwd=repository_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=90,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"isolated proof failed ({result.returncode})\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+    receipt = json.loads(result.stdout.strip().splitlines()[-1])
+    assert receipt["routeCount"] >= 400
+    assert receipt["bearerStatuses"] == {
+        "adminPdvRead": 200,
+        "invalid": 401,
+        "nonAdminOwner": 403,
+        "unauthenticated": 401,
+        "wrongScope": 403,
+    }
+    assert receipt["nativeSurfaces"] == sorted([
+        "agents", "calendar", "chat", "documents", "email", "history",
+        "notes", "providers", "research", "scheduler", "tasks",
+    ])

--- a/tests/test_pdv_provider_guard.py
+++ b/tests/test_pdv_provider_guard.py
@@ -58,6 +58,26 @@ def test_provider_outcome_requires_exact_durable_receipt_correlation(tmp_path, m
     assert receipt["provider_request_id"] == authorization["provider_request_id"]
 
 
+def test_normal_sync_llm_call_records_provider_outcome_and_usage(monkeypatch):
+    import src.llm_core as llm_core
+
+    authorization = {"authorization_receipt_id": "auth", "provider_request_id": "request"}
+    outcomes = []
+    monkeypatch.setattr(pdv_provider_guard, "authorize_provider_sync", lambda _endpoint, _model: authorization)
+    monkeypatch.setattr(pdv_provider_guard, "record_provider_outcome_sync", lambda auth, outcome, duration, **telemetry: outcomes.append((auth, outcome, telemetry)))
+    monkeypatch.setattr(llm_core, "httpx_post_kimi_aware", lambda *_args, **_kwargs: httpx.Response(200, json={"choices": [{"message": {"content": "synthetic result"}}], "usage": {"prompt_tokens": 3, "completion_tokens": 2}}))
+    result = llm_core.llm_call("https://provider.example.invalid/v1", "synthetic-model", [{"role": "user", "content": "synthetic"}], max_tokens=4)
+    assert result == "synthetic result"
+    assert outcomes == [(authorization, "completed", {"input_tokens": 3, "output_tokens": 2})]
+
+
+def test_normal_async_and_stream_paths_record_provider_outcomes():
+    from pathlib import Path
+    source = (Path(__file__).parents[1] / "src" / "llm_core.py").read_text(encoding="utf-8")
+    assert source.count("record_provider_outcome(") >= 7
+    assert "record_provider_outcome_sync(authorization, \"completed\"" in source
+
+
 def test_every_direct_model_post_path_has_provider_preflight():
     from pathlib import Path
     root = Path(__file__).parents[1]

--- a/tests/test_pdv_provider_guard.py
+++ b/tests/test_pdv_provider_guard.py
@@ -1,5 +1,6 @@
 import httpx
 import pytest
+from contextlib import asynccontextmanager
 
 from src import pdv_provider_guard
 
@@ -40,6 +41,76 @@ def test_provider_guard_fails_closed_on_denial_or_mismatch(tmp_path, monkeypatch
         pdv_provider_guard.authorize_provider_sync("http://127.0.0.1:11435/v1/chat/completions", "model-1")
 
 
+def test_provider_ranking_reorders_without_serializing_credentials(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    candidates = [
+        ("https://paid.example/v1/chat/completions", "paid-model", {"Authorization": "Bearer secret"}),
+        ("http://127.0.0.1:11435/v1/chat/completions", "local-model", {"X-Local-Key": "secret"}),
+    ]
+    captured = {}
+
+    def rank(*_args, **kwargs):
+        captured.update(kwargs["json"])
+        return httpx.Response(200, json={
+            "allowed": True,
+            "reason_code": "AUTHORIZED",
+            "routing_receipt_id": "ody_provider_routing_1",
+            "task_class": "chat",
+            "selected_endpoint": candidates[1][0],
+            "selected_model": candidates[1][1],
+            "ordered_candidates": [
+                {"candidate_index": 1, "endpoint": candidates[1][0], "model": candidates[1][1], "timeout_ms": 30000, "retry_limit": 1},
+                {"candidate_index": 0, "endpoint": candidates[0][0], "model": candidates[0][1], "timeout_ms": 60000, "retry_limit": 0},
+            ],
+        })
+
+    monkeypatch.setattr(pdv_provider_guard.httpx, "post", rank)
+    assert pdv_provider_guard.rank_provider_candidates_sync(candidates) == [candidates[1], candidates[0]]
+    assert captured == {"task_class": "chat", "candidates": [{"endpoint": item[0], "model": item[1]} for item in candidates]}
+    assert "secret" not in repr(captured)
+    assert pdv_provider_guard.get_ranked_route_policy(candidates[1][0], candidates[1][1])["retry_limit"] == 1
+
+
+def test_provider_ranking_fails_closed_on_malformed_order(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    candidate = ("http://127.0.0.1:11435/v1/chat/completions", "local-model", {})
+    monkeypatch.setattr(pdv_provider_guard.httpx, "post", lambda *_args, **_kwargs: httpx.Response(200, json={
+        "allowed": True, "routing_receipt_id": "receipt", "task_class": "chat",
+        "selected_endpoint": candidate[0], "selected_model": candidate[1],
+        "ordered_candidates": [{"candidate_index": 7, "endpoint": candidate[0], "model": candidate[1], "timeout_ms": 30000, "retry_limit": 1}],
+    }))
+    with pytest.raises(RuntimeError, match="correlation mismatch"):
+        pdv_provider_guard.rank_provider_candidates_sync([candidate])
+
+
+@pytest.mark.asyncio
+async def test_async_provider_ranking_preserves_opaque_candidate_headers(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    candidate = ("http://127.0.0.1:11435/v1/chat/completions", "local-model", {"Authorization": "secret"})
+
+    class Client:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        async def post(self, _url, **kwargs):
+            assert kwargs["json"]["candidates"] == [{"endpoint": candidate[0], "model": candidate[1]}]
+            assert "secret" not in repr(kwargs["json"])
+            return httpx.Response(200, json={
+                "allowed": True, "routing_receipt_id": "receipt", "task_class": "chat",
+                "selected_endpoint": candidate[0], "selected_model": candidate[1],
+                "ordered_candidates": [{"candidate_index": 0, "endpoint": candidate[0], "model": candidate[1], "timeout_ms": 30000, "retry_limit": 1}],
+            })
+
+    monkeypatch.setattr(pdv_provider_guard.httpx, "AsyncClient", Client)
+    assert await pdv_provider_guard.rank_provider_candidates([candidate]) == [candidate]
+
+
 def test_provider_outcome_requires_exact_durable_receipt_correlation(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
     authorization = {"authorization_receipt_id": "ody_provider_auth_" + "1" * 36, "provider_request_id": "2" * 36}
@@ -76,6 +147,34 @@ def test_normal_async_and_stream_paths_record_provider_outcomes():
     source = (Path(__file__).parents[1] / "src" / "llm_core.py").read_text(encoding="utf-8")
     assert source.count("record_provider_outcome(") >= 7
     assert "record_provider_outcome_sync(authorization, \"completed\"" in source
+
+
+@pytest.mark.asyncio
+async def test_stream_error_event_records_failed_outcome(monkeypatch):
+    import src.llm_core as llm_core
+
+    outcomes = []
+
+    async def authorize(_endpoint, _model):
+        return {"authorization_receipt_id": "auth", "provider_request_id": "request"}
+
+    async def record(_authorization, outcome, _duration, **_telemetry):
+        outcomes.append(outcome)
+
+    async def inner(*_args, **_kwargs):
+        yield 'event: error\ndata: {"status": 502, "text": "synthetic"}\n\n'
+
+    @asynccontextmanager
+    async def slot(*_args, **_kwargs):
+        yield
+
+    monkeypatch.setattr(pdv_provider_guard, "authorize_provider", authorize)
+    monkeypatch.setattr(pdv_provider_guard, "record_provider_outcome", record)
+    monkeypatch.setattr(llm_core, "_stream_llm_inner", inner)
+    monkeypatch.setattr(llm_core, "_local_model_slot", slot)
+    chunks = [chunk async for chunk in llm_core.stream_llm("https://provider.example/v1", "model", [{"role": "user", "content": "hi"}])]
+    assert chunks[0].startswith("event: error")
+    assert outcomes == ["failed"]
 
 
 def test_every_direct_model_post_path_has_provider_preflight():

--- a/tests/test_pdv_provider_guard.py
+++ b/tests/test_pdv_provider_guard.py
@@ -1,0 +1,93 @@
+import httpx
+import pytest
+
+from src import pdv_provider_guard
+
+
+def _configure(tmp_path, monkeypatch):
+    key = tmp_path / "adapter.key"
+    key.write_text("a" * 64, encoding="ascii")
+    monkeypatch.setenv("PDV_PROVIDER_GUARD_REQUIRED", "true")
+    monkeypatch.setenv("PDV_EXECUTION_OS_URL", "http://127.0.0.1:4173")
+    monkeypatch.setenv("ODYSSEUS_PDV_ADAPTER_KEY_FILE", str(key))
+
+
+def test_provider_guard_is_inert_for_standalone_upstream(monkeypatch):
+    monkeypatch.delenv("PDV_PROVIDER_GUARD_REQUIRED", raising=False)
+    assert pdv_provider_guard.authorize_provider_sync("https://example.invalid/v1", "model") is None
+
+
+def test_provider_guard_accepts_only_correlated_authorization(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    endpoint = "http://127.0.0.1:11435/v1/chat/completions"
+    def authorize(*_args, **kwargs):
+        request_id = kwargs["json"]["provider_request_id"]
+        return httpx.Response(200, json={"allowed": True, "selected_model": "model-1", "selected_endpoint": endpoint, "provider_request_id": request_id, "authorization_receipt_id": "receipt-1"})
+    monkeypatch.setattr(pdv_provider_guard.httpx, "post", authorize)
+    receipt = pdv_provider_guard.authorize_provider_sync(endpoint, "model-1")
+    assert receipt["allowed"] is True
+    assert pdv_provider_guard.get_last_authorization_receipt() == receipt
+
+
+def test_provider_guard_fails_closed_on_denial_or_mismatch(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.setattr(pdv_provider_guard.httpx, "post", lambda *_args, **_kwargs: httpx.Response(403, json={"allowed": False, "reason_code": "LOCAL_CAPACITY_NOT_AUTHORIZED"}))
+    with pytest.raises(RuntimeError, match="LOCAL_CAPACITY_NOT_AUTHORIZED"):
+        pdv_provider_guard.authorize_provider_sync("http://127.0.0.1:11435/v1/chat/completions", "model-1")
+    assert pdv_provider_guard.get_last_authorization_receipt() is None
+    monkeypatch.setattr(pdv_provider_guard.httpx, "post", lambda *_args, **kwargs: httpx.Response(200, json={"allowed": True, "selected_model": "other", "selected_endpoint": "http://127.0.0.1:11435/v1/chat/completions", "provider_request_id": kwargs["json"]["provider_request_id"], "authorization_receipt_id": "receipt-1"}))
+    with pytest.raises(RuntimeError, match="correlation mismatch"):
+        pdv_provider_guard.authorize_provider_sync("http://127.0.0.1:11435/v1/chat/completions", "model-1")
+
+
+def test_provider_outcome_requires_exact_durable_receipt_correlation(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    authorization = {"authorization_receipt_id": "ody_provider_auth_" + "1" * 36, "provider_request_id": "2" * 36}
+
+    def record(*_args, **kwargs):
+        payload = kwargs["json"]
+        return httpx.Response(201, json={
+            "outcome_receipt_id": "ody_provider_outcome_" + "3" * 36,
+            "authorization_receipt_id": payload["authorization_receipt_id"],
+            "provider_request_id": payload["provider_request_id"],
+            "outcome": payload["outcome"],
+        })
+
+    monkeypatch.setattr(pdv_provider_guard.httpx, "post", record)
+    receipt = pdv_provider_guard.record_provider_outcome_sync(authorization, "timed_out", 60000, cost_microusd=0)
+    assert receipt["provider_request_id"] == authorization["provider_request_id"]
+
+
+def test_every_direct_model_post_path_has_provider_preflight():
+    from pathlib import Path
+    root = Path(__file__).parents[1]
+    assert "authorize_provider_sync(target_url, model_id)" in (root / "routes" / "model_routes.py").read_text(encoding="utf-8")
+    image_source = (root / "src" / "ai_interaction.py").read_text(encoding="utf-8")
+    for call in ("authorize_provider(images_url, model_id)", "authorize_provider(edits_url, model_id)", "authorize_provider(harmonize_url, model_id)"):
+        assert call in image_source
+    gallery_source = (root / "routes" / "gallery" / "gallery_routes.py").read_text(encoding="utf-8")
+    assert gallery_source.count("authorize_provider(") >= 7
+    assert "authorize_provider_sync(url, model or \"embedding-endpoint\")" in (root / "routes" / "embedding_routes.py").read_text(encoding="utf-8")
+    assert "authorize_provider_sync(self.url, self.model)" in (root / "src" / "embeddings.py").read_text(encoding="utf-8")
+    assert "await authorize_provider(images_url, model_id)" in (root / "mcp_servers" / "image_gen_server.py").read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_builtin_image_mcp_denial_prevents_provider_post(monkeypatch):
+    import mcp_servers.image_gen_server as image_server
+    import src.ai_interaction as ai_interaction
+    import src.settings as settings
+
+    monkeypatch.setattr(settings, "get_setting", lambda name, default=None: default)
+    monkeypatch.setattr(settings, "load_settings", lambda: {"image_model": "gpt-image-1"})
+    monkeypatch.setattr(ai_interaction, "_resolve_model", lambda *_args, **_kwargs: ("https://images.example/v1/chat/completions", "gpt-image-1", {}))
+    called = []
+
+    async def denied(endpoint, model):
+        called.append((endpoint, model))
+        raise RuntimeError("synthetic policy denial")
+
+    monkeypatch.setattr(pdv_provider_guard, "authorize_provider", denied)
+    result = await image_server.call_tool("generate_image", {"prompt": "synthetic"})
+    assert called == [("https://images.example/v1/images/generations", "gpt-image-1")]
+    assert "synthetic policy denial" in result[0].text

--- a/tests/test_pdv_provider_guard.py
+++ b/tests/test_pdv_provider_guard.py
@@ -13,6 +13,14 @@ def _configure(tmp_path, monkeypatch):
     monkeypatch.setenv("ODYSSEUS_PDV_ADAPTER_KEY_FILE", str(key))
 
 
+def _set_ranking(endpoint, model):
+    pdv_provider_guard._last_routing.set({
+        "routing_receipt_id": "ody_provider_routing_" + "1" * 36,
+        "task_class": "chat",
+        "ordered_candidates": [{"candidate_index": 0, "endpoint": endpoint, "model": model, "timeout_ms": 30000, "retry_limit": 1}],
+    })
+
+
 def test_provider_guard_is_inert_for_standalone_upstream(monkeypatch):
     monkeypatch.delenv("PDV_PROVIDER_GUARD_REQUIRED", raising=False)
     assert pdv_provider_guard.authorize_provider_sync("https://example.invalid/v1", "model") is None
@@ -21,24 +29,54 @@ def test_provider_guard_is_inert_for_standalone_upstream(monkeypatch):
 def test_provider_guard_accepts_only_correlated_authorization(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
     endpoint = "http://127.0.0.1:11435/v1/chat/completions"
+    _set_ranking(endpoint, "model-1")
     def authorize(*_args, **kwargs):
         request_id = kwargs["json"]["provider_request_id"]
-        return httpx.Response(200, json={"allowed": True, "selected_model": "model-1", "selected_endpoint": endpoint, "provider_request_id": request_id, "authorization_receipt_id": "receipt-1"})
+        return httpx.Response(200, json={"allowed": True, "selected_model": "model-1", "selected_endpoint": endpoint, "provider_request_id": request_id, "routing_receipt_id": kwargs["json"]["routing_receipt_id"], "candidate_index": kwargs["json"]["candidate_index"], "authorization_receipt_id": "receipt-1"})
     monkeypatch.setattr(pdv_provider_guard.httpx, "post", authorize)
     receipt = pdv_provider_guard.authorize_provider_sync(endpoint, "model-1")
     assert receipt["allowed"] is True
     assert pdv_provider_guard.get_last_authorization_receipt() == receipt
 
 
+def test_direct_authorization_first_obtains_a_bound_ranking_receipt(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    pdv_provider_guard._last_routing.set(None)
+    endpoint = "http://127.0.0.1:11435/v1/chat/completions"
+    calls = []
+
+    def post(url, **kwargs):
+        calls.append(url)
+        if url.endswith("/provider/rank"):
+            return httpx.Response(200, json={
+                "allowed": True, "routing_receipt_id": "ody_provider_routing_" + "2" * 36, "task_class": "chat",
+                "selected_provider": "llama.cpp", "selected_endpoint": endpoint, "selected_model": "model-1",
+                "ordered_candidates": [{"candidate_index": 0, "endpoint": endpoint, "model": "model-1", "timeout_ms": 30000, "retry_limit": 0}],
+            })
+        payload = kwargs["json"]
+        return httpx.Response(200, json={
+            "allowed": True, "selected_provider": "llama.cpp", "selected_model": "model-1", "selected_endpoint": endpoint,
+            "provider_request_id": payload["provider_request_id"], "routing_receipt_id": payload["routing_receipt_id"],
+            "candidate_index": payload["candidate_index"], "authorization_receipt_id": "receipt-1",
+        })
+
+    monkeypatch.setattr(pdv_provider_guard.httpx, "post", post)
+    receipt = pdv_provider_guard.authorize_provider_sync(endpoint, "model-1")
+    assert calls[0].endswith("/provider/rank") and calls[1].endswith("/provider/authorize")
+    assert receipt["routing_receipt_id"].startswith("ody_provider_routing_")
+
+
 def test_provider_guard_fails_closed_on_denial_or_mismatch(tmp_path, monkeypatch):
     _configure(tmp_path, monkeypatch)
+    endpoint = "http://127.0.0.1:11435/v1/chat/completions"
+    _set_ranking(endpoint, "model-1")
     monkeypatch.setattr(pdv_provider_guard.httpx, "post", lambda *_args, **_kwargs: httpx.Response(403, json={"allowed": False, "reason_code": "LOCAL_CAPACITY_NOT_AUTHORIZED"}))
     with pytest.raises(RuntimeError, match="LOCAL_CAPACITY_NOT_AUTHORIZED"):
-        pdv_provider_guard.authorize_provider_sync("http://127.0.0.1:11435/v1/chat/completions", "model-1")
+        pdv_provider_guard.authorize_provider_sync(endpoint, "model-1")
     assert pdv_provider_guard.get_last_authorization_receipt() is None
-    monkeypatch.setattr(pdv_provider_guard.httpx, "post", lambda *_args, **kwargs: httpx.Response(200, json={"allowed": True, "selected_model": "other", "selected_endpoint": "http://127.0.0.1:11435/v1/chat/completions", "provider_request_id": kwargs["json"]["provider_request_id"], "authorization_receipt_id": "receipt-1"}))
+    monkeypatch.setattr(pdv_provider_guard.httpx, "post", lambda *_args, **kwargs: httpx.Response(200, json={"allowed": True, "selected_model": "other", "selected_endpoint": endpoint, "provider_request_id": kwargs["json"]["provider_request_id"], "routing_receipt_id": kwargs["json"]["routing_receipt_id"], "candidate_index": kwargs["json"]["candidate_index"], "authorization_receipt_id": "receipt-1"}))
     with pytest.raises(RuntimeError, match="correlation mismatch"):
-        pdv_provider_guard.authorize_provider_sync("http://127.0.0.1:11435/v1/chat/completions", "model-1")
+        pdv_provider_guard.authorize_provider_sync(endpoint, "model-1")
 
 
 def test_provider_ranking_reorders_without_serializing_credentials(tmp_path, monkeypatch):
@@ -127,6 +165,38 @@ def test_provider_outcome_requires_exact_durable_receipt_correlation(tmp_path, m
     monkeypatch.setattr(pdv_provider_guard.httpx, "post", record)
     receipt = pdv_provider_guard.record_provider_outcome_sync(authorization, "timed_out", 60000, cost_microusd=0)
     assert receipt["provider_request_id"] == authorization["provider_request_id"]
+
+
+def test_bound_dispatch_receives_exact_provider_outcome_correlation(tmp_path, monkeypatch):
+    _configure(tmp_path, monkeypatch)
+    endpoint = "http://127.0.0.1:11435/v1/chat/completions"
+    _set_ranking(endpoint, "model-1")
+    monkeypatch.setenv("PDV_EXECUTION_OS_DISPATCH_ID", "ody_dispatch_" + "4" * 36)
+    transitions = []
+
+    def post(url, **kwargs):
+        payload = kwargs["json"]
+        if url.endswith("/provider/authorize"):
+            return httpx.Response(200, json={
+                "allowed": True, "selected_provider": "llama.cpp", "selected_model": "model-1", "selected_endpoint": endpoint,
+                "provider_request_id": payload["provider_request_id"], "routing_receipt_id": payload["routing_receipt_id"],
+                "candidate_index": payload["candidate_index"], "authorization_receipt_id": "ody_provider_auth_" + "5" * 36,
+            })
+        if url.endswith("/provider/outcome"):
+            return httpx.Response(201, json={
+                "outcome_receipt_id": "ody_provider_outcome_" + "6" * 36,
+                "authorization_receipt_id": payload["authorization_receipt_id"], "provider_request_id": payload["provider_request_id"], "outcome": payload["outcome"],
+            })
+        transitions.append(payload)
+        return httpx.Response(200, json={"state": payload["state"]})
+
+    monkeypatch.setattr(pdv_provider_guard.httpx, "post", post)
+    authorization = pdv_provider_guard.authorize_provider_sync(endpoint, "model-1")
+    outcome = pdv_provider_guard.record_provider_outcome_sync(authorization, "failed", 10)
+    assert transitions == [
+        {"state": "running", "provider_request_id": authorization["provider_request_id"], "final_receipt_id": None},
+        {"state": "failed", "provider_request_id": authorization["provider_request_id"], "final_receipt_id": outcome["outcome_receipt_id"]},
+    ]
 
 
 def test_normal_sync_llm_call_records_provider_outcome_and_usage(monkeypatch):

--- a/tests/test_pdv_routes.py
+++ b/tests/test_pdv_routes.py
@@ -150,7 +150,10 @@ def test_pdv_health_reports_readiness_without_disclosing_secret(tmp_path, monkey
     }
     assert payload["sourceArchiveAvailable"] is True
     assert len(payload["sourceArchiveSha256"]) == 64
-    assert payload["capabilities"]["chat"] == "AVAILABLE"
+    assert payload["capabilities"]["chat"] == "DEGRADED"
+    assert payload["capabilities"]["agents"] == "DEGRADED"
+    assert payload["capabilities"]["research"] == "DEGRADED"
+    assert payload["capabilities"]["memory"] == "AVAILABLE"
     assert payload["capabilities"]["calendar"] == "AVAILABLE"
     assert payload["capabilities"]["email"] == "AUTH_REQUIRED"
     assert secret not in response.text

--- a/tests/test_pdv_routes.py
+++ b/tests/test_pdv_routes.py
@@ -2,6 +2,8 @@
 
 import hashlib
 import json
+import subprocess
+import zipfile
 from pathlib import Path
 
 from fastapi import FastAPI, Request
@@ -72,15 +74,33 @@ def _snapshot(repository_root: Path):
         ),
         encoding="utf-8",
     )
+    (repository_root / "LICENSE").write_text("GNU AFFERO GENERAL PUBLIC LICENSE\n", encoding="utf-8")
+    if not (repository_root / ".git").exists():
+        subprocess.run(["git", "init"], cwd=repository_root, check=True, capture_output=True)
+    subprocess.run(["git", "add", "PDV_UPSTREAM_SNAPSHOT.json", "LICENSE"], cwd=repository_root, check=True, capture_output=True)
     _archive(repository_root)
 
 
 def _archive(repository_root: Path, content: bytes = b"source archive"):
+    from scripts.pdv_build_source_archive import _source_tree_sha256
+
+    (repository_root / "app.py").write_bytes(content)
+    subprocess.run(["git", "add", "app.py"], cwd=repository_root, check=True, capture_output=True)
     archive = repository_root / "data" / "pdv-integration-v1" / "source" / "odysseus-corresponding-source.zip"
     archive.parent.mkdir(parents=True, exist_ok=True)
-    archive.write_bytes(content)
+    files = {
+        name: hashlib.sha256((repository_root / name).read_bytes()).hexdigest()
+        for name in ("LICENSE", "PDV_UPSTREAM_SNAPSHOT.json", "app.py")
+    }
+    source_tree_sha256 = _source_tree_sha256(files)
+    manifest = {"files": files, "sourceTreeSha256": source_tree_sha256}
+    with zipfile.ZipFile(archive, "w") as source_zip:
+        for name in sorted(files):
+            source_zip.write(repository_root / name, name)
+        source_zip.writestr("CORRESPONDING_SOURCE_MANIFEST.json", json.dumps(manifest))
+    archive_bytes = archive.read_bytes()
     archive.with_suffix(".zip.json").write_text(
-        json.dumps({"archiveSha256": hashlib.sha256(content).hexdigest()}), encoding="utf-8"
+        json.dumps({"archiveSha256": hashlib.sha256(archive_bytes).hexdigest(), "explicitIncludes": [], "sourceTreeSha256": source_tree_sha256}), encoding="utf-8"
     )
     return archive
 
@@ -280,8 +300,8 @@ def test_pdv_routes_allow_only_scoped_admin_owned_api_tokens(tmp_path, monkeypat
 
 def test_pdv_source_archive_is_hash_verified_and_never_discloses_path(tmp_path, monkeypatch):
     _snapshot(tmp_path)
-    expected = b"verified archive bytes"
-    archive = _archive(tmp_path, expected)
+    archive = _archive(tmp_path, b"verified source bytes")
+    expected = archive.read_bytes()
     monkeypatch.setenv("AUTH_ENABLED", "true")
     client = _client(tmp_path)
 
@@ -296,3 +316,16 @@ def test_pdv_source_archive_is_hash_verified_and_never_discloses_path(tmp_path, 
     assert client.get(
         "/api/pdv/source/archive", headers={"X-Test-User": "owner"}
     ).status_code == 503
+
+
+def test_source_archive_fails_closed_after_tracked_source_drift_until_rebuilt(tmp_path, monkeypatch):
+    _snapshot(tmp_path)
+    monkeypatch.setenv("AUTH_ENABLED", "true")
+    client = _client(tmp_path)
+    headers = {"X-Test-User": "owner"}
+    assert client.get("/api/pdv/source/archive", headers=headers).status_code == 200
+    (tmp_path / "app.py").write_text("changed after archive\n", encoding="utf-8")
+    assert client.get("/api/pdv/source/archive", headers=headers).status_code == 503
+    assert client.get("/api/pdv/source", headers=headers).json()["sourceArchiveAvailable"] is False
+    _archive(tmp_path, b"rebuilt source bytes")
+    assert client.get("/api/pdv/source/archive", headers=headers).status_code == 200

--- a/tests/test_pdv_routes.py
+++ b/tests/test_pdv_routes.py
@@ -1,0 +1,298 @@
+"""Public HTTP contract tests for the PDV adapter boundary."""
+
+import hashlib
+import json
+from pathlib import Path
+
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+
+class _AuthManager:
+    is_configured = True
+
+    @staticmethod
+    def is_admin(username):
+        return username == "owner"
+
+
+def _client(repository_root: Path, runtime_state_provider=None, integration_probe=None) -> TestClient:
+    from routes.pdv_routes import setup_pdv_routes
+
+    app = FastAPI()
+    app.state.auth_manager = _AuthManager()
+
+    @app.middleware("http")
+    async def stamp_test_user(request: Request, call_next):
+        request.state.current_user = request.headers.get("X-Test-User")
+        request.state.api_token = request.headers.get("X-Test-Api-Token") == "true"
+        request.state.api_token_owner = request.headers.get("X-Test-Api-Owner")
+        request.state.api_token_scopes = (request.headers.get("X-Test-Api-Scopes") or "").split(",")
+        return await call_next(request)
+
+    app.include_router(
+        setup_pdv_routes(
+            repository_root=repository_root,
+            readiness_checker=lambda: {
+                "ready": True,
+                "version": "1.0.2",
+                "checks": {"database": {"ok": True}, "data_dir": {"ok": True}},
+            },
+            runtime_state_provider=runtime_state_provider or (lambda: {
+                "provider": None,
+                "model": None,
+                "currentRunStatus": "UNKNOWN",
+                "taskCorrelationId": None,
+                "failureMessage": None,
+            }),
+            integration_probe=integration_probe or (lambda _url, _key: _ready_probe()),
+        )
+    )
+    return TestClient(app)
+
+
+async def _ready_probe():
+    return {
+        "executionOsReachable": True,
+        "pdvControlMcpConnected": True,
+        "pdvControlBridgeVerified": True,
+    }
+
+
+def _snapshot(repository_root: Path):
+    (repository_root / "PDV_UPSTREAM_SNAPSHOT.json").write_text(
+        json.dumps(
+            {
+                "canonicalRepository": "https://github.com/odysseus-dev/odysseus",
+                "upstreamCommit": "25c9e735ef5ce605f47f8f666ac6689056d2c10c",
+                "upstreamBranch": "dev",
+                "integrationBranch": "codex/pdv-integration-v1",
+                "license": "AGPL-3.0-or-later",
+            }
+        ),
+        encoding="utf-8",
+    )
+    _archive(repository_root)
+
+
+def _archive(repository_root: Path, content: bytes = b"source archive"):
+    archive = repository_root / "data" / "pdv-integration-v1" / "source" / "odysseus-corresponding-source.zip"
+    archive.parent.mkdir(parents=True, exist_ok=True)
+    archive.write_bytes(content)
+    archive.with_suffix(".zip.json").write_text(
+        json.dumps({"archiveSha256": hashlib.sha256(content).hexdigest()}), encoding="utf-8"
+    )
+    return archive
+
+
+def _integrated_boundary(monkeypatch, key_file: Path, bind: str = "127.0.0.1"):
+    monkeypatch.setenv("AUTH_ENABLED", "true")
+    monkeypatch.setenv("APP_BIND", bind)
+    monkeypatch.setenv("ODYSSEUS_PDV_ADAPTER_KEY_FILE", str(key_file))
+    monkeypatch.setenv("PDV_EXECUTION_OS_URL", "http://127.0.0.1:4310")
+    monkeypatch.setenv("PDV_PROVIDER_GUARD_REQUIRED", "true")
+    monkeypatch.setenv("PDV_ADAPTER_KEY_ACL_VERIFIED", "true")
+
+
+def test_pdv_routes_require_existing_admin_auth(tmp_path, monkeypatch):
+    _snapshot(tmp_path)
+    key_file = tmp_path / "adapter.key"
+    key_file.write_text("a" * 64, encoding="utf-8")
+    _integrated_boundary(monkeypatch, key_file)
+    client = _client(tmp_path)
+
+    assert client.get("/api/pdv/health").status_code == 403
+    assert client.get("/api/pdv/source", headers={"X-Test-User": "member"}).status_code == 403
+
+
+def test_pdv_health_reports_readiness_without_disclosing_secret(tmp_path, monkeypatch):
+    _snapshot(tmp_path)
+    key_file = tmp_path / "adapter.key"
+    secret = "a" * 64
+    key_file.write_text(secret, encoding="utf-8")
+    _integrated_boundary(monkeypatch, key_file)
+
+    response = _client(tmp_path).get("/api/pdv/health", headers={"X-Test-User": "owner"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ready"] is True
+    assert payload["boundary"] == {
+        "loopback": True,
+        "adapterKeyReferenceConfigured": True,
+        "adapterKeyReadable": True,
+        "adapterKeyAclRestricted": True,
+        "executionOsConfigured": True,
+        "executionOsReachable": True,
+        "pdvControlMcpConnected": True,
+        "pdvControlBridgeVerified": True,
+        "providerGuardRequired": True,
+    }
+    assert payload["sourceArchiveAvailable"] is True
+    assert len(payload["sourceArchiveSha256"]) == 64
+    assert payload["capabilities"]["chat"] == "AVAILABLE"
+    assert payload["capabilities"]["calendar"] == "AVAILABLE"
+    assert payload["capabilities"]["email"] == "AUTH_REQUIRED"
+    assert secret not in response.text
+    assert str(key_file) not in response.text
+
+
+def test_pdv_health_fails_closed_when_bind_is_not_loopback(tmp_path, monkeypatch):
+    _snapshot(tmp_path)
+    key_file = tmp_path / "adapter.key"
+    key_file.write_text("a" * 64, encoding="utf-8")
+    _integrated_boundary(monkeypatch, key_file, bind="0.0.0.0")
+
+    response = _client(tmp_path).get("/api/pdv/health", headers={"X-Test-User": "owner"})
+
+    assert response.status_code == 503
+    assert response.json()["ready"] is False
+
+
+def test_pdv_health_fails_closed_when_execution_os_guard_is_disconnected(tmp_path, monkeypatch):
+    _snapshot(tmp_path)
+    key_file = tmp_path / "adapter.key"
+    key_file.write_text("a" * 64, encoding="utf-8")
+    _integrated_boundary(monkeypatch, key_file)
+    monkeypatch.delenv("PDV_EXECUTION_OS_URL")
+
+    response = _client(tmp_path).get("/api/pdv/health", headers={"X-Test-User": "owner"})
+
+    assert response.status_code == 503
+    payload = response.json()
+    assert payload["ready"] is False
+    assert payload["boundary"]["executionOsConfigured"] is False
+    assert payload["capabilities"]["mcp"] == "DEGRADED"
+
+
+def test_pdv_health_fails_closed_when_live_bridge_or_mcp_child_is_missing(tmp_path, monkeypatch):
+    _snapshot(tmp_path)
+    key_file = tmp_path / "adapter.key"
+    key_file.write_text("a" * 64, encoding="utf-8")
+    _integrated_boundary(monkeypatch, key_file)
+
+    async def disconnected(_url, _key):
+        return {
+            "executionOsReachable": True,
+            "pdvControlMcpConnected": False,
+            "pdvControlBridgeVerified": True,
+        }
+
+    response = _client(tmp_path, integration_probe=disconnected).get(
+        "/api/pdv/health", headers={"X-Test-User": "owner"}
+    )
+    assert response.status_code == 503
+    assert response.json()["ready"] is False
+    assert response.json()["boundary"]["pdvControlMcpConnected"] is False
+
+
+def test_default_integration_probe_requires_connected_child_and_governed_provenance(monkeypatch):
+    import asyncio
+    import src.tool_utils as tool_utils
+    from routes import pdv_routes
+
+    class Manager:
+        def get_server_status(self, server_id):
+            assert server_id == "pdv_control"
+            return {"status": "connected", "tool_count": 7}
+
+    class Response:
+        status_code = 200
+        def json(self):
+            return {"allowed": True, "provenance": {"source_system": "pdv-execution-os", "tool_name": "health.status"}}
+
+    class Client:
+        async def __aenter__(self): return self
+        async def __aexit__(self, *_args): return None
+        async def post(self, url, headers, json):
+            assert url == "http://127.0.0.1:4310/v1/integrations/odysseus/mcp/invoke"
+            assert headers == {"X-PDV-Odysseus-Key": "a" * 64}
+            assert json["tool_name"] == "health.status"
+            return Response()
+
+    monkeypatch.setattr(tool_utils, "get_mcp_manager", lambda: Manager())
+    monkeypatch.setattr(pdv_routes.httpx, "AsyncClient", lambda **_kwargs: Client())
+    observed = asyncio.run(pdv_routes._default_integration_probe("http://127.0.0.1:4310", "a" * 64))
+    assert observed == {
+        "executionOsReachable": True,
+        "pdvControlMcpConnected": True,
+        "pdvControlBridgeVerified": True,
+    }
+
+
+def test_pdv_source_returns_attribution_without_local_paths(tmp_path, monkeypatch):
+    _snapshot(tmp_path)
+    monkeypatch.setenv("AUTH_ENABLED", "true")
+    response = _client(tmp_path).get("/api/pdv/source", headers={"X-Test-User": "owner"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["license"] == "AGPL-3.0-or-later"
+    assert payload["upstreamCommit"] == "25c9e735ef5ce605f47f8f666ac6689056d2c10c"
+    assert payload["correspondingSourceRequired"] is True
+    assert str(tmp_path) not in response.text
+
+
+def test_pdv_health_reports_truthful_optional_runtime_state(tmp_path, monkeypatch):
+    _snapshot(tmp_path)
+    key_file = tmp_path / "adapter.key"
+    key_file.write_text("a" * 64, encoding="utf-8")
+    _integrated_boundary(monkeypatch, key_file)
+    runtime = {
+        "provider": "ollama",
+        "model": "qwen3:8b",
+        "currentRunStatus": "UNKNOWN",
+        "taskCorrelationId": None,
+        "failureMessage": None,
+        "apiKey": "must-not-leak",
+    }
+
+    response = _client(tmp_path, runtime_state_provider=lambda: runtime).get(
+        "/api/pdv/health", headers={"X-Test-User": "owner"}
+    )
+
+    assert response.status_code == 200
+    assert response.json()["runtime"] == {
+        "provider": "ollama",
+        "model": "qwen3:8b",
+        "currentRunStatus": "UNKNOWN",
+        "taskCorrelationId": None,
+        "failureMessage": None,
+    }
+    assert "must-not-leak" not in response.text
+
+
+def test_pdv_routes_allow_only_scoped_admin_owned_api_tokens(tmp_path, monkeypatch):
+    _snapshot(tmp_path)
+    monkeypatch.setenv("AUTH_ENABLED", "true")
+    client = _client(tmp_path)
+    base = {"X-Test-Api-Token": "true", "X-Test-Api-Owner": "owner"}
+
+    assert client.get("/api/pdv/source", headers=base).status_code == 403
+    assert client.get(
+        "/api/pdv/source", headers={**base, "X-Test-Api-Scopes": "pdv:read"}
+    ).status_code == 200
+    assert client.get(
+        "/api/pdv/source",
+        headers={**base, "X-Test-Api-Owner": "member", "X-Test-Api-Scopes": "pdv:read"},
+    ).status_code == 403
+
+
+def test_pdv_source_archive_is_hash_verified_and_never_discloses_path(tmp_path, monkeypatch):
+    _snapshot(tmp_path)
+    expected = b"verified archive bytes"
+    archive = _archive(tmp_path, expected)
+    monkeypatch.setenv("AUTH_ENABLED", "true")
+    client = _client(tmp_path)
+
+    response = client.get("/api/pdv/source/archive", headers={"X-Test-User": "owner"})
+    assert response.status_code == 200
+    assert response.content == expected
+    assert response.headers["content-type"] == "application/zip"
+    assert response.headers["digest"] == f"sha-256={hashlib.sha256(expected).hexdigest()}"
+    assert str(tmp_path) not in response.text
+
+    archive.write_bytes(b"tampered")
+    assert client.get(
+        "/api/pdv/source/archive", headers={"X-Test-User": "owner"}
+    ).status_code == 503


### PR DESCRIPTION
Reconciled version of codex/pdv-integration-v1 (stale head cdbbf73) rebased cleanly onto current dev with zero conflicts. Includes the UI/runtime truthfulness repair: PDV capability readiness (chat/agents/research) now derives from a live authorize->outcome round-trip through the governed PDV provider adapter instead of storage/DB readiness. Focused tests: 40/40 passing on the reconciled head.