### PR TITLE
fix(agent): respect bash/shell toggle as source of truth for tool ava…

### DIFF
--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -3594,6 +3594,20 @@ async def stream_agent_loop(
                 _removed_doc_file_tools,
             )
 
+    # ── Respect user's bash/shell toggle ──────────────────────────────
+    # Per-turn RAG/keyword/domain selection can drop bash from the tool
+    # list even when the user's toggle is ON (e.g. non-English queries
+    # that don't match the English-only domain regex).  The toggle is
+    # the user's explicit choice — when bash is not disabled, it MUST
+    # be available every turn.
+    # Plan mode, guide-only mode, non-admin restrictions, and web-intent
+    # modes all correctly add "bash" to disabled_tools before this point.
+    if "bash" not in disabled_tools:
+        if _relevant_tools is None:
+            from src.tool_index import ALWAYS_AVAILABLE
+            _relevant_tools = set(ALWAYS_AVAILABLE)
+        _relevant_tools.add("bash")
+
     if _relevant_tools is not None:
         logger.info("[agent-intent] selected_tools=%s", sorted(_relevant_tools)[:50])
 

--- a/src/tool_index.py
+++ b/src/tool_index.py
@@ -513,6 +513,14 @@ class ToolIndex:
         frozenset({"write a", "create a doc", "draft", "compose", "poem", "story",
                    "essay", "outline", "letter"}):
             {"create_document", "edit_document", "update_document"},
+        # Shell/terminal/bash intent — covers common English and
+        # Portuguese terms so the keyword fallback path can surface
+        # bash when RAG retrieval fails or times out.
+        frozenset({"bash", "shell", "terminal", "command", "cmd",
+                   "execute", "exec", "sh",
+                   "rodar", "rode", "roda", "comando", "comandos",
+                   "executar", "execute", "terminal", "terminais"}):
+            {"bash"},
     }
 
     def get_tools_for_query(


### PR DESCRIPTION
## Summary

The per-turn tool selection in `stream_agent_loop()` drops `bash` from the model's tool list on non-English queries because `_classify_agent_request()` uses English-only regex patterns. When no domain matches, the query is flagged `low_signal` and bash is excluded — even with the toggle ON. This fix adds a guard after all tool selection logic: if `bash` is not in `disabled_tools` (toggle is ON, not plan mode, not guide-only, not non-admin), it is force-added to `_relevant_tools`. Additionally, `_KEYWORD_HINTS` in `tool_index.py` is extended with bash/shell/terminal keywords in English and Portuguese.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #3766

This fix is complementary to [#5751](https://github.com/odysseus-dev/odysseus/pull/5751) (pluggable LLM domain classifier):

- **#5751**: improves *which* domains are detected (language-agnostic, opt-in via `ODYSSEUS_DOMAIN_CLASSIFIER=llm`)
- **This PR**: guarantees the bash/shell toggle is *the source of truth* for bash availability, regardless of domain classifier quality

Both fixes work independently. This fix works even when `ODYSSEUS_DOMAIN_CLASSIFIER` is unset (default) or when the utility model is too small to classify reliably.


## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Start Odysseus with bash toggle ON in agent mode.
2. Send a non-English query that requests shell usage: `"rode o free -h"` (Portuguese).
3. Before fix: model responds "no terminal available" because `selected_tools` lacks `bash`.
4. After fix: model calls `bash` tool normally because `bash` is force-added to `_relevant_tools`.
5. Regression: set bash toggle OFF. Send any query. Bash must NOT appear in tools.
6. Regression: enable plan mode. Bash must NOT appear (blocked by `plan_mode_disabled_tools()`).

## Visual / UI changes

No UI changes. Backend only.

- [ ] **Screenshot or short clip** — N/A, no UI changes.
- [ ] **Style match** — N/A.
- [ ] **No new component patterns** — N/A.
- [x] **I am not an LLM agent submitting a bulk PR.**