### PR TITLE
fix(docker): install CUDA toolkit so Cookbook's llama.cpp build can target GPU

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,31 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libmagic1 \
     && rm -rf /var/lib/apt/lists/*
 
+# CUDA toolkit (nvcc + cudart + cuBLAS etc.) so Cookbook's runtime llama.cpp
+# build (routes/cookbook_helpers.py's _append_llama_cpp_linux_accel_build_lines)
+# can actually compile llama-server with -DGGML_CUDA=ON. That function already
+# gates the CUDA cmake branch on `command -v nvcc` + a libcudart check and
+# falls back to a CPU-only build when they're absent — without the toolkit
+# installed here, every container silently built CPU-only regardless of GPU
+# passthrough, since the base image ships no CUDA developer tooling at all.
+# Codename is read from /etc/os-release at build time (debian12, debian13,
+# ...) instead of hardcoded, since python:3.14-slim's underlying Debian
+# release moves out from under this Dockerfile over time. Unversioned
+# cuda-toolkit-13 (rather than pinning e.g. 12-8) because NVIDIA's debian13
+# repo only carries CUDA 13.x meta-packages — 12.x is debian12/ubuntu-only.
+RUN apt-get update && apt-get install -y --no-install-recommends gnupg \
+    && . /etc/os-release \
+    && curl -fsSL "https://developer.download.nvidia.com/compute/cuda/repos/debian${VERSION_ID%%.*}/x86_64/cuda-keyring_1.1-1_all.deb" -o /tmp/cuda-keyring.deb \
+    && dpkg -i /tmp/cuda-keyring.deb \
+    && rm /tmp/cuda-keyring.deb \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends cuda-toolkit-13 \
+    && apt-get purge -y --auto-remove gnupg \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/usr/local/cuda/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/usr/local/cuda/lib64:${LD_LIBRARY_PATH}"
+
 # libgl1/libglib2.0-0t64/libxcb1 are runtime shared libs (libGL.so.1,
 # libglib-2.0/libgthread, libxcb.so.1) that opencv-python (cv2) loads. The
 # slim base omits them, so the Cookbook "install realesrgan" path imports cv2


### PR DESCRIPTION
Cookbook's runtime llama.cpp build (_append_llama_cpp_linux_accel_build_lines) already gates -DGGML_CUDA=ON on finding nvcc + libcudart, but the image shipped no CUDA developer toolkit at all, so every container silently fell back to a CPU-only build regardless of GPU passthrough. Installs CUDA 13 via NVIDIA's apt repo (codename resolved from /etc/os-release since the base image's Debian release drifts over time), verified end-to-end: GGML_CUDA:BOOL=ON in a fresh build, real GPU VRAM usage, and ~93 tok/s vs ~5 tok/s CPU-only.

## Summary

Cookbook's runtime llama.cpp build (`_append_llama_cpp_linux_accel_build_flags` in `routes/cookbook_helpers.py`) already correctly detects `nvcc` + `libcudart` and passes `-DGGML_CUDA=ON` when both are present — but the container image ships with no CUDA developer toolkit at all, so `nvcc` is never found and every container silently falls back to a CPU-only `llama-server` build regardless of GPU passthrough being correctly configured.

This installs the CUDA 13 toolkit via NVIDIA's official apt repo, with the Debian codename resolved dynamically from /etc/os-release so it stays correct as the base image's Debian release drifts over time. Verified end-to-end on real hardware: GGML_CUDA:BOOL=ON in a fresh build, real GPU VRAM usage during inference, and throughput went from ~5 tok/s (CPU) to ~93 tok/s (GPU) on an RTX 5080.

## Target branch

- [ ] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue 

<!-- Every PR should be linked to an issue.
     Use one of:  Fixes #5606 |  Part of #NNN  |  Closes #NNN  -->

Fixes #5606 

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

<!-- Step-by-step instructions a reviewer can follow to verify this works.
     Do not leave this empty — a PR without test steps will be sent back. -->

1. docker compose build odysseus
2. docker exec odysseus-odysseus-1 grep -i cuda /app/llama.cpp/build/CMakeCache.txt → confirm GGML_CUDA:BOOL=ON (was OFF before this fix)
3. docker exec odysseus-odysseus-1 nvcc --version → confirm CUDA compiler is present
4. Start the service, load a GGUF model via Cookbook, run a chat completion while watching nvidia-smi
5. Confirm VRAM usage jumps well above idle baseline with a live compute process attached, and token throughput is GPU-class (tested: ~5 tok/s CPU → ~93 tok/s GPU on RTX 5080)

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

<!-- Drag and drop images or a screen recording here. Required for any UI/visual change. -->
