### PR TITLE
fix(rag): let runtime adopt the recovered document store

### DIFF
--- a/routes/personal_routes.py
+++ b/routes/personal_routes.py
@@ -143,7 +143,10 @@ def setup_personal_routes(personal_docs_manager, rag_manager, rag_available):
 
     def _rag():
         """Get the current RAG manager, retrying init if needed."""
-        return get_rag_manager()
+        recovered = get_rag_manager()
+        if recovered is not None:
+            personal_docs_manager.rag_manager = recovered
+        return recovered
 
     def _resolve_allowed_personal_dir(directory: str) -> str:
         """Resolve a user-supplied personal-docs path under the allowed root."""

--- a/src/ai_interaction.py
+++ b/src/ai_interaction.py
@@ -67,6 +67,18 @@ def set_rag_manager(rag_mgr, personal_docs_mgr=None):
     _personal_docs_manager = personal_docs_mgr
 
 
+def _get_live_rag_manager():
+    """Resolve startup-degraded RAG through the shared personal-doc manager."""
+    global _rag_manager
+
+    get_rag = getattr(_personal_docs_manager, "get_rag_manager", None)
+    if callable(get_rag):
+        recovered = get_rag()
+        if recovered is not None:
+            _rag_manager = recovered
+    return _rag_manager
+
+
 # ---------------------------------------------------------------------------
 # Model resolution
 # ---------------------------------------------------------------------------
@@ -571,11 +583,12 @@ async def do_manage_rag(content: str, session_id: Optional[str] = None) -> Dict:
         if not os.path.isdir(directory):
             return {"error": f"Directory not found: {directory}"}
 
-        if not _rag_manager:
+        rag_manager = _get_live_rag_manager()
+        if not rag_manager:
             return {"error": "RAG manager not available"}
 
         try:
-            result = _rag_manager.index_personal_documents(directory)
+            result = rag_manager.index_personal_documents(directory)
             indexed = result.get("indexed", 0) if isinstance(result, dict) else 0
             return {"action": "add_directory", "directory": directory,
                     "results": f"Directory '{directory}' added to RAG index ({indexed} files indexed)"}

--- a/src/chat_processor.py
+++ b/src/chat_processor.py
@@ -361,7 +361,12 @@ class ChatProcessor:
         # RAG: search if enabled and rag_manager available, inject only above threshold
         if use_rag:
             try:
-                rag_manager = getattr(self.personal_docs_manager, 'rag_manager', None)
+                get_rag = getattr(self.personal_docs_manager, "get_rag_manager", None)
+                rag_manager = (
+                    get_rag()
+                    if callable(get_rag)
+                    else getattr(self.personal_docs_manager, "rag_manager", None)
+                )
                 if rag_manager:
                     results = rag_manager.search(message, k=5, owner=owner)
                     # Filter by similarity threshold

--- a/src/personal_docs.py
+++ b/src/personal_docs.py
@@ -220,6 +220,25 @@ class PersonalDocsManager:
         self._load_excluded()
         self.refresh_index()
 
+    def get_rag_manager(self):
+        """Return the live RAG manager and adopt lazy startup recovery.
+
+        The application may start while Chroma is unavailable. Personal routes
+        already retry the singleton later, but the long-lived manager retained
+        the startup ``None`` and chat/agent retrieval stayed keyword-only. Keep
+        the recovered singleton on this shared manager so every caller sees the
+        same live provider.
+        """
+        if self.rag_manager is not None:
+            return self.rag_manager
+
+        from src.rag_singleton import get_rag_manager
+
+        recovered = get_rag_manager()
+        if recovered is not None:
+            self.rag_manager = recovered
+        return recovered
+
     def load_directories(self):
         """Load the list of indexed directories from persistent storage."""
         try:
@@ -297,9 +316,10 @@ class PersonalDocsManager:
             # If RAG manager is available, index the directory immediately.
             # Callers that already indexed with owner metadata can pass
             # index=False so we do not create a second ownerless copy.
-            if index and self.rag_manager:
+            rag_manager = self.get_rag_manager() if index else None
+            if rag_manager:
                 try:
-                    result = self.rag_manager.index_personal_documents(directory, owner=owner)
+                    result = rag_manager.index_personal_documents(directory, owner=owner)
                     logger.info(f"Indexed {result.get('indexed_count', 0)} chunks from {directory}")
                 except Exception as e:
                     logger.error(f"Failed to index directory {directory}: {e}")
@@ -328,9 +348,10 @@ class PersonalDocsManager:
             # re-indexed only the remaining tracked dirs — ownerless and never
             # personal_dir — a catastrophic wipe (#1660). remove_directory now
             # removes exactly this directory's chunks and leaves the rest intact.
-            if self.rag_manager:
+            rag_manager = self.get_rag_manager()
+            if rag_manager:
                 try:
-                    self.rag_manager.remove_directory(directory)
+                    rag_manager.remove_directory(directory)
                 except Exception as e:
                     logger.error(f"Failed to remove directory from RAG index: {e}")
         else:
@@ -417,7 +438,7 @@ class PersonalDocsManager:
 
     def retrieve(self, query: str, k: int = 5) -> List[str]:
         """Retrieve relevant documents for a query."""
-        return retrieve_personal(self.index, query, k, self.rag_manager)
+        return retrieve_personal(self.index, query, k, self.get_rag_manager())
 
     def get_file_list(self) -> List[Dict[str, Any]]:
         """Get list of indexed files with metadata."""
@@ -447,7 +468,8 @@ class PersonalDocsManager:
         
     def index_all_directories(self):
         """Re-index all tracked directories in the RAG system."""
-        if not self.rag_manager:
+        rag_manager = self.get_rag_manager()
+        if not rag_manager:
             logger.warning("No RAG manager available for indexing")
             return
         
@@ -456,7 +478,7 @@ class PersonalDocsManager:
         
         # Index the base personal directory
         try:
-            result = self.rag_manager.index_personal_documents(self.personal_dir)
+            result = rag_manager.index_personal_documents(self.personal_dir)
             if result.get('success'):
                 success_count += 1
                 logger.info(f"Indexed base directory: {self.personal_dir}")
@@ -472,7 +494,7 @@ class PersonalDocsManager:
                 continue
             
             try:
-                result = self.rag_manager.index_personal_documents(directory)
+                result = rag_manager.index_personal_documents(directory)
                 if result.get('success'):
                     success_count += 1
                     logger.info(f"Indexed directory: {directory}")

--- a/tests/test_rag_live_manager_recovery.py
+++ b/tests/test_rag_live_manager_recovery.py
@@ -1,0 +1,31 @@
+from src import ai_interaction
+from src import personal_docs
+
+
+class _RecoveredRag:
+    def search(self, query, k=5, owner=None):
+        return []
+
+
+def test_personal_docs_manager_adopts_recovered_singleton(monkeypatch):
+    recovered = _RecoveredRag()
+    manager = personal_docs.PersonalDocsManager.__new__(personal_docs.PersonalDocsManager)
+    manager.rag_manager = None
+    monkeypatch.setattr("src.rag_singleton.get_rag_manager", lambda: recovered)
+
+    assert manager.get_rag_manager() is recovered
+    assert manager.rag_manager is recovered
+
+
+def test_ai_interaction_uses_shared_recovered_manager(monkeypatch):
+    recovered = _RecoveredRag()
+    personal_manager = type(
+        "PersonalManager",
+        (),
+        {"get_rag_manager": lambda self: recovered},
+    )()
+    monkeypatch.setattr(ai_interaction, "_rag_manager", None)
+    monkeypatch.setattr(ai_interaction, "_personal_docs_manager", personal_manager)
+
+    assert ai_interaction._get_live_rag_manager() is recovered
+    assert ai_interaction._rag_manager is recovered


### PR DESCRIPTION
## Summary

Allow the runtime to adopt a recovered document store through a shared `PersonalDocsManager` so chat, personal-document routes, indexing/removal, and agent document tools use the same live RAG instance after delayed backend recovery. This prevents startup-time fallback state from remaining permanently disconnected after the document store becomes available.

Publication must retain a live delayed-Chroma and end-to-end gate: the automated recovery tests pass, but recovery from an unavailable-at-startup Chroma instance still needs to be demonstrated through chat and agent document operations in the running application.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #5948

Part of #4377

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

The live delayed-Chroma startup/recovery and end-to-end chat/agent scenarios remain required before claiming application-level validation.

## How to Test

1. Run `python -m pytest -q tests/test_rag_live_manager_recovery.py tests/test_rag_keyword_fallback_owner.py tests/test_rag_manager_owner_compat.py tests/test_rag_remove_directory_scope.py tests/test_rag_search_signature.py tests/test_personal_docs_state_store.py`; the validated head reports 12 passing tests and one warning.
2. Start the application while Chroma is unavailable, then make Chroma available and trigger recovery without restarting Odysseus.
3. Confirm an existing chat session can search newly indexed personal documents after recovery.
4. Confirm agent document add, search, and remove operations use the recovered store and remain owner-scoped.
5. Treat steps 2–4 as a required publication gate; they have not yet been completed against a live delayed-Chroma environment.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

N/A — no rendered UI files are changed; the remaining end-to-end gate concerns runtime behavior.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

N/A — no rendered UI files changed.
