### PR TITLE
fix(scheduler): treat /api/email/unread-state as passive UI poll

### DIFF
--- a/src/interactive_gate.py
+++ b/src/interactive_gate.py
@@ -65,6 +65,8 @@ _PASSIVE_EXACT_PATHS = {
     "/api/tasks/notifications",
     "/api/research/active",
     "/api/email/urgency-state",
+    # UI idle poll sibling of urgency-state; must not pre-empt background tasks.
+    "/api/email/unread-state",
 }
 
 _PASSIVE_PREFIXES = (

--- a/tests/test_interactive_gate_passive_paths.py
+++ b/tests/test_interactive_gate_passive_paths.py
@@ -1,0 +1,19 @@
+"""Regression for idle UI polls that must not count as foreground activity."""
+
+from src.interactive_gate import should_track_interactive_request
+
+
+def test_email_unread_state_is_passive_like_urgency_state():
+    assert should_track_interactive_request("/api/email/urgency-state") is False
+    assert should_track_interactive_request("/api/email/unread-state") is False
+
+
+def test_real_interactive_paths_still_tracked():
+    assert should_track_interactive_request("/api/chat_stream") is True
+    assert should_track_interactive_request("/api/email/messages") is True
+    assert should_track_interactive_request("/api/tasks", method="POST") is True
+
+
+def test_options_never_tracked():
+    assert should_track_interactive_request("/api/email/unread-state", method="OPTIONS") is False
+    assert should_track_interactive_request("/api/chat_stream", method="OPTIONS") is False


### PR DESCRIPTION
## Summary

With the web UI open, scheduled/background agent runs were being aborted within about a minute and logged as `Stopped by user`, even though no real user interaction happened. The idle poll `GET /api/email/unread-state` was treated as foreground activity by `_InteractiveActivityMiddleware`, which calls `stop_background_tasks_for_foreground()`. Its sibling `GET /api/email/urgency-state` was already on the passive exact-path list; unread-state was missing.

This PR adds `/api/email/unread-state` to `_PASSIVE_EXACT_PATHS` in `src/interactive_gate.py` so the UI timer poll no longer pre-empts background work, and adds focused regression tests for the passive/interactive path classification.

## Target branch
- [x] This PR targets **`dev`**, not `main`.

## Linked Issue
Fixes #5981

## Type of Change
- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## What changed
1. `src/interactive_gate.py`: add `/api/email/unread-state` next to `/api/email/urgency-state` in `_PASSIVE_EXACT_PATHS`.
2. `tests/test_interactive_gate_passive_paths.py`: assert unread-state and urgency-state are passive; real interactive paths still track; OPTIONS still untracked.

No change to the foreground-gate design itself — only the passive allowlist for idle email polls.

## How to Test
```bash
python -m pytest tests/test_interactive_gate_passive_paths.py -q
# 3 passed
python -m py_compile src/interactive_gate.py tests/test_interactive_gate_passive_paths.py
```

Manual (with web UI open):
1. Create a scheduled agent task that runs longer than ~60s.
2. Leave the Odysseus UI open so it polls `/api/email/unread-state`.
3. Force-run the task.
4. Expect the run to complete (or fail for real reasons), not abort as `Stopped by user` from `foreground request GET /api/email/unread-state`.

## Checklist
- [x] I searched open issues and open PRs — no open PR already fixes #5981 / unread-state passive path.
- [x] This PR targets `dev`.
- [x] Changes are limited to the passive path list + focused tests (no unrelated refactors).
- [ ] Full app e2e with a long scheduled agent run was not run on this Linux host. Path classification is covered by unit tests; the issue reporter already verified the one-line allowlist change locally against `should_track_interactive_request()` and a live scheduled run.

## Visual / UI changes
None — backend gate classification only.

## Limitations / notes
- Secondary suggestion from the issue (clearer abort message than `Stopped by user`) is intentionally out of scope here so the PR stays one-line + tests.