### PR TITLE
docs(setup): document the HTTP/2 reverse-proxy setup

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -500,15 +500,17 @@ Cloudflare Access, Tailscale, Caddy, nginx, and Traefik can all fit this pattern
 #### Faster over the network: HTTP/2
 
 The frontend is raw ES modules with no bundler, so a page load is a few hundred
-small same-origin requests. Over HTTP/1.1 browsers cap concurrency at 6
-connections per origin, so those requests serialise into dozens of sequential
-round trips. On localhost that costs almost nothing. Over a LAN, VPN, or any
-remote link it dominates load time, and it gets worse the higher the latency.
+small same-origin requests. Over HTTP/1.1 browsers typically allow only a small
+number of concurrent connections per host (commonly around six), so many of
+those requests are serialized across multiple round trips. On localhost that
+costs almost nothing. Over a LAN, VPN, or remote link it can become a major
+part of load time, especially as latency increases.
 
 HTTP/2 multiplexes them onto one connection and the serialisation disappears.
 Odysseus needs no changes for this — uvicorn keeps speaking HTTP/1.1 on
-loopback and the proxy speaks HTTP/2 to the browser. Browsers only negotiate
-HTTP/2 over TLS, so a certificate is required; there is no cleartext path. The
+loopback and the proxy speaks HTTP/2 to the browser. Mainstream browsers
+negotiate HTTP/2 for normal web pages over TLS; they do not use the cleartext
+h2c mode here, so browser-facing HTTP/2 requires a certificate. The
 `--ssl-certfile` route in *HTTPS + LAN/Tailscale exposure* above gives you
 HTTPS but not HTTP/2 — uvicorn does not speak it.
 
@@ -636,9 +638,12 @@ arrives token by token; add `flush_interval -1` inside the `reverse_proxy`
 block if you want that pinned explicitly. nginx needs `proxy_buffering off;`
 for the same reason.
 
-Changing the external origin also resets anything scoped to the old one: the
-service worker and its caches do not carry over, so the first load is cold, and
-session cookies do not carry over, so expect one re-login.
+Changing the external origin also affects state scoped to it. Service workers
+and their caches are origin-scoped, so moving to a different origin starts with
+a cold load. Cookies follow their own domain/path/security rules rather than
+being port-scoped: changing the hostname normally requires a new login, while
+changing only the scheme or port does not by itself guarantee that existing
+cookies disappear.
 
 Common internal-only ports from the default docs/compose setup:
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -497,6 +497,149 @@ Odysseus serves plain HTTP on its app port. Docker Compose binds Odysseus and th
 Cloudflare Access, Tailscale, Caddy, nginx, and Traefik can all fit this pattern; none are required by Odysseus. If your access layer reaches Odysseus on the same host, proxy to `http://127.0.0.1:7000` and keep `AUTH_ENABLED=true`, `LOCALHOST_BYPASS=false`, and `SECURE_COOKIES=true`.
 `ALLOWED_ORIGINS` lists exact permitted origins for cross-origin browser/API clients; ordinary same-origin reverse-proxy access usually does not need a special CORS entry.
 
+#### Faster over the network: HTTP/2
+
+The frontend is raw ES modules with no bundler, so a page load is a few hundred
+small same-origin requests. Over HTTP/1.1 browsers cap concurrency at 6
+connections per origin, so those requests serialise into dozens of sequential
+round trips. On localhost that costs almost nothing. Over a LAN, VPN, or any
+remote link it dominates load time, and it gets worse the higher the latency.
+
+HTTP/2 multiplexes them onto one connection and the serialisation disappears.
+Odysseus needs no changes for this — uvicorn keeps speaking HTTP/1.1 on
+loopback and the proxy speaks HTTP/2 to the browser. Browsers only negotiate
+HTTP/2 over TLS, so a certificate is required; there is no cleartext path. The
+`--ssl-certfile` route in *HTTPS + LAN/Tailscale exposure* above gives you
+HTTPS but not HTTP/2 — uvicorn does not speak it.
+
+**1. Install Caddy.** See the [install docs](https://caddyserver.com/docs/install)
+for your platform; on macOS, `brew install caddy`.
+
+**2. Write a `Caddyfile`.** Pick the block that matches how you reach the
+machine. Replace `7000` if Odysseus listens elsewhere — the macOS start script
+uses `7860`.
+
+Public domain, Caddy obtains and renews the certificate itself:
+
+```
+odysseus.example.com {
+	reverse_proxy 127.0.0.1:7000
+}
+```
+
+Tailscale, no public DNS needed — `tailscale cert` issues a browser-trusted
+certificate for a tailnet name and writes `<domain>.crt` and `<domain>.key`:
+
+```bash
+tailscale cert myhost.tailnet-name.ts.net
+```
+
+```
+myhost.tailnet-name.ts.net {
+	tls /path/to/myhost.tailnet-name.ts.net.crt /path/to/myhost.tailnet-name.ts.net.key
+	reverse_proxy 127.0.0.1:7000
+}
+```
+
+LAN with your own certificate — same shape, your own files:
+
+```
+odysseus.lan {
+	tls /path/to/cert.pem /path/to/key.pem
+	reverse_proxy 127.0.0.1:7000
+}
+```
+
+Give `tls` absolute paths: a service starts in a working directory you did not
+choose. If port 443 is already taken, append a port to the site address
+(`odysseus.example.com:8443`) and use it in the URL. That alone does not free
+port 80 — Caddy still binds it for the HTTP-to-HTTPS redirect, and fails to
+start with `listen tcp :80: bind: address already in use` if something else
+holds it. Turn the redirect off with a global block at the top of the file:
+
+```
+{
+	auto_https disable_redirects
+}
+```
+
+**3. Run it in the foreground first:**
+
+```bash
+caddy run --config ./Caddyfile
+```
+
+Once that works, run it as a service:
+
+```bash
+brew services start caddy          # macOS — reads $(brew --prefix)/etc/Caddyfile, not ./Caddyfile
+sudo systemctl enable --now caddy  # Linux, if your package installed the unit
+```
+
+Odysseus's own service is unchanged; the proxy runs alongside it. Under Docker,
+run the proxy as another container, or on the host pointing at the published
+port.
+
+**4. Point Odysseus at the new origin** in `.env`, then restart it:
+
+```bash
+SECURE_COOKIES=true
+# only if you use remote MCP servers with OAuth:
+OAUTH_REDIRECT_BASE_URL=https://odysseus.example.com
+```
+
+Gmail OAuth needs nothing here when the proxy runs on the same host: the
+redirect URI is built from the incoming request, and uvicorn rewrites the
+scheme from `X-Forwarded-Proto` for proxies it trusts — by default only
+`127.0.0.1`. A proxy in a separate container or on another machine is not
+trusted, so pin the URI there:
+
+```bash
+GOOGLE_OAUTH_REDIRECT_URI=https://odysseus.example.com/api/email/oauth/google/callback
+```
+
+(uvicorn's own `FORWARDED_ALLOW_IPS` widens that trust, but it has to be in the
+environment uvicorn starts with — `.env` is read by the app afterwards, too
+late for it to take effect.)
+
+**5. Confirm HTTP/2 is really on:**
+
+```bash
+curl -s -o /dev/null -w '%{http_version}\n' https://odysseus.example.com/
+# 2
+```
+
+The status code is not the thing to check here — a logged-out request redirects
+to the login page, so `curl -I` shows `HTTP/2 302`, and the `HTTP/2` prefix is
+the part that matters. The browser reports the same in the Network panel's
+Protocol column (`h2`); in Chrome and Firefox that column is hidden until you
+enable it by right-clicking the column headers.
+
+Three things bite when moving an existing install behind TLS:
+
+- Set `SECURE_COOKIES=true` **at the same time** you stop serving plain HTTP,
+  not before. The flag is applied to every login regardless of the scheme the
+  request arrived on, so while an HTTP entrypoint is still reachable the
+  browser will reject the `Secure` cookie there and login will appear to loop.
+- `OAUTH_REDIRECT_BASE_URL` defaults to `http://localhost:7000`. Unlike the
+  Gmail redirect URI it cannot be derived from a request — it is registered
+  with each MCP authorization server up front — so set it to the external
+  origin if you use remote MCP servers over OAuth.
+- Odysseus sends `Strict-Transport-Security` once it sees `X-Forwarded-Proto:
+  https`. HSTS applies to the whole hostname and ignores the port, so any other
+  plain-HTTP service on that same hostname becomes unreachable in browsers that
+  have visited Odysseus. Give Odysseus its own hostname, or strip the header at
+  the proxy (`header_down -Strict-Transport-Security` in Caddy).
+
+Server-sent events are not buffered by this configuration, so chat streaming
+arrives token by token; add `flush_interval -1` inside the `reverse_proxy`
+block if you want that pinned explicitly. nginx needs `proxy_buffering off;`
+for the same reason.
+
+Changing the external origin also resets anything scoped to the old one: the
+service worker and its caches do not carry over, so the first load is cold, and
+session cookies do not carry over, so expect one re-login.
+
 Common internal-only ports from the default docs/compose setup:
 
 | Port | Service |


### PR DESCRIPTION
## Summary

`docs/setup.md` already told people to put Odysseus behind a reverse proxy and named Caddy, nginx, Traefik and Cloudflare Access, but gave no runnable config for any of them and never explained why the proxy is worth the trouble beyond terminating TLS. This adds a subsection under **Private or proxied deployments** covering the reason that is specific to this app — the frontend is unbundled ES modules, 159 files under `static/js` on current `dev`, so a page load is a few hundred small same-origin requests, and HTTP/1.1's 6-connection cap serialises them into dozens of sequential round trips. That is free on localhost and dominant over a LAN, VPN or Tailscale link. The section is five steps you can paste: install Caddy, write a `Caddyfile` (one block each for a public domain, a Tailscale tailnet name, and a LAN host with your own certificate), run it in the foreground and then as a service, update the `.env` keys that follow the external origin, and confirm HTTP/2 actually negotiated instead of assuming it did. It closes with the three things that bite when an existing install moves behind TLS. No code changes — running behind HTTP/2 already works on every platform today, it was simply undocumented.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Part of #6045

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [x] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

Everything below was run on this branch against a scratch checkout, not just read.

1. Extract the `Caddyfile` blocks from the new section and check they are real configs:
   ```bash
   caddy validate --config <block> --adapter caddyfile
   ```
   All four validate on Caddy v2.11.4. The two using `tls` need the `/path/to/...` placeholders swapped for files that exist, because `validate` checks that.

2. Follow the section end to end. Start the app, then put Caddy in front of it:
   ```bash
   CHROMADB_PORT=9 python -m uvicorn app:app --host 127.0.0.1 --port 7099
   ```
   ```
   {
   	auto_https disable_redirects
   }

   odysseus.lan:7444 {
   	tls /abs/path/cert.pem /abs/path/key.pem
   	reverse_proxy 127.0.0.1:7099
   }
   ```

3. Run step 5 of the new section against it and confirm the protocol, which is the whole point of the section:
   ```bash
   curl -sk -o /dev/null -w '%{http_version}\n' --resolve odysseus.lan:7444:127.0.0.1 https://odysseus.lan:7444/
   # 2
   curl -skI --http2 --resolve odysseus.lan:7444:127.0.0.1 https://odysseus.lan:7444/
   # HTTP/2 302
   ```

4. Confirm the HSTS warning in the section is real — the header appears only through the proxy:
   ```bash
   curl -sk -D- -o /dev/null --resolve odysseus.lan:7444:127.0.0.1 https://odysseus.lan:7444/login | grep -i strict-transport
   # strict-transport-security: max-age=31536000; includeSubDomains
   curl -s -D- -o /dev/null http://127.0.0.1:7099/login | grep -i strict-transport
   # (absent)
   ```

5. The tests that read `setup.md` still pass:
   ```bash
   python -m pytest -q tests/test_security_regressions.py tests/test_setup_admin_user.py \
     tests/test_email_oauth.py tests/test_mcp_oauth.py tests/test_email_oauth_docker_config.py
   # 155 passed
   ```
   Full suite on this branch: 5276 passed, 2 failed, 4 skipped. Both failures are the known macOS-environment ones (`test_workspace_confine.py::test_glob_confined_e2e`, where `/tmp` resolves to `/private/tmp`, and `test_integration_api_call_ssrf.py::test_real_socket_falls_back_from_dead_first_to_live_second`, which uses real sockets). This branch touches one Markdown file, so neither is related.

**What I did not run:** Caddy on Linux or Windows. Everything here was done on macOS, which is why step 1 of the section points at Caddy's install docs rather than asserting a package command, and why the systemd line is hedged. I also did not run the Docker path with a proxy container — it gets one sentence, not a config. The scratch test used a self-signed certificate, so the HTTP/2 negotiation is verified but not the browser certificate-trust path.

## Visual / UI changes — REQUIRED if you touched anything that renders

Nothing renders — the diff is one Markdown file, `docs/setup.md`, +143 lines with no deletions.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

Not applicable — documentation only, nothing in the app renders differently.
