### PR TITLE
docs(readme): add a Community clients section for the native mobile clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ Native installs, GPU notes, Windows/macOS instructions, HTTPS, and configuration
 
 A full hover-to-play tour lives on the landing page: [`docs/index.html`](docs/index.html).
 
+## Community clients
+
+Community-built native mobile clients that talk to a self-hosted Odysseus server over its HTTP API. They are maintained in their own repositories, not by this project — review the code and pair only with tokens you can revoke (Settings → API tokens).
+
+- [odysseus-mobile](https://github.com/mahdi-salmanzade/odysseus-mobile) — free, MIT-licensed Expo / React Native client for iOS and Android; pairs over the LAN (or HTTPS) with a revocable, owner-scoped token.
+- [odysseus-ios](https://github.com/JoaoZaokk/odysseus-ios) — source-available native SwiftUI client for iPhone/iPad/Mac (PolyForm Noncommercial), also on the App Store as a paid app.
+
 ## Contributing
 
 Help is welcome. The best entry points are fresh-install testing, provider setup bugs, mobile/editor polish, docs, and small focused refactors. See [CONTRIBUTING.md](CONTRIBUTING.md) and [ROADMAP.md](ROADMAP.md).


### PR DESCRIPTION
## Summary

Adds a short **Community clients** section to the README (between *Demo* and *Contributing*) listing the community-built native mobile clients that talk to a self-hosted Odysseus server over its existing HTTP API:

- [odysseus-mobile](https://github.com/mahdi-salmanzade/odysseus-mobile) — free, MIT-licensed Expo / React Native client for iOS and Android
- [odysseus-ios](https://github.com/JoaoZaokk/odysseus-ios) — source-available native SwiftUI client (PolyForm Noncommercial), also on the App Store as a paid app

Both surfaced in #3244, which keeps getting re-asked ("is there a native app?") and re-answered by people building one from scratch. Putting them in one discoverable place is the cheap fix. The section is explicit that these are maintained in their own repositories — **no maintenance burden on this project** — and reminds readers that a pairing token is a real credential that should be revocable.

Deliberately neutral: it lists both known clients, including one that isn't mine, and doesn't rank them.

This replaces #5462, which GitHub closed on 2026-07-23 during the repository transfer and fork-network separation rather than on review. Rebuilt on current `dev`; the descriptions are corrected since then — odysseus-mobile now actually carries its MIT LICENSE file, and odysseus-ios is described as source-available rather than open-source, which its PolyForm Noncommercial license makes more accurate.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Part of #3244

## Type of Change

- [x] Documentation only

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate (the predecessor #5462 is CLOSED).
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — one section, one file, no unrelated edits.
- [x] Docs-only change: no code paths are touched, so there is nothing to run. Verified by rendering the README.

## How to Test

1. Open `README.md` on this branch.
2. Confirm the **Community clients** section renders between *Demo* and *Contributing*.
3. Confirm both repository links resolve.
