### PR TITLE
refactor(settings): extract modular settings shell

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -3,8 +3,20 @@
 
 import uiModule from './ui.js';
 import searchModule from './search.js';
-import { makeWindowDraggable } from './windowDrag.js';
-import { clearDockSide } from './modalSnap.js';
+import { byId } from './settings/dom.js';
+import {
+  ADMIN_TABS,
+  activateSettingsPanel,
+  getActiveSettingsTab,
+  bindSettingsNavigation,
+} from './settings/navigation.js';
+import {
+  bindSettingsDrag,
+  bindSettingsClose,
+  bindOpenPromptModalLink,
+  showSettingsModal,
+  hideSettingsModal,
+} from './settings/lifecycle.js';
 import { sortModelIds } from './modelSort.js';
 import { providerLogo } from './providers.js';
 import { isAltGrEvent } from './platform.js';
@@ -14,133 +26,29 @@ let initialized = false;
 let modalEl = null;
 let _authPolicy = { password_min_length: 8 };
 
-function el(id) { return document.getElementById(id); }
+const el = byId;
 function esc(s) { return uiModule.esc(s); }
 function safeRasterDataUrl(raw) {
   const value = String(raw || '').trim();
   return /^data:image\/(?:png|jpe?g|gif|webp);base64,[a-z0-9+/=\s]+$/i.test(value) ? value : '';
 }
 
-/* ── Tab switching ── */
-const ADMIN_TABS = new Set(['services', 'added-models', 'integrations', 'tools', 'users', 'system']);
+/* ── Settings shell coordination ── */
+function onSettingsPanelActivated(tab) {
+  // Appearance keeps its existing transparent preview behavior.
+  document.body.classList.toggle('settings-appearance-open', tab === 'appearance');
+  syncAppearanceOpacity(tab === 'appearance');
 
-function initTabs() {
-  modalEl.querySelectorAll('[data-settings-tab]').forEach(btn => {
-    btn.addEventListener('click', () => {
-      const tab = btn.dataset.settingsTab;
-      // Lazy-init admin when first clicking an admin tab
-      if (ADMIN_TABS.has(tab) && window.adminModule && typeof window.adminModule.open === 'function') {
-        window.adminModule.open(tab);
-        return;
-      }
-      modalEl.querySelectorAll('[data-settings-tab]').forEach(b => b.classList.toggle('active', b.dataset.settingsTab === tab));
-      modalEl.querySelectorAll('[data-settings-panel]').forEach(p => p.classList.toggle('hidden', p.dataset.settingsPanel !== tab));
-      // Mark when the Appearance tab is open so the modal can go
-      // semi-transparent — lets the user see the rest of the UI react as
-      // they flip toggles instead of having to close + reopen the modal.
-      document.body.classList.toggle('settings-appearance-open', tab === 'appearance');
-      syncAppearanceOpacity(tab === 'appearance');
-      if (tab === 'ai') refreshAiModelEndpoints();
-    });
-  });
+  // AI endpoints are intentionally refreshed only when entering the AI panel.
+  if (tab === 'ai') refreshAiModelEndpoints();
 }
 
-/* ── Dragging ── */
-function initDrag() {
-  const header = modalEl.querySelector('.modal-header');
-  const content = modalEl.querySelector('.settings-modal-content');
-  if (!header || !content) return;
-  // Skip interactive controls in the header (e.g. the opacity slider) so
-  // grabbing them doesn't start a window-drag.
-  makeWindowDraggable(modalEl, {
-    content,
-    header,
-    skipSelector: 'button, input, select, .theme-opacity-wrap',
-    enableDock: true,
-  });
-}
-
-function resetWindowPlacement() {
-  const content = modalEl && modalEl.querySelector('.settings-modal-content');
-  if (!content) return;
-  const hadLeft = modalEl.classList.contains('modal-left-docked');
-  const hadRight = modalEl.classList.contains('modal-right-docked');
-  modalEl.classList.remove('modal-left-docked', 'modal-right-docked');
-  if (hadLeft) clearDockSide('left', modalEl);
-  if (hadRight) clearDockSide('right', modalEl);
-  if (content._leftDockNavObs) {
-    try { content._leftDockNavObs.navObs && content._leftDockNavObs.navObs.disconnect(); } catch (_) {}
-    try { window.removeEventListener('resize', content._leftDockNavObs.reanchor); } catch (_) {}
-    delete content._leftDockNavObs;
+function openAdminSettingsTab(tab) {
+  if (window.adminModule && typeof window.adminModule.open === 'function') {
+    window.adminModule.open(tab);
+    return true;
   }
-  delete content._preDockSnapshot;
-  delete content._dockSide;
-  delete content._dockSuspended;
-  delete content.dataset._tilePreSnap;
-  delete content.dataset._tileZone;
-  [
-    'position', 'left', 'top', 'right', 'bottom', 'margin', 'transform',
-    'width', 'height', 'max-width', 'max-height', 'border-radius', 'transition',
-  ].forEach(prop => content.style.removeProperty(prop));
-}
-
-/* ── Delegated link: close Settings + open the Prompt (characters) modal ── */
-function initOpenPromptModalLink() {
-  document.addEventListener('click', async (e) => {
-    const link = e.target.closest('[data-open-prompt-modal]');
-    if (!link) return;
-    e.preventDefault();
-    // Close settings first so the prompt modal isn't stacked on top.
-    if (modalEl && !modalEl.classList.contains('hidden')) close();
-    try {
-      const m = await import('./presets.js');
-      const fn = m.openCustomPresetModal || (m.default && m.default.openCustomPresetModal);
-      if (typeof fn === 'function') fn();
-    } catch (_) {
-      const modal = document.getElementById('custom-preset-modal');
-      if (modal) modal.classList.remove('hidden');
-    }
-    // Force the Persona tab (data-chartab="character") since the link's
-    // whole purpose is editing personas — not landing on Inject by default.
-    const personaTab = document.querySelector('#custom-preset-modal .preset-tab[data-chartab="character"]');
-    if (personaTab) personaTab.click();
-  });
-}
-
-/* ── Close on backdrop / X ── */
-function initClose() {
-  modalEl.querySelector('.close-btn').addEventListener('click', close);
-  modalEl.addEventListener('mousedown', e => {
-    if (uiModule.isTouchInsideModal()) return;
-    if (e.target === modalEl) close();
-  });
-  document.addEventListener('keydown', e => {
-    if (e.key !== 'Escape' || !modalEl || modalEl.classList.contains('hidden')) return;
-    // Bail when a transient popover inside the modal is open — Esc should
-    // dismiss just that, not the whole modal. Same-document listeners fire
-    // in registration order regardless of capture/bubble, so the popover's
-    // own handler can't pre-empt ours; we have to opt out here.
-    const popoverOpen = modalEl.querySelector(
-      '#adm-epLocalMoreMenu, #adm-epApiMoreMenu, #adm-provider-menu, #search-provider-menu, [data-popover-open="1"]'
-    );
-    if (popoverOpen && popoverOpen.style.display !== 'none' && !popoverOpen.classList.contains('hidden')) {
-      return;
-    }
-    // If an integration edit/add form is open inside the modal, close
-    // just that — don't dismiss the whole settings modal. (Pressing
-    // ESC mid-edit and losing the modal was a fast-typing footgun.)
-    const innerForm = modalEl.querySelector('#unified-intg-form, #set-email-accounts-form');
-    if (innerForm && innerForm.style.display !== 'none' && innerForm.children.length > 0) {
-      e.preventDefault();
-      e.stopPropagation();
-      innerForm.style.display = 'none';
-      innerForm.innerHTML = '';
-      return;
-    }
-    e.preventDefault();
-    e.stopPropagation();
-    close();
-  });
+  return false;
 }
 
 /* ── Appearance-tab opacity slider ──
@@ -2238,10 +2146,24 @@ function initAccount() {
 
 function initAll() {
   modalEl = el('settings-modal');
-  initTabs();
-  initDrag();
-  initClose();
-  initOpenPromptModalLink();
+
+  bindSettingsNavigation(modalEl, {
+    openAdminTab: openAdminSettingsTab,
+    onPanelActivated: onSettingsPanelActivated,
+  });
+
+  bindSettingsDrag(modalEl);
+
+  bindSettingsClose(modalEl, {
+    closeSettings: close,
+    isTouchInsideModal: () => uiModule.isTouchInsideModal(),
+  });
+
+  bindOpenPromptModalLink({
+    getModal: () => modalEl,
+    closeSettings: close,
+  });
+
   initOpacityToggle();
   initialized = true;
   initDefaultChat();
@@ -5661,22 +5583,21 @@ function syncAdminVisibility() {
    ═══════════════════════════════════════════ */
 export function open(tab) {
   if (!initialized) initAll();
+
   syncAppearanceCheckboxes();
-  if (modalEl.classList.contains('hidden')) {
-    resetWindowPlacement();
-  }
-  modalEl.classList.remove('hidden');
+  showSettingsModal(modalEl);
   syncAdminVisibility();
-  const content = modalEl.querySelector('.settings-modal-content');
+
   if (tab) {
-    modalEl.querySelectorAll('[data-settings-tab]').forEach(b => b.classList.toggle('active', b.dataset.settingsTab === tab));
-    modalEl.querySelectorAll('[data-settings-panel]').forEach(p => p.classList.toggle('hidden', p.dataset.settingsPanel !== tab));
+    activateSettingsPanel(modalEl, tab);
   }
-  // Auto-init admin data if showing an admin tab
-  const activeTab = tab || (modalEl.querySelector('[data-settings-tab].active') || {}).dataset?.settingsTab || 'services';
-  document.body.classList.toggle('settings-appearance-open', activeTab === 'appearance');
-  syncAppearanceOpacity(activeTab === 'appearance');
-  if (activeTab === 'ai') refreshAiModelEndpoints();
+
+  // Preserve existing panel-specific side effects when Settings is opened
+  // directly to a tab as well as when the user navigates there.
+  const activeTab = tab || getActiveSettingsTab(modalEl, 'services');
+  onSettingsPanelActivated(activeTab);
+
+  // Auto-init admin data if showing an admin tab.
   if (ADMIN_TABS.has(activeTab) && window.adminModule && !window.adminModule._initialized) {
     window.adminModule._initData();
   }
@@ -5684,21 +5605,13 @@ export function open(tab) {
 
 export function close() {
   if (!modalEl) return;
-  // Always clear the appearance-tab body class so the rest of the app
-  // doesn't keep its dimmed state if the modal got closed mid-tab.
+
+  // Always clear the Appearance state so the rest of the app does not remain
+  // dimmed if Settings is closed while that panel is active.
   document.body.classList.remove('settings-appearance-open');
-  syncAppearanceOpacity(false); // clear any opacity-slider fade
-  const content = modalEl.querySelector('.modal-content, .settings-modal-content');
-  if (content && !content.classList.contains('modal-closing')) {
-    content.classList.add('modal-closing');
-    content.addEventListener('animationend', () => {
-      modalEl.classList.add('hidden');
-      content.classList.remove('modal-closing');
-    }, { once: true });
-    setTimeout(() => { if (!modalEl.classList.contains('hidden')) { modalEl.classList.add('hidden'); content.classList.remove('modal-closing'); } }, 250);
-  } else {
-    modalEl.classList.add('hidden');
-  }
+  syncAppearanceOpacity(false);
+
+  hideSettingsModal(modalEl);
 }
 
 // Handle redirect back from Google OAuth2 — open settings to integrations and show status.

--- a/static/js/settings/dom.js
+++ b/static/js/settings/dom.js
@@ -1,0 +1,7 @@
+// Shared DOM helpers for the Settings modules.
+// Keep this module intentionally small so panel modules do not grow their own
+// element-lookup conventions as Settings is split out of settings.js.
+
+export function byId(id) {
+  return document.getElementById(id);
+}

--- a/static/js/settings/lifecycle.js
+++ b/static/js/settings/lifecycle.js
@@ -1,0 +1,176 @@
+// Settings modal lifecycle primitives.
+//
+// Panel-specific behavior belongs elsewhere. This module owns only the window
+// shell: dragging/docking reset, close semantics, visibility animation, and the
+// delegated link that leaves Settings for the Persona editor.
+
+import { makeWindowDraggable } from '../windowDrag.js';
+import { clearDockSide } from '../modalSnap.js';
+
+const _dragBound = new WeakSet();
+const _closeBound = new WeakSet();
+let _promptLinkBound = false;
+
+export function bindSettingsDrag(modalEl) {
+  if (!modalEl || _dragBound.has(modalEl)) return;
+
+  const header = modalEl.querySelector('.modal-header');
+  const content = modalEl.querySelector('.settings-modal-content');
+  if (!header || !content) return;
+
+  _dragBound.add(modalEl);
+  makeWindowDraggable(modalEl, {
+    content,
+    header,
+    skipSelector: 'button, input, select, .theme-opacity-wrap',
+    enableDock: true,
+  });
+}
+
+export function resetSettingsWindowPlacement(modalEl) {
+  const content = modalEl?.querySelector('.settings-modal-content');
+  if (!content) return;
+
+  const hadLeft = modalEl.classList.contains('modal-left-docked');
+  const hadRight = modalEl.classList.contains('modal-right-docked');
+  modalEl.classList.remove('modal-left-docked', 'modal-right-docked');
+  if (hadLeft) clearDockSide('left', modalEl);
+  if (hadRight) clearDockSide('right', modalEl);
+
+  if (content._leftDockNavObs) {
+    try { content._leftDockNavObs.navObs && content._leftDockNavObs.navObs.disconnect(); } catch (_) {}
+    try { window.removeEventListener('resize', content._leftDockNavObs.reanchor); } catch (_) {}
+    delete content._leftDockNavObs;
+  }
+
+  delete content._preDockSnapshot;
+  delete content._dockSide;
+  delete content._dockSuspended;
+  delete content.dataset._tilePreSnap;
+  delete content.dataset._tileZone;
+
+  [
+    'position', 'left', 'top', 'right', 'bottom', 'margin', 'transform',
+    'width', 'height', 'max-width', 'max-height', 'border-radius', 'transition',
+  ].forEach(property => content.style.removeProperty(property));
+}
+
+export function bindOpenPromptModalLink({ getModal, closeSettings } = {}) {
+  if (_promptLinkBound) return;
+  _promptLinkBound = true;
+
+  document.addEventListener('click', async event => {
+    const link = event.target?.closest?.('[data-open-prompt-modal]');
+    if (!link) return;
+    event.preventDefault();
+
+    const settingsModal = typeof getModal === 'function' ? getModal() : null;
+    if (
+      settingsModal
+      && !settingsModal.classList.contains('hidden')
+      && typeof closeSettings === 'function'
+    ) {
+      closeSettings();
+    }
+
+    try {
+      const module = await import('../presets.js');
+      const openPrompt = module.openCustomPresetModal
+        || (module.default && module.default.openCustomPresetModal);
+      if (typeof openPrompt === 'function') openPrompt();
+    } catch (_) {
+      const modal = document.getElementById('custom-preset-modal');
+      if (modal) modal.classList.remove('hidden');
+    }
+
+    const personaTab = document.querySelector(
+      '#custom-preset-modal .preset-tab[data-chartab="character"]'
+    );
+    if (personaTab) personaTab.click();
+  });
+}
+
+export function bindSettingsClose(modalEl, options = {}) {
+  if (!modalEl || _closeBound.has(modalEl)) return;
+  _closeBound.add(modalEl);
+
+  const closeSettings = options.closeSettings;
+  const isTouchInsideModal = options.isTouchInsideModal;
+
+  const closeButton = modalEl.querySelector('.close-btn');
+  closeButton?.addEventListener('click', () => {
+    if (typeof closeSettings === 'function') closeSettings();
+  });
+
+  modalEl.addEventListener('mousedown', event => {
+    if (typeof isTouchInsideModal === 'function' && isTouchInsideModal()) return;
+    if (event.target === modalEl && typeof closeSettings === 'function') {
+      closeSettings();
+    }
+  });
+
+  document.addEventListener('keydown', event => {
+    if (event.key !== 'Escape' || modalEl.classList.contains('hidden')) return;
+
+    // Esc should dismiss transient popovers before the Settings window.
+    const popoverOpen = modalEl.querySelector(
+      '#adm-epLocalMoreMenu, #adm-epApiMoreMenu, #adm-provider-menu, #search-provider-menu, [data-popover-open="1"]'
+    );
+    if (
+      popoverOpen
+      && popoverOpen.style.display !== 'none'
+      && !popoverOpen.classList.contains('hidden')
+    ) {
+      return;
+    }
+
+    // Integration/account editors are nested flows. Close the editor first so
+    // an accidental Esc does not discard the entire Settings context.
+    const innerForm = modalEl.querySelector('#unified-intg-form, #set-email-accounts-form');
+    if (
+      innerForm
+      && innerForm.style.display !== 'none'
+      && innerForm.children.length > 0
+    ) {
+      event.preventDefault();
+      event.stopPropagation();
+      innerForm.style.display = 'none';
+      innerForm.innerHTML = '';
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    if (typeof closeSettings === 'function') closeSettings();
+  });
+}
+
+export function showSettingsModal(modalEl) {
+  if (!modalEl) return;
+  if (modalEl.classList.contains('hidden')) {
+    resetSettingsWindowPlacement(modalEl);
+  }
+  modalEl.classList.remove('hidden');
+}
+
+export function hideSettingsModal(modalEl) {
+  if (!modalEl) return;
+
+  const content = modalEl.querySelector('.modal-content, .settings-modal-content');
+  if (content && !content.classList.contains('modal-closing')) {
+    content.classList.add('modal-closing');
+    content.addEventListener('animationend', () => {
+      modalEl.classList.add('hidden');
+      content.classList.remove('modal-closing');
+    }, { once: true });
+    setTimeout(() => {
+      if (!modalEl.classList.contains('hidden')) {
+        modalEl.classList.add('hidden');
+        content.classList.remove('modal-closing');
+      }
+    }, 250);
+    return;
+  }
+
+  modalEl.classList.add('hidden');
+}

--- a/static/js/settings/navigation.js
+++ b/static/js/settings/navigation.js
@@ -1,0 +1,64 @@
+// Settings navigation primitives.
+//
+// This module owns panel activation and sidebar click routing only. Individual
+// panels continue to own their data loading and side effects.
+
+export const ADMIN_TABS = new Set([
+  'services',
+  'added-models',
+  'integrations',
+  'tools',
+  'users',
+  'system',
+]);
+
+const _boundModals = new WeakSet();
+
+export function activateSettingsPanel(modalEl, tab) {
+  if (!modalEl || !tab) return null;
+
+  modalEl.querySelectorAll('[data-settings-tab]').forEach(button => {
+    button.classList.toggle('active', button.dataset.settingsTab === tab);
+  });
+  modalEl.querySelectorAll('[data-settings-panel]').forEach(panel => {
+    panel.classList.toggle('hidden', panel.dataset.settingsPanel !== tab);
+  });
+  return tab;
+}
+
+export function getActiveSettingsTab(modalEl, fallback = 'services') {
+  if (!modalEl) return fallback;
+  const active = modalEl.querySelector('[data-settings-tab].active');
+  return active?.dataset?.settingsTab || fallback;
+}
+
+export function bindSettingsNavigation(modalEl, options = {}) {
+  if (!modalEl || _boundModals.has(modalEl)) return;
+  _boundModals.add(modalEl);
+
+  const openAdminTab = options.openAdminTab;
+  const onPanelActivated = options.onPanelActivated;
+
+  modalEl.querySelectorAll('[data-settings-tab]').forEach(button => {
+    button.addEventListener('click', () => {
+      const tab = button.dataset.settingsTab;
+      if (!tab) return;
+
+      // Preserve the existing lazy-admin path: when the admin module accepts
+      // the tab, it owns activation/rendering and the Settings shell does not
+      // perform a second local switch.
+      if (
+        ADMIN_TABS.has(tab)
+        && typeof openAdminTab === 'function'
+        && openAdminTab(tab, button) === true
+      ) {
+        return;
+      }
+
+      activateSettingsPanel(modalEl, tab);
+      if (typeof onPanelActivated === 'function') {
+        onPanelActivated(tab, button);
+      }
+    });
+  });
+}

--- a/tests/helpers/test_settings_shell.js
+++ b/tests/helpers/test_settings_shell.js
@@ -1,0 +1,361 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+class ClassList {
+  constructor() { this.values = new Set(); }
+  add(...names) { names.filter(Boolean).forEach(name => this.values.add(name)); }
+  remove(...names) { names.forEach(name => this.values.delete(name)); }
+  contains(name) { return this.values.has(name); }
+  toggle(name, force) {
+    if (force === undefined) force = !this.contains(name);
+    force ? this.add(name) : this.remove(name);
+    return force;
+  }
+}
+
+class Style {
+  constructor() { this.values = {}; this.display = ''; this.cssText = ''; }
+  setProperty(name, value) { this.values[name] = value; this[name] = value; }
+  removeProperty(name) { delete this.values[name]; delete this[name]; }
+}
+
+class Element {
+  constructor(tagName, documentRef) {
+    this.tagName = String(tagName || 'div').toUpperCase();
+    this.ownerDocument = documentRef;
+    this.children = [];
+    this.parentElement = null;
+    this.attributes = {};
+    this.dataset = {};
+    this.classList = new ClassList();
+    this.style = new Style();
+    this._listeners = new Map();
+    this._innerHTML = '';
+  }
+  set id(value) { this.attributes.id = String(value); }
+  get id() { return this.attributes.id || ''; }
+  set className(value) {
+    this.classList.values = new Set(String(value || '').split(/\s+/).filter(Boolean));
+  }
+  get className() { return Array.from(this.classList.values).join(' '); }
+  set innerHTML(value) {
+    this._innerHTML = String(value || '');
+    if (!this._innerHTML) {
+      this.children.forEach(child => { child.parentElement = null; });
+      this.children = [];
+    }
+  }
+  get innerHTML() { return this._innerHTML; }
+  setAttribute(name, value) {
+    const text = String(value);
+    this.attributes[name] = text;
+    if (name === 'class') this.className = text;
+    if (name.startsWith('data-')) {
+      const key = name.slice(5).replace(/-([a-z])/g, (_, char) => char.toUpperCase());
+      this.dataset[key] = text;
+    }
+  }
+  getAttribute(name) { return this.attributes[name] ?? null; }
+  appendChild(child) {
+    child.parentElement = this;
+    this.children.push(child);
+    return child;
+  }
+  append(...children) { children.forEach(child => this.appendChild(child)); }
+  addEventListener(type, handler, options = {}) {
+    if (!this._listeners.has(type)) this._listeners.set(type, []);
+    this._listeners.get(type).push({ handler, once: !!options.once });
+  }
+  removeEventListener(type, handler) {
+    const entries = this._listeners.get(type) || [];
+    this._listeners.set(type, entries.filter(entry => entry.handler !== handler));
+  }
+  dispatchEvent(event) {
+    event.target ||= this;
+    event.currentTarget = this;
+    const entries = [...(this._listeners.get(event.type) || [])];
+    for (const entry of entries) {
+      entry.handler.call(this, event);
+      if (entry.once) this.removeEventListener(event.type, entry.handler);
+    }
+  }
+  click() {
+    this.dispatchEvent({ type: 'click', preventDefault() {}, stopPropagation() {} });
+  }
+  matches(selector) { return matchesSelector(this, selector); }
+  querySelector(selector) { return queryAll(this, selector)[0] || null; }
+  querySelectorAll(selector) { return queryAll(this, selector); }
+  closest(selector) {
+    let node = this;
+    while (node) {
+      if (matchesSelector(node, selector)) return node;
+      node = node.parentElement;
+    }
+    return null;
+  }
+}
+
+function simpleMatch(element, selector) {
+  const text = selector.trim();
+  if (!text) return false;
+  const id = text.match(/#([\w-]+)/);
+  if (id && element.id !== id[1]) return false;
+  for (const match of text.matchAll(/\.([\w-]+)/g)) {
+    if (!element.classList.contains(match[1])) return false;
+  }
+  for (const match of text.matchAll(/\[([\w-]+)(?:="([^"]*)")?\]/g)) {
+    const actual = element.getAttribute(match[1]);
+    if (actual === null) return false;
+    if (match[2] !== undefined && actual !== match[2]) return false;
+  }
+  return true;
+}
+
+function matchesSelector(element, selector) {
+  return selector.split(',').some(part => simpleMatch(element, part));
+}
+
+function descendants(root) {
+  const result = [];
+  const visit = node => {
+    for (const child of node.children || []) {
+      result.push(child);
+      visit(child);
+    }
+  };
+  visit(root);
+  return result;
+}
+
+function queryAll(root, selector) {
+  const selectors = selector.split(',').map(item => item.trim()).filter(Boolean);
+  const nodes = descendants(root);
+  const result = [];
+  for (const candidate of nodes) {
+    if (selectors.some(sel => simpleMatch(candidate, sel))) result.push(candidate);
+  }
+  return result;
+}
+
+class DocumentShim {
+  constructor() {
+    this.body = new Element('body', this);
+    this.head = new Element('head', this);
+    this.listeners = new Map();
+  }
+  createElement(tag) { return new Element(tag, this); }
+  getElementById(id) {
+    return [this.body, this.head, ...descendants(this.body), ...descendants(this.head)]
+      .find(node => node.id === id) || null;
+  }
+  querySelector(selector) {
+    return this.querySelectorAll(selector)[0] || null;
+  }
+  querySelectorAll(selector) {
+    return [...queryAll(this.body, selector), ...queryAll(this.head, selector)];
+  }
+  addEventListener(type, handler) {
+    if (!this.listeners.has(type)) this.listeners.set(type, []);
+    this.listeners.get(type).push(handler);
+  }
+  removeEventListener(type, handler) {
+    this.listeners.set(type, (this.listeners.get(type) || []).filter(item => item !== handler));
+  }
+  dispatch(type, event) {
+    for (const handler of [...(this.listeners.get(type) || [])]) handler(event);
+  }
+}
+
+function buildFixture(document) {
+  const modal = document.createElement('div');
+  modal.id = 'settings-modal';
+  document.body.appendChild(modal);
+
+  const header = document.createElement('div');
+  header.className = 'modal-header';
+  modal.appendChild(header);
+
+  const close = document.createElement('button');
+  close.className = 'close-btn';
+  header.appendChild(close);
+
+  const content = document.createElement('div');
+  content.className = 'settings-modal-content modal-content';
+  modal.appendChild(content);
+
+  const nav = document.createElement('div');
+  content.appendChild(nav);
+  const panels = document.createElement('div');
+  content.appendChild(panels);
+
+  const makeTab = (id, active = false) => {
+    const button = document.createElement('button');
+    button.setAttribute('data-settings-tab', id);
+    if (active) button.classList.add('active');
+    nav.appendChild(button);
+    const panel = document.createElement('section');
+    panel.setAttribute('data-settings-panel', id);
+    if (!active) panel.classList.add('hidden');
+    panels.appendChild(panel);
+    return { button, panel };
+  };
+
+  const services = makeTab('services', true);
+  const appearance = makeTab('appearance');
+  const system = makeTab('system');
+
+  return { modal, header, close, content, services, appearance, system };
+}
+
+function moduleSource(relativePath) {
+  return fs.readFileSync(path.join(__dirname, '../../static/js/settings', relativePath), 'utf8')
+    .replace(/^import\s+.*;\s*$/gm, '')
+    .replace(/\bexport\s+/g, '');
+}
+
+(function runTests() {
+  const document = new DocumentShim();
+  const fixture = buildFixture(document);
+  const dragCalls = [];
+  const dockCalls = [];
+  const removedWindowListeners = [];
+
+  const context = {
+    console,
+    document,
+    window: {
+      removeEventListener: (...args) => removedWindowListeners.push(args),
+      addEventListener() {},
+    },
+    makeWindowDraggable: (...args) => dragCalls.push(args),
+    clearDockSide: (...args) => dockCalls.push(args),
+    setTimeout: callback => { callback(); return 1; },
+    WeakSet,
+  };
+  vm.createContext(context);
+  vm.runInContext(moduleSource('navigation.js'), context, { filename: 'navigation.js' });
+  vm.runInContext(moduleSource('lifecycle.js'), context, { filename: 'lifecycle.js' });
+  vm.runInContext(moduleSource('dom.js'), context, { filename: 'dom.js' });
+
+  const results = [];
+  const check = (test, pass, detail = '') => results.push({ test, pass: Boolean(pass), detail });
+
+  check('byId resolves elements through the production DOM helper', context.byId('settings-modal') === fixture.modal);
+
+  context.activateSettingsPanel(fixture.modal, 'appearance');
+  check(
+    'activateSettingsPanel switches sidebar and panel state together',
+    fixture.appearance.button.classList.contains('active')
+      && !fixture.appearance.panel.classList.contains('hidden')
+      && !fixture.services.button.classList.contains('active')
+      && fixture.services.panel.classList.contains('hidden'),
+  );
+  check('getActiveSettingsTab reports the active panel', context.getActiveSettingsTab(fixture.modal) === 'appearance');
+
+  let activated = null;
+  let delegated = null;
+  context.bindSettingsNavigation(fixture.modal, {
+    openAdminTab(tab) { delegated = tab; return tab === 'system'; },
+    onPanelActivated(tab) { activated = tab; },
+  });
+  fixture.services.button.click();
+  check(
+    'normal navigation activates locally and notifies the coordinator',
+    activated === 'services' && fixture.services.button.classList.contains('active'),
+  );
+  activated = null;
+  fixture.system.button.click();
+  check(
+    'admin navigation delegates without performing a second local activation',
+    delegated === 'system' && activated === null && fixture.services.button.classList.contains('active'),
+  );
+
+  context.bindSettingsDrag(fixture.modal);
+  check(
+    'drag binding preserves the existing Settings drag contract',
+    dragCalls.length === 1
+      && dragCalls[0][0] === fixture.modal
+      && dragCalls[0][1].content === fixture.content
+      && dragCalls[0][1].header === fixture.header
+      && dragCalls[0][1].enableDock === true
+      && dragCalls[0][1].skipSelector === 'button, input, select, .theme-opacity-wrap',
+  );
+
+  let disconnected = 0;
+  fixture.modal.classList.add('modal-left-docked');
+  fixture.content.style.setProperty('left', '123px');
+  fixture.content.dataset._tileZone = 'left';
+  fixture.content._leftDockNavObs = {
+    navObs: { disconnect() { disconnected += 1; } },
+    reanchor() {},
+  };
+  context.resetSettingsWindowPlacement(fixture.modal);
+  check(
+    'window placement reset clears docking observers and inline placement',
+    !fixture.modal.classList.contains('modal-left-docked')
+      && dockCalls.some(call => call[0] === 'left' && call[1] === fixture.modal)
+      && disconnected === 1
+      && !('_tileZone' in fixture.content.dataset)
+      && fixture.content.style.left === undefined
+      && removedWindowListeners.some(call => call[0] === 'resize'),
+  );
+
+  fixture.modal.classList.add('modal-right-docked', 'hidden');
+  context.showSettingsModal(fixture.modal);
+  check(
+    'showSettingsModal restores a hidden modal before showing it',
+    !fixture.modal.classList.contains('hidden')
+      && !fixture.modal.classList.contains('modal-right-docked')
+      && dockCalls.some(call => call[0] === 'right'),
+  );
+
+  let closeCount = 0;
+  context.bindSettingsClose(fixture.modal, {
+    closeSettings() { closeCount += 1; },
+    isTouchInsideModal() { return false; },
+  });
+
+  const form = document.createElement('div');
+  form.id = 'unified-intg-form';
+  form.style.display = '';
+  form.appendChild(document.createElement('input'));
+  fixture.content.appendChild(form);
+  document.dispatch('keydown', {
+    key: 'Escape',
+    preventDefault() {},
+    stopPropagation() {},
+  });
+  check(
+    'Escape closes an inner integration editor before closing Settings',
+    form.style.display === 'none' && form.children.length === 0 && closeCount === 0,
+  );
+
+  document.dispatch('keydown', {
+    key: 'Escape',
+    preventDefault() {},
+    stopPropagation() {},
+  });
+  check('Escape closes Settings when no nested flow is active', closeCount === 1);
+
+  const popover = document.createElement('div');
+  popover.setAttribute('data-popover-open', '1');
+  popover.style.display = 'block';
+  fixture.content.appendChild(popover);
+  document.dispatch('keydown', {
+    key: 'Escape',
+    preventDefault() {},
+    stopPropagation() {},
+  });
+  check('Escape leaves Settings open while a transient popover is active', closeCount === 1);
+  popover.classList.add('hidden');
+
+  context.hideSettingsModal(fixture.modal);
+  check(
+    'hideSettingsModal preserves the closing animation fallback semantics',
+    fixture.modal.classList.contains('hidden') && !fixture.content.classList.contains('modal-closing'),
+  );
+
+  console.log(JSON.stringify(results));
+  if (results.some(result => !result.pass)) process.exitCode = 1;
+})();

--- a/tests/helpers/test_settings_shell_coordinator.mjs
+++ b/tests/helpers/test_settings_shell_coordinator.mjs
@@ -1,0 +1,973 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+const REPO = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+);
+
+const JS = path.join(REPO, 'static/js');
+const SETTINGS_JS = path.join(JS, 'settings.js');
+
+const REAL_MODULES = new Set([
+  SETTINGS_JS,
+  path.join(JS, 'settings/dom.js'),
+  path.join(JS, 'settings/navigation.js'),
+  path.join(JS, 'settings/lifecycle.js'),
+]);
+
+const realModulesLoaded = new Set();
+
+
+class ClassList {
+  constructor(values = []) {
+    this.values = new Set(values);
+  }
+
+  add(...names) {
+    names.filter(Boolean).forEach(name => this.values.add(name));
+  }
+
+  remove(...names) {
+    names.forEach(name => this.values.delete(name));
+  }
+
+  contains(name) {
+    return this.values.has(name);
+  }
+
+  toggle(name, force) {
+    const enabled = force === undefined
+      ? !this.contains(name)
+      : Boolean(force);
+
+    enabled ? this.add(name) : this.remove(name);
+    return enabled;
+  }
+}
+
+
+class Style {
+  constructor() {
+    this.display = '';
+    this.cssText = '';
+    this.values = {};
+  }
+
+  setProperty(name, value) {
+    this.values[name] = value;
+    this[name] = value;
+  }
+
+  removeProperty(name) {
+    delete this.values[name];
+    delete this[name];
+  }
+}
+
+
+function dataKey(name) {
+  return name
+    .slice(5)
+    .replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+}
+
+
+function simpleMatch(element, selector) {
+  const text = String(selector || '').trim();
+  if (!text) return false;
+
+  const tag = text.match(/^[a-zA-Z][\w-]*/);
+  if (tag && element.tagName !== tag[0].toUpperCase()) {
+    return false;
+  }
+
+  const id = text.match(/#([\w-]+)/);
+  if (id && element.id !== id[1]) {
+    return false;
+  }
+
+  for (const match of text.matchAll(/\.([\w-]+)/g)) {
+    if (!element.classList.contains(match[1])) {
+      return false;
+    }
+  }
+
+  for (const match of text.matchAll(/\[([\w-]+)(?:="([^"]*)")?\]/g)) {
+    const actual = element.getAttribute(match[1]);
+
+    if (actual === null) {
+      return false;
+    }
+
+    if (match[2] !== undefined && actual !== match[2]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+
+function descendants(root) {
+  const result = [];
+
+  function visit(node) {
+    for (const child of node.children || []) {
+      result.push(child);
+      visit(child);
+    }
+  }
+
+  visit(root);
+  return result;
+}
+
+
+function queryAll(root, selector) {
+  const selectors = String(selector)
+    .split(',')
+    .map(value => value.trim())
+    .filter(Boolean);
+
+  return descendants(root).filter(
+    node => selectors.some(value => simpleMatch(node, value)),
+  );
+}
+
+
+class Element {
+  constructor(tagName = 'div', documentRef = null) {
+    this.tagName = String(tagName).toUpperCase();
+    this.ownerDocument = documentRef;
+
+    this.children = [];
+    this.parentElement = null;
+
+    this.attributes = {};
+    this.dataset = {};
+
+    this.classList = new ClassList();
+    this.style = new Style();
+
+    this._listeners = new Map();
+
+    this.value = '';
+    this.checked = false;
+    this.disabled = false;
+    this.selected = false;
+    this.hidden = false;
+
+    this.textContent = '';
+    this.innerHTML = '';
+
+    this.options = [];
+    this.selectedOptions = [];
+    this.files = [];
+
+    this.scrollTop = 0;
+    this.scrollHeight = 0;
+    this.clientHeight = 100;
+    this.clientWidth = 100;
+  }
+
+  set id(value) {
+    this.attributes.id = String(value);
+  }
+
+  get id() {
+    return this.attributes.id || '';
+  }
+
+  set className(value) {
+    this.classList = new ClassList(
+      String(value || '').split(/\s+/).filter(Boolean),
+    );
+  }
+
+  get className() {
+    return [...this.classList.values].join(' ');
+  }
+
+  setAttribute(name, value) {
+    const text = String(value);
+    this.attributes[name] = text;
+
+    if (name === 'class') {
+      this.className = text;
+    }
+
+    if (name.startsWith('data-')) {
+      this.dataset[dataKey(name)] = text;
+    }
+  }
+
+  getAttribute(name) {
+    return this.attributes[name] ?? null;
+  }
+
+  removeAttribute(name) {
+    delete this.attributes[name];
+
+    if (name.startsWith('data-')) {
+      delete this.dataset[dataKey(name)];
+    }
+  }
+
+  toggleAttribute(name, force) {
+    const enabled = force === undefined
+      ? this.getAttribute(name) === null
+      : Boolean(force);
+
+    if (enabled) this.setAttribute(name, '');
+    else this.removeAttribute(name);
+
+    return enabled;
+  }
+
+  appendChild(child) {
+    child.parentElement = this;
+    this.children.push(child);
+    return child;
+  }
+
+  append(...children) {
+    children.forEach(child => this.appendChild(child));
+  }
+
+  prepend(...children) {
+    for (const child of [...children].reverse()) {
+      child.parentElement = this;
+      this.children.unshift(child);
+    }
+  }
+
+  replaceChildren(...children) {
+    this.children = [];
+    this.append(...children);
+  }
+
+  insertBefore(child, before) {
+    const index = this.children.indexOf(before);
+
+    if (index === -1) {
+      return this.appendChild(child);
+    }
+
+    child.parentElement = this;
+    this.children.splice(index, 0, child);
+    return child;
+  }
+
+  insertAdjacentHTML() {}
+
+  remove() {
+    if (!this.parentElement) return;
+
+    this.parentElement.children =
+      this.parentElement.children.filter(child => child !== this);
+
+    this.parentElement = null;
+  }
+
+  addEventListener(type, handler, options = {}) {
+    if (!this._listeners.has(type)) {
+      this._listeners.set(type, []);
+    }
+
+    this._listeners.get(type).push({
+      handler,
+      once: Boolean(options?.once),
+    });
+  }
+
+  removeEventListener(type, handler) {
+    const listeners = this._listeners.get(type) || [];
+
+    this._listeners.set(
+      type,
+      listeners.filter(entry => entry.handler !== handler),
+    );
+  }
+
+  dispatchEvent(event) {
+    event.target ||= this;
+    event.currentTarget = this;
+
+    for (const entry of [...(this._listeners.get(event.type) || [])]) {
+      entry.handler.call(this, event);
+
+      if (entry.once) {
+        this.removeEventListener(event.type, entry.handler);
+      }
+    }
+
+    return true;
+  }
+
+  click() {
+    this.dispatchEvent({
+      type: 'click',
+      target: this,
+      preventDefault() {},
+      stopPropagation() {},
+    });
+  }
+
+  querySelector(selector) {
+    const result = queryAll(this, selector)[0];
+
+    if (result) return result;
+
+    const id = String(selector).match(/^#([\w-]+)$/);
+    if (id && this.ownerDocument) {
+      return this.ownerDocument.getElementById(id[1]);
+    }
+
+    return null;
+  }
+
+  querySelectorAll(selector) {
+    return queryAll(this, selector);
+  }
+
+  matches(selector) {
+    return String(selector)
+      .split(',')
+      .some(value => simpleMatch(this, value));
+  }
+
+  closest(selector) {
+    let node = this;
+
+    while (node) {
+      if (node.matches(selector)) return node;
+      node = node.parentElement;
+    }
+
+    return null;
+  }
+
+  focus() {}
+  blur() {}
+  select() {}
+  scrollIntoView() {}
+  setSelectionRange() {}
+
+  getBoundingClientRect() {
+    return {
+      top: 0,
+      left: 0,
+      right: 100,
+      bottom: 100,
+      width: 100,
+      height: 100,
+    };
+  }
+}
+
+
+class DocumentShim {
+  constructor() {
+    this._generated = new Map();
+    this._listeners = new Map();
+
+    // Pre-existing Settings initializers sometimes inspect an element's
+    // parent container. Generated fallback elements therefore live under one
+    // inert root instead of being detached DOM nodes.
+    this._generatedRoot = new Element('div', this);
+
+    this.readyState = 'loading';
+
+    this.body = new Element('body', this);
+    this.head = new Element('head', this);
+    this.documentElement = new Element('html', this);
+  }
+
+  createElement(tagName) {
+    return new Element(tagName, this);
+  }
+
+  createDocumentFragment() {
+    return new Element('fragment', this);
+  }
+
+  addEventListener(type, handler, options = {}) {
+    if (!this._listeners.has(type)) {
+      this._listeners.set(type, []);
+    }
+
+    this._listeners.get(type).push({
+      handler,
+      once: Boolean(options?.once),
+    });
+  }
+
+  removeEventListener(type, handler) {
+    const listeners = this._listeners.get(type) || [];
+
+    this._listeners.set(
+      type,
+      listeners.filter(entry => entry.handler !== handler),
+    );
+  }
+
+  getElementById(id) {
+    const real = [
+      this.body,
+      this.head,
+      ...descendants(this.body),
+      ...descendants(this.head),
+    ].find(node => node.id === id);
+
+    if (real) return real;
+
+    if (!this._generated.has(id)) {
+      const generated = new Element('div', this);
+      generated.id = id;
+      this._generatedRoot.appendChild(generated);
+      this._generated.set(id, generated);
+    }
+
+    return this._generated.get(id);
+  }
+
+  querySelector(selector) {
+    const result = this.querySelectorAll(selector)[0];
+    if (result) return result;
+
+    const id = String(selector).match(/^#([\w-]+)$/);
+    return id ? this.getElementById(id[1]) : null;
+  }
+
+  querySelectorAll(selector) {
+    return [
+      ...queryAll(this.body, selector),
+      ...queryAll(this.head, selector),
+    ];
+  }
+
+  getElementsByClassName(name) {
+    return this.querySelectorAll(`.${name}`);
+  }
+
+  getElementsByTagName(name) {
+    return this.querySelectorAll(name);
+  }
+}
+
+
+function makeTab(document, nav, panels, name, active = false) {
+  const button = document.createElement('button');
+  button.setAttribute('data-settings-tab', name);
+
+  if (active) {
+    button.classList.add('active');
+  }
+
+  nav.appendChild(button);
+
+  const panel = document.createElement('section');
+  panel.setAttribute('data-settings-panel', name);
+
+  if (!active) {
+    panel.classList.add('hidden');
+  }
+
+  panels.appendChild(panel);
+
+  return { button, panel };
+}
+
+
+function buildFixture(document) {
+  const modal = document.createElement('div');
+  modal.id = 'settings-modal';
+  modal.classList.add('hidden');
+  document.body.appendChild(modal);
+
+  const header = document.createElement('div');
+  header.className = 'modal-header';
+  modal.appendChild(header);
+
+  const close = document.createElement('button');
+  close.className = 'close-btn';
+  header.appendChild(close);
+
+  const content = document.createElement('div');
+  content.className = 'settings-modal-content modal-content';
+  modal.appendChild(content);
+
+  const nav = document.createElement('nav');
+  const panels = document.createElement('div');
+
+  content.append(nav, panels);
+
+  return {
+    modal,
+    content,
+    services: makeTab(document, nav, panels, 'services', true),
+    appearance: makeTab(document, nav, panels, 'appearance'),
+    ai: makeTab(document, nav, panels, 'ai'),
+    system: makeTab(document, nav, panels, 'system'),
+  };
+}
+
+
+function functionProxy(overrides = {}) {
+  return new Proxy(overrides, {
+    get(target, property) {
+      if (property in target) {
+        return target[property];
+      }
+
+      return () => [];
+    },
+  });
+}
+
+
+const document = new DocumentShim();
+const fixture = buildFixture(document);
+
+const sandbox = {
+  console,
+  document,
+
+  location: {
+    search: '',
+    pathname: '/',
+    hash: '',
+    origin: 'http://localhost',
+  },
+
+  history: {
+    replaceState() {},
+  },
+
+  adminModule: null,
+
+  navigator: {
+    userAgent: 'node-settings-shell-test',
+    clipboard: {
+      async writeText() {},
+    },
+  },
+
+  CSS: {
+    escape(value) {
+      return String(value);
+    },
+  },
+
+  localStorage: {
+    getItem() { return null; },
+    setItem() {},
+    removeItem() {},
+  },
+
+  sessionStorage: {
+    getItem() { return null; },
+    setItem() {},
+    removeItem() {},
+  },
+
+  MutationObserver: class {
+    observe() {}
+    disconnect() {}
+  },
+
+  ResizeObserver: class {
+    observe() {}
+    disconnect() {}
+  },
+
+  IntersectionObserver: class {
+    observe() {}
+    disconnect() {}
+  },
+
+  CustomEvent: class {
+    constructor(type, options = {}) {
+      this.type = type;
+      this.detail = options.detail;
+    }
+  },
+
+  Event: class {
+    constructor(type) {
+      this.type = type;
+    }
+  },
+
+  Option: class extends Element {
+    constructor(text = '', value = '') {
+      super('option', document);
+      this.textContent = text;
+      this.value = value;
+    }
+  },
+
+  Image: class extends Element {
+    constructor() {
+      super('img', document);
+    }
+  },
+
+  URL,
+  URLSearchParams,
+  TextEncoder,
+  TextDecoder,
+  AbortController,
+
+  fetch() {
+    // Keep unrelated asynchronous Settings initializers suspended. The shell
+    // behavior asserted below is synchronous and intentionally backend-free.
+    return new Promise(() => {});
+  },
+
+  requestAnimationFrame(callback) {
+    callback?.();
+    return 1;
+  },
+
+  cancelAnimationFrame() {},
+
+  setTimeout(callback, delay) {
+    // Preserve lifecycle.js's close-animation fallback without introducing
+    // real delays into the test.
+    if (delay === 250) {
+      callback?.();
+    }
+
+    return 1;
+  },
+
+  clearTimeout() {},
+
+  setInterval() {
+    return 1;
+  },
+
+  clearInterval() {},
+
+  addEventListener() {},
+  removeEventListener() {},
+  dispatchEvent() {},
+
+  matchMedia() {
+    return {
+      matches: false,
+      addEventListener() {},
+      removeEventListener() {},
+    };
+  },
+
+  getComputedStyle() {
+    return {};
+  },
+
+  innerWidth: 1280,
+  innerHeight: 720,
+
+  alert() {},
+  confirm() { return true; },
+  prompt() { return ''; },
+};
+
+sandbox.window = sandbox;
+sandbox.globalThis = sandbox;
+
+const context = vm.createContext(sandbox);
+
+
+const uiModule = functionProxy({
+  esc(value) {
+    return String(value ?? '');
+  },
+
+  isTouchInsideModal() {
+    return false;
+  },
+});
+
+const searchModule = functionProxy();
+
+
+const STUBS = new Map([
+  [
+    path.join(JS, 'ui.js'),
+    { default: uiModule },
+  ],
+  [
+    path.join(JS, 'search.js'),
+    { default: searchModule },
+  ],
+  [
+    path.join(JS, 'modelSort.js'),
+    {
+      sortModelIds(values) {
+        return values || [];
+      },
+    },
+  ],
+  [
+    path.join(JS, 'providers.js'),
+    {
+      providerLogo() {
+        return '';
+      },
+    },
+  ],
+  [
+    path.join(JS, 'platform.js'),
+    {
+      isAltGrEvent() {
+        return false;
+      },
+    },
+  ],
+  [
+    path.join(JS, 'escMenuStack.js'),
+    {
+      bindMenuDismiss() {},
+    },
+  ],
+  [
+    path.join(JS, 'windowDrag.js'),
+    {
+      makeWindowDraggable() {},
+    },
+  ],
+  [
+    path.join(JS, 'modalSnap.js'),
+    {
+      clearDockSide() {},
+    },
+  ],
+]);
+
+
+const moduleCache = new Map();
+
+
+function resolveImport(specifier, parent) {
+  if (!specifier.startsWith('.')) {
+    throw new Error(`Unexpected non-relative import: ${specifier}`);
+  }
+
+  return path.resolve(
+    path.dirname(parent),
+    specifier,
+  );
+}
+
+
+function syntheticModule(identifier, exports) {
+  return new vm.SyntheticModule(
+    Object.keys(exports),
+    function initialize() {
+      for (const [name, value] of Object.entries(exports)) {
+        this.setExport(name, value);
+      }
+    },
+    {
+      context,
+      identifier,
+    },
+  );
+}
+
+
+async function loadModule(filename) {
+  const resolved = path.resolve(filename);
+
+  if (moduleCache.has(resolved)) {
+    return moduleCache.get(resolved);
+  }
+
+  if (STUBS.has(resolved)) {
+    const module = syntheticModule(
+      resolved,
+      STUBS.get(resolved),
+    );
+
+    moduleCache.set(resolved, module);
+    return module;
+  }
+
+  if (!REAL_MODULES.has(resolved)) {
+    throw new Error(
+      `Unexpected real module requested by coordinator smoke: ${resolved}`,
+    );
+  }
+
+  realModulesLoaded.add(resolved);
+
+  const source = fs.readFileSync(resolved, 'utf8');
+
+  const module = new vm.SourceTextModule(source, {
+    context,
+    identifier: resolved,
+
+    importModuleDynamically: async specifier => {
+      const target = resolveImport(specifier, resolved);
+
+      if (target === path.join(JS, 'presets.js')) {
+        const dynamic = syntheticModule(target, {
+          openCustomPresetModal() {},
+          default: {},
+        });
+
+        await dynamic.link(() => {});
+        await dynamic.evaluate();
+
+        return dynamic;
+      }
+
+      throw new Error(
+        `Unexpected dynamic import from Settings smoke: ${specifier}`,
+      );
+    },
+  });
+
+  moduleCache.set(resolved, module);
+  return module;
+}
+
+
+async function linker(specifier, referencingModule) {
+  const target = resolveImport(
+    specifier,
+    referencingModule.identifier,
+  );
+
+  return loadModule(target);
+}
+
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+
+// ---------------------------------------------------------------------------
+// Load the real settings.js coordinator.
+//
+// Its new Settings shell dependencies are real files too. Only unrelated
+// pre-existing dependencies are synthetic stubs.
+// ---------------------------------------------------------------------------
+
+const coordinator = await loadModule(SETTINGS_JS);
+
+await coordinator.link(linker);
+await coordinator.evaluate();
+
+const settings = coordinator.namespace;
+
+assert(
+  typeof settings.open === 'function',
+  'real settings.js did not export open()',
+);
+
+assert(
+  typeof settings.close === 'function',
+  'real settings.js did not export close()',
+);
+
+
+// A broken path/export in any new shell module must fail during native ESM
+// linking before these assertions can run.
+for (const required of REAL_MODULES) {
+  assert(
+    realModulesLoaded.has(required),
+    `real ESM graph did not load ${path.relative(REPO, required)}`,
+  );
+}
+
+
+// First open drives initAll() and therefore the real shell bindings.
+settings.open('services');
+
+assert(
+  !fixture.modal.classList.contains('hidden'),
+  'first open() did not show Settings',
+);
+
+assert(
+  fixture.services.button.classList.contains('active'),
+  'first open("services") did not activate Services',
+);
+
+
+// Navigation must travel through bindSettingsNavigation() installed by
+// initAll(), then invoke settings.js's coordinator callback.
+fixture.appearance.button.click();
+
+assert(
+  fixture.appearance.button.classList.contains('active'),
+  'navigation click did not activate Appearance',
+);
+
+assert(
+  !fixture.appearance.panel.classList.contains('hidden'),
+  'navigation click did not show Appearance panel',
+);
+
+assert(
+  document.body.classList.contains('settings-appearance-open'),
+  'navigation callback did not apply Appearance coordinator state',
+);
+
+
+// Direct public open() after initialization must still coordinate activation.
+settings.open('ai');
+
+assert(
+  fixture.ai.button.classList.contains('active'),
+  'direct open("ai") did not activate AI',
+);
+
+assert(
+  !fixture.ai.panel.classList.contains('hidden'),
+  'direct open("ai") did not show AI panel',
+);
+
+assert(
+  !document.body.classList.contains('settings-appearance-open'),
+  'direct open("ai") did not clear Appearance coordinator state',
+);
+
+
+// Public close() must route through the real lifecycle module.
+settings.close();
+
+assert(
+  fixture.modal.classList.contains('hidden'),
+  'close() did not hide Settings',
+);
+
+assert(
+  !document.body.classList.contains('settings-appearance-open'),
+  'close() left Appearance coordinator state behind',
+);
+
+
+// initAll() starts some existing async panel initializers without awaiting
+// them. Give already-ready continuations a chance to run before declaring the
+// smoke successful, so late coordinator/setup exceptions still fail the test.
+await Promise.resolve();
+await new Promise(resolve => setImmediate(resolve));
+
+console.log(JSON.stringify({
+  realEsmGraph: true,
+  initialization: true,
+  navigationCallback: true,
+  directOpen: true,
+  directClose: true,
+}));

--- a/tests/test_settings_shell_js_behavior.py
+++ b/tests/test_settings_shell_js_behavior.py
@@ -1,0 +1,37 @@
+"""Behavioral tests for the modular Settings shell.
+
+The Node harness executes the production navigation/lifecycle modules against a
+small DOM shim. This keeps the test dependency-free while ensuring the
+extracted shell code, rather than a handwritten copy, drives the assertions.
+"""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_JS_HELPER = _REPO / "tests" / "helpers" / "test_settings_shell.js"
+_HAS_NODE = shutil.which("node") is not None
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_settings_shell_frontend_behavior():
+    proc = subprocess.run(
+        ["node", str(_JS_HELPER)],
+        cwd=str(_REPO),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=30,
+    )
+    assert proc.returncode == 0, f"Node execution error: {proc.stderr}\n{proc.stdout}"
+
+    results = json.loads(proc.stdout.strip())
+    assert results, "Settings shell harness returned no assertions"
+    for result in results:
+        assert result["pass"] is True, (
+            f"Failed JS behavioral test: {result['test']}"
+            + (f" ({result.get('detail')})" if result.get("detail") else "")
+        )

--- a/tests/test_settings_shell_js_behavior.py
+++ b/tests/test_settings_shell_js_behavior.py
@@ -1,9 +1,12 @@
-"""Behavioral tests for the modular Settings shell.
+"""Behavioral coverage for the modular Settings shell.
 
-The Node harness executes the production navigation/lifecycle modules against a
-small DOM shim. This keeps the test dependency-free while ensuring the
-extracted shell code, rather than a handwritten copy, drives the assertions.
+The leaf harness provides focused assertions around the extracted navigation
+and lifecycle primitives. The coordinator smoke separately loads the real
+settings.js module through Node's native ESM linker together with the real
+Settings shell modules, covering their import/export contract and the public
+open/close wiring.
 """
+
 import json
 import shutil
 import subprocess
@@ -11,27 +14,68 @@ from pathlib import Path
 
 import pytest
 
+
 _REPO = Path(__file__).resolve().parent.parent
-_JS_HELPER = _REPO / "tests" / "helpers" / "test_settings_shell.js"
+_LEAF_HELPER = _REPO / "tests" / "helpers" / "test_settings_shell.js"
+_COORDINATOR_HELPER = (
+    _REPO / "tests" / "helpers" / "test_settings_shell_coordinator.mjs"
+)
 _HAS_NODE = shutil.which("node") is not None
 
 
-@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
-def test_settings_shell_frontend_behavior():
-    proc = subprocess.run(
-        ["node", str(_JS_HELPER)],
+def _run_node(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["node", *args],
         cwd=str(_REPO),
         capture_output=True,
         text=True,
         encoding="utf-8",
         timeout=30,
     )
-    assert proc.returncode == 0, f"Node execution error: {proc.stderr}\n{proc.stdout}"
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_settings_shell_leaf_behavior():
+    proc = _run_node(str(_LEAF_HELPER))
+
+    assert proc.returncode == 0, (
+        f"Node execution error:\nSTDERR:\n{proc.stderr}\nSTDOUT:\n{proc.stdout}"
+    )
 
     results = json.loads(proc.stdout.strip())
-    assert results, "Settings shell harness returned no assertions"
+
+    assert results, "Settings shell leaf harness returned no assertions"
+
     for result in results:
         assert result["pass"] is True, (
             f"Failed JS behavioral test: {result['test']}"
-            + (f" ({result.get('detail')})" if result.get("detail") else "")
+            + (
+                f" ({result.get('detail')})"
+                if result.get("detail")
+                else ""
+            )
         )
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_settings_shell_real_esm_coordinator():
+    proc = _run_node(
+        "--experimental-vm-modules",
+        str(_COORDINATOR_HELPER),
+    )
+
+    assert proc.returncode == 0, (
+        "Real Settings coordinator smoke failed:\n"
+        f"STDERR:\n{proc.stderr}\n"
+        f"STDOUT:\n{proc.stdout}"
+    )
+
+    result = json.loads(proc.stdout.strip())
+
+    assert result == {
+        "realEsmGraph": True,
+        "initialization": True,
+        "navigationCallback": True,
+        "directOpen": True,
+        "directClose": True,
+    }


### PR DESCRIPTION
## Summary

Extract the existing Settings window shell from the monolithic
`static/js/settings.js` into focused DOM, navigation, and lifecycle modules.

The change is intended to be behavior-preserving. It centralizes tab/panel
activation, admin-tab delegation, modal dragging/dock reset, close/Escape
semantics, visibility lifecycle, and the Persona-editor handoff without
redesigning Settings or changing persistence/backend behavior.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #6036

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [x] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app with Docker Compose and verified the Settings behavior end-to-end.

## How to Test

1. Run `python -m pytest -q tests/test_settings_shell_js_behavior.py`.
2. Start Odysseus and open Settings.
3. Verify normal and admin tabs, Appearance/Peek, AI settings, X/backdrop/Escape close behavior, nested-form Escape behavior, drag/dock reset, and the Persona-editor handoff.

Additional validation performed:

- `node --check static/js/settings.js`
- `node --check` on all new Settings shell modules
- `git diff --check upstream/dev..HEAD`
- isolated Docker Compose build/run on `127.0.0.1:7089`
- `GET /api/health` returned HTTP 200
- manual UI regression passed

## Visual / UI changes — REQUIRED if you touched anything that renders

- [ ] **Screenshot or short clip** of the change in the running app, attached below.
- [x] **Style match**: no visual redesign; existing Settings markup and styling are preserved.
- [x] **No new component patterns.** This extracts existing behavior into focused ES modules.
- [x] **I am not an LLM agent submitting a bulk PR.** This is a focused six-file refactor submitted by the contributor.

### Screenshots / clips

No visual change is intended. Attach a screenshot of the running Settings window here before marking this PR ready for review.
