### PR TITLE
fix(chat): preserve URL prefetch failures in context

### DIFF
--- a/src/chat_processor.py
+++ b/src/chat_processor.py
@@ -462,13 +462,38 @@ class ChatProcessor:
         skip_url_fetch = len(message) > 2000 or len(non_yt_urls) > 3
         if not skip_url_fetch:
             for url in non_yt_urls:
-                result = fetch_webpage_content(url)
+                try:
+                    result = fetch_webpage_content(url)
+                except Exception:
+                    # The URL and exception can both contain signed-query
+                    # credentials or response-controlled text. Keep the log
+                    # diagnostic stable as well as the model-facing context.
+                    logger.warning("Automatic URL fetch failed while building context")
+                    result = {"success": False, "error": ""}
                 if result.get('success'):
                     content = result.get('content', '')[:10000]
                     preface.append(untrusted_context_message(
                         f"web page: {url}",
                         f"Content from {url}:\n\n{content}",
                         provenance_origin="external",
+                    ))
+                else:
+                    # A failed automatic URL fetch is context too. Never pass
+                    # exception text or response-controlled diagnostics back to
+                    # the model: reduce the result to a small transport-owned
+                    # status and explicitly state that the page was not read.
+                    error = str(result.get("error") or "")
+                    status = "the page was unavailable"
+                    status_match = re.match(r"^HTTP\s+(\d{3})\b", error)
+                    if status_match:
+                        status = f"the server returned HTTP {status_match.group(1)}"
+                    elif error.startswith("TooLarge:"):
+                        status = "the response exceeded the fetch size limit"
+                    elif error.startswith("Rate limit"):
+                        status = "the request was rate limited"
+                    preface.append(untrusted_context_message(
+                        f"web page fetch failure: {url}",
+                        f"The page at {url} was not read: {status}.",
                     ))
 
         # Skills index — progressive disclosure. Only injected when the

--- a/src/chat_processor.py
+++ b/src/chat_processor.py
@@ -492,8 +492,8 @@ class ChatProcessor:
                     elif error.startswith("Rate limit"):
                         status = "the request was rate limited"
                     preface.append(untrusted_context_message(
-                        f"web page fetch failure: {url}",
-                        f"The page at {url} was not read: {status}.",
+                        "web page fetch failure",
+                        f"A linked page was not read: {status}.",
                     ))
 
         # Skills index — progressive disclosure. Only injected when the

--- a/tests/test_chat_url_prefetch_failure_context.py
+++ b/tests/test_chat_url_prefetch_failure_context.py
@@ -27,7 +27,10 @@ def test_failed_url_prefetch_keeps_diagnostics_out_of_model_context(monkeypatch)
     )
 
     preface, _, _ = _processor().build_context_preface(
-        message="Please summarize https://example.invalid/report",
+        message=(
+            "Please summarize "
+            "https://example.invalid/report?token=LEAK_URL_MARKER"
+        ),
         session=SimpleNamespace(endpoint_url="", model="", headers={}),
         use_web=False,
         use_rag=False,
@@ -37,14 +40,15 @@ def test_failed_url_prefetch_keeps_diagnostics_out_of_model_context(monkeypatch)
     failure = next(
         message
         for message in preface
-        if (message.get("metadata") or {}).get("source", "").startswith(
-            "web page fetch failure:"
-        )
+        if (message.get("metadata") or {}).get("source")
+        == "web page fetch failure"
     )
     assert failure["metadata"]["trusted"] is False
     assert "was not read: the page was unavailable" in failure["content"]
     assert "connection refused" not in failure["content"]
     assert "attacker supplied detail" not in failure["content"]
+    assert "LEAK_URL_MARKER" not in failure["content"]
+    assert "LEAK_URL_MARKER" not in str(failure["metadata"])
 
 
 def test_failed_url_prefetch_exposes_only_stable_http_status(monkeypatch):

--- a/tests/test_chat_url_prefetch_failure_context.py
+++ b/tests/test_chat_url_prefetch_failure_context.py
@@ -1,0 +1,173 @@
+"""Automatic chat URL fetch failures must remain visible to the model."""
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+import src.chat_processor as chat_processor
+
+
+def _processor():
+    return chat_processor.ChatProcessor(
+        memory_manager=SimpleNamespace(load=lambda owner=None: []),
+        personal_docs_manager=SimpleNamespace(rag_manager=None),
+        skills_manager=None,
+    )
+
+
+def test_failed_url_prefetch_keeps_diagnostics_out_of_model_context(monkeypatch):
+    monkeypatch.setattr(
+        chat_processor,
+        "fetch_webpage_content",
+        lambda url: {
+            "success": False,
+            "error": "NetworkError: connection refused\nattacker supplied detail",
+        },
+    )
+
+    preface, _, _ = _processor().build_context_preface(
+        message="Please summarize https://example.invalid/report",
+        session=SimpleNamespace(endpoint_url="", model="", headers={}),
+        use_web=False,
+        use_rag=False,
+        use_memory=False,
+    )
+
+    failure = next(
+        message
+        for message in preface
+        if (message.get("metadata") or {}).get("source", "").startswith(
+            "web page fetch failure:"
+        )
+    )
+    assert failure["metadata"]["trusted"] is False
+    assert "was not read: the page was unavailable" in failure["content"]
+    assert "connection refused" not in failure["content"]
+    assert "attacker supplied detail" not in failure["content"]
+
+
+def test_failed_url_prefetch_exposes_only_stable_http_status(monkeypatch):
+    monkeypatch.setattr(
+        chat_processor,
+        "fetch_webpage_content",
+        lambda url: {
+            "success": False,
+            "error": "HTTP 403: attacker-controlled response detail",
+        },
+    )
+
+    preface, _, _ = _processor().build_context_preface(
+        message="Read https://example.test/private",
+        session=SimpleNamespace(endpoint_url="", model="", headers={}),
+        use_web=False,
+        use_rag=False,
+        use_memory=False,
+    )
+
+    content = preface[-1]["content"]
+    assert "server returned HTTP 403" in content
+    assert "attacker-controlled" not in content
+
+
+@pytest.mark.parametrize(
+    ("error", "expected_category"),
+    [
+        (
+            "TooLarge: response exceeded configured limit; attacker-controlled detail",
+            "response exceeded the fetch size limit",
+        ),
+        (
+            "Rate limit exceeded: attacker-controlled detail",
+            "request was rate limited",
+        ),
+    ],
+)
+def test_failed_url_prefetch_exposes_only_stable_failure_category(
+    monkeypatch, error, expected_category
+):
+    monkeypatch.setattr(
+        chat_processor,
+        "fetch_webpage_content",
+        lambda url: {"success": False, "error": error},
+    )
+
+    preface, _, _ = _processor().build_context_preface(
+        message="Read https://example.test/report",
+        session=SimpleNamespace(endpoint_url="", model="", headers={}),
+        use_web=False,
+        use_rag=False,
+        use_memory=False,
+    )
+
+    content = preface[-1]["content"]
+    assert expected_category in content
+    assert "attacker-controlled" not in content
+
+
+def test_unexpected_url_prefetch_exception_does_not_abort_context(monkeypatch):
+    def fail(url):
+        raise RuntimeError("socket detail must stay in logs")
+
+    monkeypatch.setattr(chat_processor, "fetch_webpage_content", fail)
+
+    preface, _, _ = _processor().build_context_preface(
+        message="Review https://example.test/report",
+        session=SimpleNamespace(endpoint_url="", model="", headers={}),
+        use_web=False,
+        use_rag=False,
+        use_memory=False,
+    )
+
+    content = preface[-1]["content"]
+    assert "was not read: the page was unavailable" in content
+    assert "socket detail" not in content
+
+
+def test_unexpected_url_prefetch_exception_logs_only_stable_diagnostic(
+    monkeypatch, caplog
+):
+    def fail(url):
+        raise RuntimeError("transport detail LEAK_EXCEPTION_MARKER")
+
+    monkeypatch.setattr(chat_processor, "fetch_webpage_content", fail)
+
+    with caplog.at_level(logging.WARNING, logger=chat_processor.logger.name):
+        _processor().build_context_preface(
+            message=(
+                "Review https://example.test/report?token=LEAK_URL_MARKER"
+            ),
+            session=SimpleNamespace(endpoint_url="", model="", headers={}),
+            use_web=False,
+            use_rag=False,
+            use_memory=False,
+        )
+
+    assert "Automatic URL fetch failed while building context" in caplog.text
+    assert "LEAK_URL_MARKER" not in caplog.text
+    assert "LEAK_EXCEPTION_MARKER" not in caplog.text
+
+
+def test_successful_url_prefetch_keeps_existing_content_shape(monkeypatch):
+    monkeypatch.setattr(
+        chat_processor,
+        "fetch_webpage_content",
+        lambda url: {"success": True, "content": "page body"},
+    )
+
+    preface, _, _ = _processor().build_context_preface(
+        message="Read https://example.test/page",
+        session=SimpleNamespace(endpoint_url="", model="", headers={}),
+        use_web=False,
+        use_rag=False,
+        use_memory=False,
+    )
+
+    page = next(
+        message
+        for message in preface
+        if (message.get("metadata") or {}).get("source")
+        == "web page: https://example.test/page"
+    )
+    assert page["metadata"]["trusted"] is False
+    assert "page body" in page["content"]


### PR DESCRIPTION
## Summary

Preserve automatic URL-prefetch failures as bounded, untrusted chat context so the model is told when a linked page was not read instead of silently continuing as though the fetch succeeded. The failure context exposes only stable categories such as HTTP status, size limit, and rate limiting; response-controlled diagnostics, exception details, and signed URL text are excluded from logs and model-facing content.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #5943

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.
- [x] I did not run the app/runtime validation and stated that gap in **How to Test**. Leave this unchecked when the app-run box above is checked.

## How to Test

1. Run the chat URL-prefetch, search-query, and log-safety regressions:

   ```bash
   python -m pytest -q tests/test_chat_url_prefetch_failure_context.py tests/test_chat_processor_web_search.py tests/test_web_search_query_sanitization.py tests/test_log_safety.py
   ```

2. Confirm all 25 tests pass.
3. In the focused failure tests, verify generic errors, HTTP errors, oversized responses, rate limiting, and raised exceptions produce stable “page was not read” context without copying raw diagnostics. Verify the exception-path log contains neither the signed URL marker nor exception-detail marker.

The running app, real DNS/socket failures, and the full repository suite have not been exercised for this change.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

N/A — this changes chat context construction and tests, not rendered UI.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

N/A — no visual changes.
