### PR TITLE
feat(cookbook): add MLX serving backend for Apple Silicon (mlx-lm + oMLX)

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -319,8 +319,13 @@ docker compose logs odysseus | grep -E 'ChromaDB|MemoryVectorStore|DEGRADED'
 
 **macOS details.** `start-macos.sh` installs Homebrew deps, creates the venv,
 runs setup, and starts uvicorn on port `7860` because AirPlay often holds
-`7000`. It uses llama.cpp/Ollama for Metal. vLLM/SGLang are CUDA/ROCm-only and
-do not run on macOS. MLX-only models are not served by Odysseus.
+`7000`. It uses llama.cpp/Ollama and MLX for Metal. vLLM/SGLang are
+CUDA/ROCm-only and do not run on macOS. To serve MLX models, install Apple's
+mlx-lm (`pip install mlx-lm`, the default engine) or oMLX
+(https://github.com/jundot/omlx); pick the engine in the Cookbook serve panel.
+oMLX serves a whole directory of models rather than one path, so it launches
+against the panel's **MLX Model Dir** field — prefilled from the model's own
+folder when Odysseus can resolve one, and left for you to fill in when it can't.
 
 </details>
 

--- a/routes/cookbook_helpers.py
+++ b/routes/cookbook_helpers.py
@@ -5,9 +5,11 @@ import json
 import logging
 import ntpath
 import os
+import platform
 import posixpath
 import re
 import shlex
+import sys
 from pathlib import Path
 
 from fastapi import HTTPException
@@ -612,6 +614,8 @@ _SERVE_CMD_ALLOWLIST = {
     "python", "python3",
     "sglang", "lmdeploy",
     "node", "npx",
+    "omlx",  # oMLX — MLX inference server (Apple Silicon, OpenAI-compatible)
+    "mlx_lm.server",  # Apple's official MLX server console script
 }
 
 
@@ -732,6 +736,70 @@ def _check_serve_binary(seg: str) -> None:
             f"cmd binary '{base or '(empty)'}' is not allowed. Must start with one of: "
             f"{', '.join(sorted(_SERVE_CMD_ALLOWLIST))}",
         )
+
+
+def _is_apple_silicon() -> bool:
+    """True on local Apple-Silicon macOS (the only place MLX can run)."""
+    return sys.platform == "darwin" and platform.machine() == "arm64"
+
+
+def _is_mlx_serve_cmd(cmd: str | None) -> bool:
+    """True for an MLX serve command in any of the three shapes Cookbook emits:
+    `omlx serve`, the `mlx_lm.server` console script, or `python3 -m mlx_lm.server`."""
+    if not cmd:
+        return False
+    if re.search(r"(?:^|\s)-m\s+mlx_lm\.server\b", cmd):
+        return True
+    try:
+        tokens = shlex.split(cmd)
+    except ValueError:
+        return False
+    # Skip leading env-var assignments (e.g. KMP_DUPLICATE_LIB_OK=TRUE mlx_lm.server).
+    env_re = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+    binary = next((os.path.basename(t) for t in tokens if not env_re.match(t)), "")
+    return binary in ("omlx", "mlx_lm.server")
+
+
+def _guard_mlx_platform(cmd: str | None, remote_host: str | None) -> None:
+    """Reject an MLX serve command (oMLX or mlx-lm) on a non-Apple-Silicon LOCAL
+    host. MLX has no CUDA/CPU fallback. Remote hosts are trusted to be Macs (the
+    SSH target is the user's call); only the local machine is gated.
+    """
+    if not remote_host and _is_mlx_serve_cmd(cmd) and not _is_apple_silicon():
+        raise HTTPException(
+            400,
+            "MLX (oMLX / mlx-lm) only runs on Apple Silicon. Serve it on a "
+            "local arm64 Mac or a remote Mac host.",
+        )
+
+
+# An MLX model is a folder bundle whose manifest is config.json; picking the
+# manifest (or one of the weight shards) out of a file browser is the natural
+# mistake, and both engines then fail late with an opaque load error.
+_MLX_MODEL_ARG_RE = re.compile(
+    r"(--model(?:-dir)?[= ]\s*)(?:'([^']*)'|\"([^\"]*)\"|([^'\"\s]+))"
+)
+_MLX_BUNDLE_FILE_RE = re.compile(r"/(?:config\.json|[^/]*\.safetensors)$")
+
+
+def _normalize_mlx_model_path(cmd: str | None) -> str | None:
+    """Point an MLX `--model`/`--model-dir` at the containing bundle directory
+    when it was given a config.json or a *.safetensors shard."""
+    if not cmd or not _is_mlx_serve_cmd(cmd):
+        return cmd
+
+    def _to_dir(m: re.Match[str]) -> str:
+        single, double, bare = m.group(2), m.group(3), m.group(4)
+        value = single if single is not None else double if double is not None else bare
+        if not _MLX_BUNDLE_FILE_RE.search(value or ""):
+            return m.group(0)
+        parent = posixpath.dirname(value)
+        if not parent:
+            return m.group(0)
+        quote = "'" if single is not None else '"' if double is not None else ""
+        return f"{m.group(1)}{quote}{parent}{quote}"
+
+    return _MLX_MODEL_ARG_RE.sub(_to_dir, cmd)
 
 
 def _is_safe_serve_subshell(subshell: str) -> bool:
@@ -1087,6 +1155,36 @@ class ServeRequest(BaseModel):
     platform: str | None = None    # "linux", "termux", or "windows"
 
 
+# mlx-lm refuses a checkpoint whose tensor keys don't match the architecture it
+# knows — almost always an mlx-lm older than the model. The raw output is a bare
+# KeyError (Python) or keyNotFound (the Swift bridge) on a tensor name, which
+# reads like an Odysseus bug rather than "upgrade mlx-lm".
+_MLX_KEY_MISMATCH_RE = re.compile(
+    r"keyNotFound"
+    r"|Received parameters not in model"
+    r"|Missing parameters:"
+    r"|KeyError:\s*['\"](?:model|language_model|transformer|vision_tower)[.\w]*['\"]",
+    re.I,
+)
+# Scopes the key-mismatch signal to output that actually came from an MLX
+# server. A bare "mlx" is far too loose: a vLLM launch on a CUDA box reads
+# `--model /models/mlx-community/foo`, so the model PATH alone would claim any
+# vLLM/llama.cpp KeyError for mlx-lm. Every real MLX serve echoes its launch
+# command (`mlx_lm.server` / `python3 -m mlx_lm.server` / `omlx serve`) or names
+# mlx_lm in the traceback, so require the engine name, not the substring.
+_MLX_ENGINE_MARKER_RE = re.compile(r"mlx[-_]?lm|omlx", re.I)
+# Same signal for _diagnose_serve_output, but scoped to MLX output — a bare
+# KeyError on a tensor name is not MLX-specific on its own.
+_MLX_KEY_MISMATCH_DIAGNOSIS_RE = (
+    rf"(?s)^(?=.*(?:{_MLX_ENGINE_MARKER_RE.pattern}))"
+    rf"(?=.*(?:{_MLX_KEY_MISMATCH_RE.pattern}))"
+)
+_MLX_KEY_MISMATCH_MESSAGE = (
+    "mlx-lm could not load this checkpoint — its tensor keys don't match any "
+    "architecture this mlx-lm knows. The model needs a newer mlx-lm."
+)
+
+
 def _parse_serve_phase(snapshot: str, task_type: str = "serve") -> dict:
     """Parse a tmux snapshot of a serve task into structured phase info.
 
@@ -1131,6 +1229,13 @@ def _parse_serve_phase(snapshot: str, task_type: str = "serve") -> dict:
     # HTTP access logs (e.g. GET /v1/models 200 OK) mean the server is up and serving
     if re.search(r'(?:GET|POST)\s+/[^\s]*\s+HTTP/[\d.]+"\s*\d{3}', flat):
         return {"phase": "idle", "status": "ready"}
+    # mlx-lm's built-in server (Apple's official MLX server) prints this on bind.
+    if re.search(r'Starting httpd at .*? on port\s+\d+', flat):
+        return {"phase": "ready", "status": "ready"}
+    # Checked after the ready lines so a server that came up and only later hit
+    # a bad request still reads "ready" — a key mismatch is a load-time failure.
+    if _MLX_KEY_MISMATCH_RE.search(flat) and _MLX_ENGINE_MARKER_RE.search(flat):
+        return {"phase": "load failed (mlx-lm too old)", "status": ""}
     if "Loading weights took" in flat:
         return {"phase": "initializing", "status": "running"}
     # "GPU KV cache" alone (during allocation) — not "GPU KV cache usage" (runtime log)
@@ -1356,6 +1461,11 @@ def _diagnose_serve_output(text: str) -> dict | None:
                 {"label": "relaunch from the cached local Hugging Face snapshot path on this Mac", "op": "manual"},
                 {"label": "Odysseus now rewrites MLX repo-id launches to a cached snapshot when one exists", "op": "manual"},
             ],
+        ),
+        (
+            _MLX_KEY_MISMATCH_DIAGNOSIS_RE,
+            _MLX_KEY_MISMATCH_MESSAGE,
+            [{"label": "upgrade mlx-lm in Cookbook Dependencies", "op": "dependency", "package": "mlx-lm"}],
         ),
         # System build deps come BEFORE the generic llama.cpp catch-all so
         # cmake / build-essential / git missing → a specific OS-package

--- a/routes/cookbook_output.py
+++ b/routes/cookbook_output.py
@@ -1,10 +1,15 @@
-"""Pure helpers for shaping cookbook task output for the status response.
+"""Helpers for shaping cookbook task output for the status response.
 
-Kept dependency-free (no FastAPI / SQLAlchemy imports) so the behavior can be
-unit-tested without standing up the whole app.
+Mostly pure; the cache/snapshot probes here shell out (locally or over SSH) and
+own the probe scripts they run. Kept dependency-free (stdlib only — no FastAPI /
+SQLAlchemy imports) so the behavior can be unit-tested without standing up the
+whole app.
 """
 
 import re
+import shlex
+import subprocess
+import time
 
 _FETCHING_ZERO_FILES_RE = re.compile(r"Fetching\s+0\s+files", re.IGNORECASE)
 
@@ -38,6 +43,203 @@ HF_CACHE_INCOMPLETE_PROBE = (
     "inc=os.path.isdir(blobs) and any(x.endswith('.incomplete') for x in os.listdir(blobs));"
     "sys.exit(0 if inc else 1)"
 )
+
+# Lists the newest snapshot's file names, one per line, for the MLX bundle
+# check below. Same cache-root contract as the two probes above.
+HF_SNAPSHOT_LISTING_PROBE = (
+    "import os,sys;"
+    "repo=sys.argv[1];"
+    "root=os.path.expanduser(sys.argv[2]) if len(sys.argv)>2 and sys.argv[2] else '';"
+    "base=os.path.join(root,'hub') if root else (os.environ.get('HUGGINGFACE_HUB_CACHE') or os.path.join(os.environ.get('HF_HOME', os.path.expanduser('~/.cache/huggingface')), 'hub'));"
+    "snap=os.path.join(base,'models--'+repo.replace('/','--'),'snapshots');"
+    "dirs=[os.path.join(snap,x) for x in os.listdir(snap)] if os.path.isdir(snap) else [];"
+    "dirs=[d for d in dirs if os.path.isdir(d)];"
+    "sys.exit(1) if not dirs else None;"
+    "newest=max(dirs,key=os.path.getmtime);"
+    "print('\\n'.join(sorted(os.listdir(newest))))"
+)
+
+# An MLX *text* model is a folder bundle, not a single file: config.json is the
+# manifest, the weights are safetensors shards, and the tokenizer ships
+# alongside. A repo missing any of the three loads fine as far as HuggingFace
+# is concerned and then fails deep inside mlx-lm.
+#
+# Weights can also arrive as a *.npz archive (the older mlx-examples container),
+# so "no *.safetensors" is not on its own a missing-weights verdict.
+_MLX_WEIGHT_SUFFIXES = (".safetensors", ".npz")
+_MLX_TOKENIZER_FILES = {"tokenizer.json", "tokenizer_config.json", "tokenizer.model"}
+
+_MLX_BUNDLE_REQUIREMENTS = (
+    ("config.json", lambda names: "config.json" in names),
+    (
+        "a weights file (*.safetensors or *.npz)",
+        lambda names: any(n.endswith(_MLX_WEIGHT_SUFFIXES) for n in names),
+    ),
+    (
+        "a tokenizer (tokenizer.json / tokenizer_config.json)",
+        lambda names: bool(names & _MLX_TOKENIZER_FILES),
+    ),
+)
+
+# A diffusers-style pipeline (image, audio) is a manifest plus per-component
+# SUBDIRECTORIES — its weights and tokenizer live one level down, so none of the
+# top-level requirements above apply to it.
+_MLX_PIPELINE_MANIFESTS = {"model_index.json", "pipeline.json"}
+_MLX_PIPELINE_COMPONENT_DIRS = {
+    "tokenizer", "tokenizer_2", "tokenizer_3",
+    "text_encoder", "text_encoder_2", "text_encoder_3",
+    "transformer", "unet", "vae", "vae_decoder", "vae_encoder",
+    "scheduler", "image_encoder", "feature_extractor", "safety_checker",
+}
+
+# Files that only ever ship with a HuggingFace *text* model — the one shape
+# mlx-lm loads. Requiring one of these is what lets the check say "this is an
+# MLX LLM bundle and it is broken" instead of guessing at a layout it doesn't
+# understand: mlx-community also hosts whisper builds (config.json + a
+# weights.npz, no tokenizer at all) and mflux/diffusers image bundles, and both
+# of those are complete and loadable exactly as they are.
+_MLX_LLM_MARKERS = {
+    "tokenizer.json", "tokenizer_config.json", "tokenizer.model",
+    "special_tokens_map.json", "added_tokens.json", "vocab.json", "merges.txt",
+    "chat_template.jinja", "chat_template.json", "generation_config.json",
+    "model.safetensors.index.json",
+}
+
+
+_MLX_REPO_RE = re.compile(r"^mlx-community/|\bmlx\b|[-_]mlx(?:[-_]|$)", re.IGNORECASE)
+
+
+def looks_like_mlx_repo(repo_id: str) -> bool:
+    """Whether a downloaded repo id is an MLX build, so the bundle check below
+    stays scoped to MLX and never fires on GGUF/safetensors downloads."""
+    return bool(repo_id) and bool(_MLX_REPO_RE.search(repo_id))
+
+
+def _listing_names(names) -> set[str]:
+    """Snapshot listing (files AND directories) as a set of bare names."""
+    return {str(n).strip() for n in (names or []) if str(n).strip()}
+
+
+def looks_like_mlx_llm_bundle(names) -> bool:
+    """Whether a snapshot listing is positively an MLX *text* LLM bundle.
+
+    The requirement check below is only meaningful for the transformers-style
+    text bundle mlx-lm loads, so it only ever runs on a listing that carries a
+    text-model marker and isn't a diffusers-style pipeline. Everything else
+    under mlx-community — whisper, image pipelines, bare adapters, layouts we
+    have never seen — is left alone rather than declared broken.
+    """
+    have = _listing_names(names)
+    if not have:
+        return False
+    if have & _MLX_PIPELINE_MANIFESTS:
+        return False
+    if have & _MLX_PIPELINE_COMPONENT_DIRS:
+        return False
+    return bool(have & _MLX_LLM_MARKERS)
+
+
+def missing_mlx_bundle_files(names) -> list[str]:
+    """Which required MLX bundle members are absent from a downloaded snapshot.
+
+    `names` is the snapshot directory listing (bare file and directory names).
+    Returns [] for a complete bundle, for an empty listing ("no files at all" is
+    already reported by the download markers), and for any listing that isn't
+    positively an MLX LLM text bundle.
+    """
+    have = _listing_names(names)
+    if not looks_like_mlx_llm_bundle(have):
+        return []
+    return [label for label, present in _MLX_BUNDLE_REQUIREMENTS if not present(have)]
+
+
+def mlx_bundle_diagnosis(repo_id: str, names) -> dict | None:
+    """Post-download shape check for an MLX repo, phrased as a serve diagnosis."""
+    missing = missing_mlx_bundle_files(names)
+    if not missing:
+        return None
+    return {
+        "message": (
+            f"{repo_id} downloaded but is not a loadable MLX bundle — missing "
+            f"{', '.join(missing)}. MLX models are folder bundles with config.json "
+            f"as the manifest; re-download the repo or pick an mlx-community build."
+        ),
+        "suggestions": [{"label": "re-download this model (or choose an mlx-community build)", "op": "manual"}],
+    }
+
+
+# Memoized MLX post-download bundle checks, keyed by
+# (download session id, repo_id, host, cache root). The status endpoint polls
+# every few seconds and a finished download's snapshot doesn't change, so probe
+# it once — but key on the download SESSION, which is generated fresh per
+# download, so re-downloading a repo that was reported broken re-probes instead
+# of replaying the stale gap until the server restarts.
+#
+# Values are (expires_at, gap). A successful probe never expires (the snapshot
+# it read is final for that session); a probe that could not read the snapshot
+# expires after _MLX_BUNDLE_PROBE_RETRY_S, so a completed download on an
+# unreachable remote host doesn't re-run a 12s SSH subprocess on every poll but
+# still recovers once the host comes back.
+_MLX_BUNDLE_CHECK_MAX = 64
+_MLX_BUNDLE_PROBE_RETRY_S = 300.0
+_mlx_bundle_checks: dict[tuple[str, str, str, str], tuple[float, dict | None]] = {}
+
+
+def _remember_mlx_bundle_check(key: tuple, gap: dict | None, ttl: float | None = None) -> None:
+    """Memoize one bundle-check result, keeping the memo bounded.
+
+    ttl=None means "never re-probe for this session"; a float means retry after
+    that many seconds. Re-inserting moves the key to the end, so the eviction
+    below drops the least recently written entry.
+    """
+    _mlx_bundle_checks.pop(key, None)
+    _mlx_bundle_checks[key] = (float("inf") if ttl is None else time.monotonic() + ttl, gap)
+    while len(_mlx_bundle_checks) > _MLX_BUNDLE_CHECK_MAX:
+        _mlx_bundle_checks.pop(next(iter(_mlx_bundle_checks)))
+
+
+def mlx_bundle_gap(
+    session_id: str,
+    repo_id: str,
+    remote_host: str = "",
+    ssh_port: str = "",
+    cache_root: str = "",
+) -> dict | None:
+    """Diagnose a finished MLX download whose bundle isn't loadable.
+
+    An MLX repo can complete cleanly and still be missing config.json, its
+    weights, or its tokenizer — mlx-lm then fails at load time with an opaque
+    error. Only a listing that is positively an MLX LLM text bundle is ever
+    reported (see looks_like_mlx_llm_bundle); whisper- and diffusers-shaped MLX
+    repos pass through untouched.
+    """
+    if not repo_id or "/" not in repo_id or not looks_like_mlx_repo(repo_id):
+        return None
+    key = (session_id or "", repo_id, remote_host or "", cache_root or "")
+    cached = _mlx_bundle_checks.get(key)
+    if cached is not None and time.monotonic() < cached[0]:
+        return cached[1]
+    cmd = ["python3", "-c", HF_SNAPSHOT_LISTING_PROBE, repo_id, cache_root or ""]
+    try:
+        if remote_host:
+            ssh_base = ["ssh"]
+            if ssh_port and ssh_port != "22":
+                ssh_base.extend(["-p", str(ssh_port)])
+            shell_cmd = " ".join(shlex.quote(x) for x in cmd)
+            proc = subprocess.run(ssh_base + [remote_host, shell_cmd], timeout=12, capture_output=True, text=True)
+        else:
+            proc = subprocess.run(cmd, timeout=12, capture_output=True, text=True)
+        if proc.returncode != 0:
+            # Snapshot unreadable (host down, cache moved, no python3 there).
+            # Don't guess — but don't pay for the probe on every poll either.
+            _remember_mlx_bundle_check(key, None, ttl=_MLX_BUNDLE_PROBE_RETRY_S)
+            return None
+        gap = mlx_bundle_diagnosis(repo_id, (proc.stdout or "").splitlines())
+    except Exception:
+        _remember_mlx_bundle_check(key, None, ttl=_MLX_BUNDLE_PROBE_RETRY_S)
+        return None
+    _remember_mlx_bundle_check(key, gap)
+    return gap
 
 
 def classify_dead_download(full_snapshot: str):

--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -42,6 +42,7 @@ from src.host_docker_access import (
 from routes.cookbook_output import (
     error_aware_output_tail, classify_dead_download,
     HF_CACHE_COMPLETE_PROBE, HF_CACHE_INCOMPLETE_PROBE,
+    mlx_bundle_gap,
 )
 
 logger = logging.getLogger(__name__)
@@ -60,6 +61,7 @@ from routes.cookbook_helpers import (
     _user_shell_path_bootstrap, _venv_safe_local_pip_install_cmd,
     _append_pip_install_runner_lines, _pip_install_command_without_break_system_packages,
     _normalize_llama_cpp_python_cache_types,
+    _guard_mlx_platform, _normalize_mlx_model_path,
     ModelDownloadRequest, ServeRequest,
 )
 
@@ -1953,11 +1955,13 @@ def setup_cookbook_routes() -> APIRouter:
         req.cmd = _normalize_llama_cpp_python_cache_types(req.cmd) or ""
         req.cmd = _normalize_minimax_m3_vllm_cmd(req.cmd)
         req.cmd = _normalize_deepseek_v4_sglang_cmd(req.cmd)
+        req.cmd = _normalize_mlx_model_path(req.cmd) or ""
         req.cmd = _venv_safe_local_pip_install_cmd(
             req.cmd,
             local=not bool(req.remote_host),
             in_venv=sys.prefix != sys.base_prefix,
         )
+        _guard_mlx_platform(req.cmd, req.remote_host)
         is_pip_install = bool(req.cmd and "pip install" in req.cmd)
         if is_pip_install:
             # Keep big dependency wheel builds (vLLM, …) off the home filesystem's
@@ -4521,6 +4525,15 @@ def setup_cookbook_routes() -> APIRouter:
                 status = "error"
             if download_zero_files:
                 diagnosis = {"message": "No matching files were downloaded. The model repo or filename/quant pattern may be wrong (for example a ':Q4_K_M' tag that does not exist in the repo). Check the repo and the include/quant pattern."}
+            # An MLX download that "completed" but isn't a loadable folder bundle
+            # should say so here, not fail cryptically at serve time.
+            if task_type == "download" and status == "completed":
+                mlx_gap = mlx_bundle_gap(
+                    session_id, _payload.get("repo_id") or model, remote, str(_tport or ""), _payload.get("local_dir") or ""
+                )
+                if mlx_gap:
+                    status = "error"
+                    diagnosis = mlx_gap
             output_tail = error_aware_output_tail(full_snapshot, status)
 
             results.append({

--- a/services/hwfit/data/mlx_curated_models.json
+++ b/services/hwfit/data/mlx_curated_models.json
@@ -1,0 +1,40 @@
+{
+  "_comment": [
+    "CURATED BY HAND — the HuggingFace API cannot supply this for MLX repos.",
+    "safetensors.total (which feeds the API's numParameters) counts PACKED",
+    "tensors, so a 4-bit MLX build reports a fraction of its real parameter",
+    "count: mlx-community/Devstral-Small-2505-4bit reports 3.68B for a 23.6B",
+    "model, and mlx-community/Qwen3-0.6B-4bit reports ~93M for a 596M model.",
+    "Every hwfit number downstream (VRAM fit, speed, score) is derived from the",
+    "parameter count, so an uncorrected MLX row ranks as a model an order of",
+    "magnitude smaller than it is.",
+    "params_b = real (unpacked) parameters in billions. bits = MLX quant width.",
+    "download_gb = approximate bundle size on disk. context = trained context.",
+    "Dense models only — MoE rows need an active-parameter count this table",
+    "doesn't carry, and a wrong active count skews speed worse than the packed",
+    "total does. Add a row here when a popular mlx-community repo ranks visibly",
+    "wrong; there is no API to derive these from."
+  ],
+  "models": {
+    "mlx-community/Qwen3-0.6B-4bit": {"params_b": 0.596, "bits": 4, "download_gb": 0.35, "context": 32768},
+    "mlx-community/Qwen3-0.6B-8bit": {"params_b": 0.596, "bits": 8, "download_gb": 0.64, "context": 32768},
+    "mlx-community/Qwen3-1.7B-4bit": {"params_b": 1.72, "bits": 4, "download_gb": 0.99, "context": 32768},
+    "mlx-community/Qwen3-1.7B-8bit": {"params_b": 1.72, "bits": 8, "download_gb": 1.83, "context": 32768},
+    "mlx-community/Qwen3-4B-4bit": {"params_b": 4.02, "bits": 4, "download_gb": 2.28, "context": 32768},
+    "mlx-community/Qwen3-4B-8bit": {"params_b": 4.02, "bits": 8, "download_gb": 4.28, "context": 32768},
+    "mlx-community/Qwen3-8B-4bit": {"params_b": 8.19, "bits": 4, "download_gb": 4.63, "context": 32768},
+    "mlx-community/Qwen3-8B-8bit": {"params_b": 8.19, "bits": 8, "download_gb": 8.71, "context": 32768},
+    "mlx-community/Qwen3-14B-4bit": {"params_b": 14.8, "bits": 4, "download_gb": 8.32, "context": 32768},
+    "mlx-community/Llama-3.2-1B-Instruct-4bit": {"params_b": 1.24, "bits": 4, "download_gb": 0.73, "context": 131072},
+    "mlx-community/Llama-3.2-3B-Instruct-4bit": {"params_b": 3.21, "bits": 4, "download_gb": 1.82, "context": 131072},
+    "mlx-community/Meta-Llama-3.1-8B-Instruct-4bit": {"params_b": 8.03, "bits": 4, "download_gb": 4.53, "context": 131072},
+    "mlx-community/Mistral-7B-Instruct-v0.3-4bit": {"params_b": 7.25, "bits": 4, "download_gb": 4.08, "context": 32768},
+    "mlx-community/Mistral-Nemo-Instruct-2407-4bit": {"params_b": 12.2, "bits": 4, "download_gb": 6.91, "context": 131072},
+    "mlx-community/Devstral-Small-2505-4bit": {"params_b": 23.6, "bits": 4, "download_gb": 13.4, "context": 131072},
+    "mlx-community/gemma-3-4b-it-4bit": {"params_b": 4.3, "bits": 4, "download_gb": 2.44, "context": 131072},
+    "mlx-community/gemma-3-12b-it-4bit": {"params_b": 12.2, "bits": 4, "download_gb": 6.87, "context": 131072},
+    "mlx-community/Phi-4-mini-instruct-4bit": {"params_b": 3.84, "bits": 4, "download_gb": 2.17, "context": 131072},
+    "mlx-community/Phi-3-mini-4k-instruct-4bit": {"params_b": 3.82, "bits": 4, "download_gb": 2.16, "context": 4096},
+    "mlx-community/Phi-3-mini-128k-instruct-4bit": {"params_b": 3.82, "bits": 4, "download_gb": 2.16, "context": 131072}
+  }
+}

--- a/services/hwfit/fit.py
+++ b/services/hwfit/fit.py
@@ -476,7 +476,7 @@ def analyze_model(model, system, target_quant=None, scoring_use_case=None, targe
     # Determine which quant to evaluate at
     native_quant_prefixes = (
         "AWQ-", "GPTQ-", "FP8", "FP4", "NVFP4", "MXFP4", "NF4",
-        "INT4", "INT8", "W4A16", "W8A8", "W8A16",
+        "INT4", "INT8", "W4A16", "W8A8", "W8A16", "mlx-",
     )
 
     if preq:
@@ -757,7 +757,7 @@ def rank_models(system, use_case=None, limit=50, search=None, sort="score", quan
     # If user picked a native prequantized format, filter to only those models.
     filter_native = quant and any(quant.startswith(p) for p in (
         "AWQ-", "GPTQ-", "FP8", "FP4", "NVFP4", "MXFP4", "NF4",
-        "INT4", "INT8", "W4A16", "W8A8", "W8A16",
+        "INT4", "INT8", "W4A16", "W8A8", "W8A16", "mlx-",
     ))
 
     system_backend = (system.get("backend") or "").lower()
@@ -818,6 +818,10 @@ def rank_models(system, use_case=None, limit=50, search=None, sort="score", quan
             if quant == "FP4" and native_q not in ("FP4", "NVFP4", "MXFP4", "NF4"):
                 continue
             if quant.startswith("AWQ") and not native_q.startswith("AWQ"):
+                continue
+            # The MLX tab must show MLX builds only — without this a GGUF row
+            # survives the filter and gets relabeled at the requested mlx- tier.
+            if quant.startswith("mlx-") and not native_q.startswith("mlx-"):
                 continue
             if quant.startswith("GPTQ") and not native_q.startswith("GPTQ"):
                 continue

--- a/services/hwfit/mlx_curated.py
+++ b/services/hwfit/mlx_curated.py
@@ -1,0 +1,84 @@
+"""Curated metadata for well-known mlx-community repos.
+
+The HuggingFace API cannot supply parameter counts for MLX builds: the figure it
+reports comes from safetensors.total, which counts PACKED tensors, so a 4-bit
+repo reports roughly a quarter of its real parameter count (Qwen3-0.6B-4bit
+reports ~93M for a 596M model). Everything hwfit computes — VRAM fit, speed,
+score — hangs off the parameter count, so an uncorrected MLX row ranks as a much
+smaller model than it is. There is no API to fix this with; the table in
+data/mlx_curated_models.json is maintained by hand.
+"""
+
+import json
+import os
+
+_CURATED_PATH = os.path.join(os.path.dirname(__file__), "data", "mlx_curated_models.json")
+_curated_cache = None
+
+# Bytes per parameter for an MLX quant tier, matching services.hwfit.models.
+_MLX_BPP = {3: 0.42, 4: 0.55, 5: 0.65, 6: 0.75, 8: 1.0}
+
+
+def load_curated_mlx_models():
+    """The curated table, keyed by exact repo id. Empty dict if unreadable."""
+    global _curated_cache
+    if _curated_cache is None:
+        try:
+            with open(_CURATED_PATH, encoding="utf-8") as f:
+                loaded = json.load(f)
+            models = loaded.get("models") if isinstance(loaded, dict) else None
+            _curated_cache = {
+                k: v for k, v in (models or {}).items() if isinstance(v, dict)
+            }
+        except (OSError, ValueError, AttributeError):
+            _curated_cache = {}
+    return _curated_cache
+
+
+def reset_curated_cache():
+    global _curated_cache
+    _curated_cache = None
+
+
+def curated_mlx_entry(repo_id):
+    """Curated row for a repo id, or None when it isn't in the table."""
+    if not repo_id or not isinstance(repo_id, str):
+        return None
+    return load_curated_mlx_models().get(repo_id.strip())
+
+
+def apply_curated_mlx_metadata(model):
+    """Overwrite a catalog row's size/quant/context from the curated table.
+
+    A no-op for every repo that isn't curated, so the normal HF-derived path is
+    untouched. Mutates and returns `model` (catalog rows are dicts built fresh
+    per load, and the caller already treats them as owned).
+    """
+    if not isinstance(model, dict):
+        return model
+    curated = curated_mlx_entry(model.get("name"))
+    if not curated:
+        return model
+
+    params_b = curated.get("params_b")
+    bits = curated.get("bits")
+    if params_b:
+        model["parameters_raw"] = int(float(params_b) * 1_000_000_000)
+        model["parameter_count"] = f"{float(params_b):.4g}B"
+    if bits:
+        model["quantization"] = f"mlx-{int(bits)}bit"
+    if curated.get("context"):
+        model["context_length"] = int(curated["context"])
+
+    # Size the RAM budget off the bundle itself when we know it — a measured
+    # download beats bytes-per-param arithmetic. Fall back to the tier's BPP.
+    # `size_gb` is what the serve-profile path reads for model weights.
+    weights_gb = curated.get("download_gb")
+    if not weights_gb and params_b and bits:
+        weights_gb = float(params_b) * _MLX_BPP.get(int(bits), 0.55)
+    if weights_gb:
+        model["min_ram_gb"] = round(float(weights_gb) + 0.8, 1)
+        model["recommended_ram_gb"] = round(model["min_ram_gb"] * 1.3 + 0.5, 1)
+        model["size_gb"] = round(float(weights_gb), 2)
+    model["_mlx_curated"] = True
+    return model

--- a/services/hwfit/models.py
+++ b/services/hwfit/models.py
@@ -2,6 +2,8 @@ import json
 import os
 import re
 
+from services.hwfit.mlx_curated import apply_curated_mlx_metadata
+
 QUANT_HIERARCHY = ["Q8_0", "Q6_K", "Q5_K_M", "Q4_K_M", "Q3_K_M", "Q2_K"]
 
 QUANT_BPP = {
@@ -132,6 +134,10 @@ def _normalize_model_entry(model):
     inferred = infer_quantization_from_name(model.get("name", ""))
     if inferred and (model.get("quantization") in (None, "", "Q4_K_M") or model.get("_discovered")):
         model["quantization"] = inferred
+    # MLX rows arrive with a PACKED parameter count (the HF API has no other
+    # number to give for them), which under-sizes the model by the quant's
+    # packing factor. Correct the well-known repos from the curated table.
+    apply_curated_mlx_metadata(model)
     return model
 
 

--- a/static/js/cookbook-hwfit.js
+++ b/static/js/cookbook-hwfit.js
@@ -787,7 +787,15 @@ export async function _hwfitFetch(fresh = false, opts = {}) {
   }
   try {
     const sortBy = document.getElementById('hwfit-sort')?.value || 'newest';
-    const quantPref = document.getElementById('hwfit-quant')?.value || '';
+    let quantPref = document.getElementById('hwfit-quant')?.value || '';
+    // MLX builds carry their own quant tier (mlx-Nbit), so a GGUF tier like Q4
+    // matches nothing and drops every MLX row. The engine picks the format, the
+    // quant tier picks the bit-width — map e.g. Q4 -> mlx-4bit. Native (no
+    // quant) still shows all bit-widths via the client-side view filter.
+    if ((document.getElementById('hwfit-engine')?.value || '') === 'mlx' && quantPref) {
+      const _b = quantPref.match(/(\d+)/);
+      quantPref = _b ? `mlx-${_b[1]}bit` : '';
+    }
     const targetCtx = _ctxValue();
     // Get active GPU count from toggles
     const toggleContainer = document.getElementById('hwfit-gpu-toggles');
@@ -2177,6 +2185,14 @@ export function _hwfitInit() {
   const engine = document.getElementById('hwfit-engine');
   if (engine) _bindHwfitEnginePicker(engine);
   if (engine) engine.addEventListener('change', () => {
+    // MLX re-maps the quant tier to mlx-Nbit server-side, so switching to or
+    // away from it must re-probe; every other engine is a client-side filter.
+    const isMlx = engine.value === 'mlx';
+    if (isMlx || engine.dataset.wasMlx === '1') {
+      engine.dataset.wasMlx = isMlx ? '1' : '';
+      _hwfitFetch();
+      return;
+    }
     const list = document.getElementById('hwfit-list');
     if (list && _hwfitCache && Array.isArray(_hwfitCache.models)) {
       _hwfitRenderList(list, _applyEngineFilter(_hwfitCache.models));

--- a/static/js/cookbook.js
+++ b/static/js/cookbook.js
@@ -10,6 +10,11 @@ import { makeWindowDraggable } from './windowDrag.js';
 import { _diagnose, _showDiagnosis, _clearDiagnosis, _runQuickCmd, ERROR_PATTERNS } from './cookbook-diagnosis.js';
 import { RECIPE_BACKENDS, recipesForBackend, pickRecipe, recipeCommands, RECIPE_DEFAULT_VARIANT } from './cookbook-deps-recipes.js';
 import { _hwfitCache, _hwfitDebounce, _hwfitFetch, _hwfitInit, _hwfitRenderList, _hwfitRenderHw, _renderGpuToggles, _expandModelRow, _fitColors, _hwfitColumns, _cachedModelIds, _gpuToggleTotal, _resetGpuToggleState } from './cookbook-hwfit.js';
+// MLX serve engines live in their own browser-free module so their launch
+// commands stay unit-testable; re-exported here because that's where the serve
+// panel already looks for them.
+import { MLX_ENGINES, buildMlxServeCmd as _buildMlxServeCmd } from './cookbookMlxEngines.js';
+export { MLX_ENGINES };
 
 // Sub-modules
 import {
@@ -986,18 +991,8 @@ export function _buildServeCmd(f, modelName, backend) {
     const _mlxLoraScales = _listField(f.mlx_lora_scales).filter(s => /^-?\d+(?:\.\d+)?$/.test(s));
     if (_mlxLoraScales.length) cmd += ` --lora-scales ${_mlxLoraScales.map(_shellQuote).join(' ')}`;
   } else if (backend === 'mlx') {
-    const mlxPy = _isWindows() ? 'python' : _py3Bin;
-    const mlxHost = f.host ? '0.0.0.0' : '127.0.0.1';
-    cmd += `${mlxPy} -m mlx_lm.server --model ${_shellQuote(modelName)} --host ${mlxHost} --port ${f.port || '8080'}`;
-    const mlxMaxTokens = String(f.ctx || '').trim();
-    if (/minimax|mini-max/i.test(modelName)) {
-      cmd += ` --temp 0.7 --top-p 0.9 --max-tokens ${mlxMaxTokens || '2048'}`;
-    } else if (/^\d+$/.test(mlxMaxTokens)) {
-      // MLX-LM server has no vLLM-style --context-length flag. The closest
-      // server-side request budget it exposes is --max-tokens, so wire the
-      // Cookbook Context/Auto control there for MLX launches.
-      cmd += ` --max-tokens ${mlxMaxTokens}`;
-    }
+    // Pluggable MLX engine (mlx-lm default, oMLX optional) — see MLX_ENGINES.
+    cmd += _buildMlxServeCmd(f, modelName, _isWindows() ? 'python' : _py3Bin);
   }
   return cmd;
 }
@@ -3622,6 +3617,7 @@ const shared = {
   _isMetal,
   _buildEnvPrefix,
   _buildServeCmd,
+  MLX_ENGINES,
   _shellQuote,
   _psQuote,
   _detectBackend,

--- a/static/js/cookbookMlxEngines.js
+++ b/static/js/cookbookMlxEngines.js
@@ -1,0 +1,91 @@
+// static/js/cookbookMlxEngines.js
+//
+// MLX serving engines. Every one speaks the OpenAI-compatible /v1 protocol, so
+// only the launch command differs — Odysseus talks to all of them as `openai`.
+// Add a new engine by adding a row here (+ its binary to _SERVE_CMD_ALLOWLIST
+// in routes/cookbook_helpers.py).
+//
+// Pure (fields in, command string out) so the launch commands are unit-testable
+// under node; cookbook.js itself pulls in browser-only modules and can't load.
+// Same split as cookbookPorts.js / cookbookProgressSignal.js.
+
+// Local copy of cookbook.js's _shellQuote — importing it would drag the whole
+// browser-bound module back in and defeat the point of this file.
+function _q(value) {
+  return "'" + String(value ?? '').replace(/'/g, "'\\''") + "'";
+}
+
+// Quote a directory argument, keeping a leading `~` expandable: single quotes
+// would make the shell take the tilde literally, so emit it as "$HOME" with the
+// rest quoted next to it ("$HOME"'/models' is one word to the shell).
+function _pathArg(path) {
+  const s = String(path || '');
+  if (s === '~') return '"$HOME"';
+  if (s.startsWith('~/')) return '"$HOME"' + _q(s.slice(1));
+  return _q(s);
+}
+
+// A serve aimed at a REMOTE host has to bind 0.0.0.0 or the Odysseus host can't
+// reach it; a local serve stays on loopback. Both MLX engines take --host.
+function _bindHost(f) {
+  return (f && f.host) ? '0.0.0.0' : '127.0.0.1';
+}
+
+// oMLX serves a DIRECTORY of models and the client picks one by name via the
+// request `model` field, so --model-dir is the PARENT of the model's own
+// folder. Derive it from the same resolved path mlx-lm's --model receives — NOT
+// from the download base dir, which for HF-cache layouts holds
+// `models--org--name/snapshots` indirections rather than loadable bundles.
+//
+// A bare repo id ("mlx-community/Qwen3-4B-4bit") is not a filesystem path at
+// all: mlx-lm resolves it through the HF cache, oMLX can't. That returns '' and
+// the command below simply leaves --model-dir off, so the user fills the model
+// path in (or edits the command) instead of being handed a guessed directory.
+export function mlxModelDirFor(serveModel) {
+  const p = String(serveModel || '').trim().replace(/\/+$/, '');
+  if (!/^(?:\/|~\/|\.{1,2}\/)/.test(p)) return '';
+  const cut = p.lastIndexOf('/');
+  if (cut < 0) return '';
+  return p.slice(0, cut) || '/';
+}
+
+export const MLX_ENGINES = {
+  mlx_lm: {
+    label: 'MLX (mlx-lm)',
+    // Apple's official single-model server. --model takes the model dir/repo
+    // (modelName is already resolved to the local path for cached models).
+    cmd: (f, modelName, py3Bin) => {
+      let c = `${py3Bin} -m mlx_lm.server --model ${_q(modelName)} --host ${_bindHost(f)} --port ${f.port || '8080'}`;
+      const maxTokens = String(f.ctx || '').trim();
+      if (/minimax|mini-max/i.test(modelName)) {
+        c += ` --temp 0.7 --top-p 0.9 --max-tokens ${maxTokens || '2048'}`;
+      } else if (/^\d+$/.test(maxTokens)) {
+        // MLX-LM server has no vLLM-style --context-length flag. The closest
+        // server-side request budget it exposes is --max-tokens, so wire the
+        // Cookbook Context/Auto control there for MLX launches.
+        c += ` --max-tokens ${maxTokens}`;
+      }
+      return c;
+    },
+  },
+  omlx: {
+    label: 'oMLX',
+    // Serves a whole model DIRECTORY (auto-discovers subdirs); the client picks
+    // the model via the request `model` field. FastAPI/uvicorn under the hood,
+    // so --host is the standard bind flag, same as the mlx-lm row.
+    cmd: (f) => {
+      const dir = (f._mlx_model_dir || '').toString().trim();
+      let c = 'omlx serve';
+      // No resolvable directory → omit the flag rather than point oMLX at a
+      // guessed "$HOME/models" that probably holds nothing.
+      if (dir) c += ` --model-dir ${_pathArg(dir)}`;
+      c += ` --host ${_bindHost(f)} --port ${f.port || '8000'}`;
+      if (f.max_seqs && f.max_seqs.toString().trim()) c += ` --max-concurrent-requests ${f.max_seqs.toString().trim()}`;
+      return c;
+    },
+  },
+};
+
+export function buildMlxServeCmd(f, modelName, py3Bin) {
+  return (MLX_ENGINES[f && f.mlx_engine] || MLX_ENGINES.mlx_lm).cmd(f, modelName, py3Bin);
+}

--- a/static/js/cookbookServe.js
+++ b/static/js/cookbookServe.js
@@ -12,6 +12,7 @@ import { bindMenuDismiss, dismissOrRemove } from './escMenuStack.js';
 import { openCookbookDependencies } from './cookbook-diagnosis.js';
 import { _hwfitCache } from './cookbook-hwfit.js';
 import { topPortalZ } from './toolWindowZOrder.js';
+import { mlxModelDirFor } from './cookbookMlxEngines.js';
 
 // Shared state/functions injected by init()
 let _envState;
@@ -25,6 +26,7 @@ let _isWindows;
 let _isMetal;
 let _buildEnvPrefix;
 let _buildServeCmd;
+let MLX_ENGINES;
 let _shellQuote;
 let _psQuote;
 let _detectBackend;
@@ -194,6 +196,14 @@ function _repoLooksGgufLike(model, repo) {
 }
 
 function _serveBackendWarning(model, repo, backend, fields = {}) {
+  // MLX has no CUDA/CPU fallback. A remote host is trusted to be a Mac (the
+  // SSH target is the user's call) — same rule the server-side guard applies.
+  if (backend === 'mlx' && !_isMetal() && !fields.host) {
+    return {
+      title: 'MLX needs Apple Silicon',
+      body: 'MLX runs only on Apple Silicon (Metal). On this machine, use vLLM/SGLang (CUDA/ROCm) or llama.cpp/Ollama (GGUF) instead — or pick a remote Mac as the serve target.',
+    };
+  }
   const awqLike = _repoLooksAwqLike(model, repo);
   const ggufLike = _repoLooksGgufLike(model, repo);
   if (awqLike && (backend === 'llamacpp' || backend === 'ollama')) {
@@ -1512,6 +1522,13 @@ function _rerenderCachedModels() {
       // (updateBackendVisibility, runtime readiness, command builder)
       // still fires via dispatchEvent('change') on selection.
       panelHtml += `<label>${_l('Engine','Inference engine: MLX, vLLM, SGLang, llama.cpp, Ollama, or Diffusers')}<div class="hwfit-backend-picker" data-backend-picker style="position:relative;width:100%;"><select class="hwfit-sf hwfit-backend-source" data-field="backend" style="display:none;">${backendOpts}</select><button type="button" class="hwfit-backend-btn" data-backend-btn aria-haspopup="listbox" aria-expanded="false" style="display:flex;align-items:center;gap:6px;width:100%;height:32px;padding:0 8px;background:var(--bg);color:var(--fg);border:1px solid var(--border);border-radius:4px;font:inherit;font-size:11px;cursor:pointer;text-align:left;position:relative;top:-4px;"><span class="hwfit-backend-btn-icon" data-backend-icon-slot aria-hidden="true" style="display:inline-flex;align-items:center;justify-content:center;width:16px;height:16px;color:var(--accent, var(--red));flex-shrink:0;"></span><span class="hwfit-backend-btn-label" data-backend-label style="flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;"></span><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="opacity:0.6;flex-shrink:0;"><polyline points="6 9 12 15 18 9"/></svg></button><div class="hwfit-backend-menu" data-backend-menu role="listbox" hidden style="position:absolute;top:calc(100% + 4px);left:0;right:0;z-index:100;background:var(--panel, var(--bg));border:1px solid var(--border);border-radius:6px;box-shadow:0 6px 20px rgba(0,0,0,0.22);padding:4px;"></div></div></label>`;
+      // MLX is a family of servers, not one binary — every engine speaks the
+      // same OpenAI-compatible /v1 protocol, so only the launch command differs.
+      panelHtml += `<label class="hwfit-backend-mlx">${_l('MLX Engine', 'Which MLX server to launch. mlx-lm = Apple’s official single-model server (already installed with the mlx-lm dependency). oMLX = continuous batching and multi-model serving from a directory.')}<select class="hwfit-sf" data-field="mlx_engine">${Object.entries(MLX_ENGINES).map(([v, e]) => `<option value="${v}"${sv('mlx_engine', 'mlx_lm') === v ? ' selected' : ''}>${esc(e.label)}</option>`).join('')}</select></label>`;
+      // oMLX's --model-dir. Prefilled from the model's own resolved location;
+      // blank for a default-HF-cache model, whose only handle is a repo id that
+      // oMLX can't resolve — that's the case this input exists for.
+      panelHtml += `<label class="hwfit-backend-mlx">${_l('MLX Model Dir', 'oMLX only: the directory oMLX scans for models (the request’s model field then picks one). Prefilled from this model’s own folder when Odysseus can resolve a path; leave blank to let oMLX use its own default. The mlx-lm engine ignores it.')}<input type="text" class="hwfit-sf" data-field="mlx_model_dir" value="${esc(sv('mlx_model_dir', mlxModelDirFor(_savedModelPath || _defaultServeModel)))}" placeholder="auto" /></label>`;
       panelHtml += `<input type="hidden" class="hwfit-sf" data-field="host" value="${esc(_es.remoteHost || '')}" />`;
       // Inference mode pill (llama.cpp only) — lives directly to the
       // RIGHT of Backend in Row 1 so the engine and the GPU/CPU choice
@@ -1887,6 +1904,15 @@ function _rerenderCachedModels() {
         if (f.reasoning_parser) {
           const _rpEl2 = panel.querySelector('[data-field="reasoning_parser"]');
           f._reasoning_parser_value = _rpEl2?.dataset?.parser || '';
+        }
+        if (backend === 'mlx') {
+          // oMLX serves a directory of models; mlx-lm takes the resolved model
+          // path (serveModel). Derive oMLX's dir from that SAME resolved path,
+          // never from the download base dir — see mlxModelDirFor. What the
+          // user typed into MLX Model Dir wins; an unresolvable model (a bare
+          // repo id in the default HF cache) stays empty on purpose, and the
+          // command then omits --model-dir instead of guessing one.
+          f._mlx_model_dir = String(f.mlx_model_dir || '').trim() || mlxModelDirFor(serveModel);
         }
         if (f.vllm_env_preset === 'minimax_m3_cuda') {
           const existingEnv = String(f.extra_env || '').trim();
@@ -4249,6 +4275,7 @@ export function initServe(shared) {
   _isMetal = shared._isMetal;
   _buildEnvPrefix = shared._buildEnvPrefix;
   _buildServeCmd = shared._buildServeCmd;
+  MLX_ENGINES = shared.MLX_ENGINES;
   _shellQuote = shared._shellQuote;
   _psQuote = shared._psQuote;
   _detectBackend = shared._detectBackend;

--- a/tests/test_hwfit_macos.py
+++ b/tests/test_hwfit_macos.py
@@ -7,7 +7,7 @@ guarantee that non-macOS (Linux/Windows) detection is unchanged.
 import json
 
 from services.hwfit import hardware
-from services.hwfit.fit import rank_models
+from services.hwfit.fit import _native_quant, rank_models
 from services.hwfit.models import get_models
 
 
@@ -62,6 +62,34 @@ def test_mlx_hidden_on_cuda_backend_unchanged():
     """Regression guard: Linux/CUDA users never saw MLX before and still don't."""
     mlx = [m for m in rank_models(_cuda_system(), limit=900) if str(m.get("quant", "")).startswith("mlx-")]
     assert mlx == []
+
+
+def test_mlx_quant_filter_surfaces_all_mlx_bitwidths_on_metal():
+    """Picking the MLX quant filter surfaces MLX models at their native
+    bit-widths and excludes every non-MLX format."""
+    res = rank_models(_metal_system(), use_case="general", limit=900, quant="mlx-")
+    assert res, "MLX quant filter returned nothing on Metal"
+    assert all(str(r.get("quant", "")).startswith("mlx-") for r in res)
+    # …and the rows are genuinely MLX builds, not other formats relabeled at
+    # the requested tier (which is what happened before "mlx-" was a native
+    # prequantized format).
+    catalog = {m["name"]: m for m in get_models()}
+    assert all(_native_quant(catalog.get(r["name"], {})).startswith("mlx-") for r in res)
+
+
+def test_mlx_quant_filter_empty_off_metal():
+    """MLX is Apple-Silicon-only, so the MLX quant filter shows nothing on CUDA."""
+    assert rank_models(_cuda_system(), use_case="general", limit=900, quant="mlx-") == []
+
+
+def test_mlx_quant_filter_respects_bit_width_on_metal():
+    """MLX + a specific bit tier (the UI maps Q4 -> mlx-4bit) returns only that
+    bit-width, so the engine and quant filters compose correctly."""
+    res = rank_models(_metal_system(), use_case="general", limit=900, quant="mlx-4bit")
+    assert res, "mlx-4bit returned nothing on Metal"
+    assert all(r.get("quant") == "mlx-4bit" for r in res)
+    catalog = {m["name"]: m for m in get_models()}
+    assert all(_native_quant(catalog.get(r["name"], {})) == "mlx-4bit" for r in res)
 
 
 def test_only_gguf_or_mlx_models_recommended_on_metal():

--- a/tests/test_mlx_backend.py
+++ b/tests/test_mlx_backend.py
@@ -1,0 +1,79 @@
+"""MLX serve backends (mlx-lm + oMLX): allow-list, readiness, platform guard."""
+
+import platform
+import sys
+
+import pytest
+
+from routes.cookbook_helpers import (
+    _SERVE_CMD_ALLOWLIST,
+    _check_serve_binary,
+    _parse_serve_phase,
+    _is_apple_silicon,
+    _guard_mlx_platform,
+)
+
+MLX_LM_CMD = "KMP_DUPLICATE_LIB_OK=TRUE mlx_lm.server --model ~/m --host 127.0.0.1 --port 8080"
+OMLX_CMD = "omlx serve --model-dir ~/models --port 8000"
+# The shape the Cookbook UI actually emits for the default mlx-lm engine.
+MLX_LM_MODULE_CMD = "python3 -m mlx_lm.server --model '/m' --host 127.0.0.1 --port 8080"
+
+
+def test_both_mlx_binaries_allowlisted():
+    assert "omlx" in _SERVE_CMD_ALLOWLIST
+    assert "mlx_lm.server" in _SERVE_CMD_ALLOWLIST
+
+
+def test_mlx_serve_cmds_pass_validation():
+    # Leading env-var assignments (KMP_DUPLICATE_LIB_OK) are skipped; the real
+    # binary is the one that must be allow-listed.
+    _check_serve_binary(OMLX_CMD)
+    _check_serve_binary(MLX_LM_CMD)
+
+
+def test_ready_via_uvicorn_startup():
+    # oMLX is a FastAPI/uvicorn server.
+    out = _parse_serve_phase("INFO:     Application startup complete.", "serve")
+    assert out.get("status") == "ready"
+
+
+def test_ready_via_models_access_log():
+    out = _parse_serve_phase('INFO: 127.0.0.1 - "GET /v1/models HTTP/1.1" 200 OK', "serve")
+    assert out.get("status") == "ready"
+
+
+def test_ready_via_mlx_lm_httpd_line():
+    # mlx-lm's built-in server prints this on bind.
+    out = _parse_serve_phase("INFO Starting httpd at 127.0.0.1 on port 8080...", "serve")
+    assert out.get("status") == "ready"
+
+
+def test_apple_silicon_helper(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(platform, "machine", lambda: "arm64")
+    assert _is_apple_silicon() is True
+    monkeypatch.setattr(platform, "machine", lambda: "x86_64")
+    assert _is_apple_silicon() is False
+
+
+@pytest.mark.parametrize("cmd", [OMLX_CMD, MLX_LM_CMD, MLX_LM_MODULE_CMD])
+def test_mlx_rejected_off_apple_silicon(monkeypatch, cmd):
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(platform, "machine", lambda: "x86_64")
+    with pytest.raises(Exception):  # HTTPException(400)
+        _guard_mlx_platform(cmd, remote_host=None)
+
+
+@pytest.mark.parametrize("cmd", [OMLX_CMD, MLX_LM_CMD, MLX_LM_MODULE_CMD])
+def test_mlx_allowed_on_remote_host(monkeypatch, cmd):
+    # A remote Mac is reachable over SSH; don't gate the local machine then.
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(platform, "machine", lambda: "x86_64")
+    _guard_mlx_platform(cmd, remote_host="mac.local")  # no raise
+
+
+def test_non_mlx_cmd_not_guarded(monkeypatch):
+    # A non-MLX serve command must never be rejected by the MLX guard.
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(platform, "machine", lambda: "x86_64")
+    _guard_mlx_platform("vllm serve org/model --port 8000", remote_host=None)  # no raise

--- a/tests/test_mlx_bundle.py
+++ b/tests/test_mlx_bundle.py
@@ -1,0 +1,258 @@
+"""MLX folder-bundle handling: serve-path normalization + post-download check.
+
+An MLX model is a directory whose manifest is config.json, not a single file.
+Both halves here exist so that mistake is caught with a clear message instead of
+surfacing as an opaque mlx-lm load failure minutes later.
+
+The post-download check is deliberately narrow: mlx-community hosts far more
+than transformers text bundles (whisper, diffusers-style image pipelines), and
+those are complete and loadable in shapes that have no tokenizer.json and no
+safetensors at top level. Flipping a finished download to "error" is only ever
+allowed for a listing positively identified as an MLX LLM text bundle.
+"""
+
+import types
+
+import pytest
+
+from routes.cookbook_helpers import _normalize_mlx_model_path
+from routes import cookbook_output
+from routes.cookbook_output import (
+    looks_like_mlx_llm_bundle,
+    looks_like_mlx_repo,
+    missing_mlx_bundle_files,
+    mlx_bundle_diagnosis,
+    mlx_bundle_gap,
+)
+
+# A real mlx-community text-model listing (the shape mlx-lm loads).
+_FULL_BUNDLE = [
+    "config.json",
+    "generation_config.json",
+    "model.safetensors",
+    "special_tokens_map.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
+]
+_REPO = "mlx-community/Qwen3-4B-4bit"
+
+
+# ── serve-command normalization ──
+
+@pytest.mark.parametrize("given, expected", [
+    (
+        "python3 -m mlx_lm.server --model /m/Qwen3-4bit/config.json --port 8080",
+        "python3 -m mlx_lm.server --model /m/Qwen3-4bit --port 8080",
+    ),
+    (
+        "python3 -m mlx_lm.server --model /m/Qwen3-4bit/model.safetensors --port 8080",
+        "python3 -m mlx_lm.server --model /m/Qwen3-4bit --port 8080",
+    ),
+    (
+        "python3 -m mlx_lm.server --model /m/Q/model-00001-of-00002.safetensors --port 8080",
+        "python3 -m mlx_lm.server --model /m/Q --port 8080",
+    ),
+    (
+        "omlx serve --model-dir /m/Qwen3-4bit/config.json --port 8000",
+        "omlx serve --model-dir /m/Qwen3-4bit --port 8000",
+    ),
+])
+def test_bundle_file_normalizes_to_its_directory(given, expected):
+    assert _normalize_mlx_model_path(given) == expected
+
+
+def test_quoted_bundle_path_keeps_its_quotes():
+    out = _normalize_mlx_model_path("mlx_lm.server --model '/m/My Model/config.json' --port 8080")
+    assert out == "mlx_lm.server --model '/m/My Model' --port 8080"
+
+
+def test_directory_model_path_is_left_alone():
+    cmd = "python3 -m mlx_lm.server --model /m/Qwen3-4bit --port 8080"
+    assert _normalize_mlx_model_path(cmd) == cmd
+
+
+def test_non_mlx_commands_are_never_rewritten():
+    # vLLM takes a repo/dir too, but this rewrite is MLX's contract, not its own.
+    cmd = "vllm serve /m/model/config.json --port 8000"
+    assert _normalize_mlx_model_path(cmd) == cmd
+
+
+def test_empty_cmd_passes_through():
+    assert _normalize_mlx_model_path("") == ""
+    assert _normalize_mlx_model_path(None) is None
+
+
+# ── post-download bundle verification ──
+
+def test_complete_bundle_has_no_gaps():
+    assert missing_mlx_bundle_files(_FULL_BUNDLE) == []
+    assert mlx_bundle_diagnosis(_REPO, _FULL_BUNDLE) is None
+
+
+def test_tokenizer_config_alone_satisfies_the_tokenizer_requirement():
+    assert missing_mlx_bundle_files(
+        ["config.json", "model.safetensors", "tokenizer_config.json"]
+    ) == []
+
+
+@pytest.mark.parametrize("dropped, needle", [
+    ("config.json", "config.json"),
+    ("model.safetensors", "safetensors"),
+    ("tokenizer.json", "tokenizer"),
+])
+def test_missing_member_is_named_in_the_error(dropped, needle):
+    names = [n for n in _FULL_BUNDLE if n not in (dropped, "tokenizer_config.json")]
+    diag = mlx_bundle_diagnosis(_REPO, names)
+    assert diag is not None
+    assert needle in diag["message"]
+    assert _REPO in diag["message"]
+
+
+def test_empty_listing_is_not_reported_as_a_bundle_gap():
+    # "nothing downloaded" is already covered by the download markers; claiming
+    # a broken MLX bundle there would mislabel an unrelated failure.
+    assert missing_mlx_bundle_files([]) == []
+    assert mlx_bundle_diagnosis(_REPO, None) is None
+
+
+# ── the check only ever fires on MLX *LLM text* bundles ──
+
+def test_npz_is_a_valid_weight_container():
+    # mlx-examples-era bundles ship weights.npz instead of safetensors shards.
+    names = ["config.json", "weights.npz", "tokenizer.json", "tokenizer_config.json"]
+    assert missing_mlx_bundle_files(names) == []
+
+
+def test_whisper_style_bundle_is_left_alone():
+    """mlx-community/whisper-large-v3-mlx is config.json + weights.npz and no
+    tokenizer at all — complete and loadable. It must not be called broken."""
+    names = ["config.json", "weights.npz"]
+    assert looks_like_mlx_llm_bundle(names) is False
+    assert missing_mlx_bundle_files(names) == []
+    assert mlx_bundle_diagnosis("mlx-community/whisper-large-v3-mlx", names) is None
+
+
+@pytest.mark.parametrize("names", [
+    # diffusers pipeline: manifest at top level, everything else in subdirs.
+    ["model_index.json", "scheduler", "text_encoder", "tokenizer", "transformer", "vae"],
+    # same layout without the manifest — the component dirs still give it away.
+    ["text_encoder", "tokenizer", "transformer", "vae"],
+])
+def test_diffusers_style_image_bundle_is_left_alone(names):
+    assert looks_like_mlx_llm_bundle(names) is False
+    assert missing_mlx_bundle_files(names) == []
+    assert mlx_bundle_diagnosis("mlx-community/FLUX.1-schnell-4bit", names) is None
+
+
+def test_unfamiliar_layout_is_left_alone():
+    # No text-model marker anywhere → not something this check understands.
+    names = ["config.json", "pytorch_model.bin", "README.md"]
+    assert looks_like_mlx_llm_bundle(names) is False
+    assert missing_mlx_bundle_files(names) == []
+
+
+@pytest.mark.parametrize("names", [
+    ["config.json", "model.safetensors", "tokenizer_config.json"],
+    ["config.json", "model.safetensors", "generation_config.json"],
+    ["config.json", "model.safetensors.index.json", "model-00001-of-00002.safetensors"],
+])
+def test_text_model_markers_put_a_listing_in_scope(names):
+    assert looks_like_mlx_llm_bundle(names) is True
+
+
+def test_llm_bundle_with_no_weights_at_all_is_flagged():
+    names = ["config.json", "generation_config.json", "tokenizer.json", "tokenizer_config.json"]
+    diag = mlx_bundle_diagnosis(_REPO, names)
+    assert diag is not None
+    assert "weights" in diag["message"]
+
+
+@pytest.mark.parametrize("repo", [
+    "mlx-community/Qwen3-4B-4bit",
+    "someone/Qwen3-4B-mlx",
+    "someone/qwen3_mlx_4bit",
+])
+def test_mlx_repos_are_in_scope(repo):
+    assert looks_like_mlx_repo(repo)
+
+
+@pytest.mark.parametrize("repo", [
+    "unsloth/Qwen3-8B-GGUF",
+    "Qwen/Qwen3-8B",
+    "",
+])
+def test_non_mlx_repos_are_out_of_scope(repo):
+    assert not looks_like_mlx_repo(repo)
+
+
+# ── probe memoization (per download session, bounded, failures re-tried) ──
+
+@pytest.fixture(autouse=True)
+def _clear_bundle_memo():
+    cookbook_output._mlx_bundle_checks.clear()
+    yield
+    cookbook_output._mlx_bundle_checks.clear()
+
+
+def _fake_probe(monkeypatch, listings, returncode=0):
+    """Patch the snapshot probe to return successive listings; count the calls."""
+    calls = []
+
+    def _run(cmd, **kwargs):
+        calls.append(cmd)
+        names = listings[min(len(calls) - 1, len(listings) - 1)]
+        return types.SimpleNamespace(
+            returncode=returncode, stdout="\n".join(names), stderr="",
+        )
+
+    monkeypatch.setattr(cookbook_output.subprocess, "run", _run)
+    return calls
+
+
+def test_a_finished_session_is_probed_once(monkeypatch):
+    broken = [n for n in _FULL_BUNDLE if n != "model.safetensors"]
+    calls = _fake_probe(monkeypatch, [broken])
+    first = mlx_bundle_gap("cookbook-aaaa1111", _REPO)
+    second = mlx_bundle_gap("cookbook-aaaa1111", _REPO)
+    assert first is not None and second is first
+    assert len(calls) == 1
+
+
+def test_a_re_download_re_probes_instead_of_replaying_the_old_gap(monkeypatch):
+    """The user fixes the repo and downloads again. The new download gets a new
+    session id, so the stale 'broken bundle' verdict must not follow it."""
+    broken = [n for n in _FULL_BUNDLE if n != "model.safetensors"]
+    calls = _fake_probe(monkeypatch, [broken, _FULL_BUNDLE])
+    assert mlx_bundle_gap("cookbook-aaaa1111", _REPO) is not None
+    assert mlx_bundle_gap("cookbook-bbbb2222", _REPO) is None
+    assert len(calls) == 2
+
+
+def test_probe_failure_is_memoized_then_retried(monkeypatch):
+    """An unreachable remote host must not cost a 12s SSH on every status poll,
+    but the memo has to expire so a host that comes back is picked up."""
+    calls = _fake_probe(monkeypatch, [[]], returncode=255)
+    assert mlx_bundle_gap("cookbook-cccc3333", _REPO, remote_host="mac.local") is None
+    assert mlx_bundle_gap("cookbook-cccc3333", _REPO, remote_host="mac.local") is None
+    assert len(calls) == 1
+
+    (key, (expires_at, gap)), = cookbook_output._mlx_bundle_checks.items()
+    assert gap is None
+    # Failures expire; successes never do.
+    assert expires_at != float("inf")
+    cookbook_output._mlx_bundle_checks[key] = (0.0, None)
+    mlx_bundle_gap("cookbook-cccc3333", _REPO, remote_host="mac.local")
+    assert len(calls) == 2
+
+
+def test_memo_stays_bounded(monkeypatch):
+    _fake_probe(monkeypatch, [_FULL_BUNDLE])
+    for i in range(cookbook_output._MLX_BUNDLE_CHECK_MAX * 2):
+        mlx_bundle_gap(f"cookbook-{i:08x}", _REPO)
+    assert len(cookbook_output._mlx_bundle_checks) <= cookbook_output._MLX_BUNDLE_CHECK_MAX
+
+
+def test_non_mlx_repo_is_never_probed(monkeypatch):
+    calls = _fake_probe(monkeypatch, [_FULL_BUNDLE])
+    assert mlx_bundle_gap("cookbook-dddd4444", "unsloth/Qwen3-8B-GGUF") is None
+    assert calls == []

--- a/tests/test_mlx_curated_models.py
+++ b/tests/test_mlx_curated_models.py
@@ -1,0 +1,80 @@
+"""Curated MLX metadata (services/hwfit/mlx_curated.py).
+
+The HuggingFace API reports PACKED parameter counts for MLX repos — its number
+comes from safetensors.total, which counts the uint32 words a 4-bit build stores
+its weights in, so mlx-community/Devstral-Small-2505-4bit advertises 3.68B for a
+23.6B model. There is no API that can correct this, hence the hand-curated table.
+"""
+
+import json
+
+from services.hwfit.mlx_curated import (
+    _CURATED_PATH,
+    apply_curated_mlx_metadata,
+    curated_mlx_entry,
+    load_curated_mlx_models,
+)
+from services.hwfit.models import get_models
+
+
+def test_curated_table_is_seeded_and_well_formed():
+    table = load_curated_mlx_models()
+    assert len(table) >= 10, "curated table should cover the popular mlx-community repos"
+    for repo, row in table.items():
+        assert repo.startswith("mlx-community/"), repo
+        assert row["params_b"] > 0
+        assert row["bits"] in (3, 4, 5, 6, 8)
+        assert row["download_gb"] > 0
+        assert row["context"] > 0
+
+
+def test_curated_file_documents_why_it_is_hand_maintained():
+    with open(_CURATED_PATH, encoding="utf-8") as f:
+        raw = json.load(f)
+    note = " ".join(raw["_comment"]).lower()
+    assert "safetensors" in note and "packed" in note
+
+
+def test_unknown_repo_is_untouched():
+    assert curated_mlx_entry("mlx-community/Not-A-Real-Repo-4bit") is None
+    row = {"name": "mlx-community/Not-A-Real-Repo-4bit", "parameters_raw": 123, "quantization": "mlx-4bit"}
+    assert apply_curated_mlx_metadata(dict(row)) == row
+
+
+def test_curated_row_overrides_packed_parameter_count():
+    row = apply_curated_mlx_metadata({
+        "name": "mlx-community/Devstral-Small-2505-4bit",
+        # What the HF API reports: the packed tensor count, ~6x too small.
+        "parameters_raw": 3_683_537_920,
+        "parameter_count": "3.68354B",
+        "quantization": "mlx-4bit",
+        "context_length": 32768,
+    })
+    assert row["parameters_raw"] == 23_600_000_000
+    assert row["parameter_count"] == "23.6B"
+    assert row["quantization"] == "mlx-4bit"
+    assert row["context_length"] == 131072
+    assert row["size_gb"] == 13.4
+    assert row["min_ram_gb"] == 14.2
+    assert row["_mlx_curated"] is True
+
+
+def test_curated_metadata_reaches_the_catalog():
+    """The correction has to land on the rows hwfit actually ranks, not just in
+    the table — this repo ships in the bundled MLX catalog with the packed count."""
+    catalog = {m["name"]: m for m in get_models()}
+    row = catalog["mlx-community/Devstral-Small-2505-4bit"]
+    assert row["parameters_raw"] == 23_600_000_000
+    assert row["_mlx_curated"] is True
+
+
+def test_non_mlx_catalog_rows_are_not_curated():
+    catalog = {m["name"]: m for m in get_models()}
+    assert not any(
+        m.get("_mlx_curated") for name, m in catalog.items() if not name.startswith("mlx-community/")
+    )
+
+
+def test_apply_is_a_noop_for_non_dicts():
+    assert apply_curated_mlx_metadata(None) is None
+    assert apply_curated_mlx_metadata("nope") == "nope"

--- a/tests/test_mlx_engines_js.py
+++ b/tests/test_mlx_engines_js.py
@@ -1,0 +1,149 @@
+"""MLX serve-engine launch commands (static/js/cookbookMlxEngines.js).
+
+Two things the UI has to get right for a REMOTE Mac serve target:
+
+* bind address — a server that binds loopback on the remote host is unreachable
+  from the Odysseus host, so every engine must mirror the mlx-lm host rule;
+* --model-dir — oMLX needs a real directory, and the download base dir is not
+  one: for HF-cache layouts it holds `models--org--name/snapshots` indirections,
+  and for a default-cache model there is no path at all. Guessing a directory
+  there produces a server that starts and serves nothing.
+
+The registry is a browser-free module precisely so these are executable under
+node (cookbook.js itself pulls in DOM-bound modules and can't load).
+"""
+
+import json
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from routes.cookbook_helpers import _normalize_mlx_model_path, _validate_serve_cmd
+
+_REPO = Path(__file__).resolve().parent.parent
+_SERVE_JS = (_REPO / "static/js/cookbookServe.js").read_text(encoding="utf-8")
+_HAS_NODE = shutil.which("node") is not None
+
+requires_node = pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+
+
+def _run_node(body: str):
+    script = textwrap.dedent(f"""
+        const {{ MLX_ENGINES, buildMlxServeCmd, mlxModelDirFor }} =
+          await import('./static/js/cookbookMlxEngines.js');
+        {body}
+    """)
+    res = subprocess.run(
+        ["node", "--input-type=module", "-e", script],
+        cwd=_REPO, capture_output=True, timeout=30, text=True,
+    )
+    if res.returncode != 0:
+        raise AssertionError(f"node failed:\n{res.stderr}")
+    out = [ln for ln in res.stdout.splitlines() if ln.strip()]
+    if not out:
+        raise AssertionError("node produced no stdout")
+    return json.loads(out[-1])
+
+
+def _omlx(fields):
+    return _run_node(
+        f"console.log(JSON.stringify(buildMlxServeCmd({json.dumps(fields)}, 'org/model', 'python3')));"
+    )
+
+
+def _mlx_lm(fields):
+    fields = {**fields, "mlx_engine": "mlx_lm"}
+    return _run_node(
+        f"console.log(JSON.stringify(buildMlxServeCmd({json.dumps(fields)}, '/m/Qwen3-4bit', 'python3')));"
+    )
+
+
+# ── bind address ──
+
+@requires_node
+def test_omlx_binds_all_interfaces_for_a_remote_target():
+    cmd = _omlx({"mlx_engine": "omlx", "host": "mac.local", "_mlx_model_dir": "/models"})
+    assert "--host 0.0.0.0" in cmd
+
+
+@requires_node
+def test_omlx_stays_on_loopback_for_a_local_target():
+    cmd = _omlx({"mlx_engine": "omlx", "_mlx_model_dir": "/models"})
+    assert "--host 127.0.0.1" in cmd
+
+
+@requires_node
+def test_both_engines_use_the_same_host_rule():
+    remote = {"host": "mac.local", "_mlx_model_dir": "/models"}
+    local = {"_mlx_model_dir": "/models"}
+    assert "--host 0.0.0.0" in _mlx_lm(remote)
+    assert "--host 127.0.0.1" in _mlx_lm(local)
+    assert "--host 0.0.0.0" in _omlx({**remote, "mlx_engine": "omlx"})
+    assert "--host 127.0.0.1" in _omlx({**local, "mlx_engine": "omlx"})
+
+
+# ── --model-dir resolution ──
+
+@requires_node
+def test_model_dir_is_the_parent_of_the_resolved_model_path():
+    # Same path mlx-lm's --model receives, one level up: oMLX scans a directory
+    # of models and the request's `model` field picks one out of it.
+    assert _run_node(
+        "console.log(JSON.stringify(mlxModelDirFor('/srv/models/Qwen3-4B-4bit')));"
+    ) == "/srv/models"
+
+
+@pytest.mark.parametrize("serve_model", [
+    "mlx-community/Qwen3-4B-4bit",   # default HF cache — a repo id, not a path
+    "Qwen3-4B-4bit",
+    "",
+])
+@requires_node
+def test_unresolvable_model_yields_no_directory(serve_model):
+    assert _run_node(f"console.log(JSON.stringify(mlxModelDirFor({json.dumps(serve_model)})));") == ""
+
+
+@requires_node
+def test_no_directory_means_no_flag_not_a_guessed_one():
+    cmd = _omlx({"mlx_engine": "omlx"})
+    assert "--model-dir" not in cmd
+    assert "$HOME/models" not in cmd
+    assert cmd.startswith("omlx serve ")
+
+
+@requires_node
+def test_home_relative_dir_stays_expandable():
+    # Single-quoting the whole path would make the shell take `~` literally.
+    cmd = _omlx({"mlx_engine": "omlx", "_mlx_model_dir": "~/models"})
+    assert '--model-dir "$HOME"\'/models\'' in cmd
+
+
+@requires_node
+def test_generated_omlx_commands_pass_the_server_side_validator():
+    for fields in (
+        {"mlx_engine": "omlx", "_mlx_model_dir": "/srv/models", "host": "mac.local"},
+        {"mlx_engine": "omlx", "_mlx_model_dir": "~/models"},
+        {"mlx_engine": "omlx"},
+        {"mlx_engine": "omlx", "_mlx_model_dir": "/srv/my models", "max_seqs": "8"},
+    ):
+        cmd = _omlx(fields)
+        assert _validate_serve_cmd(cmd) == cmd
+        # …and survive the server-side bundle-path rewrite untouched: a
+        # directory is already the shape both engines want.
+        assert _normalize_mlx_model_path(cmd) == cmd
+
+
+# ── the serve panel feeds it the resolved path, not the download base dir ──
+
+def test_serve_panel_resolves_the_dir_from_the_model_path():
+    assert "f._mlx_model_dir = String(f.mlx_model_dir || '').trim() || mlxModelDirFor(serveModel);" in _SERVE_JS
+    # The old bug: handing oMLX the scan/download base dir verbatim.
+    assert "f._mlx_model_dir = m.path" not in _SERVE_JS
+
+
+def test_serve_panel_exposes_a_model_dir_input():
+    # When nothing resolves, the user needs somewhere to put one.
+    assert 'data-field="mlx_model_dir"' in _SERVE_JS

--- a/tests/test_mlx_load_error.py
+++ b/tests/test_mlx_load_error.py
@@ -1,0 +1,90 @@
+"""Translation of mlx-lm's checkpoint key-mismatch load failure.
+
+mlx-lm rejects a checkpoint whose tensor keys don't match any architecture it
+knows — nearly always an mlx-lm older than the model. Raw, that surfaces as a
+bare KeyError on a tensor name (or keyNotFound from the Swift bridge), which
+reads like an Odysseus bug. The raw output stays in the log either way.
+"""
+
+from routes.cookbook_helpers import _diagnose_serve_output, _parse_serve_phase
+
+_KEY_ERROR_LOG = (
+    "Traceback (most recent call last):\n"
+    '  File "/opt/venv/lib/python3.12/site-packages/mlx_lm/utils.py", line 201, in load_model\n'
+    "    model.load_weights(list(weights.items()))\n"
+    "KeyError: 'model.layers.0.self_attn.q_proj.weight'\n"
+)
+_SWIFT_LOG = "mlx_lm.server: fatal error: keyNotFound(CodingKeys(stringValue: \"model.embed_tokens\"))"
+_MISSING_PARAMS_LOG = "mlx_lm.server: ValueError: Received parameters not in model: model.layers.0.mlp.gate.weight"
+
+
+def test_phase_reports_the_load_failure():
+    out = _parse_serve_phase(_KEY_ERROR_LOG, "serve")
+    assert "mlx-lm too old" in out["phase"]
+    # Not "ready" — the caller flips the task to error via the diagnosis.
+    assert out["status"] == ""
+
+
+def test_diagnosis_names_the_real_cause():
+    diag = _diagnose_serve_output(_KEY_ERROR_LOG)
+    assert diag is not None
+    assert "newer mlx-lm" in diag["message"]
+    assert any(s.get("package") == "mlx-lm" for s in diag["suggestions"])
+
+
+def test_swift_key_not_found_is_recognized():
+    assert _diagnose_serve_output(_SWIFT_LOG)["message"] == _diagnose_serve_output(_KEY_ERROR_LOG)["message"]
+
+
+def test_received_parameters_not_in_model_is_recognized():
+    assert "newer mlx-lm" in _diagnose_serve_output(_MISSING_PARAMS_LOG)["message"]
+
+
+def test_a_serving_mlx_process_still_reads_ready():
+    """A key mismatch is a load-time failure. If the server got up and served a
+    request, the ready signal must win over a stale error further up the pane."""
+    log = _KEY_ERROR_LOG + '\nINFO Starting httpd at 127.0.0.1 on port 8080\n'
+    assert _parse_serve_phase(log, "serve")["status"] == "ready"
+
+
+def test_non_mlx_key_error_is_not_claimed():
+    """A KeyError from a vLLM/llama.cpp launch must not be blamed on mlx-lm."""
+    vllm_log = (
+        "Traceback (most recent call last):\n"
+        '  File "/opt/venv/lib/python3.12/site-packages/vllm/model_executor/loader.py", line 88\n'
+        "KeyError: 'model.layers.0.self_attn.q_proj.weight'\n"
+    )
+    out = _parse_serve_phase(vllm_log, "serve")
+    assert "mlx" not in out.get("phase", "")
+    diag = _diagnose_serve_output(vllm_log)
+    assert diag is None or "mlx-lm" not in diag["message"]
+
+
+def test_mlx_community_model_path_alone_does_not_make_it_an_mlx_failure():
+    """A CUDA box serving a repo whose PATH contains "mlx" is still vLLM. The
+    pane echoes the launch command, so the bare substring "mlx" is everywhere —
+    only the engine name (mlx_lm / omlx) may claim the failure."""
+    vllm_log = (
+        "+ vllm serve /models/mlx-community/Qwen3-4B-4bit --port 8000\n"
+        "Traceback (most recent call last):\n"
+        '  File "/opt/venv/lib/python3.12/site-packages/vllm/model_executor/loader.py", line 88\n'
+        "KeyError: 'model.layers.0.self_attn.q_proj.weight'\n"
+    )
+    out = _parse_serve_phase(vllm_log, "serve")
+    assert "mlx-lm too old" not in out.get("phase", "")
+    diag = _diagnose_serve_output(vllm_log)
+    assert diag is None or "newer mlx-lm" not in diag["message"]
+
+
+def test_real_mlx_launch_lines_still_claim_the_failure():
+    """The three shapes Cookbook emits all name the engine, so a genuine MLX
+    key mismatch is still translated."""
+    key_error = "KeyError: 'model.layers.0.self_attn.q_proj.weight'\n"
+    for launch in (
+        "+ python3 -m mlx_lm.server --model /m/Qwen3-4bit --port 8080\n",
+        "+ mlx_lm.server --model /m/Qwen3-4bit --port 8080\n",
+        "+ omlx serve --model-dir /m --host 127.0.0.1 --port 8000\n",
+    ):
+        log = launch + key_error
+        assert "mlx-lm too old" in _parse_serve_phase(log, "serve")["phase"], launch
+        assert "newer mlx-lm" in _diagnose_serve_output(log)["message"], launch


### PR DESCRIPTION
## Summary

Adds MLX as a first-class Cookbook serving backend on Apple Silicon, reviving #2211 by @RandevRanjit (closed after going stale) re-ported onto current `dev` at its original scope. Much of that PR's periphery has since landed upstream (Metal detection, MLX backend routing, readiness lines), so this PR adds only what is still missing: `mlx_lm.server` and `omlx` in the serve-command allowlist, a server-side Apple Silicon guard (`_guard_mlx_platform`, remote hosts trusted), an `MLX_ENGINES` registry with an engine picker (mlx-lm default, oMLX for continuous batching/multi-model), and mlx-lm httpd readiness detection. On top of the port, four MLX-specific reliability fixes: curated size/context metadata for MLX repos in hwfit (the HF API cannot report MLX parameter counts: `safetensors.total` counts packed tensors, so e.g. `mlx-community/Qwen3-0.6B-4bit` reports ~93M for a 596M model, and the shipped catalog had `Devstral-Small-2505-4bit` at 3.68B instead of 23.6B), bundle-path normalization (MLX models are folder bundles with `config.json` as manifest, so `--model` paths pointing at `config.json`/`*.safetensors` reduce to the bundle directory), post-download bundle verification that only flags positively-identified MLX LLM text bundles (whisper/diffusers-style repos pass through untouched), and translation of mlx-lm tensor-key-mismatch load failures into a clear "needs a newer mlx-lm" message (raw traceback stays in logs, and the check requires an actual mlx-lm/oMLX serve so vLLM boxes serving `mlx-community` paths are never claimed).

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #683

## Type of Change

- [x] New feature (non-breaking — adds new behaviour)

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate. (Coordinated on #683 first; #2211 is the predecessor this revives, with credit.)
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in. (`git diff --check` clean; diff stat identical under `--ignore-all-space`.)
- [x] I actually ran the app (`./start-macos.sh` on an M-series Mac) and verified the change works end-to-end: downloaded `mlx-community/Qwen3-0.6B-4bit` through Cookbook, served it via the MLX (mlx-lm) engine, and chatted against the running endpoint. Screenshots below.

## How to Test

1. On an Apple Silicon Mac: `./start-macos.sh`, open the app, go to Cookbook.
2. Search/scan for an MLX repo (e.g. `mlx-community/Qwen3-0.6B-4bit`) and download it. On completion the new bundle verification confirms `config.json` + weights + tokenizer are present (delete `tokenizer.json` from the bundle and re-check status to see the clear error instead of a cryptic load failure).
3. Open Serve for the model: on Metal the backend auto-selects MLX and the new "MLX Engine" picker appears (mlx-lm default, oMLX optional). Launch and wait for ready (detected from mlx-lm's `Starting httpd` line / `/v1/models` access log).
4. Chat against the served endpoint to confirm completions flow.
5. Negative path: on a non-Apple-Silicon host, an MLX serve command is rejected server-side with a clear message (`_guard_mlx_platform`); remote SSH targets stay allowed.
6. Unit tests: `python -m pytest tests/test_mlx_backend.py tests/test_mlx_bundle.py tests/test_mlx_curated_models.py tests/test_mlx_load_error.py tests/test_mlx_engines_js.py tests/test_hwfit_macos.py tests/test_hwfit_manual_backend.py` (97 pass). Full `test_*cookbook*/test_*serve*/test_*hwfit*` sweep produces a failure list byte-identical to `dev`'s.

## Visual / UI changes — REQUIRED if you touched anything that renders

- [x] **Screenshot or short clip** of the change in the running app, attached below.
- [x] **Style match**: the MLX Engine picker and model-dir input reuse the existing `hwfit-sf` select/input classes and `hwfit-backend-mlx` visibility row; no new colors, fonts, spacing units, or component patterns; no emoji.
- [x] **No new component patterns.**
- [ ] **I am not an LLM agent submitting a bulk PR.** Honest disclosure instead of a checked box: this work was AI-assisted under my direction, and per the contribution guidance the approach was proposed and discussed on #683 before any code (see https://github.com/odysseus-dev/odysseus/issues/683#issuecomment-5235942501). It is a single scoped PR, not bulk, and I ran the app and the flow end-to-end on real hardware (M-series) myself.

### Screenshots / clips

All captured on an Apple Silicon MacBook (M-series, 16 GB) running this branch via `./start-macos.sh`.

**1. Hardware-fit scan on Metal: MLX models ranked with real metadata (MODE=MLX):**

![hwfit scan ranking MLX models on Apple Silicon](https://raw.githubusercontent.com/josuediazflores/odysseus/mlx-evidence/01-hwfit-mlx-ranking.png)

**2. Serve panel for a cached MLX model: Engine=MLX, the MLX Engine picker (mlx-lm default / oMLX), MLX preflight, unified-memory-aware context auto:**

![serve panel with MLX engine picker](https://raw.githubusercontent.com/josuediazflores/odysseus/mlx-evidence/02-serve-panel-mlx.png)

**3. Serve launched and running (readiness detected from the mlx-lm httpd line):**

![serve running in Active tab](https://raw.githubusercontent.com/josuediazflores/odysseus/mlx-evidence/06-serve-ready-active.png)

**4. Chatting with the served MLX model from the Odysseus chat UI (0.73s response):**

![chat against served MLX model](https://raw.githubusercontent.com/josuediazflores/odysseus/mlx-evidence/07-chat-mlx-served.png)

Endpoint proof (same serve, via curl):

```
$ curl -s http://127.0.0.1:8000/v1/chat/completions -H "Content-Type: application/json" \
    -d '{"model":"mlx-community/Qwen3-0.6B-4bit","messages":[{"role":"user","content":"Say hello from MLX serving on Odysseus in one short sentence. /no_think"}],"max_tokens":80}'
→ "Odysseus, with MLX's expertise, will greet you with a friendly and insightful welcome!"
   usage: {prompt_tokens: 28, completion_tokens: 26, total_tokens: 54}
```
