### PR TITLE
fix: alias tool names that collide with Poe's built-in platform tools when using their API

### DIFF
--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -1094,6 +1094,35 @@ def _unalias_poe_tool_name(name: str, url: str) -> str:
     return _POE_TOOL_ALIASES_REVERSE.get(name, name)
 
 
+def _alias_poe_messages(messages: List[Dict], url: str) -> List[Dict]:
+    """Rename tool references in message history to match Poe-aliased declarations."""
+    if not messages or not _is_poe_endpoint(url):
+        return messages
+    out = []
+    for msg in messages:
+        role = msg.get("role")
+
+        if role == "assistant" and msg.get("tool_calls"):
+            msg = {**msg}
+            new_tcs = []
+            for tc in msg["tool_calls"]:
+                fn = tc.get("function") or {}
+                alias = _POE_TOOL_ALIASES.get(fn.get("name"))
+                if alias:
+                    tc = {**tc, "function": {**fn, "name": alias}}
+                new_tcs.append(tc)
+            msg["tool_calls"] = new_tcs
+            out.append(msg)
+
+        elif role == "tool" and msg.get("name") in _POE_TOOL_ALIASES:
+            out.append({**msg, "name": _POE_TOOL_ALIASES[msg["name"]]})
+
+        else:
+            out.append(msg)
+
+    return out
+
+
 # gpt-oss (harmony) ships BUILT-IN tools named `python` and `browser`, invoked
 # with the raw body as the argument (`to=python` + bare source), while custom
 # functions use `to=functions.NAME` + JSON. A tool we expose under a built-in's
@@ -2331,6 +2360,7 @@ async def _stream_llm_inner(url: str, model: str, messages: List[Dict], temperat
             payload["tools"] = aliased
         elif tool_choice_none:
             payload["tool_choice"] = "none"
+        payload["messages"] = _alias_poe_messages(payload["messages"], url)
         # Mistral thinking-capable models — send reasoning_effort so Mistral
         # activates thinking mode and returns structured reasoning_content.
         # Effort level is configurable via ODYSSEUS_MISTRAL_REASONING_EFFORT

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -1056,6 +1056,44 @@ def _model_disallows_reasoning_effort_with_chat_tools(model: str) -> bool:
     return bool(re.match(r"^(?:openai/)?gpt-5(?:[.\-]\d+)?(?:[-_:].*)?$", m))
 
 
+# ── Poe platform tool collision aliases ──
+# Poe injects its own server-side tools (web_search, python) for certain
+# models. Sending user tools with those same names triggers HTTP 400
+# "Tool names must be unique" even though the client-side list is unique.
+_POE_TOOL_ALIASES = {
+    "web_search": "odysseus_web_search",
+    "python": "odysseus_python",
+}
+_POE_TOOL_ALIASES_REVERSE = {v: k for k, v in _POE_TOOL_ALIASES.items()}
+
+
+def _is_poe_endpoint(url: str) -> bool:
+    return _host_match(url, "poe.com")
+
+
+def _alias_poe_tools(tools: Optional[List[Dict]], url: str) -> Optional[List[Dict]]:
+    """Rename tools that collide with Poe's built-in platform tools."""
+    if not tools or not _is_poe_endpoint(url):
+        return tools
+    out = []
+    for t in tools:
+        fn = t.get("function") or {}
+        alias = _POE_TOOL_ALIASES.get(fn.get("name"))
+        if alias:
+            t = copy.deepcopy(t)
+            t["function"]["name"] = alias
+            logger.info("[poe-alias] renamed tool %s -> %s", fn["name"], alias)
+        out.append(t)
+    return out
+
+
+def _unalias_poe_tool_name(name: str, url: str) -> str:
+    """Map a Poe-aliased tool name back to the real name."""
+    if not _is_poe_endpoint(url):
+        return name
+    return _POE_TOOL_ALIASES_REVERSE.get(name, name)
+
+
 # gpt-oss (harmony) ships BUILT-IN tools named `python` and `browser`, invoked
 # with the raw body as the argument (`to=python` + bare source), while custom
 # functions use `to=functions.NAME` + JSON. A tool we expose under a built-in's
@@ -2288,7 +2326,9 @@ async def _stream_llm_inner(url: str, model: str, messages: List[Dict], temperat
             tok_key = "max_completion_tokens" if _uses_max_completion_tokens(model) else "max_tokens"
             payload[tok_key] = max_tokens
         if tools:
-            payload["tools"] = _alias_harmony_tools(tools, model)
+            aliased = _alias_harmony_tools(tools, model)
+            aliased = _alias_poe_tools(aliased, url)
+            payload["tools"] = aliased
         elif tool_choice_none:
             payload["tool_choice"] = "none"
         # Mistral thinking-capable models — send reasoning_effort so Mistral
@@ -2802,10 +2842,16 @@ async def _stream_llm_inner(url: str, model: str, messages: List[Dict], temperat
                                             if tc.get("extra_content"):
                                                 _tc_acc[idx]["extra_content"] = tc["extra_content"]
                                             if func.get("name"):
-                                                # Map harmony aliases back to real
+                                                # Map harmony and Poe aliases back to real
                                                 # tool names before anything
                                                 # downstream sees them.
-                                                _tc_acc[idx]["name"] = _unalias_harmony_tool_name(func["name"], model)
+                                                real_name = _unalias_harmony_tool_name(
+                                                    func["name"], model
+                                                )
+                                                real_name = _unalias_poe_tool_name(
+                                                    real_name, url
+                                                )
+                                                _tc_acc[idx]["name"] = real_name
                                             if "arguments" in func:
                                                 # Guard against a null arguments delta: `func` can be
                                                 # {"arguments": None} (JSON null), and a raw `+= None`

--- a/tests/test_poe_tool_alias.py
+++ b/tests/test_poe_tool_alias.py
@@ -1,0 +1,224 @@
+"""Regression tests for Poe tool-name aliasing.
+
+Validates that:
+1. Tool declarations are aliased on the initial request.
+2. Message history (assistant tool_calls + tool results) is re-aliased on
+   follow-up rounds, without mutating the caller-owned messages.
+"""
+
+import copy
+import pytest
+
+from src.llm_core import _alias_poe_tools, _alias_poe_messages, _POE_TOOL_ALIASES
+
+
+POE_URL = "https://api.poe.com/v1/chat/completions"
+NON_POE_URL = "https://api.anthropic.com/v1/messages"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample_tools():
+    """Minimal tool declarations including conflicting names."""
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "description": "Search the web",
+                "parameters": {},
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "python",
+                "description": "Run Python code",
+                "parameters": {},
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "description": "Read a file",
+                "parameters": {},
+            },
+        },
+    ]
+
+
+@pytest.fixture
+def sample_history():
+    """Message history after one tool-using round (local names)."""
+    return [
+        {"role": "user", "content": "Search for the latest news"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_001",
+                    "type": "function",
+                    "function": {
+                        "name": "web_search",
+                        "arguments": '{"query": "latest news"}',
+                    },
+                },
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_001",
+            "name": "web_search",
+            "content": "Here are the results...",
+        },
+        {"role": "user", "content": "Now run some python to parse that"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_002",
+                    "type": "function",
+                    "function": {"name": "python", "arguments": '{"code": "print(1)"}'},
+                },
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_002",
+            "name": "python",
+            "content": "1",
+        },
+        {"role": "user", "content": "Thanks, summarize everything"},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Tests: Tool declaration aliasing (round 1)
+# ---------------------------------------------------------------------------
+
+
+class TestToolDeclarationAliasing:
+    def test_poe_declarations_are_aliased(self, sample_tools):
+        aliased = _alias_poe_tools(sample_tools, POE_URL)
+        names = [t["function"]["name"] for t in aliased]
+
+        assert "odysseus_web_search" in names
+        assert "odysseus_python" in names
+        assert "web_search" not in names
+        assert "python" not in names
+        # Non-conflicting tools are untouched
+        assert "read_file" in names
+
+    def test_non_poe_declarations_unchanged(self, sample_tools):
+        result = _alias_poe_tools(sample_tools, NON_POE_URL)
+        names = [t["function"]["name"] for t in result]
+
+        assert "web_search" in names
+        assert "python" in names
+
+    def test_declaration_aliasing_does_not_mutate_input(self, sample_tools):
+        original = copy.deepcopy(sample_tools)
+        _alias_poe_tools(sample_tools, POE_URL)
+
+        assert sample_tools == original
+
+
+# ---------------------------------------------------------------------------
+# Tests: Message history aliasing (follow-up rounds)
+# ---------------------------------------------------------------------------
+
+
+class TestMessageHistoryAliasing:
+    def test_poe_history_tool_calls_are_aliased(self, sample_history):
+        aliased = _alias_poe_messages(sample_history, POE_URL)
+
+        # Find assistant messages with tool_calls
+        assistant_msgs = [m for m in aliased if m.get("tool_calls")]
+        assert len(assistant_msgs) == 2
+
+        assert (
+            assistant_msgs[0]["tool_calls"][0]["function"]["name"]
+            == "odysseus_web_search"
+        )
+        assert (
+            assistant_msgs[1]["tool_calls"][0]["function"]["name"] == "odysseus_python"
+        )
+
+    def test_poe_history_tool_results_are_aliased(self, sample_history):
+        aliased = _alias_poe_messages(sample_history, POE_URL)
+
+        tool_msgs = [m for m in aliased if m.get("role") == "tool"]
+        assert len(tool_msgs) == 2
+
+        assert tool_msgs[0]["name"] == "odysseus_web_search"
+        assert tool_msgs[1]["name"] == "odysseus_python"
+
+    def test_poe_history_preserves_non_aliased_fields(self, sample_history):
+        aliased = _alias_poe_messages(sample_history, POE_URL)
+
+        tool_msgs = [m for m in aliased if m.get("role") == "tool"]
+        assert tool_msgs[0]["tool_call_id"] == "call_001"
+        assert tool_msgs[0]["content"] == "Here are the results..."
+        assert tool_msgs[1]["tool_call_id"] == "call_002"
+        assert tool_msgs[1]["content"] == "1"
+
+    def test_poe_history_user_messages_unchanged(self, sample_history):
+        aliased = _alias_poe_messages(sample_history, POE_URL)
+
+        user_msgs = [m for m in aliased if m.get("role") == "user"]
+        assert len(user_msgs) == 3
+        assert user_msgs[0]["content"] == "Search for the latest news"
+
+    def test_non_poe_history_unchanged(self, sample_history):
+        result = _alias_poe_messages(sample_history, NON_POE_URL)
+        assert result == sample_history
+
+    def test_history_aliasing_does_not_mutate_input(self, sample_history):
+        original = copy.deepcopy(sample_history)
+        _alias_poe_messages(sample_history, POE_URL)
+
+        assert sample_history == original, (
+            "_alias_poe_messages must not mutate caller-owned messages"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Integration: Full round-trip scenario
+# ---------------------------------------------------------------------------
+
+
+class TestFullRoundTrip:
+    """Simulates building payloads for two consecutive Poe requests."""
+
+    def test_second_round_payload_is_consistent(self, sample_tools, sample_history):
+        """Declarations and history must use the same aliased names."""
+        # Build payload as the real code would
+        aliased_tools = _alias_poe_tools(sample_tools, POE_URL)
+        aliased_messages = _alias_poe_messages(sample_history, POE_URL)
+
+        declared_names = {t["function"]["name"] for t in aliased_tools}
+
+        # Every tool name referenced in history must exist in declarations
+        for msg in aliased_messages:
+            if msg.get("tool_calls"):
+                for tc in msg["tool_calls"]:
+                    fn_name = tc["function"]["name"]
+                    assert (
+                        fn_name in declared_names or fn_name not in _POE_TOOL_ALIASES
+                    ), (
+                        f"Tool call '{fn_name}' in history not found in declarations {declared_names}"
+                    )
+            if msg.get("role") == "tool":
+                tool_name = msg.get("name")
+                assert (
+                    tool_name in declared_names or tool_name not in _POE_TOOL_ALIASES
+                ), (
+                    f"Tool result name '{tool_name}' in history not found in declarations {declared_names}"
+                )


### PR DESCRIPTION
## Summary

At some point in August 2026, Poe started to inject server-side tools (`web_search`, `python`) into the tool list before forwarding to Claude. Sending user tools with the same names triggers HTTP 400 'Tool names must be unique'. This fix adds a transparent alias/unalias layer for Poe endpoints, renaming conflicting tools on the wire and mapping them back when tool calls are received. 

## Target branch

- [X] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #6010 

## Type of Change

- [X] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [X] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [X] This PR targets `dev`
- [X] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [X] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

<!-- Step-by-step instructions a reviewer can follow to verify this works.
     Do not leave this empty — a PR without test steps will be sent back. -->

1. Add Poe API
2. Select models that start with `Claude`
3.  Send any message in chat. It will return a `tool names must be unique` error without the `llm_core.py` fix; the message would be normal after fix
