### PR TITLE
fix(issues): require exact bug-report revisions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,6 +26,18 @@ body:
         - label: I am running the latest code from the `dev` branch (the default branch you get on clone, where fixes land first) and the bug still reproduces there. Please `git pull` the latest `dev` before filing.
           required: true
 
+  - type: input
+    id: revision
+    attributes:
+      label: Odysseus Revision
+      description: |
+        From the repository root (on the host when using Docker), run
+        `git show -s --abbrev=12 --format='%h (%cs)' HEAD`
+        and paste the output exactly.
+      placeholder: "1fef4929cf1d (2026-08-11)"
+    validations:
+      required: true
+
   - type: dropdown
     id: install-method
     attributes:

--- a/.github/scripts/check-issue-description.js
+++ b/.github/scripts/check-issue-description.js
@@ -41,6 +41,14 @@ module.exports = async ({ github, context, core }) => {
       break;
 
     case 'bug': {
+      const revisionText = section('Odysseus Revision');
+      if (!/^[0-9a-f]{12} \(\d{4}-\d{2}-\d{2}\)$/i.test(revisionText)) {
+        failures.push(
+          '**Odysseus Revision** — paste the 12-character commit SHA and date, ' +
+          'for example `1fef4929cf1d (2026-08-11)`',
+        );
+      }
+
       if (!section('Install Method')) {
         failures.push('**Install Method** — select how you installed Odysseus');
       }

--- a/tests/test_issue_description_check.py
+++ b/tests/test_issue_description_check.py
@@ -6,10 +6,12 @@ import subprocess
 from pathlib import Path
 
 import pytest
+import yaml
 
 
 _REPO = Path(__file__).resolve().parent.parent
 _CHECKER = _REPO / ".github" / "scripts" / "check-issue-description.js"
+_BUG_TEMPLATE = _REPO / ".github" / "ISSUE_TEMPLATE" / "bug_report.yml"
 _WORKFLOW = _REPO / ".github" / "workflows" / "issue-description-check.yml"
 pytestmark = pytest.mark.skipif(not shutil.which("node"), reason="node not on PATH")
 
@@ -66,9 +68,112 @@ checkIssueDescription({ github, context, core })
     return json.loads(proc.stdout)
 
 
+def _run_bug_issue(revision):
+    body = f"""# Odysseus Revision
+{revision}
+
+# Install Method
+Docker
+
+# Operating System
+Linux
+
+# Steps to Reproduce
+1. Start Odysseus.
+
+# Expected Behaviour
+The application starts normally.
+
+# Actual Behaviour
+The application exits unexpectedly.
+"""
+    harness = r"""
+const checkIssueDescription = require(process.argv[1]);
+const body = process.argv[2];
+const calls = [];
+
+const github = {
+  rest: {
+    issues: {
+      removeLabel: async (params) => calls.push({ method: 'removeLabel', params }),
+      getLabel: async () => ({}),
+      addLabels: async (params) => calls.push({ method: 'addLabels', params }),
+      listComments: async () => ({ data: [] }),
+      createComment: async (params) => calls.push({ method: 'createComment', params }),
+      updateComment: async (params) => calls.push({ method: 'updateComment', params }),
+      deleteComment: async (params) => calls.push({ method: 'deleteComment', params }),
+    },
+  },
+};
+const context = {
+  payload: {
+    action: 'opened',
+    issue: { number: 42, state: 'open', body, labels: [{ name: 'bug' }] },
+  },
+  repo: { owner: 'odysseus-dev', repo: 'odysseus' },
+};
+const core = {
+  warning: (message) => calls.push({ method: 'warning', message }),
+  setFailed: (message) => calls.push({ method: 'setFailed', message }),
+};
+
+checkIssueDescription({ github, context, core })
+  .then(() => process.stdout.write(JSON.stringify(calls)))
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+"""
+    proc = subprocess.run(
+        ["node", "-e", harness, str(_CHECKER), body],
+        capture_output=True,
+        text=True,
+        cwd=str(_REPO),
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
 def test_workflow_handles_issue_closures():
     workflow = _WORKFLOW.read_text()
     assert "types: [opened, edited, reopened, closed]" in workflow
+
+
+def test_bug_template_requires_exact_revision():
+    template = yaml.safe_load(_BUG_TEMPLATE.read_text())
+    revision = next(item for item in template["body"] if item.get("id") == "revision")
+    assert revision["type"] == "input"
+    assert revision["attributes"]["label"] == "Odysseus Revision"
+    assert "git show -s --abbrev=12 --format='%h (%cs)' HEAD" in revision["attributes"]["description"]
+    assert revision["attributes"]["placeholder"] == "1fef4929cf1d (2026-08-11)"
+    assert revision["validations"]["required"] is True
+
+
+def test_bug_checker_accepts_exact_revision():
+    calls = _run_bug_issue("1fef4929cf1d (2026-08-11)")
+    assert not any(call["method"] in {"createComment", "setFailed"} for call in calls)
+    assert any(
+        call["method"] == "addLabels" and call["params"]["labels"] == ["ready for review"]
+        for call in calls
+    )
+
+
+@pytest.mark.parametrize(
+    "revision",
+    [
+        "",
+        "1fef492",
+        "1fef4929cf1d",
+        "1fef4929cf1d (11 August 2026)",
+        "1fef4929cf1d (2026-08-11) extra",
+    ],
+)
+def test_bug_checker_rejects_missing_or_malformed_revision(revision):
+    calls = _run_bug_issue(revision)
+    comment = next(call["params"]["body"] for call in calls if call["method"] == "createComment")
+    assert "**Odysseus Revision**" in comment
+    assert any(call["method"] == "setFailed" for call in calls)
 
 
 @pytest.mark.parametrize("action", ["closed", "edited"])


### PR DESCRIPTION
## Summary

Bug reports currently confirm that they reproduce on the latest `dev` branch but do not identify the exact checkout that was tested. This adds a required **Odysseus Revision** field with one copyable command that emits a 12-character commit SHA plus ISO commit date, and extends the issue-description checker so missing or malformed revision values cannot bypass triage through edits or manually written issue bodies. The repository revision is used because Odysseus does not currently expose one canonical app version across its web app, API metadata, and CLI.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Part of #2396

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

Not run: this change only affects GitHub issue intake and does not alter the application runtime.

## How to Test

1. Run `python -m pytest -q tests/test_issue_description_check.py`; all 10 tests should pass.
2. Run `node --check .github/scripts/check-issue-description.js`; it should exit successfully with no output.
3. Inspect `.github/ISSUE_TEMPLATE/bug_report.yml` and confirm **Odysseus Revision** is a required input before **Install Method**, with `git show -s --abbrev=12 --format='%h (%cs)' HEAD` as the copyable command.
4. Confirm the regression test accepts `1fef4929cf1d (2026-08-11)` and rejects a missing value, a short SHA, a SHA without a date, a non-ISO date, and trailing text.

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable: no application UI or rendering code changed.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

N/A
