### PR TITLE
fix(models): bind provider detection to DNS labels

### DIFF
--- a/src/model_capability_readers/base.py
+++ b/src/model_capability_readers/base.py
@@ -290,17 +290,22 @@ def detect_vendor(base_url: Any = "", endpoint_kind: Any = "") -> str:
         return kind_map[kind]
 
     parsed = urlparse(compact_str(base_url))
-    host = (parsed.hostname or "").lower()
+    host = (parsed.hostname or "").lower().rstrip(".")
     port = parsed.port
-    if host.endswith("openrouter.ai"):
+
+    def host_matches(domain: str) -> bool:
+        domain = domain.lower().rstrip(".")
+        return host == domain or host.endswith(f".{domain}")
+
+    if host_matches("openrouter.ai"):
         return VENDOR_OPENROUTER
-    if host.endswith("openai.com"):
+    if host_matches("openai.com"):
         return VENDOR_OPENAI
-    if host.endswith("anthropic.com"):
+    if host_matches("anthropic.com"):
         return VENDOR_ANTHROPIC
-    if host.endswith("googleapis.com"):
+    if host_matches("googleapis.com"):
         return VENDOR_GOOGLE
-    if host.endswith("ollama.com") or port == 11434:
+    if host_matches("ollama.com") or port == 11434:
         return VENDOR_OLLAMA
     if port == 1234:
         return VENDOR_LMSTUDIO

--- a/tests/test_model_capability_readers.py
+++ b/tests/test_model_capability_readers.py
@@ -30,6 +30,15 @@ def test_detect_vendor_uses_endpoint_kind_then_host_and_common_local_ports():
     assert detect_vendor("http://localhost:7000/v1") == VENDOR_GENERIC_OPENAI
 
 
+def test_detect_vendor_requires_a_dns_label_boundary():
+    assert detect_vendor("https://api.openai.com./v1") == VENDOR_OPENAI
+    assert detect_vendor("https://notopenai.com/v1") == VENDOR_GENERIC_OPENAI
+    assert detect_vendor("https://fakeopenrouter.ai/v1") == VENDOR_GENERIC_OPENAI
+    assert detect_vendor("https://notgoogleapis.com/v1") == VENDOR_GENERIC_OPENAI
+    assert detect_vendor("https://evilanthropic.com/v1") == VENDOR_GENERIC_OPENAI
+    assert detect_vendor("https://fakeollama.com/v1") == VENDOR_GENERIC_OPENAI
+
+
 def test_generic_openai_reader_keeps_basic_model_payload_unknown():
     records = generic_openai.records_from_payload(
         {


### PR DESCRIPTION
## Summary

Make provider detection label-aware so a configured host matches only the exact provider root or a real subdomain, including a trailing-dot FQDN, and rejects suffix lookalikes. Explicit endpoint-kind and local-port handling remain unchanged. This improves capability metadata classification; it is not intended to be an authorization or network-security boundary.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #5950

Related: #5794, #815

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

Focused capability-reader tests passed; live provider connections and the full application suite have not been run.

## How to Test

1. Run `env PYTHONHASHSEED=0 ODYSSEUS_INTERNAL_TOKEN=test-only-internal-token python -m pytest -q tests/test_model_capability_readers.py`; the validated head reports 21 passing tests with one existing warning.
2. Verify a provider root host, a real subdomain, and a trailing-dot FQDN are classified as that provider.
3. Verify prefix/suffix lookalikes that do not have a DNS-label boundary are rejected.
4. Verify explicitly typed endpoints and configured local ports retain their existing classification.
5. Optionally repeat capability discovery against live configured providers; this has not yet been completed.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

N/A — no rendered UI files are changed.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

N/A — no rendered UI files changed.
