### PR TITLE
fix(speech): define the Kokoro optional install contract

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -441,9 +441,18 @@ A grab-bag of small gotchas that otherwise turn into long debugging sessions.
 | Package | Feature unlocked |
 |---------|-----------------|
 | `faster-whisper` | Local speech-to-text (microphone -> text) via the "local" STT provider. |
+| `kokoro`, `soundfile` | Local Kokoro-82M text-to-speech on a CUDA GPU. The pinned Kokoro release supports Odysseus installs on Python 3.11-3.12; these packages are intentionally skipped on Python 3.13+ (including the Python 3.14 container image). |
 | `ddgs` | DuckDuckGo as a search provider option. |
 | `PyMuPDF` | PDF page rendering in the side viewer panel and form-filling. (Note: AGPL-3.0) |
 | `markitdown` | Office/EPUB document text extraction (converts .docx/.xlsx/.pptx/.xls/.epub to Markdown). |
+
+Install the optional set only when you need these features:
+
+```bash
+pip install -r requirements-optional.txt
+```
+
+The default Docker image currently uses Python 3.14, while Kokoro 0.9.4 declares Python `>=3.10,<3.13`. Odysseus itself continues to support Python 3.11+, but this pinned optional local-TTS feature requires a native Python 3.11 or 3.12 environment. Kokoro declares `torch`, but the local provider only activates when that torch build has CUDA and a GPU is visible; install the CUDA build appropriate for your host. Browser and configured endpoint TTS remain available on Python 3.13+ and in the container image.
 
 ### Faster, reproducible installs with uv (optional)
 [uv](https://docs.astral.sh/uv/) works as a drop-in replacement for the

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -12,6 +12,16 @@
 # GPU-accelerated transcription — it's auto-detected, CPU is used otherwise.
 faster-whisper
 
+# Local text-to-speech via Kokoro-82M for the "local" TTS provider.
+# Kokoro 0.9.4 declares Python >=3.10,<3.13; Odysseus itself requires 3.11+,
+# so pip installs these extras on 3.11-3.12 and deliberately skips them on
+# Python 3.13+ (including the Python 3.14 container image). Kokoro declares
+# torch; the local provider still
+# requires a CUDA-enabled torch build and GPU at runtime. SoundFile is separate
+# in Kokoro's official install instructions and is not a transitive dependency.
+kokoro==0.9.4; python_version >= "3.11" and python_version < "3.13"
+soundfile; python_version >= "3.11" and python_version < "3.13"
+
 # DuckDuckGo as a search provider option.
 # Install if you want DDG in the search-provider dropdown.
 # Alternatives: SearXNG, Brave, Tavily, Serper, Google PSE.

--- a/tests/test_kokoro_optional_requirements.py
+++ b/tests/test_kokoro_optional_requirements.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+import pytest
+from packaging.requirements import Requirement
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _optional_requirement(name):
+    lines = (ROOT / "requirements-optional.txt").read_text(encoding="utf-8").splitlines()
+    return Requirement(next(line for line in lines if line.startswith(name)))
+
+
+def test_kokoro_optional_dependency_pins_the_verified_release():
+    kokoro = _optional_requirement("kokoro")
+
+    assert str(kokoro.specifier) == "==0.9.4"
+
+
+@pytest.mark.parametrize(
+    ("python_version", "selected"),
+    (("3.11", True), ("3.12", True), ("3.13", False), ("3.14", False)),
+)
+def test_kokoro_feature_markers_match_supported_python_range(python_version, selected):
+    for name in ("kokoro", "soundfile"):
+        requirement = _optional_requirement(name)
+        assert requirement.marker is not None
+        assert requirement.marker.evaluate({"python_version": python_version}) is selected
+
+
+def test_setup_documents_container_constraint_and_install_command():
+    setup = (ROOT / "docs" / "setup.md").read_text(encoding="utf-8")
+
+    assert "pip install -r requirements-optional.txt" in setup
+    assert "default Docker image currently uses Python 3.14" in setup
+    assert "Python `>=3.10,<3.13`" in setup
+    assert "native Python 3.11 or 3.12" in setup
+    assert "skipped on Python 3.13+" in setup
+    assert "torch build has CUDA" in setup


### PR DESCRIPTION
## Summary

Define the optional Kokoro installation contract consistently in dependency markers, documentation, and regression tests. Odysseus core remains supported on Python 3.11 and newer, while Kokoro 0.9.4 and SoundFile are installed only on Python 3.11–3.12 because Kokoro declares Python `<3.13`. Python 3.13 and newer continue without that optional native engine, and browser/endpoint TTS remains available.

Python 3.11 and 3.12 resolver dry-runs successfully resolved Kokoro and SoundFile, and the marker tests cover the skip behavior for newer interpreters. A full native installation, CUDA-enabled PyTorch verification, and GPU speech synthesis remain required before claiming end-to-end Kokoro validation.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #5951

Related: #4009, #5615

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

Dependency resolution and marker behavior were validated, but native installation and CUDA-backed synthesis were not completed.

## How to Test

1. Run `pytest -q tests/test_kokoro_optional_requirements.py`; the validated head reports 6 passing tests.
2. In disposable Python 3.11 and Python 3.12 environments, perform a resolver dry-run for `requirements-optional.txt` and verify both `kokoro==0.9.4` and `soundfile` are selected. This resolver evidence has been obtained for both versions.
3. In Python 3.13 or newer, evaluate or dry-run the same requirements and verify both optional native-engine dependencies are skipped by their environment markers.
4. Before claiming end-to-end support, complete a clean native installation on Python 3.11 or 3.12 with CUDA-enabled PyTorch, import Kokoro and SoundFile, and synthesize speech on a visible GPU. This remains an explicit validation gap.
5. Verify browser TTS and configured endpoint TTS remain available when the optional native engine is skipped.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

N/A — no rendered UI files are changed.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

N/A — no rendered UI files changed.
