### PR TITLE
fix(ui): Auto scroll not consistent

### DIFF
--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -1411,7 +1411,6 @@ import { wireArrowUpRecall, getUserMessagesFromChatHistory } from './composerArr
     try {
       // Re-enable auto-scroll when user sends a message
       uiModule.setAutoScroll(true);
-      uiModule.scrollHistoryInstant();
       // Clear completed dot now that user is interacting
       if (sessionModule.clearStreamComplete) sessionModule.clearStreamComplete(sessionModule.getCurrentSessionId());
 
@@ -1453,6 +1452,8 @@ import { wireArrowUpRecall, getUserMessagesFromChatHistory } from './composerArr
       if (!skipBubble) {
         _userMsgEl = addMessage('user', userDisplay, null, _pendingAttachInfo ? { attachments: _pendingAttachInfo } : null);
       }
+      // Scroll to the user message now that it's in the DOM
+      uiModule.scrollHistoryInstant();
       _sendPerf.mark('user_bubble_visible');
       messageInput.value = '';
       messageInput.style.height = '';

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -488,17 +488,19 @@ function _smoothScrollStep() {
   const current = box.scrollTop;
   const diff = target - current;
 
-  // If content grew substantially since we started (tool output, images),
-  // skip to bottom — don't mistake this for a user scroll-up.
+  // If we're far from the bottom and content has grown, the lag is from
+  // new content, not a user scroll-up. Snap to bottom so the lerp doesn't
+  // fall irrecoverably behind (especially when many small tool results
+  // accumulate faster than the 0.2-factor lerp can keep up).
   const contentGrew = target - _lastTargetHeight;
-  if (diff > 300 && contentGrew > 200) {
+  if (diff > 300 && contentGrew > 20) {
     box.scrollTop = target;
     _lastTargetHeight = target;
     _scrollRafId = requestAnimationFrame(_smoothScrollStep);
     return;
   }
 
-  // If user scrolled up significantly, don't force them down
+  // If user scrolled up with no meaningful new content, respect that.
   if (diff > 300) {
     _scrollRafId = null;
     return;
@@ -508,6 +510,13 @@ function _smoothScrollStep() {
     box.scrollTop = target;
     _lastTargetHeight = target;
     _scrollRafId = null;
+    // Content may have arrived during the final lerp frame (e.g. last
+    // tool output in a chain). If the true bottom is now lower, restart.
+    const finalTarget = box.scrollHeight - box.clientHeight;
+    if (finalTarget > target + 1) {
+      _lastTargetHeight = finalTarget;
+      _scrollRafId = requestAnimationFrame(_smoothScrollStep);
+    }
     return;
   }
 

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -454,6 +454,7 @@ export function showError(msg) {
  * Throttled during streaming so it doesn't fight user scrolling.
  */
 let _scrollThrottleTimer = null;
+let _lastTargetHeight = 0;
 export function scrollHistory() {
   if (!autoScrollEnabled) return;
   if (!_scrollBox) {
@@ -462,6 +463,7 @@ export function scrollHistory() {
   // Throttle: only start a new scroll animation every 500ms
   if (_scrollThrottleTimer) return;
   _scrollThrottleTimer = setTimeout(() => { _scrollThrottleTimer = null; }, 500);
+  _lastTargetHeight = _scrollBox.scrollHeight - _scrollBox.clientHeight;
   if (!_scrollRafId) {
     _scrollRafId = requestAnimationFrame(_smoothScrollStep);
   }
@@ -477,6 +479,16 @@ function _smoothScrollStep() {
   const current = box.scrollTop;
   const diff = target - current;
 
+  // If content grew substantially since we started (tool output, images),
+  // skip to bottom — don't mistake this for a user scroll-up.
+  const contentGrew = target - _lastTargetHeight;
+  if (diff > 300 && contentGrew > 200) {
+    box.scrollTop = target;
+    _lastTargetHeight = target;
+    _scrollRafId = requestAnimationFrame(_smoothScrollStep);
+    return;
+  }
+
   // If user scrolled up significantly, don't force them down
   if (diff > 300) {
     _scrollRafId = null;
@@ -485,6 +497,7 @@ function _smoothScrollStep() {
 
   if (diff <= 1) {
     box.scrollTop = target;
+    _lastTargetHeight = target;
     _scrollRafId = null;
     return;
   }
@@ -492,6 +505,7 @@ function _smoothScrollStep() {
   // Lerp: gentle catch-up
   const factor = window.innerWidth <= 768 ? 0.4 : 0.2;
   box.scrollTop = current + diff * factor;
+  _lastTargetHeight = target;
   _scrollRafId = requestAnimationFrame(_smoothScrollStep);
 }
 

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -460,8 +460,17 @@ export function scrollHistory() {
   if (!_scrollBox) {
     _scrollBox = document.getElementById('chat-history');
   }
-  // Throttle: only start a new scroll animation every 500ms
-  if (_scrollThrottleTimer) return;
+  // If the smooth-scroll loop is already running, it picks up new content
+  // height on the next frame — nothing to do.
+  if (_scrollRafId) return;
+  // Throttle restarts to avoid animation jitter, but bypass when new
+  // content appeared since we last looked (e.g. next tool in a chain).
+  if (_scrollThrottleTimer) {
+    const target = _scrollBox.scrollHeight - _scrollBox.clientHeight;
+    if (target <= _lastTargetHeight) return;
+    clearTimeout(_scrollThrottleTimer);
+    _scrollThrottleTimer = null;
+  }
   _scrollThrottleTimer = setTimeout(() => { _scrollThrottleTimer = null; }, 500);
   _lastTargetHeight = _scrollBox.scrollHeight - _scrollBox.clientHeight;
   if (!_scrollRafId) {


### PR DESCRIPTION
## Summary

When 15+ tool results stream in parallel, auto-scroll permanently aborts ~300px before the bottom because the contentGrew threshold (200px) never fires on individual frames (~80px tool headers), causing the code to mistake accumulated content-growth lag for a user scroll-up. Lowering the snap threshold to 20px and adding a post-finish re-check keeps the viewport pinned to the bottom.

## Target branch

- [X] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #5611

## Type of Change

- [X] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [X] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [X] This PR targets `dev`
- [X] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [X] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Open any chat in Odysseus.
2. Send a prompt that triggers 15+ parallel tool calls (e.g., "list every subdirectory of /home/samy/odysseus, one per command").
3. Verify auto-scroll stays pinned to the bottom through all tool outputs — no gap, no abort.
4. Scroll up mid-stream to confirm the abort-guard still works (auto-scroll should not fight the user).

## Visual / UI changes — REQUIRED if you touched anything that renders

- [X] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [X] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [X] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [X] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

https://github.com/user-attachments/assets/1392c952-e173-4371-8033-0a970e76c180

