### PR TITLE
fix(chat): keep last-picked model scoped to the session

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -10,7 +10,7 @@ import modelsModule from './js/models.js?v=20260715startupcalm2';
 import ragModule from './js/rag.js';
 import presetsModule from './js/presets.js';
 import searchModule from './js/search.js';
-import chatModule from './js/chat.js?v=20260819approvalcontrol1';
+import chatModule from './js/chat.js?v=20260820sessmodel1';
 import compareModule from './js/compare/index.js?v=20260819approvalcontrol1';
 import documentModule from './js/document.js?v=20260815approvalsave1';
 import searchChatModule from './js/search-chat.js';

--- a/static/index.html
+++ b/static/index.html
@@ -247,7 +247,7 @@
   <link rel="preload" as="font" type="font/woff2" crossorigin href="/static/fonts/FiraCode-SemiBold.woff2">
   <link rel="stylesheet" href="/static/style.css?v=20260808startupshell1">
   <link rel="modulepreload" href="/static/app.js?v=20260815toolapproval4">
-  <link rel="modulepreload" href="/static/js/chat.js?v=20260815toolapproval4">
+  <link rel="modulepreload" href="/static/js/chat.js?v=20260820sessmodel1">
   <link rel="modulepreload" href="/static/js/ui.js">
   <link rel="modulepreload" href="/static/js/sessions.js">
   <link rel="modulepreload" href="/static/js/markdown.js">
@@ -2575,7 +2575,7 @@
 <script type="module" src="/static/js/chatRenderer.js?v=20260819approvalcontrol1"></script>
 <script type="module" src="/static/js/codeRunner.js"></script>
 <script type="module" src="/static/js/chatStream.js?v=20260819approvalcontrol1"></script>
-  <script type="module" src="/static/js/chat.js?v=20260819approvalcontrol1"></script>
+  <script type="module" src="/static/js/chat.js?v=20260820sessmodel1"></script>
 <script type="module" src="/static/js/cookbook.js"></script>
 <script src="/static/js/cookbookSchedule.js"></script>
 <script type="module" src="/static/js/search-chat.js"></script>

--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -8,6 +8,7 @@
 import Storage from './storage.js';
 import uiModule from './ui.js';
 import sessionModule from './sessions.js';
+import { getLastPickedRoute } from './lastPickedRoute.js';
 import chatRenderer from './chatRenderer.js?v=20260819approvalcontrol1';
 import chatStream from './chatStream.js?v=20260819approvalcontrol1';
 import { addAITTSButton } from './tts-ai.js';
@@ -469,10 +470,9 @@ import { loadPanel } from './panels.js';
       if (pending && pending.modelId) return pending.modelId;
     } catch (_) {}
     try {
-      const lastPicked = window.__odysseusLastPickedRoute || null;
-      if (lastPicked && lastPicked.model && Date.now() - (lastPicked.picked_at || 0) < 10 * 60 * 1000) {
-        return lastPicked.model;
-      }
+      const sid = sessionModule.getCurrentSessionId ? sessionModule.getCurrentSessionId() : null;
+      const lastPicked = getLastPickedRoute(sid);
+      if (lastPicked && lastPicked.model) return lastPicked.model;
     } catch (_) {}
     if (routeSnapshot && routeSnapshot.model) return routeSnapshot.model;
     try {
@@ -1330,8 +1330,9 @@ import { loadPanel } from './panels.js';
 
     const selectedRouteForSend = (() => {
       try {
-        const lastPicked = window.__odysseusLastPickedRoute || null;
-        if (lastPicked && lastPicked.model && Date.now() - (lastPicked.picked_at || 0) < 10 * 60 * 1000) {
+        const sid = sessionModule.getCurrentSessionId ? sessionModule.getCurrentSessionId() : null;
+        const lastPicked = getLastPickedRoute(sid);
+        if (lastPicked && lastPicked.model) {
           return {
             model: lastPicked.model || '',
             endpoint_url: lastPicked.endpoint_url || '',

--- a/static/js/lastPickedRoute.js
+++ b/static/js/lastPickedRoute.js
@@ -1,0 +1,47 @@
+// Per-session last-picked model route.
+// A single window-level last pick leaked across chats: picking Model B in
+// Chat B overwrote Chat A's next send for up to 10 minutes (#6023).
+
+const TTL_MS = 10 * 60 * 1000;
+export const PENDING_ROUTE_KEY = '__pending__';
+
+function _store() {
+  try {
+    if (!window.__odysseusLastPickedRoutesBySession) {
+      window.__odysseusLastPickedRoutesBySession = Object.create(null);
+    }
+    return window.__odysseusLastPickedRoutesBySession;
+  } catch (_) {
+    return null;
+  }
+}
+
+export function lastPickedSessionKey(sessionId) {
+  return sessionId || PENDING_ROUTE_KEY;
+}
+
+export function setLastPickedRoute(sessionId, route) {
+  const store = _store();
+  if (!store || !route) return null;
+  const key = lastPickedSessionKey(sessionId);
+  const rec = {
+    model: route.model || '',
+    endpoint_url: route.endpoint_url || '',
+    endpoint_id: route.endpoint_id || '',
+    display: route.display || '',
+    picked_at: Date.now(),
+    session_id: key,
+  };
+  store[key] = rec;
+  try { window.__odysseusLastPickedRoute = rec; } catch (_) {}
+  return rec;
+}
+
+export function getLastPickedRoute(sessionId, now = Date.now()) {
+  const store = _store();
+  if (!store) return null;
+  const rec = store[lastPickedSessionKey(sessionId)];
+  if (!rec || !rec.model) return null;
+  if (now - (rec.picked_at || 0) >= TTL_MS) return null;
+  return rec;
+}

--- a/static/js/modelPicker.js
+++ b/static/js/modelPicker.js
@@ -6,6 +6,7 @@ import uiModule from './ui.js';
 import settingsModule from './settings.js';
 import { sortModelObjects } from './modelSort.js';
 import spinnerModule from './spinner.js';
+import { setLastPickedRoute } from './lastPickedRoute.js';
 
 const API_BASE = window.location.origin;
 
@@ -644,13 +645,12 @@ function _initModelPickerDropdown() {
 async function _pick(m) {
     _defaultPendingSeq++;
     try {
-      window.__odysseusLastPickedRoute = {
+      setLastPickedRoute(_deps.getCurrentSessionId && _deps.getCurrentSessionId(), {
         model: m.mid || '',
         endpoint_url: m.url || '',
         endpoint_id: m.endpointId || '',
         display: m.display || m.mid || '',
-        picked_at: Date.now(),
-      };
+      });
     } catch (_) {}
     let switchDone = null;
     const switchPromise = new Promise(resolve => { switchDone = resolve; });

--- a/static/js/sessions.js
+++ b/static/js/sessions.js
@@ -5,7 +5,7 @@ import Storage from './storage.js';
 import uiModule, { autoResize, styledPrompt } from './ui.js';
 import chatRenderer from './chatRenderer.js?v=20260815toolapproval4';
 import { providerLogo } from './providers.js';
-import { initModelPicker, updateModelPicker } from './modelPicker.js?v=20260722ctxheader1';
+import { initModelPicker, updateModelPicker } from './modelPicker.js?v=20260814sessmodel1';
 import themeModule from './theme.js';
 import spinnerModule from './spinner.js';
 

--- a/tests/test_last_picked_route_js.py
+++ b/tests/test_last_picked_route_js.py
@@ -1,0 +1,88 @@
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.skipif(not shutil.which("node"), reason="node binary not on PATH")
+
+
+def _node_eval(source: str):
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", source],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_last_picked_route_does_not_leak_across_sessions():
+    values = _node_eval(
+        """
+        globalThis.window = globalThis;
+        const { setLastPickedRoute, getLastPickedRoute } = await import('./static/js/lastPickedRoute.js');
+        setLastPickedRoute('chat-a', { model: 'model-a', endpoint_url: 'http://a', endpoint_id: 'ep-a' });
+        setLastPickedRoute('chat-b', { model: 'model-b', endpoint_url: 'http://b', endpoint_id: 'ep-b' });
+        const a = getLastPickedRoute('chat-a');
+        const b = getLastPickedRoute('chat-b');
+        console.log(JSON.stringify({
+          a: a && a.model,
+          b: b && b.model,
+          leakedToA: a && a.model === 'model-b',
+        }));
+        """
+    )
+    assert values == {"a": "model-a", "b": "model-b", "leakedToA": False}
+
+
+def test_last_picked_route_expires_after_ttl():
+    values = _node_eval(
+        """
+        globalThis.window = globalThis;
+        const { setLastPickedRoute, getLastPickedRoute } = await import('./static/js/lastPickedRoute.js');
+        const rec = setLastPickedRoute('chat-a', { model: 'model-a' });
+        const fresh = getLastPickedRoute('chat-a', rec.picked_at + 1000);
+        const stale = getLastPickedRoute('chat-a', rec.picked_at + (10 * 60 * 1000));
+        console.log(JSON.stringify({
+          fresh: !!(fresh && fresh.model === 'model-a'),
+          stale: stale === null,
+        }));
+        """
+    )
+    assert values == {"fresh": True, "stale": True}
+
+
+def test_pending_new_chat_pick_is_isolated_from_existing_session():
+    values = _node_eval(
+        """
+        globalThis.window = globalThis;
+        const { setLastPickedRoute, getLastPickedRoute } = await import('./static/js/lastPickedRoute.js');
+        setLastPickedRoute('chat-a', { model: 'model-a' });
+        setLastPickedRoute(null, { model: 'model-pending' });
+        const existing = getLastPickedRoute('chat-a');
+        const pending = getLastPickedRoute(null);
+        console.log(JSON.stringify({
+          existing: existing && existing.model,
+          pending: pending && pending.model,
+        }));
+        """
+    )
+    assert values == {"existing": "model-a", "pending": "model-pending"}
+
+
+def test_chat_send_path_reads_session_scoped_last_pick():
+    chat = (ROOT / "static" / "js" / "chat.js").read_text(encoding="utf-8")
+    picker = (ROOT / "static" / "js" / "modelPicker.js").read_text(encoding="utf-8")
+
+    assert "import { getLastPickedRoute } from './lastPickedRoute.js';" in chat
+    assert "const lastPicked = getLastPickedRoute(sid);" in chat
+    assert "window.__odysseusLastPickedRoute || null" not in chat
+
+    assert "import { setLastPickedRoute } from './lastPickedRoute.js';" in picker
+    assert "setLastPickedRoute(_deps.getCurrentSessionId && _deps.getCurrentSessionId(), {" in picker
+    assert "window.__odysseusLastPickedRoute = {" not in picker

--- a/tests/test_startup_session_bootstrap_js.py
+++ b/tests/test_startup_session_bootstrap_js.py
@@ -29,7 +29,7 @@ _IMPORT_REWRITES = {
     "import { providerLogo } from './providers.js';": (
         "import { providerLogo } from './providers.mjs';"
     ),
-    "import { initModelPicker, updateModelPicker } from './modelPicker.js?v=20260722ctxheader1';": (
+    "import { initModelPicker, updateModelPicker } from './modelPicker.js?v=20260814sessmodel1';": (
         "import { initModelPicker, updateModelPicker } from './modelPicker.mjs';"
     ),
     "import themeModule from './theme.js';": "import themeModule from './theme.mjs';",

--- a/tests/test_tool_approval_task_scope.py
+++ b/tests/test_tool_approval_task_scope.py
@@ -343,9 +343,10 @@ def test_route_context_agent_frontend_and_cache_bust_wire_the_contract():
     assert "CHAT_SESSION_APPROVAL_CONTEXT_MARKER" in capabilities
     assert "CHAT_SESSION_APPROVAL_CONTEXT_MARKER" in models
 
-    version = "20260819approvalcontrol1"
-    assert f"chat.js?v={version}" in app
-    assert f"chat.js?v={version}" in index
-    assert f"chatRenderer.js?v={version}" in frontend
-    assert f"chatRenderer.js?v={version}" in app
-    assert f"chatRenderer.js?v={version}" in index
+    chat_js_version = "20260820sessmodel1"
+    approval_version = "20260819approvalcontrol1"
+    assert f"chat.js?v={chat_js_version}" in app
+    assert f"chat.js?v={chat_js_version}" in index
+    assert f"chatRenderer.js?v={approval_version}" in frontend
+    assert f"chatRenderer.js?v={approval_version}" in app
+    assert f"chatRenderer.js?v={approval_version}" in index


### PR DESCRIPTION
## Summary

Picking a model in one chat overwrote the last-picked route for every other open chat. `window.__odysseusLastPickedRoute` is a single window-level object with a 10-minute TTL, and send uses that object before the session's own model. So Chat A would send on Model B after you picked Model B in Chat B.

This stores last-picked routes by session id (and isolates a pending new-chat pick under its own key). Send and the stream-label helper now look up the current session only.

No visual/UI change — cache-bust query only so the updated modules load.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #6023

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

I did boot `uvicorn app:app` and confirmed the new module and updated `chat.js` / `modelPicker.js` are served (200). I did **not** run the two-chat / two-model send path against live backends on this box, so I left the e2e checkbox unchecked.

## How to Test

1. `python3 -m pytest tests/test_last_picked_route_js.py tests/test_new_chat_model_preference.py -q`
   - Expected: 6 passed (needs `node` on PATH).
2. In the running app, open Chat A, pick Model A, send once.
3. Open Chat B, pick Model B, send once.
4. Go back to Chat A and send again — it should still use Model A, not Model B.
5. Start a new unsaved chat, pick a model, then switch back to an existing chat and send — the existing chat should keep its own model.

## Visual / UI changes — REQUIRED if you touched anything that renders

Routing-only change. `static/index.html` and `sessions.js` only bump the module cache-bust query. No DOM / CSS / layout change.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: the change uses Odysseus's existing visual language.
- [x] **No new component patterns.**
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

None — no rendered UI change.