### PR TITLE
fix(deps): switch psycopg2 to psycopg2-binary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -51,3 +51,8 @@ pytest-asyncio
 # TestClient import when only classic httpx is present. Runtime code keeps
 # using `httpx` above; this is test-client only.
 httpx2
+# DATABASE_URL defaults to sqlite (core/database.py), but when pointed at an
+# external Postgres, SQLAlchemy's postgresql dialect imports psycopg2 inside
+# create_engine() and raises ModuleNotFoundError if missing. -binary avoids
+# needing libpq-dev/pg_config on the host/image to compile it.
+psycopg2-binary


### PR DESCRIPTION
## Summary

`core/database.py` builds `DATABASE_URL` and calls `create_engine()` unconditionally; when it's pointed at Postgres, SQLAlchemy's `postgresql` dialect imports `psycopg2` inside `create_engine()`. Nothing in `requirements.txt` installed it, so any Postgres deployment (Docker image or bare host) hit `ModuleNotFoundError: No module named 'psycopg2'` at import time before the app could even start. Plain `psycopg2` also needs `libpq-dev`/`pg_config` to build from source, which isn't present in the Docker image or on most dev hosts, so even adding `psycopg2` outright would still fail to install. This PR adds `psycopg2-binary` to `requirements.txt`, which ships a self-contained wheel and needs no system build dependencies.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Part of #4807

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate. #4807 proposes `psycopg2-binary` for Postgres support but is not itself a fix for this import crash.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in. Single line added to `requirements.txt` plus a comment explaining why.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. On `dev` (before this fix), set `DATABASE_URL=postgresql://...` and start the app (`uvicorn app:app` or `docker compose up`) — it crashes on startup with `ModuleNotFoundError: No module named 'psycopg2'`.
2. Apply this PR, reinstall requirements: `pip install -r requirements.txt`.
3. `python -c "import psycopg2; print(psycopg2.__version__)"` succeeds.
4. Start the app again with `DATABASE_URL` pointed at Postgres — it starts cleanly and `create_engine()` no longer raises.

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable — this change is limited to `requirements.txt` and touches no rendering code.

## Risks and rollback

Purely additive dependency change, no code paths modified. Rollback is reverting the single commit / removing the `psycopg2-binary` line.
