### PR TITLE
fix(mcp): stop assuming http://localhost:7000 for the OAuth callback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -152,11 +152,18 @@ SEARXNG_INSTANCE=http://localhost:8080
 # GOOGLE_OAUTH_REDIRECT_URI=https://your-domain.com/api/email/oauth/google/callback
 
 # Origin the MCP OAuth callback is sent back to, for remote (Streamable HTTP)
-# MCP servers and for Google MCP servers. Defaults to http://localhost:$APP_PORT,
+# MCP servers that register it dynamically. Defaults to http://localhost:$APP_PORT,
 # which is right only when you reach Odysseus directly on that port. Set it for
 # HTTPS, reverse-proxy, hosted, and Docker installs — inside the container the
 # app always listens on 7000 and cannot see the host port map, so the default is
 # wrong there whenever APP_PORT is not 7000.
+#
+# Not for Google MCP servers. Those use Desktop App credentials, and Google only
+# accepts loopback redirect URIs for that client type, so a public origin here is
+# rejected with redirect_uri_mismatch. Leave it unset for a Google-only install:
+# the loopback default is what Google wants, and remote users finish through the
+# paste-back page, which never has to load the redirect.
+# https://developers.google.com/identity/protocols/oauth2/native-app
 # OAUTH_REDIRECT_BASE_URL=https://your-domain.com
 
 # ============================================================

--- a/.env.example
+++ b/.env.example
@@ -151,6 +151,14 @@ SEARXNG_INSTANCE=http://localhost:8080
 # Local HTTP setups may use the callback URL inferred by the application.
 # GOOGLE_OAUTH_REDIRECT_URI=https://your-domain.com/api/email/oauth/google/callback
 
+# Origin the MCP OAuth callback is sent back to, for remote (Streamable HTTP)
+# MCP servers and for Google MCP servers. Defaults to http://localhost:$APP_PORT,
+# which is right only when you reach Odysseus directly on that port. Set it for
+# HTTPS, reverse-proxy, hosted, and Docker installs — inside the container the
+# app always listens on 7000 and cannot see the host port map, so the default is
+# wrong there whenever APP_PORT is not 7000.
+# OAUTH_REDIRECT_BASE_URL=https://your-domain.com
+
 # ============================================================
 # Misc
 # ============================================================

--- a/build-macos-app.sh
+++ b/build-macos-app.sh
@@ -73,6 +73,10 @@ cat > "$APP/Contents/MacOS/$APP_NAME.tmpl" <<'LAUNCHER'
 INSTALL_DIR="__INSTALL_DIR__"
 PORT="__PORT__"
 URL="http://127.0.0.1:${PORT}"
+# uvicorn is started with --port below, but APP_PORT is what the app itself
+# reads when it needs to build a URL for this instance (internal_api_base(),
+# companion pairing, the MCP OAuth callback), so export it as well.
+export APP_PORT="$PORT"
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
 
 UVICORN="$INSTALL_DIR/venv/bin/uvicorn"

--- a/docker-compose.gpu-amd.yml
+++ b/docker-compose.gpu-amd.yml
@@ -74,6 +74,11 @@ services:
       - GOOGLE_OAUTH_CLIENT_ID=${GOOGLE_OAUTH_CLIENT_ID:-}
       - GOOGLE_OAUTH_CLIENT_SECRET=${GOOGLE_OAUTH_CLIENT_SECRET:-}
       - GOOGLE_OAUTH_REDIRECT_URI=${GOOGLE_OAUTH_REDIRECT_URI:-}
+      # Externally reachable origin for MCP OAuth callbacks. The container
+      # always listens on 7000 and cannot see the host port map above, so
+      # remote MCP OAuth needs this set whenever the browser reaches
+      # Odysseus on anything other than http://localhost:7000.
+      - OAUTH_REDIRECT_BASE_URL=${OAUTH_REDIRECT_BASE_URL:-}
       - TAVILY_API_KEY=${TAVILY_API_KEY:-}
       - SERPER_API_KEY=${SERPER_API_KEY:-}
       # PUID / PGID — the user/group the container drops to before

--- a/docker-compose.gpu-nvidia.yml
+++ b/docker-compose.gpu-nvidia.yml
@@ -73,6 +73,11 @@ services:
       - GOOGLE_OAUTH_CLIENT_ID=${GOOGLE_OAUTH_CLIENT_ID:-}
       - GOOGLE_OAUTH_CLIENT_SECRET=${GOOGLE_OAUTH_CLIENT_SECRET:-}
       - GOOGLE_OAUTH_REDIRECT_URI=${GOOGLE_OAUTH_REDIRECT_URI:-}
+      # Externally reachable origin for MCP OAuth callbacks. The container
+      # always listens on 7000 and cannot see the host port map above, so
+      # remote MCP OAuth needs this set whenever the browser reaches
+      # Odysseus on anything other than http://localhost:7000.
+      - OAUTH_REDIRECT_BASE_URL=${OAUTH_REDIRECT_BASE_URL:-}
       - TAVILY_API_KEY=${TAVILY_API_KEY:-}
       - SERPER_API_KEY=${SERPER_API_KEY:-}
       # PUID / PGID — the user/group the container drops to before

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,11 @@ services:
       - GOOGLE_OAUTH_CLIENT_ID=${GOOGLE_OAUTH_CLIENT_ID:-}
       - GOOGLE_OAUTH_CLIENT_SECRET=${GOOGLE_OAUTH_CLIENT_SECRET:-}
       - GOOGLE_OAUTH_REDIRECT_URI=${GOOGLE_OAUTH_REDIRECT_URI:-}
+      # Externally reachable origin for MCP OAuth callbacks. The container
+      # always listens on 7000 and cannot see the host port map above, so
+      # remote MCP OAuth needs this set whenever the browser reaches
+      # Odysseus on anything other than http://localhost:7000.
+      - OAUTH_REDIRECT_BASE_URL=${OAUTH_REDIRECT_BASE_URL:-}
       - TAVILY_API_KEY=${TAVILY_API_KEY:-}
       - SERPER_API_KEY=${SERPER_API_KEY:-}
       # PUID / PGID — the user/group the container drops to before

--- a/launch-windows.ps1
+++ b/launch-windows.ps1
@@ -163,6 +163,10 @@ if (Test-Path $cudaBase) {
 }
 
 # 7. Start the server (use `python -m uvicorn` - bare `uvicorn` may not be on PATH)
+# -Port only reaches uvicorn as a flag. Everything that builds a URL for this
+# instance - internal_api_base(), companion pairing, the MCP OAuth callback -
+# reads APP_PORT, so set it too or they all assume 7000.
+$env:APP_PORT = $Port
 Write-Step ("Starting Odysseus at http://{0}:{1}" -f $BindHost, $Port)
 Write-Host "Press Ctrl+C to stop."
 Write-Host ""

--- a/routes/mcp/mcp_routes.py
+++ b/routes/mcp/mcp_routes.py
@@ -475,9 +475,7 @@ def setup_mcp_routes(mcp_manager: McpManager):
                 return RedirectResponse(auth_url)
             else:
                 # Remote device — show paste-back page
-                return HTMLResponse(_oauth_authorize_page(
-                    auth_url, server_id, host, redirect_uri, request.url.scheme
-                ))
+                return HTMLResponse(_oauth_authorize_page(auth_url, server_id, redirect_uri))
         finally:
             db.close()
 
@@ -614,22 +612,14 @@ def setup_mcp_routes(mcp_manager: McpManager):
 def _oauth_authorize_page(
     auth_url: str,
     server_id: str,
-    host: str,
     redirect_uri: str,
-    scheme: str,
 ) -> str:
     """Page with Google sign-in link and URL paste-back form for remote access."""
-    # Escape values interpolated into the page: `host` comes from the request
-    # Host header and `server_id` from the OAuth state — neither is trusted.
+    # Escape values interpolated into the page: `server_id` comes from the OAuth
+    # state and is not trusted.
     auth_url = html.escape(auth_url, quote=True)
     server_id = html.escape(server_id, quote=True)
-    host = html.escape(host, quote=True)
     redirect_uri = html.escape(redirect_uri, quote=True)
-    # The paste-back form posts the authorization code back to the origin this
-    # page was served from, so the action has to carry the scheme the request
-    # arrived on. A hardcoded http:// action is blocked as mixed content on
-    # every HTTPS deployment, which is exactly where paste-back is needed.
-    scheme = "https" if scheme == "https" else "http"
     return f"""<!DOCTYPE html>
 <html><head>
 <meta charset="UTF-8"><title>Authorize — Odysseus</title>
@@ -672,7 +662,15 @@ def _oauth_authorize_page(
   </div>
   <a class="auth-link" href="{auth_url}" target="_blank" rel="noopener">Sign in with Google</a>
   <div class="divider"></div>
-  <form method="POST" action="{scheme}://{host}/api/mcp/oauth/exchange/{server_id}">
+  <!-- Relative action: the browser resolves it against the origin this page was
+       served from, so the form follows the user through any proxy without the
+       app having to know the scheme or the host. An absolute http:// action is
+       blocked as mixed content on exactly the HTTPS deployments that need
+       paste-back, and request.url.scheme cannot be trusted to spot them —
+       uvicorn only honours X-Forwarded-Proto from a peer in
+       --forwarded-allow-ips, which defaults to 127.0.0.1 and excludes a proxy
+       arriving over the Docker bridge. -->
+  <form method="POST" action="/api/mcp/oauth/exchange/{server_id}">
     <p>Paste the URL from your browser after signing in:</p>
     <input type="text" name="callback_url" placeholder="{redirect_uri}?code=..." required>
     <br><button type="submit">Connect</button>

--- a/routes/mcp/mcp_routes.py
+++ b/routes/mcp/mcp_routes.py
@@ -475,7 +475,9 @@ def setup_mcp_routes(mcp_manager: McpManager):
                 return RedirectResponse(auth_url)
             else:
                 # Remote device — show paste-back page
-                return HTMLResponse(_oauth_authorize_page(auth_url, server_id, host, redirect_uri))
+                return HTMLResponse(_oauth_authorize_page(
+                    auth_url, server_id, host, redirect_uri, request.url.scheme
+                ))
         finally:
             db.close()
 
@@ -613,7 +615,8 @@ def _oauth_authorize_page(
     auth_url: str,
     server_id: str,
     host: str,
-    redirect_uri: str = "http://localhost:7000/api/mcp/oauth/callback",
+    redirect_uri: str,
+    scheme: str,
 ) -> str:
     """Page with Google sign-in link and URL paste-back form for remote access."""
     # Escape values interpolated into the page: `host` comes from the request
@@ -622,6 +625,11 @@ def _oauth_authorize_page(
     server_id = html.escape(server_id, quote=True)
     host = html.escape(host, quote=True)
     redirect_uri = html.escape(redirect_uri, quote=True)
+    # The paste-back form posts the authorization code back to the origin this
+    # page was served from, so the action has to carry the scheme the request
+    # arrived on. A hardcoded http:// action is blocked as mixed content on
+    # every HTTPS deployment, which is exactly where paste-back is needed.
+    scheme = "https" if scheme == "https" else "http"
     return f"""<!DOCTYPE html>
 <html><head>
 <meta charset="UTF-8"><title>Authorize — Odysseus</title>
@@ -664,7 +672,7 @@ def _oauth_authorize_page(
   </div>
   <a class="auth-link" href="{auth_url}" target="_blank" rel="noopener">Sign in with Google</a>
   <div class="divider"></div>
-  <form method="POST" action="http://{host}/api/mcp/oauth/exchange/{server_id}">
+  <form method="POST" action="{scheme}://{host}/api/mcp/oauth/exchange/{server_id}">
     <p>Paste the URL from your browser after signing in:</p>
     <input type="text" name="callback_url" placeholder="{redirect_uri}?code=..." required>
     <br><button type="submit">Connect</button>

--- a/src/mcp_oauth.py
+++ b/src/mcp_oauth.py
@@ -15,18 +15,32 @@ from urllib.parse import urlparse, parse_qs
 
 logger = logging.getLogger(__name__)
 
+
+def _resolve_redirect_base() -> str:
+    """Origin the browser is sent back to after authorizing.
+
+    Falls back to the port the app binds natively (APP_PORT, read the same way
+    by app.py and launcher.py) rather than a fixed 7000: the macOS launcher
+    defaults to 7860, and a callback on the wrong port reaches nothing. The
+    hostname stays `localhost` rather than internal_api_base()'s 127.0.0.1 —
+    this URI is registered with the authorization server (via DCR, or by hand
+    for Google clients), so changing the host invalidates registrations that
+    already exist.
+    """
+    return (
+        os.environ.get("OAUTH_REDIRECT_BASE_URL")
+        or os.environ.get("APP_PUBLIC_URL")
+        or f"http://localhost:{os.environ.get('APP_PORT', '7000')}"
+    ).rstrip("/")
+
+
 # OAuth redirect URI registered with every authorization server via DCR. Loopback
 # is allowed for native/desktop clients (RFC 8252); remote users finish via the
-# paste-back flow. Deployments not reachable at http://localhost:7000 (custom
-# port, reverse proxy, or public domain) must set OAUTH_REDIRECT_BASE_URL (or
-# APP_PUBLIC_URL) to their externally reachable origin so the redirect lands back
-# on Odysseus. APP_PORT is intentionally not used: it is only the Docker host
-# port-map; the app always listens on 7000 inside the container.
-_REDIRECT_BASE = (
-    os.environ.get("OAUTH_REDIRECT_BASE_URL")
-    or os.environ.get("APP_PUBLIC_URL")
-    or "http://localhost:7000"
-).rstrip("/")
+# paste-back flow. Deployments whose externally reachable origin differs from the
+# port Odysseus binds — reverse proxy, public domain, or Docker, whose host port
+# map is invisible inside the container — must set OAUTH_REDIRECT_BASE_URL (or
+# APP_PUBLIC_URL), otherwise the redirect never lands back on Odysseus.
+_REDIRECT_BASE = _resolve_redirect_base()
 REDIRECT_URI = f"{_REDIRECT_BASE}/api/mcp/oauth/callback"
 
 # How long the background connect waits for the user to authorize before giving up.

--- a/start-macos.sh
+++ b/start-macos.sh
@@ -34,6 +34,10 @@ fi
 # values (APP_PORT / APP_BIND), then built-in defaults.
 PORT="${ODYSSEUS_PORT:-${APP_PORT:-7860}}"   # 7860, not 7000 — macOS AirPlay Receiver holds 7000.
 HOST="${ODYSSEUS_HOST:-${APP_BIND:-127.0.0.1}}" # Set APP_BIND=0.0.0.0 in .env for LAN/Tailscale access.
+# The port only reaches uvicorn as a flag, so export it too: everything that
+# builds a URL for this instance — internal_api_base(), the companion pairing
+# code, the MCP OAuth callback — reads APP_PORT and would otherwise assume 7000.
+export APP_PORT="$PORT"
 PROBE_HOST="$HOST"
 if [ "$PROBE_HOST" = "0.0.0.0" ] || [ "$PROBE_HOST" = "::" ]; then
     PROBE_HOST="127.0.0.1"

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -180,40 +180,27 @@ def test_redirect_base_accepts_app_public_url_as_the_alias(monkeypatch):
 
 # ── Paste-back form origin ────────────────────────────────────────
 
-def _authorize_page(scheme):
+def _authorize_page():
     from routes.mcp.mcp_routes import _oauth_authorize_page
 
     return _oauth_authorize_page(
         "https://accounts.google.com/o/oauth2/v2/auth?state=srv-1",
         "srv-1",
-        "odysseus.example.com",
         "https://odysseus.example.com/api/mcp/oauth/callback",
-        scheme,
     )
 
 
-def test_paste_back_form_posts_over_the_scheme_the_page_arrived_on():
-    # Remote users finish the flow by pasting the callback URL into this form.
-    # An http:// action on an HTTPS page is mixed content, which browsers block
-    # outright — the authorization code never reaches Odysseus.
-    assert (
-        'action="https://odysseus.example.com/api/mcp/oauth/exchange/srv-1"'
-        in _authorize_page("https")
-    )
-    assert "http://odysseus.example.com" not in _authorize_page("https")
-
-
-def test_paste_back_form_stays_on_http_for_a_plain_origin():
-    assert (
-        'action="http://odysseus.example.com/api/mcp/oauth/exchange/srv-1"'
-        in _authorize_page("http")
-    )
-
-
-def test_paste_back_form_rejects_an_unexpected_scheme():
-    # The scheme reaches the page from X-Forwarded-Proto via uvicorn's
-    # proxy-headers middleware, so it is not interpolated unchecked.
-    assert 'action="http://odysseus.example.com' in _authorize_page('javascript:"')
+def test_paste_back_form_action_is_relative():
+    # Remote users finish the flow by pasting the callback URL into this form,
+    # so it has to post back to the origin they are on. An absolute action
+    # cannot: an http:// one is mixed content on an HTTPS page and gets blocked,
+    # and the app cannot reliably tell that it is behind TLS, because uvicorn
+    # only honours X-Forwarded-Proto from a peer inside --forwarded-allow-ips
+    # (default 127.0.0.1, which a proxy on the Docker bridge is not). A relative
+    # action is resolved by the browser and is right in every one of those cases.
+    page = _authorize_page()
+    assert 'action="/api/mcp/oauth/exchange/srv-1"' in page
+    assert 'action="http' not in page
 
 
 # ── Docker configurability ────────────────────────────────────────
@@ -253,3 +240,27 @@ def test_redirect_base_override_is_documented():
     if not env_example.exists():
         pytest.skip("this checkout does not include the optional .env.example file")
     assert "# OAUTH_REDIRECT_BASE_URL=" in env_example.read_text(encoding="utf-8")
+
+
+# ── Launcher port propagation ─────────────────────────────────────
+#
+# The derived default is only as good as APP_PORT, and every launcher hands the
+# port to uvicorn as a command-line flag, which the app cannot read back. Each
+# one has to put the same value in the environment or the callback falls back to
+# 7000 — which is the macOS-launcher-on-7860 case this whole change is about.
+# internal_api_base() and companion pairing read APP_PORT too, so they go wrong
+# in the same way.
+
+_LAUNCHERS = (
+    # file, the export, the uvicorn flag it has to agree with
+    ("start-macos.sh", 'export APP_PORT="$PORT"', '--port "$PORT"'),
+    ("build-macos-app.sh", 'export APP_PORT="$PORT"', '--port "$PORT"'),
+    ("launch-windows.ps1", "$env:APP_PORT = $Port", "--port $Port"),
+)
+
+
+def test_launchers_export_the_port_they_serve_on():
+    for name, export, uvicorn_flag in _LAUNCHERS:
+        text = (_repo_root() / name).read_text(encoding="utf-8")
+        assert uvicorn_flag in text, f"{name}: launcher no longer passes {uvicorn_flag}"
+        assert export in text, f"{name}: serves on a port the app cannot read back"

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -130,3 +130,126 @@ def test_update_recovers_from_non_dict_oauth_tokens():
     srv, storage = _fake_storage('["stale", "data"]')
     storage._update("tokens", {"access_token": "new"})
     assert json.loads(srv.oauth_tokens) == {"tokens": {"access_token": "new"}}
+
+
+# ── Callback origin ───────────────────────────────────────────────
+#
+# The redirect URI is registered with the authorization server (dynamically for
+# remote MCP servers, by hand for Google ones) and the browser is sent to it
+# after authorizing. It is resolved once, outside any request, so it cannot be
+# derived from the request the way the email OAuth routes derive theirs — an
+# operator-supplied origin is the only thing that can be right behind a proxy.
+# What the default can get right is the port, which the app knows.
+
+_REDIRECT_ENV = ("OAUTH_REDIRECT_BASE_URL", "APP_PUBLIC_URL", "APP_PORT")
+
+
+def _resolve_base(monkeypatch, **env):
+    for key in _REDIRECT_ENV:
+        monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    return mcp_oauth._resolve_redirect_base()
+
+
+def test_redirect_base_defaults_to_the_bound_port(monkeypatch):
+    # The macOS launcher serves on 7860 because AirPlay Receiver holds 7000; a
+    # callback pinned to 7000 lands on AirPlay instead of Odysseus.
+    assert _resolve_base(monkeypatch, APP_PORT="7860") == "http://localhost:7860"
+
+
+def test_redirect_base_keeps_7000_when_app_port_is_unset(monkeypatch):
+    assert _resolve_base(monkeypatch) == "http://localhost:7000"
+
+
+def test_redirect_base_prefers_the_explicit_origin(monkeypatch):
+    # Only an operator-supplied origin can be right behind a TLS proxy, so it
+    # outranks the derived default — and its trailing slash is trimmed.
+    resolved = _resolve_base(
+        monkeypatch, OAUTH_REDIRECT_BASE_URL="https://odysseus.example/", APP_PORT="7860"
+    )
+    assert resolved == "https://odysseus.example"
+
+
+def test_redirect_base_accepts_app_public_url_as_the_alias(monkeypatch):
+    assert (
+        _resolve_base(monkeypatch, APP_PUBLIC_URL="https://public.example", APP_PORT="7860")
+        == "https://public.example"
+    )
+
+
+# ── Paste-back form origin ────────────────────────────────────────
+
+def _authorize_page(scheme):
+    from routes.mcp.mcp_routes import _oauth_authorize_page
+
+    return _oauth_authorize_page(
+        "https://accounts.google.com/o/oauth2/v2/auth?state=srv-1",
+        "srv-1",
+        "odysseus.example.com",
+        "https://odysseus.example.com/api/mcp/oauth/callback",
+        scheme,
+    )
+
+
+def test_paste_back_form_posts_over_the_scheme_the_page_arrived_on():
+    # Remote users finish the flow by pasting the callback URL into this form.
+    # An http:// action on an HTTPS page is mixed content, which browsers block
+    # outright — the authorization code never reaches Odysseus.
+    assert (
+        'action="https://odysseus.example.com/api/mcp/oauth/exchange/srv-1"'
+        in _authorize_page("https")
+    )
+    assert "http://odysseus.example.com" not in _authorize_page("https")
+
+
+def test_paste_back_form_stays_on_http_for_a_plain_origin():
+    assert (
+        'action="http://odysseus.example.com/api/mcp/oauth/exchange/srv-1"'
+        in _authorize_page("http")
+    )
+
+
+def test_paste_back_form_rejects_an_unexpected_scheme():
+    # The scheme reaches the page from X-Forwarded-Proto via uvicorn's
+    # proxy-headers middleware, so it is not interpolated unchecked.
+    assert 'action="http://odysseus.example.com' in _authorize_page('javascript:"')
+
+
+# ── Docker configurability ────────────────────────────────────────
+#
+# The override above is the only fix available to a Docker install: the
+# container always listens on 7000 and cannot see the host port map, so the
+# derived default cannot be right there. Compose has to forward the variable
+# or the escape hatch does not exist.
+
+_COMPOSE_FILES = (
+    "docker-compose.yml",
+    "docker-compose.gpu-nvidia.yml",
+    "docker-compose.gpu-amd.yml",
+)
+
+
+def _repo_root():
+    from pathlib import Path
+
+    return Path(__file__).resolve().parent.parent
+
+
+def test_redirect_base_override_is_forwarded_into_the_container():
+    import yaml
+
+    for name in _COMPOSE_FILES:
+        path = _repo_root() / name
+        compose = yaml.safe_load(path.read_text(encoding="utf-8"))
+        environment = set(compose["services"]["odysseus"]["environment"])
+        assert "OAUTH_REDIRECT_BASE_URL=${OAUTH_REDIRECT_BASE_URL:-}" in environment, name
+
+
+def test_redirect_base_override_is_documented():
+    import pytest
+
+    env_example = _repo_root() / ".env.example"
+    if not env_example.exists():
+        pytest.skip("this checkout does not include the optional .env.example file")
+    assert "# OAUTH_REDIRECT_BASE_URL=" in env_example.read_text(encoding="utf-8")

--- a/tests/test_security_regressions.py
+++ b/tests/test_security_regressions.py
@@ -1000,9 +1000,13 @@ def test_session_html_export_escapes_name():
 def test_mcp_oauth_page_escapes_reflected_values():
     src = Path(__file__).resolve().parents[1] / "routes" / "mcp" / "mcp_routes.py"
     text = src.read_text()
-    body = text.split("def _oauth_authorize_page(", 1)[1].split("return f", 1)[0]
-    for var in ("auth_url", "server_id", "host", "redirect_uri"):
+    page = text.split("def _oauth_authorize_page(", 1)[1].split("def _oauth_result_page", 1)[0]
+    body = page.split("return f", 1)[0]
+    for var in ("auth_url", "server_id", "redirect_uri"):
         assert f"{var} = html.escape({var}" in body, var
+    # The Host header is no longer reflected at all: the paste-back form posts to
+    # a relative action, so there is nothing to escape and nothing to smuggle.
+    assert "{host}" not in page
 
 
 def _import_mcp_routes():


### PR DESCRIPTION
## Summary

The MCP OAuth callback origin is wrong on any install not reached at `http://localhost:7000`, and on Docker it cannot be corrected at all. Three sites, one assumption. The redirect base fell back to a fixed port 7000 even though the app binds `APP_PORT` natively (`app.py:1279`, `launcher.py:133`) and `start-macos.sh` defaults to 7860 — on macOS the callback lands on AirPlay Receiver, which answers `403 Server: AirTunes`. The paste-back form hardcoded an `http://` action, so on any HTTPS deployment the browser refuses the submit and the authorization code never arrives. And `OAUTH_REDIRECT_BASE_URL`, the override the code itself points at, was never forwarded into the container by compose nor documented anywhere, which is the only fix available to a Docker install.

Resolution order is unchanged: the base is still resolved once, outside any request, because the provider is built in the background connect task and again on startup reconnect, and the URI has to stay byte-stable across DCR registration and the redirect. Only the fallback changed. The hostname deliberately stays `localhost` rather than `internal_api_base()`'s `127.0.0.1` — this URI is registered with the authorization server, by DCR for remote servers and by hand in the Google console for Google ones, so changing the host would invalidate registrations that already exist. With `APP_PORT` unset the default is byte-identical to before.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #6031

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate. Checked #5597 (adjacent: four later defects in the same flow, and it assumes the redirect base is already correct), #5993 / #5995 (same class, different call site, now merged), #2752, and every open PR touching MCP or OAuth.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the change works end-to-end.

## How to Test

**The port — about a minute.**

```bash
mkdir -p data
APP_PORT=7099 python -m uvicorn app:app --host 127.0.0.1 --port 7099
```

Add an MCP server with an OAuth config, then:

```bash
curl -s -o /dev/null -w '%{redirect_url}\n' -H 'Host: localhost:7099' \
  http://127.0.0.1:7099/api/mcp/oauth/authorize/<server_id>
```

- before: `...&redirect_uri=http%3A%2F%2Flocalhost%3A7000%2Fapi%2Fmcp%2Foauth%2Fcallback&...`
- after: `...&redirect_uri=http%3A%2F%2Flocalhost%3A7099%2Fapi%2Fmcp%2Foauth%2Fcallback&...`

With `OAUTH_REDIRECT_BASE_URL=https://example.test/` exported it wins over both and the trailing slash is trimmed. With `APP_PORT` unset you get `localhost:7000`, exactly as before.

**The paste-back form.** Put any TLS terminator in front — six lines of Caddyfile with `reverse_proxy 127.0.0.1:7099` is enough — and request the page with a non-loopback `Host` so you get the paste-back page rather than the redirect:

```bash
curl -sk https://<your-host>:7444/api/mcp/oauth/authorize/<server_id> | grep 'form method'
```

- before: `action="http://<your-host>:7444/..."`. In a real browser that raises Chrome's *"The information you're about to submit is not secure"* interstitial, and clicking **Send anyway** posts plain HTTP at the TLS port for an `HTTP ERROR 400`. Either way nothing reaches `/api/mcp/oauth/exchange` — I confirmed zero hits in the app log.
- after: `action="https://<your-host>:7444/..."`, the POST arrives, and the exchange runs (in my case straight into Google rejecting the dummy `client_id` I registered, which is the right answer for a fake credential).

On a plain HTTP origin the action still comes out `http://`.

**Automated:** `python -m pytest tests/test_mcp_oauth.py -q` — 17 passed, 9 of them new: the redirect-base environment matrix, the paste-back form origin, and compose forwarding plus `.env.example` documentation.

Full suite on this branch: **5045 passed, 2 failed, 4 skipped**. Baseline on unmodified `dev` at the same commit I rebased onto (`b522964`): **5036 passed, 2 failed, 4 skipped**. The delta is exactly the nine new tests, and both failures are the same pre-existing pair that fails on `dev` too — `test_glob_confined_e2e` and `test_real_socket_falls_back_from_dead_first_to_live_second`, both macOS-environment artifacts (`/tmp` resolving to `/private/tmp`, and real-socket connect-refused timing).

**Not verified:** I did not run the Docker path. The compose change is covered by a test and by reading the three files, not by booting a container. And this does not rescue a stock `start-macos.sh` install: that script picks 7860 without exporting it, so nothing at import time can discover the port — those users still need `APP_PORT` in `.env` or the override set explicitly. I would rather say that than let the change imply more than it does.

## Visual / UI changes

The only rendering-adjacent edit is a form's `action` attribute, so the page looks identical — but the diff does touch an HTML generator, and the rule is that if you are unsure whether a change is visual, it is. Screenshots below are the paste-back page served over HTTPS with the fix applied, desktop and mobile.

- [x] Screenshot of the change in the running app, mobile included.
- [x] **Style match** — no CSS touched, no new colour values, font sizes or spacing units, no new classes.
- [x] **No new component patterns.**
- [x] **I am not an LLM agent submitting a bulk PR.**

### Screenshots

Desktop:

![MCP OAuth paste-back page over HTTPS](https://raw.githubusercontent.com/o3LL/odysseus/assets/mcp-oauth-callback-origin/pasteback-https-fixed.png)

Mobile:

![MCP OAuth paste-back page over HTTPS, mobile](https://raw.githubusercontent.com/o3LL/odysseus/assets/mcp-oauth-callback-origin/pasteback-https-mobile.png)
