### PR TITLE
fix(cli): generate live task webhook URLs

### DIFF
--- a/scripts/odysseus-webhook
+++ b/scripts/odysseus-webhook
@@ -2,7 +2,7 @@
 """odysseus-webhook — shell wrapper for scheduled-task webhook tokens.
 
 Tasks in the scheduled-task system can carry a `webhook_token`. Any
-HTTP POST to `/api/webhook/<token>` fires the task. This CLI lists,
+HTTP POST to `/api/tasks/<task-id>/webhook/<token>` fires the task. This CLI lists,
 rotates, and revokes those tokens.
 
     odysseus-webhook list                       # tasks that have a token
@@ -21,6 +21,7 @@ quiet_logs()
 
 import argparse, json, logging, os, secrets, sys
 from pathlib import Path
+from urllib.parse import quote
 
 try:
     from core.database import SessionLocal, ScheduledTask
@@ -51,6 +52,14 @@ def _summary(t: "ScheduledTask", reveal: bool = False) -> dict:
         "webhook_token": _mask_token(tok, reveal),
         "has_token": bool(tok),
     }
+
+
+def _task_webhook_url(base: str, task_id: str, token: str) -> str:
+    """Build the live task-route URL without leaking ids into path syntax."""
+    root = (base or "http://localhost:7000").rstrip("/")
+    task_part = quote(str(task_id), safe="")
+    token_part = quote(str(token), safe="")
+    return f"{root}/api/tasks/{task_part}/webhook/{token_part}"
 
 
 def cmd_list(args):
@@ -109,8 +118,7 @@ def cmd_url(args):
             fail(f"no task with id {args.id!r}")
         if not t.webhook_token:
             fail(f"task {args.id!r} has no webhook token (rotate one first)")
-        base = (args.base or "http://localhost:7000").rstrip("/")
-        url = f"{base}/api/webhook/{t.webhook_token}"
+        url = _task_webhook_url(args.base, t.id, t.webhook_token)
         emit({
             "task_id": t.id,
             "name": t.name,

--- a/tests/cli/test_webhook_cli_mask.py
+++ b/tests/cli/test_webhook_cli_mask.py
@@ -10,3 +10,28 @@ def test_mask_token_handles_short_values(monkeypatch):
     assert cli._mask_token("short") == "***"
     assert cli._mask_token("abcdef1234567890") == "abcdef…7890"
     assert cli._mask_token("short", reveal=True) == "short"
+
+
+def test_task_webhook_url_matches_live_route_and_escapes_path_parts(monkeypatch):
+    make_core_db_stub(monkeypatch, models=["ScheduledTask"])
+    cli = load_script("odysseus-webhook")
+
+    url = cli._task_webhook_url(
+        "https://ody.example/",
+        "task/with space",
+        "token/with space",
+    )
+
+    assert url == (
+        "https://ody.example/api/tasks/task%2Fwith%20space/"
+        "webhook/token%2Fwith%20space"
+    )
+
+
+def test_default_task_webhook_url_uses_current_task_prefix(monkeypatch):
+    make_core_db_stub(monkeypatch, models=["ScheduledTask"])
+    cli = load_script("odysseus-webhook")
+
+    assert cli._task_webhook_url(None, "task-1", "secret") == (
+        "http://localhost:7000/api/tasks/task-1/webhook/secret"
+    )


### PR DESCRIPTION
## Summary

Update `odysseus-webhook url` to generate the live scheduled-task webhook route, including both the task ID and webhook token instead of the removed token-only path. Both dynamic path segments are percent-encoded, while existing token masking, rotation, revocation, and explicit reveal behavior remain unchanged.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #2136

Related: #2047 and #2300

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run the CLI URL/masking and webhook auth-exemption regressions:

   ```bash
   python -m pytest -q tests/cli/test_webhook_cli_mask.py tests/test_webhook_trigger_auth_exempt.py
   ```

2. Confirm all 5 tests pass, including default/custom base URLs and percent-encoding for both path segments.
3. Compile the executable script:

   ```bash
   python -m py_compile scripts/odysseus-webhook
   ```

4. Create or inspect a scheduled task with a webhook token and verify `odysseus-webhook url TASK_ID --base https://app.example.com` emits `/api/tasks/{task_id}/webhook/{token}`.

A live task creation and HTTP trigger have not been run, so the end-to-end app checkbox remains unchecked.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

N/A — this changes a command-line helper and tests, not rendered UI.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

N/A — no visual changes.
