### PR TITLE
docs(security): reconcile assistant and threat contracts

### DIFF
--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -74,8 +74,6 @@ These are open, acknowledged, and contributor help is welcome:
 
 1. **No shell/filesystem sandbox.** The agent `bash` and `read_file`/`write_file` tools run as the app process user with no network egress filtering or filesystem confinement. A successful prompt-injection reaching a shell-enabled admin session can make outbound requests to internal services. See #1058 for the sandbox proposal.
 
-2. **SSRF via `/api/v1/chat` `base_url` parameter.** A chat-scoped API token can supply an arbitrary `base_url`; the server forwards the LLM request to that host without validating the scheme or address. PR #1039 fixes this.
+2. **API-token coverage is surface-specific.** Tokens have separate chat, todo, document, email, calendar, memory, and Cookbook scopes. Only routes that explicitly map the token owner and enforce the relevant scope are supported; a token is not a general subset of all UI/session privileges. Companion pairing currently mints a chat-scoped token.
 
-3. **`src/search/` partial consolidation.** `src.search.core` and `src.search.providers` correctly alias `services.search` via `sys.modules` replacement. `analytics`, `cache`, `content`, `query`, and `ranking` are still independent copies that can drift. The SSRF regression tests in `tests/test_webhook_ssrf_resilience.py` test `src.webhook_manager` directly (separate from search), so the safety net there is intact. See #1058.
-
-4. **Token scopes are coarse.** There is no way to grant a session a subset of the owning user's privileges. Companion/mobile tokens carry either `chat` or `admin` scope with no per-capability granularity.
+`POST /api/v1/chat` validates a token-supplied direct `base_url` with the public-HTTP URL policy before making a provider request. Admin-configured model endpoints intentionally retain local/LAN support and are a separate trust boundary.

--- a/routes/assistant_routes.py
+++ b/routes/assistant_routes.py
@@ -1,10 +1,9 @@
 """Personal assistant routes — resolve the per-user singleton, read/write
 its settings, and list its scheduled check-in tasks.
 
-The personal assistant is just a specially-flagged CrewMember that owns one
-pinned Session and three daily ScheduledTasks ("Morning/Midday/Evening
-check-in"). Everything about it is user-editable: name, personality, model,
-enabled tools, timezone, and the three check-in times/prompts/enabled flags.
+The personal assistant is a specially-flagged CrewMember that owns one pinned
+Session. Users can attach recurring check-in ScheduledTasks explicitly; those
+tasks remain editable here, but assistant creation does not seed them.
 """
 
 import json
@@ -86,10 +85,9 @@ def setup_assistant_routes(task_scheduler) -> APIRouter:
             raise HTTPException(status_code=401, detail="Not authenticated")
         return owner
 
-    # Synthetic / non-human owners that should NEVER get an assistant +
-    # check-in tasks seeded. Hitting any /assistant route under one of these
-    # used to seed a full CrewMember + Morning/Midday/Evening tasks under that
-    # owner, which then double-fired alongside the real user's check-ins.
+    # Synthetic / non-human owners must never get a personal assistant. Older
+    # versions also seeded check-in tasks for these owners, which could
+    # double-fire alongside tasks belonging to the real user.
     # REQUEST_SENTINEL_OWNERS covers request-only identities; Default/Local is a
     # reserved login name but remains a valid storage owner.
 
@@ -135,7 +133,7 @@ def setup_assistant_routes(task_scheduler) -> APIRouter:
 
     @router.get("/settings")
     async def get_assistant_settings(request: Request):
-        """Return CrewMember fields + the three check-in task rows + task IDs for logs."""
+        """Return CrewMember fields and any user-configured check-in tasks."""
         owner = _owner(request)
         crew = await _get_or_create(owner)
         if not crew:
@@ -156,7 +154,7 @@ def setup_assistant_routes(task_scheduler) -> APIRouter:
 
     @router.patch("/settings")
     async def update_assistant_settings(payload: AssistantSettingsUpdate, request: Request):
-        """Update CrewMember fields and/or check-in tasks in one call."""
+        """Update CrewMember fields and/or existing check-in tasks in one call."""
         owner = _owner(request)
         crew = await _get_or_create(owner)
         if not crew:

--- a/src/task_scheduler.py
+++ b/src/task_scheduler.py
@@ -2513,14 +2513,15 @@ class TaskScheduler:
             logger.warning(f"Failed to seed assistant for {owner}: {e}")
 
     async def ensure_assistant_defaults(self, owner: str):
-        """Create the personal-assistant CrewMember, its pinned session, and three
-        daily check-in ScheduledTasks for this owner — idempotent on is_default_assistant."""
+        """Create the personal-assistant CrewMember and its pinned session.
+
+        Check-in tasks are user-created and are not seeded here. Creation is
+        idempotent on ``is_default_assistant``.
+        """
         # Hard-reject synthetic owners. Without this, AuthMiddleware-stamped
         # values like 'internal-tool' (loopback agent-tool callbacks) or 'api'
-        # (bearer-token integrations) would get a real assistant + 3 daily
-        # check-ins seeded, which then double-fire alongside the human user's
-        # check-ins. This was the root cause of the duplicate 'Morning check-in'
-        # rows we had to manually clean up.
+        # (bearer-token integrations) would get a real assistant. Older builds
+        # also seeded three daily check-ins for those synthetic owners.
         if not owner or owner in REQUEST_SENTINEL_OWNERS:
             logger.info(f"ensure_assistant_defaults: skip synthetic owner {owner!r}")
             return

--- a/tests/test_current_assistant_security_docs.py
+++ b/tests/test_current_assistant_security_docs.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+TOKEN_SCOPE_PARAGRAPH = "2. **API-token coverage is surface-specific.** Tokens have separate chat, todo, document, email, calendar, memory, and Cookbook scopes. Only routes that explicitly map the token owner and enforce the relevant scope are supported; a token is not a general subset of all UI/session privileges. Companion pairing currently mints a chat-scoped token."
+CHAT_URL_PARAGRAPH = "`POST /api/v1/chat` validates a token-supplied direct `base_url` with the public-HTTP URL policy before making a provider request. Admin-configured model endpoints intentionally retain local/LAN support and are a separate trust boundary."
+
+
+def test_assistant_docs_do_not_claim_checkins_are_seeded():
+    assistant = (ROOT / "routes" / "assistant_routes.py").read_text(encoding="utf-8")
+    scheduler = (ROOT / "src" / "task_scheduler.py").read_text(encoding="utf-8")
+
+    assert "three daily ScheduledTasks" not in assistant
+    assert "daily check-in ScheduledTasks for this owner" not in scheduler
+    assert "Check-in tasks are user-created" in scheduler
+
+
+def test_threat_model_matches_current_token_and_chat_url_boundaries():
+    threat_model = (ROOT / "THREAT_MODEL.md").read_text(encoding="utf-8")
+    lines = threat_model.splitlines()
+
+    assert "SSRF via `/api/v1/chat`" not in threat_model
+    assert TOKEN_SCOPE_PARAGRAPH in lines
+    assert CHAT_URL_PARAGRAPH in lines
+    assert "`src/search/` partial consolidation" not in threat_model
+    assert "still independent copies" not in threat_model
+
+
+def test_search_compat_modules_point_at_the_canonical_service():
+    for name in ("analytics.py", "cache.py", "content.py", "query.py"):
+        source = (ROOT / "src" / "search" / name).read_text(encoding="utf-8")
+        assert "from services.search" in source
+        assert "sys.modules[__name__]" in source
+
+    ranking = (ROOT / "src" / "search" / "ranking.py").read_text(encoding="utf-8")
+    assert "from services.search.ranking import" in ranking


### PR DESCRIPTION
## Summary

Reconcile the assistant/task documentation and threat-model contracts with current implementation behavior. The updated text records that check-ins are not seeded automatically, token URLs are validated, task scope families are explicit, and search compatibility shims delegate to the canonical implementation. This change does not alter runtime behavior.

Refresh the documentation against the final `dev` landing set immediately before opening this PR if the branch has moved.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #5952

Related: #5794

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [x] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

The focused documentation-contract tests passed; the application was not run because this change does not modify runtime behavior.

## How to Test

1. Run `pytest -q tests/test_current_assistant_security_docs.py`; the validated head reports 3 passing tests.
2. Verify the assistant documentation states that check-ins are not seeded automatically.
3. Verify the task documentation describes token-URL validation and the current scope families.
4. Verify the threat/search documentation describes the compatibility shims as delegating to the canonical implementation.
5. Recompare these statements with the final `dev` source immediately before publication.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

N/A — this is a documentation-only change with no rendered UI changes.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

N/A — no rendered UI files changed.
