### PR TITLE
fix(backup): version calendar task and note exports

### DIFF
--- a/app.py
+++ b/app.py
@@ -664,7 +664,11 @@ app.include_router(setup_session_routes(
 
 # Admin Danger Zone wipes (Settings → System → Danger Zone)
 from routes.admin_wipe.admin_wipe_routes import setup_admin_wipe_routes
-app.include_router(setup_admin_wipe_routes(session_manager))
+app.include_router(setup_admin_wipe_routes(
+    session_manager,
+    memory_manager=memory_manager,
+    memory_vector=memory_vector,
+))
 
 # Memory
 from routes.memory.memory_routes import setup_memory_routes
@@ -796,7 +800,12 @@ app.include_router(setup_prefs_routes())
 
 # Backup (export/import user data)
 from routes.backup_routes import setup_backup_routes
-app.include_router(setup_backup_routes(memory_manager, preset_manager, skills_manager))
+app.include_router(setup_backup_routes(
+    memory_manager,
+    preset_manager,
+    skills_manager,
+    memory_vector=memory_vector,
+))
 
 from routes.font_routes import setup_font_routes
 app.include_router(setup_font_routes())

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -1,5 +1,9 @@
 # Backup & Restore
 
+The Settings JSON export is a separate, mixed-scope portability format. Its version 2 shape includes memories, skills, presets, settings, preferences, calendars and events, scheduled tasks and run history, and notes. Memories, skills, preferences, calendars, tasks, and notes are selected for the current owner during export. Imported version 2 calendar, task, and note rows are stamped with the current owner, and primary-key collisions are remapped rather than overwriting another user's rows. Presets are shared across users, while settings and feature flags are instance-global; those sections remain shared/global rather than becoming owner-scoped. Task webhook tokens are intentionally excluded and must be regenerated after restore. References to chat/agent sessions, crew members, characters, and note upload images are detached because those domains are not part of the JSON format. Imported CalDAV calendars/events become local rows; reconnect and sync the account explicitly instead of reusing remote hrefs or pending-write markers from another instance.
+
+Version 1 JSON exports remain importable; they simply do not contain the newer calendar/task/note sections. The commands below describe full on-disk instance snapshots, which serve a different disaster-recovery use case.
+
 Odysseus keeps all of your state in the `data/` directory — the SQLite database
 (`app.db`), the Fernet encryption key (`data/.app_key`), the vault, memory, RAG
 indexes, personal documents, and uploads. The `scripts/odysseus-backup` tool

--- a/routes/admin_wipe/admin_wipe_routes.py
+++ b/routes/admin_wipe/admin_wipe_routes.py
@@ -9,7 +9,6 @@ URL shape: DELETE /api/admin/wipe/{kind}
 Kinds: chats, memory, skills, notes, tasks, documents, gallery, calendar.
 """
 
-import json
 import logging
 import os
 import shutil
@@ -36,19 +35,14 @@ from src.constants import DATA_DIR, SKILLS_DIR, SKILLS_FILE, GALLERY_DIR, GALLER
 logger = logging.getLogger(__name__)
 
 
-def _wipe_memory_files():
-    """Blank memory.json + drop the per-owner tidy-state sidecar so the
-    next audit doesn't try to diff against gone memories."""
-    for name in ("memory.json", "memory_tidy_state.json"):
+def _wipe_memory_sidecars():
+    """Drop derived memory state after the authoritative stores are empty."""
+    for name in ("memory_tidy_state.json",):
         p = os.path.join(DATA_DIR, name)
         if not os.path.exists(p):
             continue
         try:
-            if name == "memory.json":
-                with open(p, "w", encoding="utf-8") as f:
-                    json.dump([], f)
-            else:
-                os.remove(p)
+            os.remove(p)
         except OSError as e:
             logger.warning(f"Could not reset {name}: {e}")
 
@@ -62,7 +56,7 @@ def _rmtree_quiet(path: str):
             logger.warning(f"Could not remove {path}: {e}")
 
 
-def setup_admin_wipe_routes(session_manager):
+def setup_admin_wipe_routes(session_manager, memory_manager=None, memory_vector=None):
     """The session_manager is passed in so we can also clear its
     in-memory cache when wiping chats — without it the DB is empty
     but the next /api/sessions returns stale entries."""
@@ -87,20 +81,41 @@ def setup_admin_wipe_routes(session_manager):
                 return {"status": "deleted", "kind": kind, "count": count}
 
             if kind == "memory":
+                if memory_manager is None or memory_vector is None:
+                    raise HTTPException(503, "Memory stores are not available for a safe wipe")
+                if not getattr(memory_vector, "healthy", False):
+                    raise HTTPException(503, "Memory vector store is unavailable; nothing was deleted")
+
+                original_memories = memory_manager.load_all_for_update()
                 count = db.query(Memory).count()
                 db.query(Memory).delete()
-                db.commit()
-                _wipe_memory_files()
-                # Drop the vector store too so semantic search doesn't
-                # return ghosts. Lazy import — chromadb may not be
-                # initialised in every deployment.
+
                 try:
-                    from src.memory_vector import get_memory_vector_store
-                    mv = get_memory_vector_store()
-                    if mv and hasattr(mv, "clear"):
-                        mv.clear()
+                    # Clear vectors before committing SQL. Keep the clear in
+                    # the compensation boundary because a backend can fail
+                    # after deleting only some lanes.
+                    memory_vector.clear(strict=True)
+                    memory_manager.save([])
+                    db.commit()
                 except Exception as e:
-                    logger.info(f"Memory vector clear skipped: {e}")
+                    # Restore the full multi-user corpus, never only the active
+                    # request owner's slice. A failed compensation is surfaced
+                    # because silently leaving split stores would be worse.
+                    restore_errors = []
+                    try:
+                        memory_manager.save(original_memories)
+                    except Exception as restore_error:
+                        restore_errors.append(f"JSON restore failed: {restore_error}")
+                    try:
+                        memory_vector.rebuild(original_memories, strict=True)
+                    except Exception as restore_error:
+                        restore_errors.append(f"vector restore failed: {restore_error}")
+                    if restore_errors:
+                        raise RuntimeError(
+                            f"Memory wipe failed ({e}); " + "; ".join(restore_errors)
+                        ) from e
+                    raise
+                _wipe_memory_sidecars()
                 return {"status": "deleted", "kind": kind, "count": count}
 
             if kind == "skills":
@@ -165,6 +180,7 @@ def setup_admin_wipe_routes(session_manager):
 
             raise HTTPException(400, f"Unknown wipe kind: {kind!r}")
         except HTTPException:
+            db.rollback()
             raise
         except Exception as e:
             db.rollback()

--- a/routes/backup_routes.py
+++ b/routes/backup_routes.py
@@ -2,15 +2,250 @@
 
 import json
 import logging
-from datetime import datetime
+import uuid
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, HTTPException, Request, Response
 from core.middleware import require_admin
+from core.database import (
+    SessionLocal,
+    CalendarCal,
+    CalendarEvent,
+    ScheduledTask,
+    TaskRun,
+    Note,
+)
 from services.memory import MemoryStoreUnreadable
 from src.auth_helpers import get_current_user
 from src.settings import load_settings, save_settings, load_features, save_features
 
 logger = logging.getLogger(__name__)
+
+BACKUP_VERSION = 2
+
+_CALENDAR_FIELDS = (
+    "id", "name", "color", "source", "account_id", "caldav_base_url",
+)
+_EVENT_FIELDS = (
+    "uid", "calendar_id", "summary", "description", "location", "dtstart",
+    "dtend", "all_day", "is_utc", "rrule", "recurrence_exdates", "color",
+    "status", "importance", "event_type", "last_pinged", "origin",
+    "remote_href", "remote_etag", "caldav_sync_pending",
+)
+_TASK_FIELDS = (
+    "id", "name", "prompt", "task_type", "action", "schedule",
+    "scheduled_time", "scheduled_day", "scheduled_date", "trigger_type",
+    "trigger_event", "trigger_count", "trigger_counter", "next_run",
+    "last_run", "status", "output_target", "model",
+    "endpoint_url", "run_count", "cron_expression", "then_task_id",
+    "max_steps", "email_results", "notifications_enabled",
+)
+_TASK_RUN_FIELDS = (
+    "id", "task_id", "started_at", "finished_at", "status", "result",
+    "error", "tokens_used", "steps", "model",
+)
+_NOTE_FIELDS = (
+    "id", "title", "content", "items", "note_type", "color", "label",
+    "pinned", "archived", "due_date", "source", "sort_order", "repeat",
+    "ai_classification", "ai_content_hash",
+)
+_DATETIME_FIELDS = {
+    "dtstart", "dtend", "last_pinged", "scheduled_date", "next_run",
+    "last_run", "started_at", "finished_at",
+}
+
+
+def _serialize_row(row, fields):
+    out = {}
+    for field in fields:
+        value = getattr(row, field, None)
+        out[field] = value.isoformat() if isinstance(value, datetime) else value
+    return out
+
+
+def _coerce_value(field, value):
+    if field not in _DATETIME_FIELDS or value in (None, ""):
+        return value
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be an ISO datetime")
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is not None:
+        parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+    return parsed
+
+
+def _has_timezone_offset(value) -> bool:
+    """Return whether an imported ISO datetime carries timezone meaning."""
+    if not isinstance(value, str):
+        return False
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return parsed.tzinfo is not None and parsed.utcoffset() is not None
+
+
+def _assign_fields(row, payload, fields):
+    for field in fields:
+        if field in {"id", "uid", "calendar_id", "task_id", "then_task_id"}:
+            continue
+        if field in payload:
+            setattr(row, field, _coerce_value(field, payload[field]))
+
+
+def _new_id() -> str:
+    return str(uuid.uuid4())
+
+
+def _restore_database_domains(db, body, owner) -> list[str]:
+    """Merge v2 calendar/task/note data without crossing owner boundaries."""
+    restored = []
+
+    calendar_payload = body.get("calendar")
+    if isinstance(calendar_payload, dict):
+        calendar_map = {}
+        calendar_rows = calendar_payload.get("calendars")
+        for payload in calendar_rows if isinstance(calendar_rows, list) else []:
+            if not isinstance(payload, dict) or not payload.get("id") or not payload.get("name"):
+                continue
+            source_id = str(payload["id"])
+            existing = db.query(CalendarCal).filter(CalendarCal.id == source_id).first()
+            if existing is not None and existing.owner != owner:
+                target_id = _new_id()
+                existing = None
+            else:
+                target_id = source_id
+            row = existing or CalendarCal(id=target_id, owner=owner, name=str(payload["name"]))
+            if existing is None:
+                db.add(row)
+            row.owner = owner
+            _assign_fields(row, payload, _CALENDAR_FIELDS)
+            # JSON backup is portable user data, not a credential/config
+            # backup. Imported calendars are local until the owner explicitly
+            # configures and syncs a CalDAV account again.
+            row.source = "local"
+            row.account_id = None
+            row.caldav_base_url = None
+            calendar_map[source_id] = target_id
+
+        event_rows = calendar_payload.get("events")
+        event_count = 0
+        for payload in event_rows if isinstance(event_rows, list) else []:
+            if not isinstance(payload, dict):
+                continue
+            source_uid = str(payload.get("uid") or "")
+            target_calendar = calendar_map.get(str(payload.get("calendar_id") or ""))
+            if not source_uid or not target_calendar:
+                continue
+            existing = db.query(CalendarEvent).filter(CalendarEvent.uid == source_uid).first()
+            if existing is not None and existing.calendar_id != target_calendar:
+                source_uid = _new_id()
+                existing = None
+            row = existing or CalendarEvent(uid=source_uid, calendar_id=target_calendar)
+            if existing is None:
+                db.add(row)
+            row.calendar_id = target_calendar
+            _assign_fields(row, payload, _EVENT_FIELDS)
+            # Aware timestamps are normalized to naive UTC for SQLite by
+            # _coerce_value().  Keep the companion semantic flag aligned so
+            # readers do not reinterpret that UTC wall time as legacy local
+            # time, even if an imported payload omitted or cleared is_utc.
+            if any(_has_timezone_offset(payload.get(field)) for field in ("dtstart", "dtend")):
+                row.is_utc = True
+            row.origin = None
+            row.remote_href = None
+            row.remote_etag = None
+            row.caldav_sync_pending = None
+            event_count += 1
+        restored.append(f"{len(calendar_map)} calendars, {event_count} events")
+
+    task_payload = body.get("tasks")
+    if isinstance(task_payload, dict):
+        task_map = {}
+        deferred_links = []
+        task_rows = task_payload.get("scheduled")
+        for payload in task_rows if isinstance(task_rows, list) else []:
+            if not isinstance(payload, dict) or not payload.get("id"):
+                continue
+            source_id = str(payload["id"])
+            existing = db.query(ScheduledTask).filter(ScheduledTask.id == source_id).first()
+            if existing is not None and existing.owner != owner:
+                target_id = _new_id()
+                existing = None
+            else:
+                target_id = source_id
+            row = existing or ScheduledTask(id=target_id, owner=owner)
+            if existing is None:
+                db.add(row)
+            row.owner = owner
+            _assign_fields(row, payload, _TASK_FIELDS)
+            # Sessions, crew members, and characters are outside this backup
+            # domain and are not remapped. Never bind a portable task to a
+            # live row merely because its source ID exists in this instance.
+            row.session_id = None
+            row.crew_member_id = None
+            row.character_id = None
+            # Webhook tokens are path credentials and are intentionally not
+            # portable.  Clear a pre-existing same-owner token as well as
+            # leaving newly created tasks tokenless.
+            row.webhook_token = None
+            # Break any existing link until every imported task row exists.
+            # A forward reference otherwise autoflushes before its target has
+            # been inserted and violates the self-referential FK.
+            row.then_task_id = None
+            task_map[source_id] = target_id
+            deferred_links.append((row, payload.get("then_task_id")))
+
+        if task_map:
+            db.flush()
+        for row, source_then_id in deferred_links:
+            row.then_task_id = task_map.get(str(source_then_id)) if source_then_id else None
+        if deferred_links:
+            db.flush()
+
+        run_rows = task_payload.get("runs")
+        run_count = 0
+        for payload in run_rows if isinstance(run_rows, list) else []:
+            if not isinstance(payload, dict):
+                continue
+            source_id = str(payload.get("id") or "")
+            target_task = task_map.get(str(payload.get("task_id") or ""))
+            if not source_id or not target_task:
+                continue
+            existing = db.query(TaskRun).filter(TaskRun.id == source_id).first()
+            if existing is not None and existing.task_id != target_task:
+                source_id = _new_id()
+                existing = None
+            row = existing or TaskRun(id=source_id, task_id=target_task)
+            if existing is None:
+                db.add(row)
+            row.task_id = target_task
+            _assign_fields(row, payload, _TASK_RUN_FIELDS)
+            run_count += 1
+        restored.append(f"{len(task_map)} tasks, {run_count} task runs")
+
+    notes_payload = body.get("notes")
+    if isinstance(notes_payload, list):
+        note_count = 0
+        for payload in notes_payload:
+            if not isinstance(payload, dict) or not payload.get("id"):
+                continue
+            source_id = str(payload["id"])
+            existing = db.query(Note).filter(Note.id == source_id).first()
+            if existing is not None and existing.owner != owner:
+                source_id = _new_id()
+                existing = None
+            row = existing or Note(id=source_id, owner=owner)
+            if existing is None:
+                db.add(row)
+            row.owner = owner
+            _assign_fields(row, payload, _NOTE_FIELDS)
+            # Session/agent and upload IDs are not part of this format. Keep
+            # restored note text, but detach those non-portable references.
+            row.session_id = None
+            row.agent_session_id = None
+            row.image_url = None
+            note_count += 1
+        restored.append(f"{note_count} notes")
+
+    return restored
 
 
 def setup_backup_routes(
@@ -46,8 +281,28 @@ def setup_backup_routes(
         from routes.prefs_routes import _load_for_user
         preferences = _load_for_user(user)
 
+        db = SessionLocal()
+        try:
+            calendars = db.query(CalendarCal).filter(CalendarCal.owner == user).all()
+            calendar_ids = [calendar.id for calendar in calendars]
+            events = (
+                db.query(CalendarEvent)
+                .filter(CalendarEvent.calendar_id.in_(calendar_ids))
+                .all()
+                if calendar_ids else []
+            )
+            tasks = db.query(ScheduledTask).filter(ScheduledTask.owner == user).all()
+            task_ids = [task.id for task in tasks]
+            task_runs = (
+                db.query(TaskRun).filter(TaskRun.task_id.in_(task_ids)).all()
+                if task_ids else []
+            )
+            notes = db.query(Note).filter(Note.owner == user).all()
+        finally:
+            db.close()
+
         export_data = {
-            "version": 1,
+            "version": BACKUP_VERSION,
             "exported_at": datetime.now().isoformat(),
             "exported_by": user,
             "memories": memories,
@@ -56,6 +311,18 @@ def setup_backup_routes(
             "settings": settings,
             "features": features,
             "preferences": preferences,
+            "calendar": {
+                "calendars": [_serialize_row(row, _CALENDAR_FIELDS) for row in calendars],
+                "events": [_serialize_row(row, _EVENT_FIELDS) for row in events],
+            },
+            "tasks": {
+                "scheduled": [_serialize_row(row, _TASK_FIELDS) for row in tasks],
+                "runs": [_serialize_row(row, _TASK_RUN_FIELDS) for row in task_runs],
+                # Webhook path credentials are deliberately omitted. Restored
+                # tasks receive no imported token; regenerate it explicitly.
+                "webhook_tokens_included": False,
+            },
+            "notes": [_serialize_row(row, _NOTE_FIELDS) for row in notes],
         }
 
         filename = f"odysseus_backup_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
@@ -77,6 +344,10 @@ def setup_backup_routes(
 
         if not isinstance(body, dict):
             raise HTTPException(400, "Expected a JSON object")
+
+        version = body.get("version", 1)
+        if not isinstance(version, int) or version < 1 or version > BACKUP_VERSION:
+            raise HTTPException(400, f"Unsupported backup version: {version!r}")
 
         imported = []
 
@@ -260,6 +531,23 @@ def setup_backup_routes(
             current.update(body["preferences"])
             _save_for_user(user, current)
             imported.append("preferences")
+
+        # ── Calendar, tasks, task runs, notes (v2) ──
+        if any(key in body for key in ("calendar", "tasks", "notes")):
+            db = SessionLocal()
+            try:
+                restored = _restore_database_domains(db, body, user)
+                db.commit()
+            except (TypeError, ValueError) as e:
+                db.rollback()
+                raise HTTPException(400, f"Invalid v2 backup data: {e}")
+            except Exception:
+                db.rollback()
+                logger.exception("Database-domain backup import failed")
+                raise HTTPException(500, "Calendar/task/note import failed; nothing was committed")
+            finally:
+                db.close()
+            imported.extend(restored)
 
         if not imported:
             return {"ok": False, "message": "No recognized data found in the file"}

--- a/routes/backup_routes.py
+++ b/routes/backup_routes.py
@@ -13,7 +13,12 @@ from src.settings import load_settings, save_settings, load_features, save_featu
 logger = logging.getLogger(__name__)
 
 
-def setup_backup_routes(memory_manager, preset_manager, skills_manager) -> APIRouter:
+def setup_backup_routes(
+    memory_manager,
+    preset_manager,
+    skills_manager,
+    memory_vector=None,
+) -> APIRouter:
     router = APIRouter(tags=["backup"])
 
     @router.get("/api/export")
@@ -86,6 +91,7 @@ def setup_backup_routes(memory_manager, preset_manager, skills_manager) -> APIRo
                 raise HTTPException(
                     503, "Memory store is temporarily unreadable — nothing was imported."
                 )
+            original = list(existing)
             # Dedup against THIS user's own memories only. Using every tenant's
             # rows (load_all) meant a memory whose text matched any other
             # user's was silently skipped, so the importing user lost their own
@@ -104,7 +110,49 @@ def setup_backup_routes(memory_manager, preset_manager, skills_manager) -> APIRo
                 existing.append(mem)
                 existing_texts.add(mem["text"].strip().lower())
                 added += 1
+            if added and memory_vector is not None and not getattr(memory_vector, "healthy", False):
+                raise HTTPException(
+                    503,
+                    "Memory vector store is unavailable — nothing was imported.",
+                )
+
+            # Preserve the optional-vector route contract used by lightweight
+            # deployments and import callers.  Such callers still persist the
+            # authoritative JSON store; vector synchronization is performed
+            # only when a vector dependency was injected.
             memory_manager.save(existing)
+            try:
+                # The vector collection is shared by every owner. Rebuilding
+                # only the importing user's rows would erase every other
+                # tenant, so always use the complete persisted corpus.
+                if added and memory_vector is not None:
+                    memory_vector.rebuild(existing, strict=True)
+            except Exception as e:
+                logger.error("Memory vector rebuild failed; rolling back import: %s", e)
+                restore_errors = []
+                try:
+                    memory_manager.save(original)
+                except Exception as restore_error:
+                    restore_errors.append(f"JSON restore failed: {restore_error}")
+                try:
+                    memory_vector.rebuild(original, strict=True)
+                except Exception as restore_error:
+                    restore_errors.append(f"vector restore failed: {restore_error}")
+                if restore_errors:
+                    logger.critical(
+                        "Memory import compensation failed: %s",
+                        "; ".join(restore_errors),
+                    )
+                    detail = (
+                        "Memory vector rebuild failed and rollback was incomplete — "
+                        "persisted memory and vector state may be inconsistent."
+                    )
+                else:
+                    detail = "Memory vector rebuild failed — the import was rolled back."
+                raise HTTPException(
+                    503,
+                    detail,
+                )
             imported.append(f"{added} memories")
 
         # ── Skills ──

--- a/src/chat_processor.py
+++ b/src/chat_processor.py
@@ -203,11 +203,23 @@ class ChatProcessor:
             return score
 
         # ── Score all candidates ──
-        has_vector = self.memory_vector and self.memory_vector.healthy
+        has_vector = bool(self.memory_vector and self.memory_vector.healthy)
         vector_scores = {}
 
         if has_vector:
-            results = self.memory_vector.search(message, k=min(k * 3, 20))
+            try:
+                search_with_status = getattr(self.memory_vector, "search_with_status", None)
+                if callable(search_with_status):
+                    results, has_vector = search_with_status(
+                        message,
+                        k=min(k * 3, 20),
+                    )
+                else:
+                    results = self.memory_vector.search(message, k=min(k * 3, 20))
+            except Exception as e:
+                logger.warning("Vector memory query failed; using keyword scoring: %s", e)
+                results = []
+                has_vector = False
             mem_by_id = {m["id"]: m for m in mem_entries}
             for r in results:
                 if r["memory_id"] in mem_by_id:

--- a/src/memory_vector.py
+++ b/src/memory_vector.py
@@ -7,6 +7,7 @@ Stores pre-computed embeddings (ChromaDB does not manage embedding).
 """
 
 import logging
+from pathlib import Path
 from typing import List, Dict, Optional
 
 from src.embedding_lanes import (
@@ -22,13 +23,24 @@ from src.embedding_lanes import (
 logger = logging.getLogger(__name__)
 
 
+def _is_missing_collection_error(error: Exception) -> bool:
+    """Return whether Chroma reported that the named collection is absent."""
+    error_type = type(error)
+    return (
+        error_type.__module__ == "chromadb.errors"
+        and error_type.__name__ in {"NotFoundError", "InvalidCollectionException"}
+    )
+
+
 class MemoryVectorStore:
     """Vector index over memory entries for semantic retrieval."""
 
     COLLECTION_NAME = "odysseus_memories"
+    REBUILD_MARKER = ".memory-vector-rebuild-required"
 
     def __init__(self, data_dir: str, embedding_model=None):
         self._model = embedding_model
+        self._rebuild_marker = Path(data_dir) / self.REBUILD_MARKER
         self._collection = None
         self._lanes = []
         self._healthy = False
@@ -37,6 +49,16 @@ class MemoryVectorStore:
 
     def _initialize(self):
         try:
+            if self._rebuild_marker.exists():
+                # A previous rebuild did not finish durably. Never adopt its
+                # non-empty collections as authoritative merely because they
+                # survived a process restart. Reset them so startup sees an
+                # empty index and rebuilds from the JSON source of truth.
+                logger.warning("Discarding incomplete memory-vector rebuild")
+                self._replace_collections()
+                self._clear_rebuild_marker()
+                return
+
             self._lanes = build_embedding_lanes(self.COLLECTION_NAME)
             if not self._lanes:
                 raise RuntimeError("No embedding lanes available")
@@ -54,7 +76,30 @@ class MemoryVectorStore:
             )
 
         except Exception as e:
+            self._healthy = False
+            self._lanes = []
+            self._collection = None
             logger.error(f"MemoryVectorStore init failed: {e}")
+
+    def _mark_rebuild_incomplete(self) -> None:
+        """Durably poison collections until a complete rebuild is committed."""
+        self._rebuild_marker.write_text("rebuild required\n", encoding="utf-8")
+
+    def _clear_rebuild_marker(self) -> None:
+        self._rebuild_marker.unlink(missing_ok=True)
+
+    def _delete_collection_names(self, names) -> None:
+        """Delete named collections, ignoring only explicit not-found errors."""
+        from src.chroma_client import get_chroma_client
+
+        client = get_chroma_client()
+        for name in names:
+            try:
+                client.delete_collection(name)
+            except Exception as e:
+                if _is_missing_collection_error(e):
+                    continue
+                raise
 
     @property
     def healthy(self) -> bool:
@@ -129,27 +174,31 @@ class MemoryVectorStore:
             except Exception as e:
                 logger.warning(f"memory remove {memory_id}: {e}")
 
-    def search(self, query: str, k: int = 8) -> List[Dict]:
+    def search_with_status(self, query: str, k: int = 8) -> tuple[List[Dict], bool]:
         """Search for the most relevant memory IDs by semantic similarity.
-        Returns list of {"memory_id": str, "score": float}.
+        Return ``(results, query_healthy)`` so callers can distinguish a real
+        empty result from a runtime vector outage.
 
         ChromaDB cosine distance = 1 - cosine_similarity.
         We convert back: similarity = 1.0 - distance.
         """
-        if not self._healthy or self.count() == 0:
-            return []
+        if not self._healthy:
+            return [], False
 
         out = []
+        successful_lane = False
         lane_priority = {LANE_CUSTOM: 0, LANE_FASTEMBED: 1}
         for lane in self._lanes:
             try:
                 if lane.count() == 0:
+                    successful_lane = True
                     continue
                 results = lane.collection.query(
                     query_embeddings=lane.encode([query]),
                     n_results=min(k, lane.count()),
                     include=["distances"],
                 )
+                successful_lane = True
                 for idx, mid in enumerate(results["ids"][0]):
                     distance = results["distances"][0][idx]
                     out.append({
@@ -160,7 +209,12 @@ class MemoryVectorStore:
             except Exception as e:
                 logger.warning("memory search failed in %s lane: %s", lane.name, e)
         out.sort(key=lambda row: (-row["score"], lane_priority.get(row["embedding_lane"], 99)))
-        return dedupe_results(out, id_key="memory_id", limit=k)
+        return dedupe_results(out, id_key="memory_id", limit=k), successful_lane
+
+    def search(self, query: str, k: int = 8) -> List[Dict]:
+        """Compatibility search API returning only result rows."""
+        results, _query_healthy = self.search_with_status(query, k=k)
+        return results
 
     def find_similar(self, text: str, threshold: float = 0.92) -> Optional[str]:
         """Check if a near-duplicate exists. Returns memory_id if found, else None."""
@@ -185,32 +239,61 @@ class MemoryVectorStore:
                 logger.warning("memory similarity search failed in %s lane: %s", lane.name, e)
         return None
 
-    def rebuild(self, memories: List[Dict]):
-        """Rebuild the entire index from a list of memory entries.
-        Each entry must have 'id' and 'text' keys."""
-        if not self._healthy:
-            return
-
-        from src.chroma_client import get_chroma_client
-
-        client = get_chroma_client()
-        lane_names = [
+    def _replace_collections(self) -> None:
+        """Delete every memory-vector collection and create fresh lanes."""
+        names = {
             self.COLLECTION_NAME,
             collection_name(self.COLLECTION_NAME, LANE_CUSTOM),
             collection_name(self.COLLECTION_NAME, LANE_FASTEMBED),
-        ]
-        for name in lane_names:
-            try:
-                client.delete_collection(name)
-            except Exception:
-                pass
-        # Explicit rebuilds must start from the supplied memory list, so clear
-        # legacy unsuffixed collections too.
+        }
+        # Older Chroma clients and the repository's supported lightweight
+        # client contract do not expose ``list_collections``.  The collection
+        # names are deterministic, so deleting each known name is both more
+        # compatible and sufficient to prevent a stale inactive lane (or the
+        # legacy collection) from being migrated back into a rebuild.
+        self._delete_collection_names(names)
+
         self._lanes = build_embedding_lanes(self.COLLECTION_NAME)
+        if not self._lanes:
+            self._healthy = False
+            self._collection = None
+            raise RuntimeError("No embedding lanes available after memory-vector reset")
         self._collection = next(
             (lane.collection for lane in self._lanes if lane.name == LANE_FASTEMBED),
-            self._lanes[0].collection if self._lanes else None,
+            self._lanes[0].collection,
         )
+        self._healthy = True
+
+    def clear(self, *, strict: bool = False) -> bool:
+        """Clear all memory vectors.
+
+        ``strict=True`` is used by persistence transactions: failures propagate
+        so SQL/JSON state is not committed while stale vectors remain.
+        """
+        try:
+            self._replace_collections()
+            return True
+        except Exception as e:
+            self._healthy = False
+            logger.error("memory vector clear failed: %s", e)
+            if strict:
+                raise
+            return False
+
+    def rebuild(self, memories: List[Dict], *, strict: bool = False) -> bool:
+        """Rebuild the entire index from a list of memory entries.
+        Each entry must have 'id' and 'text' keys."""
+        try:
+            # Set this before mutating Chroma. A crash, strict exception, or
+            # failed cleanup must remain visible to the next process.
+            self._mark_rebuild_incomplete()
+            self._replace_collections()
+        except Exception as e:
+            self._healthy = False
+            logger.error("memory rebuild reset failed: %s", e)
+            if strict:
+                raise
+            return False
 
         texts = []
         ids = []
@@ -224,6 +307,7 @@ class MemoryVectorStore:
         if texts:
             # Batch in chunks of 100 to avoid oversized requests
             failed_lanes = set()
+            primary_error = None
             for i in range(0, len(texts), 100):
                 batch_texts = texts[i:i + 100]
                 batch_ids = ids[i:i + 100]
@@ -240,8 +324,82 @@ class MemoryVectorStore:
                     except Exception as e:
                         failed_lanes.add(lane.name)
                         logger.warning("memory rebuild failed in %s lane: %s", lane.name, e)
+                        if strict:
+                            primary_error = e
+                            break
+                if primary_error is not None:
+                    break
+
+            if primary_error is not None:
+                # Strict mode remains fail-fast, but first make every lane
+                # non-authoritative: each may contain earlier successful
+                # batches. Preserve the embedding/write exception even if
+                # best-effort cleanup also fails; the marker then protects the
+                # next process from adopting the residue.
+                all_names = {
+                    collection_name(self.COLLECTION_NAME, lane.name)
+                    for lane in self._lanes
+                }
+                self._healthy = False
+                self._lanes = []
+                self._collection = None
+                try:
+                    self._delete_collection_names(all_names)
+                except Exception as cleanup_error:
+                    logger.error(
+                        "memory rebuild cleanup failed after %s: %s",
+                        primary_error,
+                        cleanup_error,
+                    )
+                else:
+                    try:
+                        self._clear_rebuild_marker()
+                    except Exception as marker_error:
+                        logger.error("memory rebuild marker cleanup failed: %s", marker_error)
+                raise primary_error
+
+            if failed_lanes:
+                # A non-strict lifecycle rebuild may degrade to any lane that
+                # was rebuilt completely.  Exclude failed/partially populated
+                # lanes and delete their durable collections so a restart
+                # cannot mix incomplete state back in.
+                surviving_lanes = [
+                    lane for lane in self._lanes if lane.name not in failed_lanes
+                ]
+                failed_names = {
+                    collection_name(self.COLLECTION_NAME, name)
+                    for name in failed_lanes
+                }
+                try:
+                    self._delete_collection_names(failed_names)
+                except Exception as cleanup_error:
+                    logger.error("memory rebuild partial-lane cleanup failed: %s", cleanup_error)
+                    self._lanes = []
+                    self._collection = None
+                    self._healthy = False
+                    return False
+                self._lanes = surviving_lanes
+                self._collection = next(
+                    (lane.collection for lane in self._lanes if lane.name == LANE_FASTEMBED),
+                    self._lanes[0].collection if self._lanes else None,
+                )
+                self._healthy = bool(self._lanes)
+
+        try:
+            self._clear_rebuild_marker()
+        except Exception as e:
+            # The index may be complete in this process, but leaving a durable
+            # poison marker means it cannot be treated as committed.
+            self._healthy = False
+            self._lanes = []
+            self._collection = None
+            logger.error("memory rebuild marker cleanup failed: %s", e)
+            if strict:
+                raise
+            return False
 
         logger.info(f"MemoryVectorStore rebuilt with {len(ids)} entries across {len(self._lanes)} lanes")
+        return self._healthy
 
     def get_stats(self) -> Dict:
         return {

--- a/tests/test_backup_v2_database_domains.py
+++ b/tests/test_backup_v2_database_domains.py
@@ -1,0 +1,238 @@
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from core.database import (
+    Base,
+    CalendarCal,
+    CalendarEvent,
+    Note,
+    ScheduledTask,
+    Session,
+    TaskRun,
+)
+from routes.backup_routes import BACKUP_VERSION, _restore_database_domains, _serialize_row
+
+
+_SCOPE_PARAGRAPH = (
+    "The Settings JSON export is a separate, mixed-scope portability format. Its version 2 shape includes memories, "
+    "skills, presets, settings, preferences, calendars and events, scheduled tasks and run history, and notes. "
+    "Memories, skills, preferences, calendars, tasks, and notes are selected for the current owner during export. "
+    "Imported version 2 calendar, task, and note rows are stamped with the current owner, and primary-key collisions "
+    "are remapped rather than overwriting another user's rows. Presets are shared across users, while settings and "
+    "feature flags are instance-global; those sections remain shared/global rather than becoming owner-scoped. Task "
+    "webhook tokens are intentionally excluded and must be regenerated after restore. References to chat/agent "
+    "sessions, crew members, characters, and note upload images are detached because those domains are not part of "
+    "the JSON format. Imported CalDAV calendars/events become local rows; reconnect and sync the account explicitly "
+    "instead of reusing remote hrefs or pending-write markers from another instance."
+)
+_VERSION_1_PARAGRAPH = (
+    "Version 1 JSON exports remain importable; they simply do not contain the newer calendar/task/note sections. "
+    "The commands below describe full on-disk instance snapshots, which serve a different disaster-recovery use case."
+)
+
+
+def _session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    return sessionmaker(bind=engine)()
+
+
+def _assert_backup_docs_paragraph_layout(docs):
+    lines = docs.splitlines()
+
+    assert [line for line in lines if line.startswith("The Settings JSON export")] == [_SCOPE_PARAGRAPH]
+    assert [line for line in lines if line.startswith("Version 1 JSON exports")] == [_VERSION_1_PARAGRAPH]
+
+
+def test_backup_docs_describe_mixed_scope_contract():
+    docs = Path("docs/backup-restore.md").read_text(encoding="utf-8")
+
+    _assert_backup_docs_paragraph_layout(docs)
+
+
+@pytest.mark.parametrize(
+    ("paragraph", "late_sentence"),
+    (
+        (_SCOPE_PARAGRAPH, "Imported CalDAV calendars/events become local rows"),
+        (_VERSION_1_PARAGRAPH, "The commands below describe full on-disk instance snapshots"),
+    ),
+)
+def test_backup_docs_paragraph_layout_rejects_inserted_newline(paragraph, late_sentence):
+    docs = Path("docs/backup-restore.md").read_text(encoding="utf-8")
+    wrapped_docs = docs.replace(paragraph, paragraph.replace(late_sentence, f"\n{late_sentence}", 1), 1)
+
+    with pytest.raises(AssertionError):
+        _assert_backup_docs_paragraph_layout(wrapped_docs)
+
+
+def test_v2_restore_remaps_cross_owner_ids_and_preserves_relationships(monkeypatch):
+    db = _session()
+    db.add(CalendarCal(id="calendar-1", owner="bob", name="Bob"))
+    db.add(Note(id="note-1", owner="bob", title="Bob"))
+    db.add(Session(
+        id="bob-session",
+        owner="bob",
+        name="Bob chat",
+        endpoint_url="http://localhost:11434/v1/chat/completions",
+        model="bob-model",
+    ))
+    db.commit()
+    generated_ids = iter(("alice-calendar", "alice-note"))
+    monkeypatch.setattr(
+        "routes.backup_routes._new_id",
+        lambda: next(generated_ids),
+    )
+
+    body = {
+        "version": BACKUP_VERSION,
+        "calendar": {
+            "calendars": [{
+                "id": "calendar-1",
+                "name": "Alice",
+                "source": "caldav",
+                "account_id": "missing-account",
+                "caldav_base_url": "https://calendar.example/alice/",
+            }],
+            "events": [{
+                "uid": "event-1",
+                "calendar_id": "calendar-1",
+                "summary": "Standup",
+                "dtstart": "2026-08-06T08:00:00",
+                "dtend": "2026-08-06T08:30:00",
+                "origin": "caldav",
+                "remote_href": "https://calendar.example/alice/event-1.ics",
+                "caldav_sync_pending": "update",
+            }],
+        },
+        "tasks": {
+            "scheduled": [
+                {
+                    "id": "task-1",
+                    "name": "First",
+                    "then_task_id": "task-2",
+                    "session_id": "bob-session",
+                    "crew_member_id": "bob-crew",
+                    "character_id": "bob-character",
+                },
+                {"id": "task-2", "name": "Second"},
+            ],
+            "runs": [{
+                "id": "run-1",
+                "task_id": "task-1",
+                "started_at": "2026-08-06T09:00:00",
+                "status": "success",
+            }],
+        },
+        "notes": [{
+            "id": "note-1",
+            "title": "Alice",
+            "content": "restored",
+            "session_id": "bob-session",
+            "agent_session_id": "bob-session",
+            "image_url": "/api/uploads/bob-image",
+        }],
+    }
+
+    restored = _restore_database_domains(db, body, "alice")
+    db.commit()
+
+    assert restored == ["1 calendars, 1 events", "2 tasks, 1 task runs", "1 notes"]
+    alice_calendar = db.query(CalendarCal).filter(CalendarCal.owner == "alice").one()
+    assert alice_calendar.id != "calendar-1"
+    assert alice_calendar.source == "local"
+    assert alice_calendar.account_id is None
+    assert alice_calendar.caldav_base_url is None
+    event = db.query(CalendarEvent).filter(CalendarEvent.uid == "event-1").one()
+    assert event.calendar_id == alice_calendar.id
+    assert event.origin is None
+    assert event.remote_href is None
+    assert event.caldav_sync_pending is None
+    first = db.query(ScheduledTask).filter(ScheduledTask.id == "task-1").one()
+    assert first.then_task_id == "task-2"
+    assert first.webhook_token is None
+    assert first.session_id is None
+    assert first.crew_member_id is None
+    assert first.character_id is None
+    assert db.query(TaskRun).filter(TaskRun.id == "run-1").one().task_id == "task-1"
+    alice_note = db.query(Note).filter(Note.owner == "alice").one()
+    assert alice_note.id != "note-1"
+    assert alice_note.session_id is None
+    assert alice_note.agent_session_id is None
+    assert alice_note.image_url is None
+    assert db.query(Note).filter(Note.owner == "bob", Note.id == "note-1").one().title == "Bob"
+
+
+def test_v2_serialization_emits_iso_datetimes():
+    event = CalendarEvent(
+        uid="event-1",
+        calendar_id="calendar-1",
+        summary="Standup",
+        dtstart=datetime(2026, 8, 6, 8, 0),
+        dtend=datetime(2026, 8, 6, 8, 30),
+    )
+
+    payload = _serialize_row(event, ("uid", "dtstart", "dtend"))
+
+    assert payload == {
+        "uid": "event-1",
+        "dtstart": "2026-08-06T08:00:00",
+        "dtend": "2026-08-06T08:30:00",
+    }
+
+
+def test_v2_restore_clears_existing_same_owner_task_webhook_token():
+    db = _session()
+    db.add(ScheduledTask(
+        id="task-1",
+        owner="alice",
+        name="Existing webhook task",
+        trigger_type="webhook",
+        webhook_token="live-secret-path-token",
+    ))
+    db.commit()
+
+    _restore_database_domains(db, {
+        "version": BACKUP_VERSION,
+        "tasks": {
+            "scheduled": [{
+                "id": "task-1",
+                "name": "Restored webhook task",
+                "trigger_type": "webhook",
+            }],
+            "runs": [],
+        },
+    }, "alice")
+    db.commit()
+
+    task = db.query(ScheduledTask).filter(ScheduledTask.id == "task-1").one()
+    assert task.name == "Restored webhook task"
+    assert task.webhook_token is None
+
+
+def test_v2_restore_marks_offset_datetimes_as_normalized_utc():
+    db = _session()
+
+    _restore_database_domains(db, {
+        "version": BACKUP_VERSION,
+        "calendar": {
+            "calendars": [{"id": "calendar-1", "name": "Alice"}],
+            "events": [{
+                "uid": "event-1",
+                "calendar_id": "calendar-1",
+                "summary": "Offset meeting",
+                "dtstart": "2026-08-06T10:00:00+02:00",
+                "dtend": "2026-08-06T10:30:00+02:00",
+                "is_utc": False,
+            }],
+        },
+    }, "alice")
+    db.commit()
+
+    event = db.query(CalendarEvent).filter(CalendarEvent.uid == "event-1").one()
+    assert event.dtstart == datetime(2026, 8, 6, 8, 0)
+    assert event.dtend == datetime(2026, 8, 6, 8, 30)
+    assert event.is_utc is True

--- a/tests/test_embedding_lanes_memory.py
+++ b/tests/test_embedding_lanes_memory.py
@@ -1,3 +1,5 @@
+import pytest
+
 from src.embedding_lanes import (
     EmbeddingLane,
     LANE_CUSTOM,
@@ -91,7 +93,7 @@ def test_memory_search_merges_fallback_only_results_before_limit():
     assert [row["memory_id"] for row in results] == ["fallback-only", "old-1"]
 
 
-def test_memory_rebuild_does_not_reimport_legacy_collection(monkeypatch):
+def test_memory_rebuild_does_not_reimport_legacy_collection(monkeypatch, tmp_path):
     fake = FakeChroma()
     legacy = fake.get_or_create_collection("odysseus_memories", metadata={"hnsw:space": "cosine"})
     legacy.add(
@@ -116,7 +118,7 @@ def test_memory_rebuild_does_not_reimport_legacy_collection(monkeypatch):
 
     from src.memory_vector import MemoryVectorStore
 
-    store = MemoryVectorStore("data")
+    store = MemoryVectorStore(tmp_path)
     assert fake.collections["odysseus_memories_fastembed"].count() == 1
 
     store.rebuild([{"id": "current-memory", "text": "current rebuilt memory"}])
@@ -168,7 +170,7 @@ def test_memory_remove_deletes_inactive_lane_collection(monkeypatch):
     assert fast_collection.count() == 0
 
 
-def test_memory_rebuild_continues_when_custom_lane_fails(monkeypatch):
+def test_memory_rebuild_continues_when_custom_lane_fails(monkeypatch, tmp_path):
     fake = FakeChroma()
     patch_chroma(monkeypatch, fake)
 
@@ -179,9 +181,44 @@ def test_memory_rebuild_continues_when_custom_lane_fails(monkeypatch):
 
     from src.memory_vector import MemoryVectorStore
 
-    store = MemoryVectorStore("data")
-    store.rebuild([{"id": "current-memory", "text": "current rebuilt memory"}])
+    store = MemoryVectorStore(tmp_path)
+    rebuilt = store.rebuild([{"id": "current-memory", "text": "current rebuilt memory"}])
 
-    assert fake.collections["odysseus_memories_custom"].count() == 0
+    assert "odysseus_memories_custom" not in fake.collections
     assert fake.collections["odysseus_memories_fastembed"].count() == 1
     assert fake.collections["odysseus_memories_fastembed"].get()["ids"] == ["current-memory"]
+    assert rebuilt is True
+    assert store.healthy is True
+    results, query_healthy = store.search_with_status("current rebuilt memory")
+    assert query_healthy is True
+    assert results[0]["memory_id"] == "current-memory"
+    assert results[0]["embedding_lane"] == LANE_FASTEMBED
+
+    restarted = MemoryVectorStore(tmp_path)
+    assert restarted.healthy is True
+    assert restarted.count() == 1
+    restarted_results, restarted_healthy = restarted.search_with_status("current rebuilt memory")
+    assert restarted_healthy is True
+    assert restarted_results[0]["memory_id"] == "current-memory"
+    assert restarted_results[0]["embedding_lane"] == LANE_FASTEMBED
+
+
+def test_memory_strict_rebuild_propagates_custom_lane_failure(monkeypatch, tmp_path):
+    fake = FakeChroma()
+    patch_chroma(monkeypatch, fake)
+
+    import src.embedding_lanes as lanes
+
+    monkeypatch.setattr(lanes, "_build_custom_client", lambda: FailingEmbedder(768, "nomic", "http://embeddings/v1"))
+    monkeypatch.setattr(lanes, "_build_fastembed_client", lambda: FakeEmbedder(384, "mini", "local://fastembed"))
+
+    from src.memory_vector import MemoryVectorStore
+
+    store = MemoryVectorStore(tmp_path)
+
+    with pytest.raises(RuntimeError, match="embedding endpoint rate limited"):
+        store.rebuild([{"id": "current-memory", "text": "current rebuilt memory"}], strict=True)
+
+    assert store.healthy is False
+    assert "odysseus_memories_custom" not in fake.collections
+    assert "odysseus_memories_fastembed" not in fake.collections

--- a/tests/test_memory_vector_lifecycle.py
+++ b/tests/test_memory_vector_lifecycle.py
@@ -1,0 +1,421 @@
+import asyncio
+import time
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from routes import backup_routes
+from routes.admin_wipe import admin_wipe_routes
+import src.chroma_client as chroma_client
+import src.memory_vector as memory_vector
+from src.chat_processor import ChatProcessor
+from src.memory_vector import MemoryVectorStore
+
+
+class _BrokenLane:
+    name = "broken"
+
+    def count(self):
+        raise RuntimeError("chroma offline")
+
+
+def test_vector_query_reports_a_per_call_outage():
+    store = MemoryVectorStore.__new__(MemoryVectorStore)
+    store._healthy = True
+    store._lanes = [_BrokenLane()]
+
+    rows, query_healthy = store.search_with_status("alpha", k=5)
+
+    assert rows == []
+    assert query_healthy is False
+    assert store.healthy is True  # startup state did not predict this call
+
+
+def test_chat_switches_to_keyword_weights_for_failed_vector_call():
+    vector = SimpleNamespace(
+        healthy=True,
+        search_with_status=lambda query, k: ([], False),
+    )
+    processor = ChatProcessor(None, None, memory_vector=vector)
+    memory = {
+        "id": "m1",
+        "text": "alpha beta",
+        "timestamp": time.time(),
+        "category": "fact",
+    }
+
+    assert processor._hybrid_retrieve("alpha beta", [memory], k=1) == [memory]
+
+    healthy_empty = SimpleNamespace(
+        healthy=True,
+        search_with_status=lambda query, k: ([], True),
+    )
+    processor.memory_vector = healthy_empty
+    assert processor._hybrid_retrieve("alpha beta", [memory], k=1) == []
+
+
+class _MemoryManager:
+    def __init__(self, rows):
+        self.rows = list(rows)
+        self.saves = []
+
+    def load_all_for_update(self):
+        return list(self.rows)
+
+    def save(self, rows):
+        self.rows = list(rows)
+        self.saves.append(list(rows))
+
+
+class _Vector:
+    healthy = True
+
+    def __init__(self, events=None, fail_clear=False):
+        self.rebuilds = []
+        self.events = events
+        self.fail_clear = fail_clear
+
+    def rebuild(self, rows, *, strict=False):
+        assert strict is True
+        self.rebuilds.append(list(rows))
+
+    def clear(self, *, strict=False):
+        assert strict is True
+        if self.events is not None:
+            self.events.append("vector_clear")
+        if self.fail_clear:
+            raise RuntimeError("partial vector clear")
+
+
+class _AlwaysFailingVector(_Vector):
+    def rebuild(self, rows, *, strict=False):
+        assert strict is True
+        self.rebuilds.append(list(rows))
+        raise RuntimeError("vector rebuild unavailable")
+
+
+class _Request:
+    def __init__(self, payload):
+        self._payload = payload
+
+    async def json(self):
+        return self._payload
+
+
+def _endpoint(router, path):
+    return next(route.endpoint for route in router.routes if route.path == path)
+
+
+def test_backup_import_rebuilds_the_complete_multi_user_corpus(monkeypatch):
+    manager = _MemoryManager([
+        {"id": "alice-old", "owner": "alice", "text": "alpha"},
+        {"id": "bob-old", "owner": "bob", "text": "beta"},
+    ])
+    vector = _Vector()
+    monkeypatch.setattr(backup_routes, "require_admin", lambda request: None)
+    monkeypatch.setattr(backup_routes, "get_current_user", lambda request: "alice")
+    router = backup_routes.setup_backup_routes(
+        manager,
+        SimpleNamespace(),
+        SimpleNamespace(),
+        memory_vector=vector,
+    )
+
+    result = asyncio.run(_endpoint(router, "/api/import")(
+        _Request({"memories": [{"id": "alice-new", "text": "gamma"}]})
+    ))
+
+    assert result["ok"] is True
+    assert {row["id"] for row in vector.rebuilds[-1]} == {
+        "alice-old",
+        "bob-old",
+        "alice-new",
+    }
+    assert next(row for row in vector.rebuilds[-1] if row["id"] == "alice-new")["owner"] == "alice"
+
+
+def test_backup_import_preserves_optional_vector_compatibility(monkeypatch):
+    manager = _MemoryManager([])
+    monkeypatch.setattr(backup_routes, "require_admin", lambda request: None)
+    monkeypatch.setattr(backup_routes, "get_current_user", lambda request: "alice")
+    router = backup_routes.setup_backup_routes(
+        manager,
+        SimpleNamespace(),
+        SimpleNamespace(),
+        memory_vector=None,
+    )
+
+    result = asyncio.run(_endpoint(router, "/api/import")(
+        _Request({"memories": [{"id": "alice-new", "text": "gamma"}]})
+    ))
+
+    assert result["ok"] is True
+    assert manager.rows == [{"id": "alice-new", "text": "gamma", "owner": "alice"}]
+
+
+def test_backup_import_reports_incomplete_vector_compensation(monkeypatch):
+    original = [{"id": "alice-old", "owner": "alice", "text": "alpha"}]
+    manager = _MemoryManager(original)
+    vector = _AlwaysFailingVector()
+    monkeypatch.setattr(backup_routes, "require_admin", lambda request: None)
+    monkeypatch.setattr(backup_routes, "get_current_user", lambda request: "alice")
+    router = backup_routes.setup_backup_routes(
+        manager,
+        SimpleNamespace(),
+        SimpleNamespace(),
+        memory_vector=vector,
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(_endpoint(router, "/api/import")(
+            _Request({"memories": [{"id": "alice-new", "text": "gamma"}]})
+        ))
+
+    assert exc.value.status_code == 503
+    assert "rollback was incomplete" in exc.value.detail
+    assert manager.rows == original
+    assert vector.rebuilds == [
+        original + [{"id": "alice-new", "text": "gamma", "owner": "alice"}],
+        original,
+    ]
+
+
+class _Query:
+    def __init__(self, events):
+        self.events = events
+
+    def count(self):
+        return 2
+
+    def delete(self):
+        self.events.append("sql_delete")
+
+
+class _Db:
+    def __init__(self, events, fail_commit=False):
+        self.events = events
+        self.fail_commit = fail_commit
+
+    def query(self, model):
+        return _Query(self.events)
+
+    def commit(self):
+        self.events.append("sql_commit")
+        if self.fail_commit:
+            raise RuntimeError("commit failed")
+
+    def rollback(self):
+        self.events.append("sql_rollback")
+
+    def close(self):
+        self.events.append("close")
+
+
+def test_admin_memory_wipe_clears_vectors_before_sql_commit(monkeypatch):
+    events = []
+    manager = _MemoryManager([
+        {"id": "alice", "owner": "alice", "text": "alpha"},
+        {"id": "bob", "owner": "bob", "text": "beta"},
+    ])
+    vector = _Vector(events)
+    monkeypatch.setattr(admin_wipe_routes, "SessionLocal", lambda: _Db(events))
+    monkeypatch.setattr(admin_wipe_routes, "require_admin", lambda request: None)
+    monkeypatch.setattr(admin_wipe_routes, "_wipe_memory_sidecars", lambda: None)
+    router = admin_wipe_routes.setup_admin_wipe_routes(
+        None,
+        memory_manager=manager,
+        memory_vector=vector,
+    )
+
+    _endpoint(router, "/api/admin/wipe/{kind}")("memory", SimpleNamespace())
+
+    assert events.index("vector_clear") < events.index("sql_commit")
+    assert manager.rows == []
+
+
+def test_admin_memory_wipe_restores_full_corpus_if_commit_fails(monkeypatch):
+    events = []
+    original = [
+        {"id": "alice", "owner": "alice", "text": "alpha"},
+        {"id": "bob", "owner": "bob", "text": "beta"},
+    ]
+    manager = _MemoryManager(original)
+    vector = _Vector(events)
+    monkeypatch.setattr(
+        admin_wipe_routes,
+        "SessionLocal",
+        lambda: _Db(events, fail_commit=True),
+    )
+    monkeypatch.setattr(admin_wipe_routes, "require_admin", lambda request: None)
+    router = admin_wipe_routes.setup_admin_wipe_routes(
+        None,
+        memory_manager=manager,
+        memory_vector=vector,
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        _endpoint(router, "/api/admin/wipe/{kind}")("memory", SimpleNamespace())
+
+    assert exc.value.status_code == 500
+    assert manager.rows == original
+    assert vector.rebuilds[-1] == original
+    assert "sql_rollback" in events
+
+
+def test_admin_memory_wipe_compensates_a_partial_vector_clear(monkeypatch):
+    events = []
+    original = [
+        {"id": "alice", "owner": "alice", "text": "alpha"},
+        {"id": "bob", "owner": "bob", "text": "beta"},
+    ]
+    manager = _MemoryManager(original)
+    vector = _Vector(events, fail_clear=True)
+    monkeypatch.setattr(admin_wipe_routes, "SessionLocal", lambda: _Db(events))
+    monkeypatch.setattr(admin_wipe_routes, "require_admin", lambda request: None)
+    router = admin_wipe_routes.setup_admin_wipe_routes(
+        None,
+        memory_manager=manager,
+        memory_vector=vector,
+    )
+
+    with pytest.raises(HTTPException):
+        _endpoint(router, "/api/admin/wipe/{kind}")("memory", SimpleNamespace())
+
+    assert "sql_commit" not in events
+    assert manager.rows == original
+    assert vector.rebuilds[-1] == original
+
+
+def test_rebuild_reset_failure_marks_store_unhealthy(monkeypatch, tmp_path):
+    store = MemoryVectorStore.__new__(MemoryVectorStore)
+    store._healthy = True
+    store._rebuild_marker = tmp_path / MemoryVectorStore.REBUILD_MARKER
+
+    def fail_reset():
+        raise RuntimeError("reset failed")
+
+    monkeypatch.setattr(store, "_replace_collections", fail_reset)
+
+    with pytest.raises(RuntimeError):
+        store.rebuild([], strict=True)
+
+    assert store.healthy is False
+
+
+class _FailSecondBatchEmbedder:
+    def __init__(self, dim):
+        self.dim = dim
+        self.calls = 0
+
+    def get_sentence_embedding_dimension(self):
+        return self.dim
+
+    def encode(self, texts, normalize_embeddings=True):
+        self.calls += 1
+        if self.calls == 2:
+            raise RuntimeError("second embedding batch failed")
+        return [[1.0] * self.dim for _ in texts]
+
+
+@pytest.mark.parametrize("strict", [False, True])
+def test_failed_later_batch_is_not_adopted_after_restart(monkeypatch, tmp_path, strict):
+    from tests.helpers.embedding_lanes import FakeChroma, patch_chroma
+    import src.embedding_lanes as lanes
+
+    fake = FakeChroma()
+    patch_chroma(monkeypatch, fake)
+    custom_clients = []
+    fast_clients = []
+
+    def custom_client():
+        client = _FailSecondBatchEmbedder(768)
+        custom_clients.append(client)
+        return client
+
+    def fast_client():
+        client = _FailSecondBatchEmbedder(384)
+        fast_clients.append(client)
+        return client
+
+    monkeypatch.setattr(lanes, "_build_custom_client", custom_client)
+    monkeypatch.setattr(lanes, "_build_fastembed_client", fast_client)
+    rows = [{"id": f"memory-{i}", "text": f"memory text {i}"} for i in range(101)]
+    store = MemoryVectorStore(tmp_path)
+
+    if strict:
+        with pytest.raises(RuntimeError, match="second embedding batch failed"):
+            store.rebuild(rows, strict=True)
+    else:
+        assert store.rebuild(rows) is False
+
+    assert store.healthy is False
+    assert store.count() == 0
+    assert "odysseus_memories_custom" not in fake.collections
+    assert "odysseus_memories_fastembed" not in fake.collections
+
+    restarted = MemoryVectorStore(tmp_path)
+
+    assert restarted.healthy is True
+    assert restarted.count() == 0
+    assert len(restarted._lanes) == 2
+    assert not (tmp_path / MemoryVectorStore.REBUILD_MARKER).exists()
+
+
+def test_strict_later_batch_preserves_primary_error_when_cleanup_fails(monkeypatch, tmp_path):
+    from tests.helpers.embedding_lanes import FakeChroma, patch_chroma
+    import src.embedding_lanes as lanes
+
+    fake = FakeChroma()
+    patch_chroma(monkeypatch, fake)
+    monkeypatch.setattr(lanes, "_build_custom_client", lambda: _FailSecondBatchEmbedder(768))
+    monkeypatch.setattr(lanes, "_build_fastembed_client", lambda: _FailSecondBatchEmbedder(384))
+    store = MemoryVectorStore(tmp_path)
+    original_delete = fake.delete_collection
+    delete_calls = 0
+
+    def fail_cleanup(name):
+        nonlocal delete_calls
+        delete_calls += 1
+        if delete_calls > 3:
+            raise RuntimeError("cleanup backend unavailable")
+        original_delete(name)
+
+    fake.delete_collection = fail_cleanup
+    rows = [{"id": f"memory-{i}", "text": f"memory text {i}"} for i in range(101)]
+
+    with pytest.raises(RuntimeError, match="second embedding batch failed"):
+        store.rebuild(rows, strict=True)
+
+    assert store.healthy is False
+    assert (tmp_path / MemoryVectorStore.REBUILD_MARKER).exists()
+    assert any(collection.count() == 100 for collection in fake.collections.values())
+
+    fake.delete_collection = original_delete
+    restarted = MemoryVectorStore(tmp_path)
+
+    assert restarted.healthy is True
+    assert restarted.count() == 0
+    assert not (tmp_path / MemoryVectorStore.REBUILD_MARKER).exists()
+
+
+def test_strict_clear_propagates_collection_delete_failure(monkeypatch):
+    class FailingClient:
+        def delete_collection(self, name):
+            raise RuntimeError(f"backend unavailable while deleting {name}")
+
+    store = MemoryVectorStore.__new__(MemoryVectorStore)
+    store._healthy = True
+    store._lanes = []
+    store._collection = None
+    monkeypatch.setattr(chroma_client, "get_chroma_client", lambda: FailingClient())
+    monkeypatch.setattr(
+        memory_vector,
+        "build_embedding_lanes",
+        lambda name: pytest.fail("reset must stop after a collection deletion failure"),
+    )
+
+    with pytest.raises(RuntimeError, match="backend unavailable while deleting"):
+        store.clear(strict=True)
+
+    assert store.healthy is False


### PR DESCRIPTION
## Summary

Version the mixed-scope Settings backup archive to include calendars, events, tasks, task runs, and notes while retaining import compatibility with version 1 archives. Memories, skills, preferences, calendars, tasks, and notes are selected for the current owner; imported version 2 calendar, task, and note records are stamped with that owner and colliding identifiers are remapped. Presets remain shared across users, while settings and feature flags remain instance-global. Imports also detach external or session-bound state, including webhook tokens, crew/character references, CalDAV remote identifiers, and note uploads. Event datetime normalization keeps timezone semantics consistent, and same-owner imports clear webhook tokens as well.

This change is intentionally stacked on the memory-vector lifecycle change in #5957 because both update backup routes. Review and merge that change first, then rebase this branch before merging.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #5947

Part of #4377

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

Automated backup and memory suites passed, but the Settings import/export flow has not yet been exercised in a live application against a large or migrated SQLite database.

## How to Test

1. Run `pytest -q tests/test_backup_v2_database_domains.py tests/test_memory_vector_lifecycle.py tests/test_embedding_lanes_memory.py tests/test_app_initializer_memory_vector_degraded.py`; the refreshed stacked head reports 28 passing tests.
2. Run the top-level backup and memory test modules together; the refreshed stacked head reports 115 passing tests.
3. Export a version 2 backup containing calendars, events, tasks, task runs, and notes, import it into a different owner, and verify identifier collisions are remapped and owner-scoped relationships remain intact while presets stay shared and settings/features stay instance-global.
4. Verify imported webhook tokens, session-bound references, CalDAV remote identifiers, and note uploads are detached, including a same-owner import.
5. Import a version 1 archive and confirm it remains accepted without the new domains.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

N/A — the change extends existing backup behavior without changing rendered UI files.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

N/A — no rendered UI files changed.
