### PR TITLE
fix: discover sessions from persisted messages

### DIFF
--- a/core/session_manager.py
+++ b/core/session_manager.py
@@ -14,6 +14,8 @@ import logging
 from datetime import datetime, timezone, timedelta
 from typing import Dict, Optional
 
+from sqlalchemy import func
+
 from .database import Session as DbSession, ChatMessage as DbChatMessage, Document as DbDocument, SessionLocal, utcnow_naive
 from .models import Session, ChatMessage
 from src.attachment_refs import persistable_message_content
@@ -92,14 +94,28 @@ class SessionManager:
         try:
             db_sessions = db.query(DbSession).filter(
                 DbSession.archived == False,
-                DbSession.message_count > 0,
+                DbSession.messages.any(),
             ).order_by(DbSession.last_accessed.desc()).limit(100).all()
+
+            # message_count is derived metadata and can drift after interrupted
+            # or legacy writes. Count only the bounded discovery set so startup
+            # remains metadata-only while lazy hydration sees an authoritative
+            # positive count for every discovered non-empty session.
+            message_counts = {}
+            if db_sessions:
+                message_counts = dict(
+                    db.query(DbChatMessage.session_id, func.count(DbChatMessage.id))
+                    .filter(DbChatMessage.session_id.in_([row.id for row in db_sessions]))
+                    .group_by(DbChatMessage.session_id)
+                    .all()
+                )
 
             loaded_count = 0
             for db_session in db_sessions:
                 try:
                     session = self._db_to_session_meta(db_session)
                     if session is not None:
+                        session.message_count = message_counts[db_session.id]
                         self.sessions[db_session.id] = session
                         loaded_count += 1
                 except Exception as e:

--- a/tests/test_session_discovery_message_count.py
+++ b/tests/test_session_discovery_message_count.py
@@ -1,19 +1,26 @@
 """Real-SQLite regressions for session discovery with stale derived counts."""
 
-import importlib
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import NullPool
+
+import core.database as database
+import core.session_manager as session_manager
 
 
 def _make_manager(db_path, monkeypatch):
-    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
-
-    import core.database as database
-
-    importlib.reload(database)
-    database.Base.metadata.create_all(bind=database.engine)
-
-    import core.session_manager as session_manager
-
-    importlib.reload(session_manager)
+    engine = create_engine(
+        f"sqlite:///{db_path}",
+        connect_args={"check_same_thread": False},
+        poolclass=NullPool,
+    )
+    database.Base.metadata.create_all(bind=engine)
+    session_local = sessionmaker(
+        bind=engine,
+        autoflush=False,
+        autocommit=False,
+    )
+    monkeypatch.setattr(session_manager, "SessionLocal", session_local)
     return session_manager.SessionManager(), database, session_manager
 
 

--- a/tests/test_session_discovery_message_count.py
+++ b/tests/test_session_discovery_message_count.py
@@ -1,0 +1,56 @@
+"""Real-SQLite regressions for session discovery with stale derived counts."""
+
+import importlib
+
+
+def _make_manager(db_path, monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    import core.database as database
+
+    importlib.reload(database)
+    database.Base.metadata.create_all(bind=database.engine)
+
+    import core.session_manager as session_manager
+
+    importlib.reload(session_manager)
+    return session_manager.SessionManager(), database, session_manager
+
+
+def test_discovery_uses_persisted_rows_and_repairs_cached_count(tmp_path, monkeypatch):
+    from core.models import ChatMessage
+
+    manager, database, session_manager = _make_manager(
+        tmp_path / "session-discovery.db", monkeypatch
+    )
+    for session_id in ("stale-low", "empty", "stale-high"):
+        manager.create_session(
+            session_id=session_id,
+            name=session_id,
+            endpoint_url="http://example.invalid",
+            model="test-model",
+            rag=False,
+            owner="tester",
+        )
+    manager.add_message("stale-low", ChatMessage("user", "persisted message"))
+
+    db = database.SessionLocal()
+    try:
+        db.query(database.Session).filter(
+            database.Session.id == "stale-low"
+        ).update({"message_count": 0})
+        db.query(database.Session).filter(
+            database.Session.id == "stale-high"
+        ).update({"message_count": 7})
+        db.commit()
+    finally:
+        db.close()
+
+    restarted = session_manager.SessionManager()
+
+    assert set(restarted.sessions) == {"stale-low"}
+    assert restarted.sessions["stale-low"].history == []
+    assert restarted.sessions["stale-low"].message_count == 1
+
+    hydrated = restarted.get_session("stale-low")
+    assert [message.content for message in hydrated.history] == ["persisted message"]

--- a/tests/test_session_discovery_message_count.py
+++ b/tests/test_session_discovery_message_count.py
@@ -4,7 +4,6 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import NullPool
 
-import core.database as database
 import core.session_manager as session_manager
 
 
@@ -14,20 +13,20 @@ def _make_manager(db_path, monkeypatch):
         connect_args={"check_same_thread": False},
         poolclass=NullPool,
     )
-    database.Base.metadata.create_all(bind=engine)
+    session_manager.DbSession.metadata.create_all(bind=engine)
     session_local = sessionmaker(
         bind=engine,
         autoflush=False,
         autocommit=False,
     )
     monkeypatch.setattr(session_manager, "SessionLocal", session_local)
-    return session_manager.SessionManager(), database, session_manager
+    return session_manager.SessionManager(), session_manager
 
 
 def test_discovery_uses_persisted_rows_and_repairs_cached_count(tmp_path, monkeypatch):
     from core.models import ChatMessage
 
-    manager, database, session_manager = _make_manager(
+    manager, session_manager = _make_manager(
         tmp_path / "session-discovery.db", monkeypatch
     )
     for session_id in ("stale-low", "empty", "stale-high"):
@@ -41,13 +40,13 @@ def test_discovery_uses_persisted_rows_and_repairs_cached_count(tmp_path, monkey
         )
     manager.add_message("stale-low", ChatMessage("user", "persisted message"))
 
-    db = database.SessionLocal()
+    db = session_manager.SessionLocal()
     try:
-        db.query(database.Session).filter(
-            database.Session.id == "stale-low"
+        db.query(session_manager.DbSession).filter(
+            session_manager.DbSession.id == "stale-low"
         ).update({"message_count": 0})
-        db.query(database.Session).filter(
-            database.Session.id == "stale-high"
+        db.query(session_manager.DbSession).filter(
+            session_manager.DbSession.id == "stale-high"
         ).update({"message_count": 7})
         db.commit()
     finally:


### PR DESCRIPTION
## Summary

Fix startup session discovery when persisted chat rows exist but the derived `message_count` metadata is stale at zero. Discovery now uses authoritative chat-row presence and computes authoritative counts only for the bounded set of at most 100 discovered sessions, preserving metadata-only startup and lazy transcript hydration. Empty sessions, including rows with an incorrectly positive stored count, remain excluded.

This is a focused follow-up for a pre-existing condition observed while validating the pagination work. It is intentionally separate from #5929.

## Target branch

- [x] This PR targets `dev`, not `main`.

## Linked Issue

Part of #5928.

## Type of Change

- [x] Bug fix (non-breaking, fixes a confirmed issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and pull requests and confirmed this is not a duplicate.
- [x] This PR targets `dev`.
- [x] Changes are limited to persisted-session discovery and its regression coverage.
- [ ] I ran the complete application end-to-end.
- [x] I did not run the app/runtime validation and stated that gap in **How to Test**. Leave this unchecked when the app-run box above is checked.
- [x] Focused and adjacent automated tests were run against the current rebased head.

The complete application was not run because this is a focused persistence/discovery correction covered using real disposable SQLite storage.

## How to Test

1. Run the focused persisted-session regressions:

    python -m pytest -q tests/test_session_discovery_message_count.py tests/test_truncate_message_count_regression.py

2. Verify a session with a persisted chat row but stale `message_count=0` is discovered after restart.
3. Verify an empty session with a stale positive count is not discovered.
4. Verify startup keeps transcript history unhydrated and repairs only the in-memory count.
5. Access the discovered session and verify the persisted transcript is lazily hydrated.
6. Run adjacent session-manager tests to ensure existing session behavior remains intact.

Current rebased-head validation:

- focused persistence regressions: 3 passed;
- adjacent session tests: 11 passed;
- changed Python files compile;
- `git diff --check` passes.

## Visual / UI changes

N/A. No rendered UI files changed.
