### PR TITLE
fix(memory): make vector lifecycle authoritative

### DIFF
--- a/app.py
+++ b/app.py
@@ -664,7 +664,11 @@ app.include_router(setup_session_routes(
 
 # Admin Danger Zone wipes (Settings → System → Danger Zone)
 from routes.admin_wipe.admin_wipe_routes import setup_admin_wipe_routes
-app.include_router(setup_admin_wipe_routes(session_manager))
+app.include_router(setup_admin_wipe_routes(
+    session_manager,
+    memory_manager=memory_manager,
+    memory_vector=memory_vector,
+))
 
 # Memory
 from routes.memory.memory_routes import setup_memory_routes
@@ -796,7 +800,12 @@ app.include_router(setup_prefs_routes())
 
 # Backup (export/import user data)
 from routes.backup_routes import setup_backup_routes
-app.include_router(setup_backup_routes(memory_manager, preset_manager, skills_manager))
+app.include_router(setup_backup_routes(
+    memory_manager,
+    preset_manager,
+    skills_manager,
+    memory_vector=memory_vector,
+))
 
 from routes.font_routes import setup_font_routes
 app.include_router(setup_font_routes())

--- a/routes/admin_wipe/admin_wipe_routes.py
+++ b/routes/admin_wipe/admin_wipe_routes.py
@@ -9,7 +9,6 @@ URL shape: DELETE /api/admin/wipe/{kind}
 Kinds: chats, memory, skills, notes, tasks, documents, gallery, calendar.
 """
 
-import json
 import logging
 import os
 import shutil
@@ -36,19 +35,14 @@ from src.constants import DATA_DIR, SKILLS_DIR, SKILLS_FILE, GALLERY_DIR, GALLER
 logger = logging.getLogger(__name__)
 
 
-def _wipe_memory_files():
-    """Blank memory.json + drop the per-owner tidy-state sidecar so the
-    next audit doesn't try to diff against gone memories."""
-    for name in ("memory.json", "memory_tidy_state.json"):
+def _wipe_memory_sidecars():
+    """Drop derived memory state after the authoritative stores are empty."""
+    for name in ("memory_tidy_state.json",):
         p = os.path.join(DATA_DIR, name)
         if not os.path.exists(p):
             continue
         try:
-            if name == "memory.json":
-                with open(p, "w", encoding="utf-8") as f:
-                    json.dump([], f)
-            else:
-                os.remove(p)
+            os.remove(p)
         except OSError as e:
             logger.warning(f"Could not reset {name}: {e}")
 
@@ -62,7 +56,7 @@ def _rmtree_quiet(path: str):
             logger.warning(f"Could not remove {path}: {e}")
 
 
-def setup_admin_wipe_routes(session_manager):
+def setup_admin_wipe_routes(session_manager, memory_manager=None, memory_vector=None):
     """The session_manager is passed in so we can also clear its
     in-memory cache when wiping chats — without it the DB is empty
     but the next /api/sessions returns stale entries."""
@@ -87,20 +81,41 @@ def setup_admin_wipe_routes(session_manager):
                 return {"status": "deleted", "kind": kind, "count": count}
 
             if kind == "memory":
+                if memory_manager is None or memory_vector is None:
+                    raise HTTPException(503, "Memory stores are not available for a safe wipe")
+                if not getattr(memory_vector, "healthy", False):
+                    raise HTTPException(503, "Memory vector store is unavailable; nothing was deleted")
+
+                original_memories = memory_manager.load_all_for_update()
                 count = db.query(Memory).count()
                 db.query(Memory).delete()
-                db.commit()
-                _wipe_memory_files()
-                # Drop the vector store too so semantic search doesn't
-                # return ghosts. Lazy import — chromadb may not be
-                # initialised in every deployment.
+
                 try:
-                    from src.memory_vector import get_memory_vector_store
-                    mv = get_memory_vector_store()
-                    if mv and hasattr(mv, "clear"):
-                        mv.clear()
+                    # Clear vectors before committing SQL. Keep the clear in
+                    # the compensation boundary because a backend can fail
+                    # after deleting only some lanes.
+                    memory_vector.clear(strict=True)
+                    memory_manager.save([])
+                    db.commit()
                 except Exception as e:
-                    logger.info(f"Memory vector clear skipped: {e}")
+                    # Restore the full multi-user corpus, never only the active
+                    # request owner's slice. A failed compensation is surfaced
+                    # because silently leaving split stores would be worse.
+                    restore_errors = []
+                    try:
+                        memory_manager.save(original_memories)
+                    except Exception as restore_error:
+                        restore_errors.append(f"JSON restore failed: {restore_error}")
+                    try:
+                        memory_vector.rebuild(original_memories, strict=True)
+                    except Exception as restore_error:
+                        restore_errors.append(f"vector restore failed: {restore_error}")
+                    if restore_errors:
+                        raise RuntimeError(
+                            f"Memory wipe failed ({e}); " + "; ".join(restore_errors)
+                        ) from e
+                    raise
+                _wipe_memory_sidecars()
                 return {"status": "deleted", "kind": kind, "count": count}
 
             if kind == "skills":
@@ -165,6 +180,7 @@ def setup_admin_wipe_routes(session_manager):
 
             raise HTTPException(400, f"Unknown wipe kind: {kind!r}")
         except HTTPException:
+            db.rollback()
             raise
         except Exception as e:
             db.rollback()

--- a/routes/backup_routes.py
+++ b/routes/backup_routes.py
@@ -13,7 +13,12 @@ from src.settings import load_settings, save_settings, load_features, save_featu
 logger = logging.getLogger(__name__)
 
 
-def setup_backup_routes(memory_manager, preset_manager, skills_manager) -> APIRouter:
+def setup_backup_routes(
+    memory_manager,
+    preset_manager,
+    skills_manager,
+    memory_vector=None,
+) -> APIRouter:
     router = APIRouter(tags=["backup"])
 
     @router.get("/api/export")
@@ -86,6 +91,7 @@ def setup_backup_routes(memory_manager, preset_manager, skills_manager) -> APIRo
                 raise HTTPException(
                     503, "Memory store is temporarily unreadable — nothing was imported."
                 )
+            original = list(existing)
             # Dedup against THIS user's own memories only. Using every tenant's
             # rows (load_all) meant a memory whose text matched any other
             # user's was silently skipped, so the importing user lost their own
@@ -104,7 +110,49 @@ def setup_backup_routes(memory_manager, preset_manager, skills_manager) -> APIRo
                 existing.append(mem)
                 existing_texts.add(mem["text"].strip().lower())
                 added += 1
+            if added and memory_vector is not None and not getattr(memory_vector, "healthy", False):
+                raise HTTPException(
+                    503,
+                    "Memory vector store is unavailable — nothing was imported.",
+                )
+
+            # Preserve the optional-vector route contract used by lightweight
+            # deployments and import callers.  Such callers still persist the
+            # authoritative JSON store; vector synchronization is performed
+            # only when a vector dependency was injected.
             memory_manager.save(existing)
+            try:
+                # The vector collection is shared by every owner. Rebuilding
+                # only the importing user's rows would erase every other
+                # tenant, so always use the complete persisted corpus.
+                if added and memory_vector is not None:
+                    memory_vector.rebuild(existing, strict=True)
+            except Exception as e:
+                logger.error("Memory vector rebuild failed; rolling back import: %s", e)
+                restore_errors = []
+                try:
+                    memory_manager.save(original)
+                except Exception as restore_error:
+                    restore_errors.append(f"JSON restore failed: {restore_error}")
+                try:
+                    memory_vector.rebuild(original, strict=True)
+                except Exception as restore_error:
+                    restore_errors.append(f"vector restore failed: {restore_error}")
+                if restore_errors:
+                    logger.critical(
+                        "Memory import compensation failed: %s",
+                        "; ".join(restore_errors),
+                    )
+                    detail = (
+                        "Memory vector rebuild failed and rollback was incomplete — "
+                        "persisted memory and vector state may be inconsistent."
+                    )
+                else:
+                    detail = "Memory vector rebuild failed — the import was rolled back."
+                raise HTTPException(
+                    503,
+                    detail,
+                )
             imported.append(f"{added} memories")
 
         # ── Skills ──

--- a/src/chat_processor.py
+++ b/src/chat_processor.py
@@ -203,11 +203,23 @@ class ChatProcessor:
             return score
 
         # ── Score all candidates ──
-        has_vector = self.memory_vector and self.memory_vector.healthy
+        has_vector = bool(self.memory_vector and self.memory_vector.healthy)
         vector_scores = {}
 
         if has_vector:
-            results = self.memory_vector.search(message, k=min(k * 3, 20))
+            try:
+                search_with_status = getattr(self.memory_vector, "search_with_status", None)
+                if callable(search_with_status):
+                    results, has_vector = search_with_status(
+                        message,
+                        k=min(k * 3, 20),
+                    )
+                else:
+                    results = self.memory_vector.search(message, k=min(k * 3, 20))
+            except Exception as e:
+                logger.warning("Vector memory query failed; using keyword scoring: %s", e)
+                results = []
+                has_vector = False
             mem_by_id = {m["id"]: m for m in mem_entries}
             for r in results:
                 if r["memory_id"] in mem_by_id:

--- a/src/memory_vector.py
+++ b/src/memory_vector.py
@@ -7,6 +7,7 @@ Stores pre-computed embeddings (ChromaDB does not manage embedding).
 """
 
 import logging
+from pathlib import Path
 from typing import List, Dict, Optional
 
 from src.embedding_lanes import (
@@ -22,13 +23,24 @@ from src.embedding_lanes import (
 logger = logging.getLogger(__name__)
 
 
+def _is_missing_collection_error(error: Exception) -> bool:
+    """Return whether Chroma reported that the named collection is absent."""
+    error_type = type(error)
+    return (
+        error_type.__module__ == "chromadb.errors"
+        and error_type.__name__ in {"NotFoundError", "InvalidCollectionException"}
+    )
+
+
 class MemoryVectorStore:
     """Vector index over memory entries for semantic retrieval."""
 
     COLLECTION_NAME = "odysseus_memories"
+    REBUILD_MARKER = ".memory-vector-rebuild-required"
 
     def __init__(self, data_dir: str, embedding_model=None):
         self._model = embedding_model
+        self._rebuild_marker = Path(data_dir) / self.REBUILD_MARKER
         self._collection = None
         self._lanes = []
         self._healthy = False
@@ -37,6 +49,16 @@ class MemoryVectorStore:
 
     def _initialize(self):
         try:
+            if self._rebuild_marker.exists():
+                # A previous rebuild did not finish durably. Never adopt its
+                # non-empty collections as authoritative merely because they
+                # survived a process restart. Reset them so startup sees an
+                # empty index and rebuilds from the JSON source of truth.
+                logger.warning("Discarding incomplete memory-vector rebuild")
+                self._replace_collections()
+                self._clear_rebuild_marker()
+                return
+
             self._lanes = build_embedding_lanes(self.COLLECTION_NAME)
             if not self._lanes:
                 raise RuntimeError("No embedding lanes available")
@@ -54,7 +76,30 @@ class MemoryVectorStore:
             )
 
         except Exception as e:
+            self._healthy = False
+            self._lanes = []
+            self._collection = None
             logger.error(f"MemoryVectorStore init failed: {e}")
+
+    def _mark_rebuild_incomplete(self) -> None:
+        """Durably poison collections until a complete rebuild is committed."""
+        self._rebuild_marker.write_text("rebuild required\n", encoding="utf-8")
+
+    def _clear_rebuild_marker(self) -> None:
+        self._rebuild_marker.unlink(missing_ok=True)
+
+    def _delete_collection_names(self, names) -> None:
+        """Delete named collections, ignoring only explicit not-found errors."""
+        from src.chroma_client import get_chroma_client
+
+        client = get_chroma_client()
+        for name in names:
+            try:
+                client.delete_collection(name)
+            except Exception as e:
+                if _is_missing_collection_error(e):
+                    continue
+                raise
 
     @property
     def healthy(self) -> bool:
@@ -129,27 +174,31 @@ class MemoryVectorStore:
             except Exception as e:
                 logger.warning(f"memory remove {memory_id}: {e}")
 
-    def search(self, query: str, k: int = 8) -> List[Dict]:
+    def search_with_status(self, query: str, k: int = 8) -> tuple[List[Dict], bool]:
         """Search for the most relevant memory IDs by semantic similarity.
-        Returns list of {"memory_id": str, "score": float}.
+        Return ``(results, query_healthy)`` so callers can distinguish a real
+        empty result from a runtime vector outage.
 
         ChromaDB cosine distance = 1 - cosine_similarity.
         We convert back: similarity = 1.0 - distance.
         """
-        if not self._healthy or self.count() == 0:
-            return []
+        if not self._healthy:
+            return [], False
 
         out = []
+        successful_lane = False
         lane_priority = {LANE_CUSTOM: 0, LANE_FASTEMBED: 1}
         for lane in self._lanes:
             try:
                 if lane.count() == 0:
+                    successful_lane = True
                     continue
                 results = lane.collection.query(
                     query_embeddings=lane.encode([query]),
                     n_results=min(k, lane.count()),
                     include=["distances"],
                 )
+                successful_lane = True
                 for idx, mid in enumerate(results["ids"][0]):
                     distance = results["distances"][0][idx]
                     out.append({
@@ -160,7 +209,12 @@ class MemoryVectorStore:
             except Exception as e:
                 logger.warning("memory search failed in %s lane: %s", lane.name, e)
         out.sort(key=lambda row: (-row["score"], lane_priority.get(row["embedding_lane"], 99)))
-        return dedupe_results(out, id_key="memory_id", limit=k)
+        return dedupe_results(out, id_key="memory_id", limit=k), successful_lane
+
+    def search(self, query: str, k: int = 8) -> List[Dict]:
+        """Compatibility search API returning only result rows."""
+        results, _query_healthy = self.search_with_status(query, k=k)
+        return results
 
     def find_similar(self, text: str, threshold: float = 0.92) -> Optional[str]:
         """Check if a near-duplicate exists. Returns memory_id if found, else None."""
@@ -185,32 +239,61 @@ class MemoryVectorStore:
                 logger.warning("memory similarity search failed in %s lane: %s", lane.name, e)
         return None
 
-    def rebuild(self, memories: List[Dict]):
-        """Rebuild the entire index from a list of memory entries.
-        Each entry must have 'id' and 'text' keys."""
-        if not self._healthy:
-            return
-
-        from src.chroma_client import get_chroma_client
-
-        client = get_chroma_client()
-        lane_names = [
+    def _replace_collections(self) -> None:
+        """Delete every memory-vector collection and create fresh lanes."""
+        names = {
             self.COLLECTION_NAME,
             collection_name(self.COLLECTION_NAME, LANE_CUSTOM),
             collection_name(self.COLLECTION_NAME, LANE_FASTEMBED),
-        ]
-        for name in lane_names:
-            try:
-                client.delete_collection(name)
-            except Exception:
-                pass
-        # Explicit rebuilds must start from the supplied memory list, so clear
-        # legacy unsuffixed collections too.
+        }
+        # Older Chroma clients and the repository's supported lightweight
+        # client contract do not expose ``list_collections``.  The collection
+        # names are deterministic, so deleting each known name is both more
+        # compatible and sufficient to prevent a stale inactive lane (or the
+        # legacy collection) from being migrated back into a rebuild.
+        self._delete_collection_names(names)
+
         self._lanes = build_embedding_lanes(self.COLLECTION_NAME)
+        if not self._lanes:
+            self._healthy = False
+            self._collection = None
+            raise RuntimeError("No embedding lanes available after memory-vector reset")
         self._collection = next(
             (lane.collection for lane in self._lanes if lane.name == LANE_FASTEMBED),
-            self._lanes[0].collection if self._lanes else None,
+            self._lanes[0].collection,
         )
+        self._healthy = True
+
+    def clear(self, *, strict: bool = False) -> bool:
+        """Clear all memory vectors.
+
+        ``strict=True`` is used by persistence transactions: failures propagate
+        so SQL/JSON state is not committed while stale vectors remain.
+        """
+        try:
+            self._replace_collections()
+            return True
+        except Exception as e:
+            self._healthy = False
+            logger.error("memory vector clear failed: %s", e)
+            if strict:
+                raise
+            return False
+
+    def rebuild(self, memories: List[Dict], *, strict: bool = False) -> bool:
+        """Rebuild the entire index from a list of memory entries.
+        Each entry must have 'id' and 'text' keys."""
+        try:
+            # Set this before mutating Chroma. A crash, strict exception, or
+            # failed cleanup must remain visible to the next process.
+            self._mark_rebuild_incomplete()
+            self._replace_collections()
+        except Exception as e:
+            self._healthy = False
+            logger.error("memory rebuild reset failed: %s", e)
+            if strict:
+                raise
+            return False
 
         texts = []
         ids = []
@@ -224,6 +307,7 @@ class MemoryVectorStore:
         if texts:
             # Batch in chunks of 100 to avoid oversized requests
             failed_lanes = set()
+            primary_error = None
             for i in range(0, len(texts), 100):
                 batch_texts = texts[i:i + 100]
                 batch_ids = ids[i:i + 100]
@@ -240,8 +324,82 @@ class MemoryVectorStore:
                     except Exception as e:
                         failed_lanes.add(lane.name)
                         logger.warning("memory rebuild failed in %s lane: %s", lane.name, e)
+                        if strict:
+                            primary_error = e
+                            break
+                if primary_error is not None:
+                    break
+
+            if primary_error is not None:
+                # Strict mode remains fail-fast, but first make every lane
+                # non-authoritative: each may contain earlier successful
+                # batches. Preserve the embedding/write exception even if
+                # best-effort cleanup also fails; the marker then protects the
+                # next process from adopting the residue.
+                all_names = {
+                    collection_name(self.COLLECTION_NAME, lane.name)
+                    for lane in self._lanes
+                }
+                self._healthy = False
+                self._lanes = []
+                self._collection = None
+                try:
+                    self._delete_collection_names(all_names)
+                except Exception as cleanup_error:
+                    logger.error(
+                        "memory rebuild cleanup failed after %s: %s",
+                        primary_error,
+                        cleanup_error,
+                    )
+                else:
+                    try:
+                        self._clear_rebuild_marker()
+                    except Exception as marker_error:
+                        logger.error("memory rebuild marker cleanup failed: %s", marker_error)
+                raise primary_error
+
+            if failed_lanes:
+                # A non-strict lifecycle rebuild may degrade to any lane that
+                # was rebuilt completely.  Exclude failed/partially populated
+                # lanes and delete their durable collections so a restart
+                # cannot mix incomplete state back in.
+                surviving_lanes = [
+                    lane for lane in self._lanes if lane.name not in failed_lanes
+                ]
+                failed_names = {
+                    collection_name(self.COLLECTION_NAME, name)
+                    for name in failed_lanes
+                }
+                try:
+                    self._delete_collection_names(failed_names)
+                except Exception as cleanup_error:
+                    logger.error("memory rebuild partial-lane cleanup failed: %s", cleanup_error)
+                    self._lanes = []
+                    self._collection = None
+                    self._healthy = False
+                    return False
+                self._lanes = surviving_lanes
+                self._collection = next(
+                    (lane.collection for lane in self._lanes if lane.name == LANE_FASTEMBED),
+                    self._lanes[0].collection if self._lanes else None,
+                )
+                self._healthy = bool(self._lanes)
+
+        try:
+            self._clear_rebuild_marker()
+        except Exception as e:
+            # The index may be complete in this process, but leaving a durable
+            # poison marker means it cannot be treated as committed.
+            self._healthy = False
+            self._lanes = []
+            self._collection = None
+            logger.error("memory rebuild marker cleanup failed: %s", e)
+            if strict:
+                raise
+            return False
 
         logger.info(f"MemoryVectorStore rebuilt with {len(ids)} entries across {len(self._lanes)} lanes")
+        return self._healthy
 
     def get_stats(self) -> Dict:
         return {

--- a/tests/test_embedding_lanes_memory.py
+++ b/tests/test_embedding_lanes_memory.py
@@ -1,3 +1,5 @@
+import pytest
+
 from src.embedding_lanes import (
     EmbeddingLane,
     LANE_CUSTOM,
@@ -91,7 +93,7 @@ def test_memory_search_merges_fallback_only_results_before_limit():
     assert [row["memory_id"] for row in results] == ["fallback-only", "old-1"]
 
 
-def test_memory_rebuild_does_not_reimport_legacy_collection(monkeypatch):
+def test_memory_rebuild_does_not_reimport_legacy_collection(monkeypatch, tmp_path):
     fake = FakeChroma()
     legacy = fake.get_or_create_collection("odysseus_memories", metadata={"hnsw:space": "cosine"})
     legacy.add(
@@ -116,7 +118,7 @@ def test_memory_rebuild_does_not_reimport_legacy_collection(monkeypatch):
 
     from src.memory_vector import MemoryVectorStore
 
-    store = MemoryVectorStore("data")
+    store = MemoryVectorStore(tmp_path)
     assert fake.collections["odysseus_memories_fastembed"].count() == 1
 
     store.rebuild([{"id": "current-memory", "text": "current rebuilt memory"}])
@@ -168,7 +170,7 @@ def test_memory_remove_deletes_inactive_lane_collection(monkeypatch):
     assert fast_collection.count() == 0
 
 
-def test_memory_rebuild_continues_when_custom_lane_fails(monkeypatch):
+def test_memory_rebuild_continues_when_custom_lane_fails(monkeypatch, tmp_path):
     fake = FakeChroma()
     patch_chroma(monkeypatch, fake)
 
@@ -179,9 +181,44 @@ def test_memory_rebuild_continues_when_custom_lane_fails(monkeypatch):
 
     from src.memory_vector import MemoryVectorStore
 
-    store = MemoryVectorStore("data")
-    store.rebuild([{"id": "current-memory", "text": "current rebuilt memory"}])
+    store = MemoryVectorStore(tmp_path)
+    rebuilt = store.rebuild([{"id": "current-memory", "text": "current rebuilt memory"}])
 
-    assert fake.collections["odysseus_memories_custom"].count() == 0
+    assert "odysseus_memories_custom" not in fake.collections
     assert fake.collections["odysseus_memories_fastembed"].count() == 1
     assert fake.collections["odysseus_memories_fastembed"].get()["ids"] == ["current-memory"]
+    assert rebuilt is True
+    assert store.healthy is True
+    results, query_healthy = store.search_with_status("current rebuilt memory")
+    assert query_healthy is True
+    assert results[0]["memory_id"] == "current-memory"
+    assert results[0]["embedding_lane"] == LANE_FASTEMBED
+
+    restarted = MemoryVectorStore(tmp_path)
+    assert restarted.healthy is True
+    assert restarted.count() == 1
+    restarted_results, restarted_healthy = restarted.search_with_status("current rebuilt memory")
+    assert restarted_healthy is True
+    assert restarted_results[0]["memory_id"] == "current-memory"
+    assert restarted_results[0]["embedding_lane"] == LANE_FASTEMBED
+
+
+def test_memory_strict_rebuild_propagates_custom_lane_failure(monkeypatch, tmp_path):
+    fake = FakeChroma()
+    patch_chroma(monkeypatch, fake)
+
+    import src.embedding_lanes as lanes
+
+    monkeypatch.setattr(lanes, "_build_custom_client", lambda: FailingEmbedder(768, "nomic", "http://embeddings/v1"))
+    monkeypatch.setattr(lanes, "_build_fastembed_client", lambda: FakeEmbedder(384, "mini", "local://fastembed"))
+
+    from src.memory_vector import MemoryVectorStore
+
+    store = MemoryVectorStore(tmp_path)
+
+    with pytest.raises(RuntimeError, match="embedding endpoint rate limited"):
+        store.rebuild([{"id": "current-memory", "text": "current rebuilt memory"}], strict=True)
+
+    assert store.healthy is False
+    assert "odysseus_memories_custom" not in fake.collections
+    assert "odysseus_memories_fastembed" not in fake.collections

--- a/tests/test_memory_vector_lifecycle.py
+++ b/tests/test_memory_vector_lifecycle.py
@@ -1,0 +1,421 @@
+import asyncio
+import time
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from routes import backup_routes
+from routes.admin_wipe import admin_wipe_routes
+import src.chroma_client as chroma_client
+import src.memory_vector as memory_vector
+from src.chat_processor import ChatProcessor
+from src.memory_vector import MemoryVectorStore
+
+
+class _BrokenLane:
+    name = "broken"
+
+    def count(self):
+        raise RuntimeError("chroma offline")
+
+
+def test_vector_query_reports_a_per_call_outage():
+    store = MemoryVectorStore.__new__(MemoryVectorStore)
+    store._healthy = True
+    store._lanes = [_BrokenLane()]
+
+    rows, query_healthy = store.search_with_status("alpha", k=5)
+
+    assert rows == []
+    assert query_healthy is False
+    assert store.healthy is True  # startup state did not predict this call
+
+
+def test_chat_switches_to_keyword_weights_for_failed_vector_call():
+    vector = SimpleNamespace(
+        healthy=True,
+        search_with_status=lambda query, k: ([], False),
+    )
+    processor = ChatProcessor(None, None, memory_vector=vector)
+    memory = {
+        "id": "m1",
+        "text": "alpha beta",
+        "timestamp": time.time(),
+        "category": "fact",
+    }
+
+    assert processor._hybrid_retrieve("alpha beta", [memory], k=1) == [memory]
+
+    healthy_empty = SimpleNamespace(
+        healthy=True,
+        search_with_status=lambda query, k: ([], True),
+    )
+    processor.memory_vector = healthy_empty
+    assert processor._hybrid_retrieve("alpha beta", [memory], k=1) == []
+
+
+class _MemoryManager:
+    def __init__(self, rows):
+        self.rows = list(rows)
+        self.saves = []
+
+    def load_all_for_update(self):
+        return list(self.rows)
+
+    def save(self, rows):
+        self.rows = list(rows)
+        self.saves.append(list(rows))
+
+
+class _Vector:
+    healthy = True
+
+    def __init__(self, events=None, fail_clear=False):
+        self.rebuilds = []
+        self.events = events
+        self.fail_clear = fail_clear
+
+    def rebuild(self, rows, *, strict=False):
+        assert strict is True
+        self.rebuilds.append(list(rows))
+
+    def clear(self, *, strict=False):
+        assert strict is True
+        if self.events is not None:
+            self.events.append("vector_clear")
+        if self.fail_clear:
+            raise RuntimeError("partial vector clear")
+
+
+class _AlwaysFailingVector(_Vector):
+    def rebuild(self, rows, *, strict=False):
+        assert strict is True
+        self.rebuilds.append(list(rows))
+        raise RuntimeError("vector rebuild unavailable")
+
+
+class _Request:
+    def __init__(self, payload):
+        self._payload = payload
+
+    async def json(self):
+        return self._payload
+
+
+def _endpoint(router, path):
+    return next(route.endpoint for route in router.routes if route.path == path)
+
+
+def test_backup_import_rebuilds_the_complete_multi_user_corpus(monkeypatch):
+    manager = _MemoryManager([
+        {"id": "alice-old", "owner": "alice", "text": "alpha"},
+        {"id": "bob-old", "owner": "bob", "text": "beta"},
+    ])
+    vector = _Vector()
+    monkeypatch.setattr(backup_routes, "require_admin", lambda request: None)
+    monkeypatch.setattr(backup_routes, "get_current_user", lambda request: "alice")
+    router = backup_routes.setup_backup_routes(
+        manager,
+        SimpleNamespace(),
+        SimpleNamespace(),
+        memory_vector=vector,
+    )
+
+    result = asyncio.run(_endpoint(router, "/api/import")(
+        _Request({"memories": [{"id": "alice-new", "text": "gamma"}]})
+    ))
+
+    assert result["ok"] is True
+    assert {row["id"] for row in vector.rebuilds[-1]} == {
+        "alice-old",
+        "bob-old",
+        "alice-new",
+    }
+    assert next(row for row in vector.rebuilds[-1] if row["id"] == "alice-new")["owner"] == "alice"
+
+
+def test_backup_import_preserves_optional_vector_compatibility(monkeypatch):
+    manager = _MemoryManager([])
+    monkeypatch.setattr(backup_routes, "require_admin", lambda request: None)
+    monkeypatch.setattr(backup_routes, "get_current_user", lambda request: "alice")
+    router = backup_routes.setup_backup_routes(
+        manager,
+        SimpleNamespace(),
+        SimpleNamespace(),
+        memory_vector=None,
+    )
+
+    result = asyncio.run(_endpoint(router, "/api/import")(
+        _Request({"memories": [{"id": "alice-new", "text": "gamma"}]})
+    ))
+
+    assert result["ok"] is True
+    assert manager.rows == [{"id": "alice-new", "text": "gamma", "owner": "alice"}]
+
+
+def test_backup_import_reports_incomplete_vector_compensation(monkeypatch):
+    original = [{"id": "alice-old", "owner": "alice", "text": "alpha"}]
+    manager = _MemoryManager(original)
+    vector = _AlwaysFailingVector()
+    monkeypatch.setattr(backup_routes, "require_admin", lambda request: None)
+    monkeypatch.setattr(backup_routes, "get_current_user", lambda request: "alice")
+    router = backup_routes.setup_backup_routes(
+        manager,
+        SimpleNamespace(),
+        SimpleNamespace(),
+        memory_vector=vector,
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(_endpoint(router, "/api/import")(
+            _Request({"memories": [{"id": "alice-new", "text": "gamma"}]})
+        ))
+
+    assert exc.value.status_code == 503
+    assert "rollback was incomplete" in exc.value.detail
+    assert manager.rows == original
+    assert vector.rebuilds == [
+        original + [{"id": "alice-new", "text": "gamma", "owner": "alice"}],
+        original,
+    ]
+
+
+class _Query:
+    def __init__(self, events):
+        self.events = events
+
+    def count(self):
+        return 2
+
+    def delete(self):
+        self.events.append("sql_delete")
+
+
+class _Db:
+    def __init__(self, events, fail_commit=False):
+        self.events = events
+        self.fail_commit = fail_commit
+
+    def query(self, model):
+        return _Query(self.events)
+
+    def commit(self):
+        self.events.append("sql_commit")
+        if self.fail_commit:
+            raise RuntimeError("commit failed")
+
+    def rollback(self):
+        self.events.append("sql_rollback")
+
+    def close(self):
+        self.events.append("close")
+
+
+def test_admin_memory_wipe_clears_vectors_before_sql_commit(monkeypatch):
+    events = []
+    manager = _MemoryManager([
+        {"id": "alice", "owner": "alice", "text": "alpha"},
+        {"id": "bob", "owner": "bob", "text": "beta"},
+    ])
+    vector = _Vector(events)
+    monkeypatch.setattr(admin_wipe_routes, "SessionLocal", lambda: _Db(events))
+    monkeypatch.setattr(admin_wipe_routes, "require_admin", lambda request: None)
+    monkeypatch.setattr(admin_wipe_routes, "_wipe_memory_sidecars", lambda: None)
+    router = admin_wipe_routes.setup_admin_wipe_routes(
+        None,
+        memory_manager=manager,
+        memory_vector=vector,
+    )
+
+    _endpoint(router, "/api/admin/wipe/{kind}")("memory", SimpleNamespace())
+
+    assert events.index("vector_clear") < events.index("sql_commit")
+    assert manager.rows == []
+
+
+def test_admin_memory_wipe_restores_full_corpus_if_commit_fails(monkeypatch):
+    events = []
+    original = [
+        {"id": "alice", "owner": "alice", "text": "alpha"},
+        {"id": "bob", "owner": "bob", "text": "beta"},
+    ]
+    manager = _MemoryManager(original)
+    vector = _Vector(events)
+    monkeypatch.setattr(
+        admin_wipe_routes,
+        "SessionLocal",
+        lambda: _Db(events, fail_commit=True),
+    )
+    monkeypatch.setattr(admin_wipe_routes, "require_admin", lambda request: None)
+    router = admin_wipe_routes.setup_admin_wipe_routes(
+        None,
+        memory_manager=manager,
+        memory_vector=vector,
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        _endpoint(router, "/api/admin/wipe/{kind}")("memory", SimpleNamespace())
+
+    assert exc.value.status_code == 500
+    assert manager.rows == original
+    assert vector.rebuilds[-1] == original
+    assert "sql_rollback" in events
+
+
+def test_admin_memory_wipe_compensates_a_partial_vector_clear(monkeypatch):
+    events = []
+    original = [
+        {"id": "alice", "owner": "alice", "text": "alpha"},
+        {"id": "bob", "owner": "bob", "text": "beta"},
+    ]
+    manager = _MemoryManager(original)
+    vector = _Vector(events, fail_clear=True)
+    monkeypatch.setattr(admin_wipe_routes, "SessionLocal", lambda: _Db(events))
+    monkeypatch.setattr(admin_wipe_routes, "require_admin", lambda request: None)
+    router = admin_wipe_routes.setup_admin_wipe_routes(
+        None,
+        memory_manager=manager,
+        memory_vector=vector,
+    )
+
+    with pytest.raises(HTTPException):
+        _endpoint(router, "/api/admin/wipe/{kind}")("memory", SimpleNamespace())
+
+    assert "sql_commit" not in events
+    assert manager.rows == original
+    assert vector.rebuilds[-1] == original
+
+
+def test_rebuild_reset_failure_marks_store_unhealthy(monkeypatch, tmp_path):
+    store = MemoryVectorStore.__new__(MemoryVectorStore)
+    store._healthy = True
+    store._rebuild_marker = tmp_path / MemoryVectorStore.REBUILD_MARKER
+
+    def fail_reset():
+        raise RuntimeError("reset failed")
+
+    monkeypatch.setattr(store, "_replace_collections", fail_reset)
+
+    with pytest.raises(RuntimeError):
+        store.rebuild([], strict=True)
+
+    assert store.healthy is False
+
+
+class _FailSecondBatchEmbedder:
+    def __init__(self, dim):
+        self.dim = dim
+        self.calls = 0
+
+    def get_sentence_embedding_dimension(self):
+        return self.dim
+
+    def encode(self, texts, normalize_embeddings=True):
+        self.calls += 1
+        if self.calls == 2:
+            raise RuntimeError("second embedding batch failed")
+        return [[1.0] * self.dim for _ in texts]
+
+
+@pytest.mark.parametrize("strict", [False, True])
+def test_failed_later_batch_is_not_adopted_after_restart(monkeypatch, tmp_path, strict):
+    from tests.helpers.embedding_lanes import FakeChroma, patch_chroma
+    import src.embedding_lanes as lanes
+
+    fake = FakeChroma()
+    patch_chroma(monkeypatch, fake)
+    custom_clients = []
+    fast_clients = []
+
+    def custom_client():
+        client = _FailSecondBatchEmbedder(768)
+        custom_clients.append(client)
+        return client
+
+    def fast_client():
+        client = _FailSecondBatchEmbedder(384)
+        fast_clients.append(client)
+        return client
+
+    monkeypatch.setattr(lanes, "_build_custom_client", custom_client)
+    monkeypatch.setattr(lanes, "_build_fastembed_client", fast_client)
+    rows = [{"id": f"memory-{i}", "text": f"memory text {i}"} for i in range(101)]
+    store = MemoryVectorStore(tmp_path)
+
+    if strict:
+        with pytest.raises(RuntimeError, match="second embedding batch failed"):
+            store.rebuild(rows, strict=True)
+    else:
+        assert store.rebuild(rows) is False
+
+    assert store.healthy is False
+    assert store.count() == 0
+    assert "odysseus_memories_custom" not in fake.collections
+    assert "odysseus_memories_fastembed" not in fake.collections
+
+    restarted = MemoryVectorStore(tmp_path)
+
+    assert restarted.healthy is True
+    assert restarted.count() == 0
+    assert len(restarted._lanes) == 2
+    assert not (tmp_path / MemoryVectorStore.REBUILD_MARKER).exists()
+
+
+def test_strict_later_batch_preserves_primary_error_when_cleanup_fails(monkeypatch, tmp_path):
+    from tests.helpers.embedding_lanes import FakeChroma, patch_chroma
+    import src.embedding_lanes as lanes
+
+    fake = FakeChroma()
+    patch_chroma(monkeypatch, fake)
+    monkeypatch.setattr(lanes, "_build_custom_client", lambda: _FailSecondBatchEmbedder(768))
+    monkeypatch.setattr(lanes, "_build_fastembed_client", lambda: _FailSecondBatchEmbedder(384))
+    store = MemoryVectorStore(tmp_path)
+    original_delete = fake.delete_collection
+    delete_calls = 0
+
+    def fail_cleanup(name):
+        nonlocal delete_calls
+        delete_calls += 1
+        if delete_calls > 3:
+            raise RuntimeError("cleanup backend unavailable")
+        original_delete(name)
+
+    fake.delete_collection = fail_cleanup
+    rows = [{"id": f"memory-{i}", "text": f"memory text {i}"} for i in range(101)]
+
+    with pytest.raises(RuntimeError, match="second embedding batch failed"):
+        store.rebuild(rows, strict=True)
+
+    assert store.healthy is False
+    assert (tmp_path / MemoryVectorStore.REBUILD_MARKER).exists()
+    assert any(collection.count() == 100 for collection in fake.collections.values())
+
+    fake.delete_collection = original_delete
+    restarted = MemoryVectorStore(tmp_path)
+
+    assert restarted.healthy is True
+    assert restarted.count() == 0
+    assert not (tmp_path / MemoryVectorStore.REBUILD_MARKER).exists()
+
+
+def test_strict_clear_propagates_collection_delete_failure(monkeypatch):
+    class FailingClient:
+        def delete_collection(self, name):
+            raise RuntimeError(f"backend unavailable while deleting {name}")
+
+    store = MemoryVectorStore.__new__(MemoryVectorStore)
+    store._healthy = True
+    store._lanes = []
+    store._collection = None
+    monkeypatch.setattr(chroma_client, "get_chroma_client", lambda: FailingClient())
+    monkeypatch.setattr(
+        memory_vector,
+        "build_embedding_lanes",
+        lambda name: pytest.fail("reset must stop after a collection deletion failure"),
+    )
+
+    with pytest.raises(RuntimeError, match="backend unavailable while deleting"):
+        store.clear(strict=True)
+
+    assert store.healthy is False


### PR DESCRIPTION
## Summary

Make the memory vector lifecycle authoritative across backup import, administrative wipe, and chat retrieval. Strict clear/rebuild operations now surface vector-backend deletion failures and leave vector health degraded instead of reporting success, while optional-vector deployments retain their existing compatibility behavior. The change also preserves owner isolation, explicit compensation failures, and keyword fallback when vector search is unavailable.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #1967

Related: #1968, #5831, #4377

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

The focused automated suites passed, but a live persistent-Chroma outage/recovery exercise in the application has not yet been completed.

## How to Test

1. Run `pytest -q tests/test_memory_vector_lifecycle.py tests/test_embedding_lanes_memory.py tests/test_app_initializer_memory_vector_degraded.py`; the refreshed cumulative validation reports 28 passing lifecycle and backup tests.
2. Configure a vector backend whose `delete_collection` operation fails, then invoke strict clear/rebuild and confirm that the failure propagates and vector health is not reported as healthy.
3. Verify administrative wipe and failed-import compensation paths do not report success when the vector mutation fails.
4. With vector search unavailable, verify an owner-scoped memory query still uses keyword fallback without exposing another owner's records.
5. Run the top-level backup and memory test modules together. The refreshed stacked branch reports 115 passing tests, exercising this packet beneath the dependent backup-format packet.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

N/A — no rendered UI files or user-interface behavior are changed.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

N/A — no rendered UI files changed.
