### PR TITLE
fix(auth): honor AUTH_ENABLED=false in admin-gated app-config routes

### DIFF
--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from core.atomic_io import atomic_write_json, atomic_write_text
 from core.auth import AuthManager, RESERVED_USERNAMES, SetAdminResult, TOKEN_TTL
 from src.constants import DEEP_RESEARCH_DIR, MEMORY_FILE, PASSWORD_MIN_LENGTH, SKILLS_DIR
+from src.auth_helpers import _auth_disabled
 from src.rate_limiter import RateLimiter
 from src.settings_scrub import scrub_settings
 from src.settings import (
@@ -94,6 +95,21 @@ def setup_auth_routes(auth_manager: AuthManager) -> APIRouter:
     def _get_current_user(request: Request) -> Optional[str]:
         token = request.cookies.get(SESSION_COOKIE)
         return auth_manager.get_username_for_token(token)
+
+    def _require_admin_user(request: Request) -> Optional[str]:
+        """Resolve the current user, enforcing admin access.
+
+        Honors AUTH_ENABLED=false the same way core.middleware.require_admin
+        does: when the operator has explicitly disabled auth (e.g. behind a
+        reverse proxy that handles login), there is no session user, and
+        admin-gated app configuration must stay reachable.
+        """
+        user = _get_current_user(request)
+        if _auth_disabled():
+            return user
+        if not user or not auth_manager.is_admin(user):
+            raise HTTPException(403, "Admin only")
+        return user
 
     @router.post("/setup")
     async def first_run_setup(body: SetupRequest, request: Request):
@@ -670,9 +686,7 @@ def setup_auth_routes(auth_manager: AuthManager) -> APIRouter:
     @router.post("/features")
     async def set_features(request: Request):
         """Admin only: update feature toggles."""
-        user = _get_current_user(request)
-        if not user or not auth_manager.is_admin(user):
-            raise HTTPException(403, "Admin only")
+        _require_admin_user(request)
         body = await request.json()
         current = _load_features()
         for key in current:
@@ -690,16 +704,14 @@ def setup_auth_routes(auth_manager: AuthManager) -> APIRouter:
         for keybinds + TTS prefs, so it stays callable without admin."""
         user = _get_current_user(request)
         settings = _load_settings()
-        if user and auth_manager.is_admin(user):
+        if _auth_disabled() or (user and auth_manager.is_admin(user)):
             return settings
         return scrub_settings(settings)
 
     @router.post("/settings")
     async def set_settings(request: Request):
         """Admin only: update app settings."""
-        user = _get_current_user(request)
-        if not user or not auth_manager.is_admin(user):
-            raise HTTPException(403, "Admin only")
+        _require_admin_user(request)
         body = await request.json()
         current = _load_settings()
         # Per-key validation for numeric settings: coerce to int and clamp to a
@@ -731,9 +743,7 @@ def setup_auth_routes(auth_manager: AuthManager) -> APIRouter:
     @router.get("/integrations")
     async def list_integrations_route(request: Request):
         """List all integrations (admin only, keys masked)."""
-        user = _get_current_user(request)
-        if not user or not auth_manager.is_admin(user):
-            raise HTTPException(403, "Admin only")
+        _require_admin_user(request)
         items = load_integrations()
         # Mask API keys for frontend display
         safe = [mask_integration_secret(item) for item in items]
@@ -747,9 +757,7 @@ def setup_auth_routes(auth_manager: AuthManager) -> APIRouter:
     @router.post("/integrations")
     async def create_integration(request: Request):
         """Create a new integration (admin only)."""
-        user = _get_current_user(request)
-        if not user or not auth_manager.is_admin(user):
-            raise HTTPException(403, "Admin only")
+        _require_admin_user(request)
         body = await request.json()
         item = add_integration(body)
         return {"ok": True, "integration": mask_integration_secret(item)}
@@ -757,9 +765,7 @@ def setup_auth_routes(auth_manager: AuthManager) -> APIRouter:
     @router.put("/integrations/{integration_id}")
     async def update_integration_route(integration_id: str, request: Request):
         """Update an existing integration (admin only)."""
-        user = _get_current_user(request)
-        if not user or not auth_manager.is_admin(user):
-            raise HTTPException(403, "Admin only")
+        _require_admin_user(request)
         body = await request.json()
         item = update_integration(integration_id, body)
         if not item:
@@ -769,9 +775,7 @@ def setup_auth_routes(auth_manager: AuthManager) -> APIRouter:
     @router.delete("/integrations/{integration_id}")
     async def delete_integration_route(integration_id: str, request: Request):
         """Delete an integration (admin only)."""
-        user = _get_current_user(request)
-        if not user or not auth_manager.is_admin(user):
-            raise HTTPException(403, "Admin only")
+        _require_admin_user(request)
         ok = delete_integration(integration_id)
         if not ok:
             raise HTTPException(404, "Integration not found")
@@ -780,9 +784,7 @@ def setup_auth_routes(auth_manager: AuthManager) -> APIRouter:
     @router.post("/integrations/{integration_id}/test")
     async def test_integration_route(integration_id: str, request: Request):
         """Test connectivity to an integration (admin only)."""
-        user = _get_current_user(request)
-        if not user or not auth_manager.is_admin(user):
-            raise HTTPException(403, "Admin only")
+        _require_admin_user(request)
         integ = get_integration(integration_id)
         if not integ:
             raise HTTPException(404, "Integration not found")

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -542,13 +542,14 @@ async function initDefaultChat() {
 
   async function saveDefault() {
     try {
-      await fetch('/api/auth/settings', { method: 'POST', credentials: 'same-origin',
+      var res = await fetch('/api/auth/settings', { method: 'POST', credentials: 'same-origin',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           default_endpoint_id: epSel.value,
           default_model: modelSel.value
         })
       });
+      if (!res.ok) throw new Error('HTTP ' + res.status);
       msg.textContent = 'Saved'; msg.style.color = 'var(--fg)';
       setTimeout(function() { msg.textContent = ''; }, 2000);
     } catch (e) { msg.textContent = 'Failed to save'; msg.style.color = 'var(--red)'; }

--- a/tests/test_admin_routes_auth_disabled.py
+++ b/tests/test_admin_routes_auth_disabled.py
@@ -1,0 +1,66 @@
+"""Admin-gated app-config routes must honor AUTH_ENABLED=false.
+
+Regression test for the inconsistency between core.middleware.require_admin
+(which allows requests when the operator disabled auth) and the inline admin
+checks in routes/auth_routes.py (which returned 403 unconditionally, so
+settings changes were silently lost behind reverse-proxy auth setups).
+"""
+import pytest
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    fastapi = pytest.importorskip("fastapi")
+    from fastapi.testclient import TestClient
+    from routes import auth_routes
+
+    stored = {}
+    monkeypatch.setattr(auth_routes, "_load_settings", lambda: dict(stored))
+    monkeypatch.setattr(auth_routes, "_save_settings", stored.update)
+    monkeypatch.setattr(auth_routes, "migrate_from_settings", lambda: None)
+
+    class _AuthManager:
+        is_configured = True
+
+        def get_username_for_token(self, token):
+            return "admin" if token == "session-token" else None
+
+        def is_admin(self, user):
+            return user == "admin"
+
+    app = fastapi.FastAPI()
+    app.include_router(auth_routes.setup_auth_routes(_AuthManager()))
+    return TestClient(app), stored
+
+
+def test_set_settings_allowed_when_auth_disabled(client, monkeypatch):
+    monkeypatch.setenv("AUTH_ENABLED", "false")
+    c, stored = client
+    r = c.post("/api/auth/settings", json={"default_model": "some-model"})
+    assert r.status_code == 200
+    assert stored.get("default_model") == "some-model"
+
+
+def test_get_settings_unscrubbed_when_auth_disabled(client, monkeypatch):
+    monkeypatch.setenv("AUTH_ENABLED", "false")
+    c, stored = client
+    stored["brave_api_key"] = "sk-secret"
+    r = c.get("/api/auth/settings")
+    assert r.status_code == 200
+    assert r.json()["brave_api_key"] == "sk-secret"
+
+
+def test_set_settings_still_403_when_auth_enabled(client, monkeypatch):
+    monkeypatch.setenv("AUTH_ENABLED", "true")
+    c, _ = client
+    r = c.post("/api/auth/settings", json={"default_model": "x"})
+    assert r.status_code == 403
+
+
+def test_set_settings_admin_session_still_works(client, monkeypatch):
+    monkeypatch.setenv("AUTH_ENABLED", "true")
+    c, stored = client
+    c.cookies.set("odysseus_session", "session-token")
+    r = c.post("/api/auth/settings", json={"default_model": "admin-model"})
+    assert r.status_code == 200
+    assert stored.get("default_model") == "admin-model"


### PR DESCRIPTION
## Summary

With `AUTH_ENABLED=false` (reverse-proxy deployments where e.g. Authelia handles login) there is no session user, so the inline admin checks in `routes/auth_routes.py` returned 403 unconditionally — settings changes (default model/provider, features, integrations) were silently lost while the UI showed "Saved". This PR makes the app-config routes honor the auth-disabled case the same way `core.middleware.require_admin` already does, and makes the settings UI surface failed saves.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #6028

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end (running in the affected deployment; settings saves now return 200 and persist across restarts).

## How to Test

1. Start Odysseus with `AUTH_ENABLED=false` (e.g. `AUTH_ENABLED=false uvicorn app:app`).
2. `curl -X POST http://127.0.0.1:8000/api/auth/settings -H 'Content-Type: application/json' -d '{"default_model":"x"}'` — before this PR: `403 {"detail":"Admin only"}`; with this PR: `200`, and a follow-up `GET /api/auth/settings` returns `"default_model": "x"`.
3. Same behaviour in the UI: Settings → default chat model — pick a model, reload, the choice persists.
4. Regression guard: `pytest tests/test_admin_routes_auth_disabled.py` (4 tests: auth disabled → 200 and persisted; auth enabled → 403 without session, 200 with admin session).

## Visual / UI changes — REQUIRED if you touched anything that renders

No visual change. The only frontend edit is one line in `static/js/settings.js` (`saveDefault()` now checks `res.ok`), which triggers the **pre-existing** "Failed to save" message path with its existing styling. No CSS/HTML/SVG touched, no new colors, no new components.

- [x] **Style match**: reuses the existing message element and CSS variables; nothing new introduced.
- [x] **No new component patterns.**
- [x] **I am not an LLM agent submitting a bulk PR.** Issue #6028 was opened first with the full analysis; this is a single targeted fix, verified in a real deployment.
