### PR TITLE
fix(launcher): detect Python via py launcher's default version

### DIFF
--- a/launch-windows.ps1
+++ b/launch-windows.ps1
@@ -78,13 +78,18 @@ $pyVersion = $null
 
 $pyLauncher = Get-Command py -ErrorAction SilentlyContinue
 if ($pyLauncher) {
-    foreach ($v in @("-3.13", "-3.12", "-3.11")) {
-        $ver = Get-PythonVersionText $pyLauncher.Source @($v)
-        if ($ver) {
+    # Ask the launcher for its own default Python 3.x (highest installed,
+    # or whatever py.ini / PY_PYTHON overrides to) instead of hardcoding
+    # version flags, which go stale every time a new Python is released.
+    $ver = Get-PythonVersionText $pyLauncher.Source @("-3")
+    if ($ver) {
+        $versionParts = $ver.Split('.')
+        $major = [int]$versionParts[0]
+        $minor = [int]$versionParts[1]
+        if ($major -gt 3 -or ($major -eq 3 -and $minor -ge 11)) {
             $pyExe = $pyLauncher.Source
-            $pyArgs = @($v)
+            $pyArgs = @("-3")
             $pyVersion = $ver
-            break
         }
     }
 }
@@ -109,7 +114,7 @@ if ($pyExe -like "*WindowsApps*python.exe") {
     $pyCmd = Get-Command py -ErrorAction SilentlyContinue
     if ($pyCmd) {
         $pyExe = $pyCmd.Source
-        $pyArgs = @("-3.11")
+        $pyArgs = @("-3")
     }
 }
 


### PR DESCRIPTION
## Summary

`launch-windows.ps1`'s `py`-launcher probe only tried hardcoded flags (`-3.13`, `-3.12`, `-3.11`), so it never found Python 3.14+ even though it satisfies the project's stated 3.11+ requirement. This PR asks `py -3` for its own default version instead and checks it's `>=3.11`, matching the bare `python` fallback branch and avoiding the need to update a version allowlist at every new Python release.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #6047

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. On a Windows machine with only Python 3.14 registered with the `py` launcher (no `python` command on PATH resolving to 3.11-3.13), run `powershell -ExecutionPolicy Bypass -File .\launch-windows.ps1` from a clean clone (no existing `venv\` folder).
2. Before this fix: the script fails immediately with `Couldn't find Python 3.11+ for Windows setup.`, even though 3.14 is installed.
3. After this fix: the script prints `Using Python 3.14.7: <path-to-py.exe> -3`, creates the venv with it, and proceeds through dependency install and first-time setup.
4. Verified separately that `pip install --dry-run -r requirements.txt` resolves cleanly against Python 3.14 on Windows (all native/compiled deps — `numpy`, `cryptography`, `bcrypt`, `nh3`, `fastembed`'s `onnxruntime`/`tokenizers`, etc. — have prebuilt `cp314` Windows wheels already), so no dependency-install regression from picking a newer interpreter.

## Visual / UI changes

Not applicable — this change is confined to Python-interpreter detection logic in `launch-windows.ps1` and does not touch any rendered UI.
