### PR TITLE
fix(agent): align Compare app API routes

### DIFF
--- a/routes/compare/compare_routes.py
+++ b/routes/compare/compare_routes.py
@@ -235,12 +235,27 @@ def setup_compare_routes(session_manager: SessionManager):
         }
 
     @router.post("/{comp_id}/vote")
-    def vote_comparison(
+    async def vote_comparison(
         request: Request,
         comp_id: str,
-        winner: str = Form(...),  # "left", "right", or "tie"
     ):
         """Record the user's vote and reveal model names if blind."""
+        content_type = request.headers.get("content-type", "").split(";", 1)[0].lower()
+        if content_type == "application/json":
+            try:
+                vote_payload = await request.json()
+            except Exception as exc:
+                raise HTTPException(400, "Invalid vote JSON") from exc
+            if not isinstance(vote_payload, dict):
+                raise HTTPException(422, "Vote request must be an object")
+            winner = vote_payload.get("winner")
+        else:
+            form = await request.form()
+            winner = form.get("winner")
+        if not isinstance(winner, str) or not winner.strip():
+            raise HTTPException(422, "winner is required")
+        winner = winner.strip()
+
         user = get_current_user(request)
         db = SessionLocal()
         try:

--- a/routes/compare/compare_routes.py
+++ b/routes/compare/compare_routes.py
@@ -5,6 +5,7 @@ import uuid
 import random
 from datetime import datetime
 from fastapi import APIRouter, Form, HTTPException, Request
+from fastapi.concurrency import run_in_threadpool
 from typing import List
 from pydantic import BaseModel
 import logging
@@ -257,43 +258,50 @@ def setup_compare_routes(session_manager: SessionManager):
         winner = winner.strip()
 
         user = get_current_user(request)
-        db = SessionLocal()
-        try:
-            comp = db.query(Comparison).filter(Comparison.id == comp_id).first()
-            if not comp:
-                raise HTTPException(404, "Comparison not found")
-            # SECURITY: strict ownership — null-owner Comparisons were
-            # accessible to every user.
-            if user and comp.owner != user:
-                raise HTTPException(404, "Comparison not found")
-            if comp.winner:
-                raise HTTPException(400, "Already voted")
 
-            mapping = json.loads(comp.blind_mapping) if comp.blind_mapping else {"left": "a", "right": "b"}
+        def _commit_vote():
+            # The handler is async only so it can parse JSON/form request bodies.
+            # Keep synchronous SQLAlchemy work off the event loop just as the
+            # original sync FastAPI route did via its threadpool dispatch.
+            db = SessionLocal()
+            try:
+                comp = db.query(Comparison).filter(Comparison.id == comp_id).first()
+                if not comp:
+                    raise HTTPException(404, "Comparison not found")
+                # SECURITY: strict ownership — null-owner Comparisons were
+                # accessible to every user.
+                if user and comp.owner != user:
+                    raise HTTPException(404, "Comparison not found")
+                if comp.winner:
+                    raise HTTPException(400, "Already voted")
 
-            if winner == "tie":
-                comp.winner = "tie"
-            elif winner == "left":
-                comp.winner = mapping["left"]
-            elif winner == "right":
-                comp.winner = mapping["right"]
-            else:
-                raise HTTPException(400, "winner must be 'left', 'right', or 'tie'")
+                mapping = json.loads(comp.blind_mapping) if comp.blind_mapping else {"left": "a", "right": "b"}
 
-            comp.voted_at = datetime.utcnow()
-            db.commit()
+                if winner == "tie":
+                    comp.winner = "tie"
+                elif winner == "left":
+                    comp.winner = mapping["left"]
+                elif winner == "right":
+                    comp.winner = mapping["right"]
+                else:
+                    raise HTTPException(400, "winner must be 'left', 'right', or 'tie'")
 
-            return {
-                "winner": comp.winner,
-                "model_a": comp.model_a,
-                "model_b": comp.model_b,
-                "revealed": {
-                    "left": comp.model_a if mapping["left"] == "a" else comp.model_b,
-                    "right": comp.model_a if mapping["right"] == "a" else comp.model_b,
-                },
-            }
-        finally:
-            db.close()
+                comp.voted_at = datetime.utcnow()
+                db.commit()
+
+                return {
+                    "winner": comp.winner,
+                    "model_a": comp.model_a,
+                    "model_b": comp.model_b,
+                    "revealed": {
+                        "left": comp.model_a if mapping["left"] == "a" else comp.model_b,
+                        "right": comp.model_a if mapping["right"] == "a" else comp.model_b,
+                    },
+                }
+            finally:
+                db.close()
+
+        return await run_in_threadpool(_commit_vote)
 
     @router.post("/record")
     def record_comparison(request: Request, body: RecordVoteRequest):

--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -784,7 +784,7 @@ GENERIC LOOPBACK to allowed Odysseus internal endpoints. Use this whenever the u
 - Themes: `/api/prefs/themes`, `/api/prefs/custom-themes`
 - Settings: `/api/settings`, `/api/prefs/{key}`
 - Research: `/api/research/start`, `/api/research/tasks` (note: `/api/research/report/{id}` renders HTML — to READ a report's text use the `manage_research` tool with `action:read`, not this endpoint)
-- Compare: `/api/compare/sessions`, `/api/compare/start`
+- Compare: history via `GET /api/compare/history`, record a completed comparison via `POST /api/compare/record`, vote via `POST /api/compare/{comp_id}/vote` with body `{"winner":"left|right|tie"}`, and delete via `DELETE /api/compare/{comp_id}`. `/api/compare/start` is a browser multipart/session-creation flow; use the Compare UI rather than calling it through this JSON bridge.
 - Email: use named email tools (`list_email_accounts`, `list_emails`, `read_email`, `scan_email_unsubscribes`, `unsubscribe_email`, `send_email`, `reply_to_email`). Do NOT use `/api/email/accounts`; it is owner-filtered in tool context and may falsely return empty.
 - Endpoints (model providers): `/api/endpoints`, `/api/endpoints/{id}`
 - Shell: do NOT use `app_api` for `/api/shell/*`; use named command tooling instead.

--- a/tests/test_agent_app_api_compare_routes.py
+++ b/tests/test_agent_app_api_compare_routes.py
@@ -1,0 +1,116 @@
+"""The agent's app_api guide must describe routes its JSON bridge can call."""
+
+import json
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def test_app_api_compare_guide_matches_live_router():
+    from routes.compare.compare_routes import setup_compare_routes
+    from src.agent_loop import TOOL_SECTIONS
+
+    class _Sessions:
+        pass
+
+    live = {
+        (method, route.path)
+        for route in setup_compare_routes(_Sessions()).routes
+        for method in getattr(route, "methods", set())
+    }
+    guide = TOOL_SECTIONS["app_api"]
+
+    assert "/api/compare/sessions" not in guide
+    assert ("GET", "/api/compare/history") in live
+    assert ("POST", "/api/compare/record") in live
+    assert ("POST", "/api/compare/{comp_id}/vote") in live
+    assert ("DELETE", "/api/compare/{comp_id}") in live
+    for path in (
+        "/api/compare/history",
+        "/api/compare/record",
+        "/api/compare/{comp_id}/vote",
+        "/api/compare/{comp_id}",
+    ):
+        assert path in guide
+
+
+def test_app_api_guide_does_not_claim_json_bridge_can_start_compare():
+    from src.agent_loop import TOOL_SECTIONS
+
+    guide = TOOL_SECTIONS["app_api"]
+
+    assert "`/api/compare/start` is a browser multipart/session-creation flow" in guide
+    assert "use the Compare UI" in guide
+
+
+def test_app_api_shaped_json_vote_reaches_compare_handler(monkeypatch):
+    import routes.compare.compare_routes as compare_routes
+
+    comparison = SimpleNamespace(
+        id="cmp-1",
+        owner=None,
+        winner=None,
+        blind_mapping=json.dumps({"left": "b", "right": "a"}),
+        model_a="model-a",
+        model_b="model-b",
+        voted_at=None,
+    )
+
+    class _Query:
+        def filter(self, *_args):
+            return self
+
+        def first(self):
+            return comparison
+
+    class _DB:
+        committed = False
+        closed = False
+
+        def query(self, _model):
+            return _Query()
+
+        def commit(self):
+            self.committed = True
+
+        def close(self):
+            self.closed = True
+
+    db = _DB()
+    monkeypatch.setattr(compare_routes, "SessionLocal", lambda: db)
+    monkeypatch.setattr(compare_routes, "get_current_user", lambda _request: None)
+
+    app = FastAPI()
+    app.include_router(compare_routes.setup_compare_routes(SimpleNamespace()))
+    bridge_call = {
+        "action": "call",
+        "method": "POST",
+        "path": "/api/compare/cmp-1/vote",
+        "body": {"winner": "left"},
+    }
+    response = TestClient(app).request(
+        bridge_call["method"], bridge_call["path"], json=bridge_call["body"]
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "winner": "b",
+        "model_a": "model-a",
+        "model_b": "model-b",
+        "revealed": {"left": "model-b", "right": "model-a"},
+    }
+    assert comparison.winner == "b"
+    assert db.committed is True
+    assert db.closed is True
+
+    comparison.winner = None
+    db.committed = False
+    db.closed = False
+    form_response = TestClient(app).post(
+        "/api/compare/cmp-1/vote", data={"winner": "right"}
+    )
+    assert form_response.status_code == 200
+    assert form_response.json()["winner"] == "a"
+    assert db.committed is True
+    assert db.closed is True


### PR DESCRIPTION
## Summary

Align the agent's Compare App API guidance with the routes the JSON bridge can actually call, and make Compare voting accept the bridge's JSON body while preserving the existing browser form flow. The guide now lists history, record, vote, and delete accurately and directs multipart Compare session creation to the Compare UI.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #5945

Part of #5942

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run the Compare route-guide, route-shim, and owner-scope tests:

   ```bash
   python -m pytest -q tests/test_agent_app_api_compare_routes.py tests/test_compare_routes_shim.py tests/test_compare_endpoint_owner_scope.py
   ```

2. Confirm all 9 tests pass.
3. Verify an App API-shaped JSON request to `POST /api/compare/{comp_id}/vote` records the selected winner, and verify the existing form request still follows the same validation and persistence path.
4. Confirm the agent guide does not advertise the removed `/api/compare/sessions` path and identifies `/api/compare/start` as a browser multipart flow.

A live model-guidance session and live loopback App API call have not been run; the JSON and form contracts are covered through the real FastAPI router with `TestClient`.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

N/A — the browser form contract is preserved, and this change does not alter rendered UI.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

N/A — no visual changes.
