### PR TITLE
fix(docs): map live VectorRAG result shapes

### DIFF
--- a/services/docs/service.py
+++ b/services/docs/service.py
@@ -50,19 +50,46 @@ class DocsService:
             List of DocChunk objects
         """
         results = self.rag.search(query, k=top_k)
-        return [
-            DocChunk(
-                text=r.get("document", r.get("text", r.get("content", ""))),
-                source=r.get(
-                    "source",
-                    (r.get("metadata") or {}).get("source", "unknown"),
-                ),
-                score=r.get("similarity", r.get("score", 0.0)),
-                metadata=r.get("metadata") or {},
+        chunks = []
+
+        for result in results:
+            if not isinstance(result, dict):
+                continue
+
+            metadata = result.get("metadata")
+            if not isinstance(metadata, dict):
+                metadata = {}
+
+            text = result.get("document")
+            if text is None:
+                text = result.get("text")
+            if text is None:
+                text = result.get("content")
+            if text is None:
+                text = ""
+
+            source = result.get("source")
+            if source is None:
+                source = metadata.get("source")
+            if source is None:
+                source = "unknown"
+
+            score = result.get("similarity")
+            if score is None:
+                score = result.get("score")
+            if score is None:
+                score = 0.0
+
+            chunks.append(
+                DocChunk(
+                    text=text,
+                    source=source,
+                    score=score,
+                    metadata=metadata,
+                )
             )
-            for r in results
-            if isinstance(r, dict)
-        ]
+
+        return chunks
 
     async def index(self, directory: str) -> IndexResult:
         """

--- a/services/docs/service.py
+++ b/services/docs/service.py
@@ -52,10 +52,13 @@ class DocsService:
         results = self.rag.search(query, k=top_k)
         return [
             DocChunk(
-                text=r.get("text", r.get("content", "")),
-                source=r.get("source", r.get("metadata", {}).get("source", "unknown")),
-                score=r.get("score", 0.0),
-                metadata=r.get("metadata"),
+                text=r.get("document", r.get("text", r.get("content", ""))),
+                source=r.get(
+                    "source",
+                    (r.get("metadata") or {}).get("source", "unknown"),
+                ),
+                score=r.get("similarity", r.get("score", 0.0)),
+                metadata=r.get("metadata") or {},
             )
             for r in results
             if isinstance(r, dict)
@@ -73,8 +76,8 @@ class DocsService:
         """
         result = self.rag.index_personal_documents(directory)
         return IndexResult(
-            indexed=result.get("indexed", 0),
-            failed=result.get("failed", 0),
+            indexed=result.get("indexed_count", result.get("indexed", 0)),
+            failed=result.get("failed_count", result.get("failed", 0)),
             errors=result.get("errors", []),
         )
 

--- a/tests/test_docs_query_nondict_rows.py
+++ b/tests/test_docs_query_nondict_rows.py
@@ -9,10 +9,17 @@ class _FakeRag:
 
     def search(self, query, k=5):
         return [
-            {"text": "alpha", "source": "a.txt", "score": 0.9},
+            {
+                "document": "alpha",
+                "metadata": {"source": "a.txt"},
+                "similarity": 0.9,
+            },
             "corrupt-row",
             None,
         ]
+
+    def index_personal_documents(self, directory):
+        return {"indexed_count": 7, "failed_count": 2, "errors": ["bad.pdf"]}
 
 
 def test_query_skips_non_dict_rag_rows():
@@ -24,3 +31,15 @@ def test_query_skips_non_dict_rag_rows():
     # old code called r.get(...) on the str/None rows and raised AttributeError.
     assert [c.text for c in out] == ["alpha"]
     assert out[0].source == "a.txt"
+    assert out[0].score == 0.9
+
+
+def test_index_maps_live_vectorrag_result_shape():
+    svc = DocsService.__new__(DocsService)
+    svc.rag = _FakeRag()
+
+    out = asyncio.run(svc.index("/documents"))
+
+    assert out.indexed == 7
+    assert out.failed == 2
+    assert out.errors == ["bad.pdf"]

--- a/tests/test_docs_query_nondict_rows.py
+++ b/tests/test_docs_query_nondict_rows.py
@@ -43,3 +43,53 @@ def test_index_maps_live_vectorrag_result_shape():
     assert out.indexed == 7
     assert out.failed == 2
     assert out.errors == ["bad.pdf"]
+
+
+def test_query_normalizes_null_canonical_fields_and_malformed_metadata():
+    class _MalformedRag:
+        def search(self, query, k=5):
+            return [
+                {
+                    "document": None,
+                    "text": "legacy text",
+                    "source": None,
+                    "similarity": None,
+                    "score": 0.4,
+                    "metadata": "not-a-dict",
+                },
+                {
+                    "document": "canonical zero",
+                    "similarity": 0.0,
+                    "metadata": {"source": "nested.txt"},
+                },
+                {
+                    "document": None,
+                    "text": None,
+                    "content": "content fallback",
+                    "similarity": 0.2,
+                    "metadata": ["unexpected"],
+                },
+            ]
+
+    svc = DocsService.__new__(DocsService)
+    svc.rag = _MalformedRag()
+
+    out = asyncio.run(svc.query("query"))
+
+    assert [chunk.text for chunk in out] == [
+        "legacy text",
+        "canonical zero",
+        "content fallback",
+    ]
+
+    assert out[0].source == "unknown"
+    assert out[0].score == 0.4
+    assert out[0].metadata == {}
+
+    assert out[1].source == "nested.txt"
+    assert out[1].score == 0.0
+    assert out[1].metadata == {"source": "nested.txt"}
+
+    assert out[2].source == "unknown"
+    assert out[2].score == 0.2
+    assert out[2].metadata == {}


### PR DESCRIPTION
## Summary

Map the live `VectorRAG` query and indexing result shapes into the existing `DocsService` contract. Query results now read canonical document text, similarity, and source metadata while retaining legacy aliases, malformed rows are skipped safely, and indexing reports use the canonical indexed/failed counts. This updates the service facade without adding a new runtime route.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #5949

Part of #4377

Related: #5794

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.
- [x] I did not run the app/runtime validation and stated that gap in **How to Test**. Leave this unchecked when the app-run box above is checked.

The facade mapping is covered by focused tests, but no live Chroma-backed application consumer has been exercised.

## How to Test

1. Run `python -m pytest -q tests/test_docs_query_nondict_rows.py tests/test_rag_search_signature.py tests/test_rag_manager_owner_compat.py tests/test_rag_keyword_fallback_owner.py`; the validated head reports 6 passing tests and one warning.
2. Feed `DocsService` canonical query rows containing `document`, `similarity`, and `metadata.source`, and verify the returned service result preserves those values.
3. Feed legacy aliases and malformed/non-dictionary rows, and verify legacy data remains accepted while malformed rows are skipped.
4. Feed canonical indexing results containing `indexed_count` and `failed_count`, and verify the service report uses those counters.
5. If a live consumer is enabled, repeat query and indexing operations against Chroma before publication.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

N/A — no rendered UI files or routes are changed.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

N/A — no rendered UI files changed.
