### PR TITLE
feat(embeddings): vendor-agnostic GPU acceleration + EMBEDDING_GPU_PROVIDER setting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -239,3 +239,10 @@ SEARXNG_INSTANCE=http://localhost:8080
 
 # APP_DATA_DIR=./data
 # APP_LOGS_DIR=./logs
+# GPU acceleration for local embeddings (fastembed / ONNX).
+#   unset / "auto"  -> auto-detect the best GPU provider on this host
+#   "cpu"           -> never use a GPU (shared GPU / VRAM-sensitive hosts)
+#   "nvidia"        -> prefer NVIDIA TensorRT/CUDA
+#   "amd"           -> prefer AMD MIGraphX (legacy ROCm fallback)
+#   "<provider>"    -> force a specific ONNX provider name
+# EMBEDDING_GPU_PROVIDER=auto

--- a/routes/diagnostics_routes.py
+++ b/routes/diagnostics_routes.py
@@ -107,4 +107,64 @@ def setup_diagnostics_routes(
         except Exception as e:
             return {"status": "error", "error": str(e), "query": query}
 
+    @router.get("/api/diagnostics/gpu")
+    async def gpu_status(request: Request) -> Dict[str, Any]:
+        """Report GPU acceleration status for embedding inference."""
+        require_admin(request)
+        import subprocess
+
+        result = {
+            "embedding_provider": "unknown",
+            "available_providers": [],
+            "gpu_detected": False,
+            "gpu_name": None,
+            "gpu_memory_total_mb": None,
+            "gpu_memory_used_mb": None,
+            "gpu_utilization_pct": None,
+            "tensorrt_available": False,
+            "cuda_available": False,
+        }
+
+        # Check ONNX Runtime providers
+        try:
+            import onnxruntime as ort
+            providers = ort.get_available_providers()
+            result["available_providers"] = providers
+            result["tensorrt_available"] = "TensorrtExecutionProvider" in providers
+            result["cuda_available"] = "CUDAExecutionProvider" in providers
+
+            try:
+                from src.embeddings import get_embedding_client
+                client = get_embedding_client()
+                if hasattr(client, "_is_gpu"):
+                    result["embedding_provider"] = f"gpu ({client._is_gpu})"
+                else:
+                    result["embedding_provider"] = f"http ({getattr(client, 'url', 'unknown')})"
+            except Exception as e:
+                result["embedding_provider"] = f"error checking: {e}"
+        except ImportError:
+            result["embedding_provider"] = "onnxruntime not installed"
+        except Exception as e:
+            result["embedding_provider"] = f"error: {e}"
+
+        # Check nvidia-smi for GPU info
+        try:
+            smi = subprocess.run(
+                ["nvidia-smi", "--query-gpu=name,memory.total,memory.used,utilization.gpu",
+                 "--format=csv,noheader,nounits"],
+                capture_output=True, text=True, timeout=5
+            )
+            if smi.returncode == 0 and smi.stdout.strip():
+                parts = [p.strip() for p in smi.stdout.strip().split(",")]
+                if len(parts) >= 4:
+                    result["gpu_detected"] = True
+                    result["gpu_name"] = parts[0]
+                    result["gpu_memory_total_mb"] = int(parts[1])
+                    result["gpu_memory_used_mb"] = int(parts[2])
+                    result["gpu_utilization_pct"] = int(parts[3])
+        except Exception:
+            pass
+
+        return result
+
     return router

--- a/routes/diagnostics_routes.py
+++ b/routes/diagnostics_routes.py
@@ -169,6 +169,8 @@ def setup_diagnostics_routes(
         except Exception:
             pass
         if not result["gpu_detected"]:
+            # AMD: rocm-smi is the vendor tool (ROCm 6.x/7.x). MIGraphX is the
+            # current AMD ORT provider; ROCm EP is legacy (removed in ORT 1.23).
             try:
                 import subprocess
                 rsmi = subprocess.run(

--- a/routes/diagnostics_routes.py
+++ b/routes/diagnostics_routes.py
@@ -117,27 +117,29 @@ def setup_diagnostics_routes(
             "embedding_provider": "unknown",
             "available_providers": [],
             "gpu_detected": False,
+            "gpu_provider": None,
             "gpu_name": None,
+            "gpu_vendor": None,
             "gpu_memory_total_mb": None,
             "gpu_memory_used_mb": None,
             "gpu_utilization_pct": None,
-            "tensorrt_available": False,
-            "cuda_available": False,
         }
 
-        # Check ONNX Runtime providers
+        # Check ONNX Runtime providers (vendor-agnostic — any GPU provider)
         try:
             import onnxruntime as ort
             providers = ort.get_available_providers()
             result["available_providers"] = providers
-            result["tensorrt_available"] = "TensorrtExecutionProvider" in providers
-            result["cuda_available"] = "CUDAExecutionProvider" in providers
 
             try:
                 from src.embeddings import get_embedding_client
                 client = get_embedding_client()
                 if hasattr(client, "_is_gpu"):
-                    result["embedding_provider"] = f"gpu ({client._is_gpu})"
+                    result["gpu_provider"] = getattr(client, "_gpu_provider", None)
+                    result["embedding_provider"] = (
+                        f"gpu ({client._gpu_provider})" if client._is_gpu
+                        else "cpu"
+                    )
                 else:
                     result["embedding_provider"] = f"http ({getattr(client, 'url', 'unknown')})"
             except Exception as e:
@@ -147,8 +149,9 @@ def setup_diagnostics_routes(
         except Exception as e:
             result["embedding_provider"] = f"error: {e}"
 
-        # Check nvidia-smi for GPU info
+        # Check GPU state via vendor-neutral tools (nvidia-smi / rocm-smi)
         try:
+            import subprocess
             smi = subprocess.run(
                 ["nvidia-smi", "--query-gpu=name,memory.total,memory.used,utilization.gpu",
                  "--format=csv,noheader,nounits"],
@@ -159,11 +162,25 @@ def setup_diagnostics_routes(
                 if len(parts) >= 4:
                     result["gpu_detected"] = True
                     result["gpu_name"] = parts[0]
+                    result["gpu_vendor"] = "nvidia"
                     result["gpu_memory_total_mb"] = int(parts[1])
                     result["gpu_memory_used_mb"] = int(parts[2])
                     result["gpu_utilization_pct"] = int(parts[3])
         except Exception:
             pass
+        if not result["gpu_detected"]:
+            try:
+                import subprocess
+                rsmi = subprocess.run(
+                    ["rocm-smi", "--showmeminfo", "vram", "--json"],
+                    capture_output=True, text=True, timeout=5
+                )
+                if rsmi.returncode == 0 and rsmi.stdout.strip():
+                    result["gpu_detected"] = True
+                    result["gpu_vendor"] = "amd"
+                    result["gpu_name"] = "AMD GPU (rocm-smi)"
+            except Exception:
+                pass
 
         return result
 

--- a/routes/diagnostics_routes.py
+++ b/routes/diagnostics_routes.py
@@ -118,12 +118,14 @@ def setup_diagnostics_routes(
             "available_providers": [],
             "gpu_detected": False,
             "gpu_provider": None,
+            "gpu_override": "auto",
             "gpu_name": None,
             "gpu_vendor": None,
             "gpu_memory_total_mb": None,
             "gpu_memory_used_mb": None,
             "gpu_utilization_pct": None,
         }
+        result["gpu_override"] = os.environ.get("EMBEDDING_GPU_PROVIDER", "auto")
 
         # Check ONNX Runtime providers (vendor-agnostic — any GPU provider)
         try:

--- a/src/embeddings.py
+++ b/src/embeddings.py
@@ -148,8 +148,45 @@ def select_gpu_providers(available_providers):
     Vendor-agnostic: returns [chosen_gpu, ...other_gpu_fallbacks, CPU] where
     chosen_gpu is the highest-priority GPU provider available, or ["CPU"]
     when no GPU provider exists. Pure function — unit-testable without a GPU.
+
+    An optional EMBEDDING_GPU_PROVIDER env override allows an operator to
+    force a specific provider (or "cpu" to disable GPU entirely):
+      - unset / "auto"  -> auto-detect the best provider
+      - "cpu"           -> never use a GPU
+      - "nvidia"        -> NVIDIA TensorRT/CUDA
+      - "amd"           -> AMD MIGraphX (or legacy ROCm)
+      - a provider name -> exactly that provider (must be available)
     """
+    import os as _os
+    override = (_os.environ.get("EMBEDDING_GPU_PROVIDER") or "auto").strip().lower()
     available = set(available_providers)
+    if override in ("cpu", "none", "off", "false", "0"):
+        return ["CPUExecutionProvider"]
+    if override == "nvidia":
+        chosen = next((p for p in ("TensorrtExecutionProvider",
+                                   "CUDAExecutionProvider")
+                       if p in available), None)
+        if chosen:
+            fallbacks = [p for p in _GPU_PRIORITY
+                         if p in available and p != chosen]
+            return [chosen] + fallbacks + ["CPUExecutionProvider"]
+        return ["CPUExecutionProvider"]
+    if override == "amd":
+        chosen = next((p for p in ("MIGraphXExecutionProvider",
+                                   "ROCmExecutionProvider")
+                       if p in available), None)
+        if chosen:
+            fallbacks = [p for p in _GPU_PRIORITY
+                         if p in available and p != chosen]
+            return [chosen] + fallbacks + ["CPUExecutionProvider"]
+        return ["CPUExecutionProvider"]
+    if override != "auto":
+        # explicit provider name — only use it if the host actually has it
+        if override in available:
+            return [override] + [p for p in _GPU_PRIORITY
+                                 if p in available and p != override] \
+                   + ["CPUExecutionProvider"]
+        return ["CPUExecutionProvider"]
     chosen = next((p for p in _GPU_PRIORITY if p in available), None)
     if chosen is None:
         return ["CPUExecutionProvider"]

--- a/src/embeddings.py
+++ b/src/embeddings.py
@@ -132,8 +132,9 @@ class EmbeddingClient:
 _GPU_PRIORITY = [
     "TensorrtExecutionProvider",   # NVIDIA, optimized
     "CUDAExecutionProvider",       # NVIDIA
-    "MIGraphXExecutionProvider",   # AMD
-    "ROCmExecutionProvider",       # AMD
+    "MIGraphXExecutionProvider",   # AMD, current (ROCm >= 6.x, ORT >= 1.23)
+    "ROCmExecutionProvider",       # AMD, legacy (removed from ORT as of 1.23;
+                                   #   kept for older ROCm/ORT installs)
     "CoreMLExecutionProvider",     # Apple Silicon
     "DirectMLExecutionProvider",   # Windows, any vendor GPU
     "OpenVINOExecutionProvider",   # Intel

--- a/src/embeddings.py
+++ b/src/embeddings.py
@@ -129,6 +129,33 @@ class EmbeddingClient:
         return [emb["embedding"] for emb in embeddings]
 
 
+_GPU_PRIORITY = [
+    "TensorrtExecutionProvider",   # NVIDIA, optimized
+    "CUDAExecutionProvider",       # NVIDIA
+    "MIGraphXExecutionProvider",   # AMD
+    "ROCmExecutionProvider",       # AMD
+    "CoreMLExecutionProvider",     # Apple Silicon
+    "DirectMLExecutionProvider",   # Windows, any vendor GPU
+    "OpenVINOExecutionProvider",   # Intel
+    "DnnlExecutionProvider",       # Intel
+]
+
+
+def select_gpu_providers(available_providers):
+    """Pick the best ONNX provider chain for the host's available providers.
+
+    Vendor-agnostic: returns [chosen_gpu, ...other_gpu_fallbacks, CPU] where
+    chosen_gpu is the highest-priority GPU provider available, or ["CPU"]
+    when no GPU provider exists. Pure function — unit-testable without a GPU.
+    """
+    available = set(available_providers)
+    chosen = next((p for p in _GPU_PRIORITY if p in available), None)
+    if chosen is None:
+        return ["CPUExecutionProvider"]
+    fallbacks = [p for p in _GPU_PRIORITY if p in available and p != chosen]
+    return [chosen] + fallbacks + ["CPUExecutionProvider"]
+
+
 class FastEmbedClient:
     """Local embedding client using fastembed (ONNX). No external service needed."""
 
@@ -178,48 +205,19 @@ class FastEmbedClient:
             except Exception as _e:
                 logger.debug("embedding cache symlink-heal skipped: %s", _e)
         kwargs = {"model_name": self.model, "cache_dir": cache_dir}
-        # GPU acceleration — VENDOR-AGNOSTIC provider selection. Instead of
-        # hardcoding one vendor (NVIDIA), we define a priority-ordered chain
-        # across every hardware family ONNX Runtime supports, then pick the
-        # highest-priority provider that is actually AVAILABLE on this host:
-        #   NVIDIA      : TensorRT > CUDA
-        #   AMD         : ROCm > MIGraphX
-        #   Apple       : CoreML
-        #   Windows GPU : DirectML
-        #   Intel       : OpenVINO > DNNL
-        #   fallback    : CPU (always present)
-        # This keeps the code general — it accelerates whichever GPU the
-        # machine has and degrades gracefully to CPU on machines with none.
-        _GPU_PRIORITY = [
-            "TensorrtExecutionProvider",   # NVIDIA, optimized
-            "CUDAExecutionProvider",       # NVIDIA
-            "MIGraphXExecutionProvider",   # AMD
-            "ROCmExecutionProvider",       # AMD
-            "CoreMLExecutionProvider",     # Apple Silicon
-            "DirectMLExecutionProvider",   # Windows, any vendor GPU
-            "OpenVINOExecutionProvider",   # Intel
-            "DnnlExecutionProvider",       # Intel
-        ]
+        # GPU acceleration — vendor-agnostic. Provider selection is handled by
+        # select_gpu_providers() (above); see the docstring there for the
+        # hardware-family priority chain and CPU fallback.
         try:
             import onnxruntime as ort
-            available = set(ort.get_available_providers())
-            # pick the highest-priority provider this host can actually run
-            chosen = next((p for p in _GPU_PRIORITY if p in available), None)
+            providers = select_gpu_providers(ort.get_available_providers())
+            kwargs["providers"] = providers
+            chosen = providers[0] if len(providers) > 1 else None
             if chosen:
-                # GPU path: chosen provider first, then the OTHER GPU providers
-                # this host supports as fallbacks, then CPU last. This keeps
-                # NVIDIA robust (TensorRT -> CUDA -> CPU) and AMD/Apple/Intel
-                # working through their own chains.
-                fallbacks = [p for p in _GPU_PRIORITY
-                             if p in available and p != chosen]
-                kwargs["providers"] = [chosen] + fallbacks + ["CPUExecutionProvider"]
                 logger.info("FastEmbed: using %s (fallbacks %s) for ONNX inference",
-                            chosen, fallbacks or ["CPU"])
+                            chosen, providers[1:])
             else:
-                logger.info(
-                    "FastEmbed: no GPU provider available (%s); using CPU",
-                    sorted(available),
-                )
+                logger.info("FastEmbed: no GPU provider available; using CPU")
             self._is_gpu = chosen is not None
             self._gpu_provider = chosen
         except Exception as _e:

--- a/src/embeddings.py
+++ b/src/embeddings.py
@@ -178,36 +178,54 @@ class FastEmbedClient:
             except Exception as _e:
                 logger.debug("embedding cache symlink-heal skipped: %s", _e)
         kwargs = {"model_name": self.model, "cache_dir": cache_dir}
-        # GPU acceleration: prefer TensorRT > CUDA > CPU for ONNX inference.
-        # TensorRT generates optimized CUDA kernels for the specific model +
-        # GPU, giving 2-5x speedup over plain CUDAExecutionProvider for
-        # repeated inference (embedding generation is embarrassingly parallel).
-        # Fall back through the chain so a missing TRT build doesn't kill GPU.
+        # GPU acceleration — VENDOR-AGNOSTIC provider selection. Instead of
+        # hardcoding one vendor (NVIDIA), we define a priority-ordered chain
+        # across every hardware family ONNX Runtime supports, then pick the
+        # highest-priority provider that is actually AVAILABLE on this host:
+        #   NVIDIA      : TensorRT > CUDA
+        #   AMD         : ROCm > MIGraphX
+        #   Apple       : CoreML
+        #   Windows GPU : DirectML
+        #   Intel       : OpenVINO > DNNL
+        #   fallback    : CPU (always present)
+        # This keeps the code general — it accelerates whichever GPU the
+        # machine has and degrades gracefully to CPU on machines with none.
+        _GPU_PRIORITY = [
+            "TensorrtExecutionProvider",   # NVIDIA, optimized
+            "CUDAExecutionProvider",       # NVIDIA
+            "MIGraphXExecutionProvider",   # AMD
+            "ROCmExecutionProvider",       # AMD
+            "CoreMLExecutionProvider",     # Apple Silicon
+            "DirectMLExecutionProvider",   # Windows, any vendor GPU
+            "OpenVINOExecutionProvider",   # Intel
+            "DnnlExecutionProvider",       # Intel
+        ]
         try:
             import onnxruntime as ort
-            available = ort.get_available_providers()
-            if "TensorrtExecutionProvider" in available:
-                kwargs["providers"] = [
-                    "TensorrtExecutionProvider",
-                    "CUDAExecutionProvider",
-                    "CPUExecutionProvider",
-                ]
-                logger.info("FastEmbed: using TensorRT GPU provider (with CUDA fallback) for ONNX inference")
-            elif "CUDAExecutionProvider" in available:
-                kwargs["providers"] = [
-                    "CUDAExecutionProvider",
-                    "CPUExecutionProvider",
-                ]
-                logger.info("FastEmbed: using CUDA GPU provider for ONNX inference")
+            available = set(ort.get_available_providers())
+            # pick the highest-priority provider this host can actually run
+            chosen = next((p for p in _GPU_PRIORITY if p in available), None)
+            if chosen:
+                # GPU path: chosen provider first, then the OTHER GPU providers
+                # this host supports as fallbacks, then CPU last. This keeps
+                # NVIDIA robust (TensorRT -> CUDA -> CPU) and AMD/Apple/Intel
+                # working through their own chains.
+                fallbacks = [p for p in _GPU_PRIORITY
+                             if p in available and p != chosen]
+                kwargs["providers"] = [chosen] + fallbacks + ["CPUExecutionProvider"]
+                logger.info("FastEmbed: using %s (fallbacks %s) for ONNX inference",
+                            chosen, fallbacks or ["CPU"])
             else:
-                logger.info(f"FastEmbed: CUDA not available, using CPU providers: {available}")
-            self._is_gpu = any(
-                p in ("TensorrtExecutionProvider", "CUDAExecutionProvider")
-                for p in kwargs.get("providers", [])
-            )
+                logger.info(
+                    "FastEmbed: no GPU provider available (%s); using CPU",
+                    sorted(available),
+                )
+            self._is_gpu = chosen is not None
+            self._gpu_provider = chosen
         except Exception as _e:
             logger.warning(f"FastEmbed: could not query ONNX providers, defaulting to CPU: {_e}")
             self._is_gpu = False
+            self._gpu_provider = None
         self._embedding = TextEmbedding(**kwargs)
         self._dim: Optional[int] = None
         self.url = "local://fastembed"

--- a/src/embeddings.py
+++ b/src/embeddings.py
@@ -178,6 +178,36 @@ class FastEmbedClient:
             except Exception as _e:
                 logger.debug("embedding cache symlink-heal skipped: %s", _e)
         kwargs = {"model_name": self.model, "cache_dir": cache_dir}
+        # GPU acceleration: prefer TensorRT > CUDA > CPU for ONNX inference.
+        # TensorRT generates optimized CUDA kernels for the specific model +
+        # GPU, giving 2-5x speedup over plain CUDAExecutionProvider for
+        # repeated inference (embedding generation is embarrassingly parallel).
+        # Fall back through the chain so a missing TRT build doesn't kill GPU.
+        try:
+            import onnxruntime as ort
+            available = ort.get_available_providers()
+            if "TensorrtExecutionProvider" in available:
+                kwargs["providers"] = [
+                    "TensorrtExecutionProvider",
+                    "CUDAExecutionProvider",
+                    "CPUExecutionProvider",
+                ]
+                logger.info("FastEmbed: using TensorRT GPU provider (with CUDA fallback) for ONNX inference")
+            elif "CUDAExecutionProvider" in available:
+                kwargs["providers"] = [
+                    "CUDAExecutionProvider",
+                    "CPUExecutionProvider",
+                ]
+                logger.info("FastEmbed: using CUDA GPU provider for ONNX inference")
+            else:
+                logger.info(f"FastEmbed: CUDA not available, using CPU providers: {available}")
+            self._is_gpu = any(
+                p in ("TensorrtExecutionProvider", "CUDAExecutionProvider")
+                for p in kwargs.get("providers", [])
+            )
+        except Exception as _e:
+            logger.warning(f"FastEmbed: could not query ONNX providers, defaulting to CPU: {_e}")
+            self._is_gpu = False
         self._embedding = TextEmbedding(**kwargs)
         self._dim: Optional[int] = None
         self.url = "local://fastembed"

--- a/tests/test_embeddings_client.py
+++ b/tests/test_embeddings_client.py
@@ -116,8 +116,24 @@ def test_gpu_provider_selection_nvidia_cuda_only():
         "CUDAExecutionProvider", "CPUExecutionProvider"]
 
 
-def test_gpu_provider_selection_amd_rocm():
-    """AMD hosts use ROCm."""
+def test_gpu_provider_selection_amd_migraphx():
+    """AMD hosts use MIGraphX (the current provider, ORT >= 1.23)."""
+    provs = ["CPUExecutionProvider", "MIGraphXExecutionProvider"]
+    assert select_gpu_providers(provs) == [
+        "MIGraphXExecutionProvider", "CPUExecutionProvider"]
+
+
+def test_gpu_provider_selection_amd_prefers_migraphx_over_legacy_rocm():
+    """When both AMD providers are present, MIGraphX wins over legacy ROCm."""
+    provs = ["CPUExecutionProvider", "ROCmExecutionProvider",
+             "MIGraphXExecutionProvider"]
+    assert select_gpu_providers(provs) == [
+        "MIGraphXExecutionProvider", "ROCmExecutionProvider",
+        "CPUExecutionProvider"]
+
+
+def test_gpu_provider_selection_amd_legacy_rocm():
+    """Older AMD installs (ORT < 1.23) still use ROCmExecutionProvider."""
     provs = ["CPUExecutionProvider", "ROCmExecutionProvider"]
     assert select_gpu_providers(provs) == [
         "ROCmExecutionProvider", "CPUExecutionProvider"]

--- a/tests/test_embeddings_client.py
+++ b/tests/test_embeddings_client.py
@@ -93,3 +93,51 @@ def test_embedding_retry_path_preserves_api_key_header():
 
     assert vecs.tolist() == [[1.0, 0.0]]
     assert seen_headers == [{"Authorization": "Bearer secret-key"}]
+
+
+# ---------------------------------------------------------------- GPU providers
+
+from src.embeddings import select_gpu_providers
+
+
+def test_gpu_provider_selection_nvidia_tensorrt_first():
+    """NVIDIA hosts with TensorRT get the optimized path, CUDA fallback, CPU last."""
+    provs = ["CPUExecutionProvider", "CUDAExecutionProvider",
+             "TensorrtExecutionProvider"]
+    assert select_gpu_providers(provs) == [
+        "TensorrtExecutionProvider", "CUDAExecutionProvider",
+        "CPUExecutionProvider"]
+
+
+def test_gpu_provider_selection_nvidia_cuda_only():
+    """NVIDIA hosts without TensorRT fall back to CUDA, then CPU."""
+    provs = ["CPUExecutionProvider", "CUDAExecutionProvider"]
+    assert select_gpu_providers(provs) == [
+        "CUDAExecutionProvider", "CPUExecutionProvider"]
+
+
+def test_gpu_provider_selection_amd_rocm():
+    """AMD hosts use ROCm."""
+    provs = ["CPUExecutionProvider", "ROCmExecutionProvider"]
+    assert select_gpu_providers(provs) == [
+        "ROCmExecutionProvider", "CPUExecutionProvider"]
+
+
+def test_gpu_provider_selection_apple_coreml():
+    """Apple Silicon uses CoreML."""
+    provs = ["CPUExecutionProvider", "CoreMLExecutionProvider"]
+    assert select_gpu_providers(provs) == [
+        "CoreMLExecutionProvider", "CPUExecutionProvider"]
+
+
+def test_gpu_provider_selection_windows_directml():
+    """Windows with any GPU uses DirectML."""
+    provs = ["CPUExecutionProvider", "DirectMLExecutionProvider"]
+    assert select_gpu_providers(provs) == [
+        "DirectMLExecutionProvider", "CPUExecutionProvider"]
+
+
+def test_gpu_provider_selection_no_gpu_cpu_only():
+    """GPU-less hosts degrade to CPU only — never crash."""
+    assert select_gpu_providers(["CPUExecutionProvider"]) == [
+        "CPUExecutionProvider"]

--- a/tests/test_embeddings_client.py
+++ b/tests/test_embeddings_client.py
@@ -157,3 +157,39 @@ def test_gpu_provider_selection_no_gpu_cpu_only():
     """GPU-less hosts degrade to CPU only — never crash."""
     assert select_gpu_providers(["CPUExecutionProvider"]) == [
         "CPUExecutionProvider"]
+
+
+def test_gpu_provider_override_force_cpu(monkeypatch):
+    """EMBEDDING_GPU_PROVIDER=cpu disables GPU even when available."""
+    monkeypatch.setenv("EMBEDDING_GPU_PROVIDER", "cpu")
+    provs = ["CPUExecutionProvider", "CUDAExecutionProvider",
+             "TensorrtExecutionProvider"]
+    assert select_gpu_providers(provs) == ["CPUExecutionProvider"]
+
+
+def test_gpu_provider_override_force_nvidia(monkeypatch):
+    """EMBEDDING_GPU_PROVIDER=nvidia picks NVIDIA over any other GPU."""
+    monkeypatch.setenv("EMBEDDING_GPU_PROVIDER", "nvidia")
+    provs = ["CPUExecutionProvider", "MIGraphXExecutionProvider",
+             "CUDAExecutionProvider"]
+    assert select_gpu_providers(provs) == [
+        "CUDAExecutionProvider", "MIGraphXExecutionProvider",
+        "CPUExecutionProvider"]
+
+
+def test_gpu_provider_override_force_amd(monkeypatch):
+    """EMBEDDING_GPU_PROVIDER=amd picks AMD even when NVIDIA is available."""
+    monkeypatch.setenv("EMBEDDING_GPU_PROVIDER", "amd")
+    provs = ["CPUExecutionProvider", "MIGraphXExecutionProvider",
+             "CUDAExecutionProvider"]
+    assert select_gpu_providers(provs) == [
+        "MIGraphXExecutionProvider", "CUDAExecutionProvider",
+        "CPUExecutionProvider"]
+
+
+def test_gpu_provider_override_auto_is_default(monkeypatch):
+    """Auto (default) picks the best provider; override unset behaves the same."""
+    monkeypatch.delenv("EMBEDDING_GPU_PROVIDER", raising=False)
+    provs = ["CPUExecutionProvider", "CUDAExecutionProvider"]
+    assert select_gpu_providers(provs) == [
+        "CUDAExecutionProvider", "CPUExecutionProvider"]


### PR DESCRIPTION
## Summary

Local embedding inference in Odysseus currently runs on CPU through fastembed (ONNX). This PR adds **vendor-agnostic GPU acceleration** for embeddings, with auto-detect as the default and an operator override, so Odysseus uses whatever GPU a machine has (NVIDIA, AMD, Apple, Intel) and degrades gracefully to CPU when there is none.

The change adds a single pure function — `select_gpu_providers()` — that picks the best available ONNX Runtime provider, an `EMBEDDING_GPU_PROVIDER` env setting to control it, a `/api/diagnostics/gpu` route so admins can see whether acceleration is active, and 12 tests covering all vendor paths plus the override cases. It is grounded in current ONNX Runtime docs (ROCm EP was removed as of ORT 1.23; MIGraphX is the current AMD path).

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Part of #4764 — this is the opt-in GPU counterpart to that issue's CPU-default proposal, and provides the `EMBEDDING_GPU_PROVIDER=cpu` escape hatch that CPU-default users need. Also related to #2918 (AMD acceleration) — my AMD provider support (MIGraphX current / ROCm legacy) aligns with that issue's AMD direction, though it targets embeddings rather than llama.cpp inference.

## Type of Change

- [x] New feature (non-breaking — adds new behaviour)

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. **Run the unit tests** (no GPU needed — `select_gpu_providers` is pure):
   ```bash
   python -m pytest tests/test_embeddings_client.py -q
   ```
   Expect all tests green, including the 6 vendor auto-detect cases and the 4 override cases.

2. **Verify auto-detect on a GPU host** (NVIDIA shown; AMD/Apple/Intel analogous):
   ```bash
   EMBEDDING_GPU_PROVIDER=auto python -c "
   from src.embeddings import select_gpu_providers
   import onnxruntime as ort
   print(select_gpu_providers(ort.get_available_providers()))"
   ```
   On a CUDA host this prints `['TensorrtExecutionProvider'|'CUDAExecutionProvider', ..., 'CPUExecutionProvider']` — a GPU provider first, CPU last. On a CPU-only host it prints `['CPUExecutionProvider']`.

3. **Verify the override forces CPU**:
   ```bash
   EMBEDDING_GPU_PROVIDER=cpu python -c "
   from src.embeddings import select_gpu_providers
   import onnxruntime as ort
   print(select_gpu_providers(ort.get_available_providers()))"
   ```
   Prints `['CPUExecutionProvider']` even on a GPU machine.

4. **Verify the diagnostics endpoint** (requires the running app):
   ```bash
   curl -H "Authorization: Bearer $TOKEN" http://localhost:7000/api/diagnostics/gpu
   ```
   Returns `available_providers`, `gpu_override`, and (on a GPU host) `gpu_name`/`gpu_vendor`/VRAM from nvidia-smi or rocm-smi. On a CPU-only host it reports `gpu_detected: false` and `embedding_provider: cpu`.

I ran the app end-to-end and verified the change works — the embedding path uses the selected GPU provider on startup, the diagnostics endpoint reports it, and the `EMBEDDING_GPU_PROVIDER=cpu` override forces the CPU path as expected.

## Visual / UI changes

**No UI/visual changes.** This touches `src/embeddings.py`, `routes/diagnostics_routes.py`, `tests/test_embeddings_client.py`, and `.env.example` — no rendering code, no static assets. The Visual/UI section does not apply.

- [x] **Not applicable** — no UI/visual change.
