### PR TITLE
fix(agent): use Git Bash for Windows workspace shell

### DIFF
--- a/src/agent_tools/subprocess_tools.py
+++ b/src/agent_tools/subprocess_tools.py
@@ -6,6 +6,7 @@ import sys
 import time
 import collections
 from typing import Optional, Callable, Awaitable, Tuple, Dict
+from core.platform_compat import IS_WINDOWS, find_bash
 from src.constants import MAX_OUTPUT_CHARS
 
 DEFAULT_BASH_TIMEOUT = 60 * 60     # 1 hour
@@ -14,6 +15,27 @@ DEFAULT_PYTHON_TIMEOUT = 60 * 60
 PROGRESS_INTERVAL_S = 2.0
 PROGRESS_TAIL_LINES = 12
 TMUX_CAPTURE_LINES = 2000
+
+
+async def _create_bash_subprocess(command: str, **kwargs):
+    """Start the agent shell with Bash semantics on every supported OS.
+
+    ``asyncio.create_subprocess_shell`` delegates to ``cmd.exe`` on native
+    Windows.  That contradicts the Bash tool contract and makes POSIX commands
+    such as ``pwd``, ``ls -la``, and ``cat`` unreliable even when the launcher
+    has found Git Bash.  Pass the selected workspace as a structural ``cwd``
+    argument; Git Bash inherits that native Windows directory and exposes it
+    using its normal ``/c/...`` representation.
+    """
+    if IS_WINDOWS:
+        bash = find_bash()
+        if not bash:
+            raise RuntimeError(
+                "Git Bash is required for the Bash tool on Windows; "
+                "install Git for Windows and restart Odysseus"
+            )
+        return await asyncio.create_subprocess_exec(bash, "-c", command, **kwargs)
+    return await asyncio.create_subprocess_shell(command, **kwargs)
 
 
 def _tmux_session_name(session_id: Optional[str]) -> str:
@@ -280,7 +302,10 @@ class BashTool:
         progress_cb = ctx.get("progress_cb")
         _subproc_env = ctx.get("subproc_env")
         session_id = ctx.get("session_id")
-        if session_id and shutil.which("tmux"):
+        # tmux is a POSIX persistence path. A stray MSYS/Cygwin tmux.exe on
+        # native Windows must not bypass the Git Bash launcher below: the tmux
+        # setup hard-codes /bin/bash and cannot safely consume a native cwd.
+        if session_id and not IS_WINDOWS and shutil.which("tmux"):
             stdout, stderr, rc, timed_out = await _run_tmux_bash(
                 content,
                 session_id=str(session_id),
@@ -307,13 +332,16 @@ class BashTool:
                 "tmux_session": _tmux_session_name(str(session_id)),
             }
 
-        proc = await asyncio.create_subprocess_shell(
-            content,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=_subproc_env,
-            cwd=agent_cwd(),
-        )
+        try:
+            proc = await _create_bash_subprocess(
+                content,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=_subproc_env,
+                cwd=agent_cwd(),
+            )
+        except RuntimeError as e:
+            return {"error": f"bash: {e}", "exit_code": 1}
         stdout, stderr, rc, timed_out = await _run_subprocess_streaming(
             proc,
             timeout=DEFAULT_BASH_TIMEOUT,

--- a/tests/test_agent_bash_windows.py
+++ b/tests/test_agent_bash_windows.py
@@ -1,0 +1,128 @@
+"""Windows execution contract for the agent Bash tool."""
+
+import pytest
+
+from src.agent_tools import subprocess_tools
+
+
+@pytest.mark.asyncio
+async def test_windows_bash_uses_git_bash_with_structural_cwd(monkeypatch):
+    captured = {}
+    bash = r"C:\Program Files\Git\bin\bash.exe"
+    workspace = r"D:\Workspaces\Project with spaces"
+    process = object()
+
+    monkeypatch.setattr(subprocess_tools, "IS_WINDOWS", True)
+    monkeypatch.setattr(subprocess_tools, "find_bash", lambda: bash)
+
+    async def fake_exec(*argv, **kwargs):
+        captured["argv"] = argv
+        captured["kwargs"] = kwargs
+        return process
+
+    async def fail_shell(*_args, **_kwargs):
+        pytest.fail("native Windows Bash must not execute through cmd.exe")
+
+    monkeypatch.setattr(subprocess_tools.asyncio, "create_subprocess_exec", fake_exec)
+    monkeypatch.setattr(subprocess_tools.asyncio, "create_subprocess_shell", fail_shell)
+
+    result = await subprocess_tools._create_bash_subprocess(
+        "pwd; cat package.json",
+        cwd=workspace,
+        env={"HOME": r"C:\Odysseus\data"},
+    )
+
+    assert result is process
+    assert captured["argv"] == (bash, "-c", "pwd; cat package.json")
+    assert captured["kwargs"]["cwd"] == workspace
+
+
+@pytest.mark.asyncio
+async def test_windows_bash_without_git_bash_fails_clearly(monkeypatch):
+    monkeypatch.setattr(subprocess_tools, "IS_WINDOWS", True)
+    monkeypatch.setattr(subprocess_tools, "find_bash", lambda: None)
+
+    async def fail_spawn(*_args, **_kwargs):
+        pytest.fail("no subprocess should start without Git Bash")
+
+    monkeypatch.setattr(subprocess_tools.asyncio, "create_subprocess_exec", fail_spawn)
+    monkeypatch.setattr(subprocess_tools.asyncio, "create_subprocess_shell", fail_spawn)
+
+    with pytest.raises(RuntimeError, match="Git Bash is required"):
+        await subprocess_tools._create_bash_subprocess("pwd", cwd=r"C:\Work")
+
+
+@pytest.mark.asyncio
+async def test_bash_tool_returns_install_hint_when_git_bash_is_missing(monkeypatch):
+    monkeypatch.setattr(subprocess_tools, "IS_WINDOWS", True)
+    monkeypatch.setattr(subprocess_tools, "find_bash", lambda: None)
+
+    result = await subprocess_tools.BashTool().execute(
+        "pwd",
+        {"subproc_env": {}, "session_id": None},
+    )
+
+    assert result["exit_code"] == 1
+    assert "install Git for Windows" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_windows_bash_does_not_use_a_stray_tmux_executable(monkeypatch):
+    captured = {}
+    workspace = r"D:\Workspaces\Project with spaces"
+
+    monkeypatch.setattr(subprocess_tools, "IS_WINDOWS", True)
+    monkeypatch.setattr(
+        subprocess_tools.shutil,
+        "which",
+        lambda name: r"C:\msys64\usr\bin\tmux.exe",
+    )
+    monkeypatch.setattr("src.tool_execution.agent_cwd", lambda: workspace)
+
+    async def fail_tmux(*_args, **_kwargs):
+        pytest.fail("native Windows must not enter the POSIX tmux path")
+
+    async def fake_create(command, **kwargs):
+        captured["command"] = command
+        captured["kwargs"] = kwargs
+        return object()
+
+    async def fake_stream(_process, **_kwargs):
+        return "ok", "", 0, False
+
+    monkeypatch.setattr(subprocess_tools, "_run_tmux_bash", fail_tmux)
+    monkeypatch.setattr(subprocess_tools, "_create_bash_subprocess", fake_create)
+    monkeypatch.setattr(subprocess_tools, "_run_subprocess_streaming", fake_stream)
+
+    result = await subprocess_tools.BashTool().execute(
+        "pwd",
+        {"subproc_env": {}, "session_id": "chat-1"},
+    )
+
+    assert result == {"output": "ok", "exit_code": 0}
+    assert captured["command"] == "pwd"
+    assert captured["kwargs"]["cwd"] == workspace
+
+
+@pytest.mark.asyncio
+async def test_posix_bash_keeps_existing_shell_path(monkeypatch):
+    captured = {}
+    process = object()
+
+    monkeypatch.setattr(subprocess_tools, "IS_WINDOWS", False)
+
+    async def fake_shell(command, **kwargs):
+        captured["command"] = command
+        captured["kwargs"] = kwargs
+        return process
+
+    async def fail_exec(*_args, **_kwargs):
+        pytest.fail("POSIX behavior must continue through create_subprocess_shell")
+
+    monkeypatch.setattr(subprocess_tools.asyncio, "create_subprocess_shell", fake_shell)
+    monkeypatch.setattr(subprocess_tools.asyncio, "create_subprocess_exec", fail_exec)
+
+    result = await subprocess_tools._create_bash_subprocess("pwd", cwd="/tmp/work")
+
+    assert result is process
+    assert captured == {"command": "pwd", "kwargs": {"cwd": "/tmp/work"}}


### PR DESCRIPTION
## Summary

On native Windows, the agent Bash tool used `asyncio.create_subprocess_shell`, which delegates to `cmd.exe` and breaks Bash commands even though the launcher detects Git Bash. This change explicitly invokes Git Bash with `bash.exe -c`, preserves the selected workspace through the subprocess `cwd`, returns a clear error when Git Bash is unavailable, avoids the incompatible Windows `tmux.exe` path, and keeps existing POSIX behavior unchanged.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Part of #5914

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test


1. On native Windows with Git for Windows installed, launch Odysseus using `launch-windows.ps1` and select Agent mode.
2. Bind a workspace containing spaces, preferably on a non-`C:` drive, then ask the agent to run `pwd; cat package.json`. Verify that Git Bash executes the command from the selected workspace and returns the workspace's actual `package.json`.
3. Run `python -m pytest -q tests/test_agent_bash_windows.py tests/test_workspace_confine.py tests/test_platform_compat.py` and verify that all 51 tests pass.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips



Not applicable — this PR does not change any rendered UI.