### PR TITLE
fix(thinking): add deepseek-v4 to thinking model patterns

### DIFF
--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -1267,8 +1267,8 @@ _MISTRAL_REASONING_EFFORT = os.getenv("ODYSSEUS_MISTRAL_REASONING_EFFORT", "high
 
 # Models that support structured thinking — may output </think> without opening tag
 _THINKING_MODEL_PATTERNS = (
-    "qwen3", "qwq", "deepseek-r1", "deepseek-reasoner", "minimax",
-    "m2-reap", "gemma", "stepfun", "step-3", "step3",
+    "qwen3", "qwq", "deepseek-r1", "deepseek-reasoner", "deepseek-v4",
+    "minimax", "m2-reap", "gemma", "stepfun", "step-3", "step3",
     "magistral", "mistral-small", "mistral-medium",
 )
 

--- a/tests/test_llm_core_thinking_models.py
+++ b/tests/test_llm_core_thinking_models.py
@@ -1,0 +1,27 @@
+"""Regression coverage for structured-thinking model detection."""
+
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+import pytest
+
+from src.llm_core import _supports_thinking
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "deepseek-v4",
+        "deepseek-v4-flash",
+        "DeepSeek-V4-Flash",
+        "deepseek/deepseek-v4-flash",
+    ],
+)
+def test_deepseek_v4_models_support_thinking(model):
+    assert _supports_thinking(model) is True
+
+
+@pytest.mark.parametrize("model", ["deepseek-v3", "deepseek-chat"])
+def test_other_deepseek_models_are_not_promoted_to_thinking(model):
+    assert _supports_thinking(model) is False


### PR DESCRIPTION
## Summary

`deepseek-v4-flash` emits `reasoning_content` via the API but was not recognized in `_THINKING_MODEL_PATTERNS` (only `deepseek-r1` and `deepseek-reasoner` were listed). Add the `deepseek-v4` prefix so the model is properly recognized as thinking-capable.

The between-round `_thinkOpen` leakage was separately fixed by [#5931](https://github.com/odysseus-dev/odysseus/pull/5931) which added `_closeOpenThinkingMarkup()` called at `agent_step`.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Related: [#3998](https://github.com/odysseus-dev/odysseus/issues/3998), [#5931](https://github.com/odysseus-dev/odysseus/pull/5931)

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Use deepseek-v4-flash in agent mode.
2. Observe that `_supports_thinking("deepseek-v4-flash")` now returns `true`.
3. Thinking/reasoning content is properly streamed and rendered.

## Changes

| File | Change | Lines |
|------|--------|-------|
| `src/llm_core.py` | Add `deepseek-v4` to `_THINKING_MODEL_PATTERNS` | +1 |

## Visual / UI changes

No UI changes. Backend only.

- [x] **I am not an LLM agent submitting a bulk PR.**