### PR TITLE
fix(chat): centre the agent-thread terminating dot on the rail

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -9685,11 +9685,11 @@ body.fullwidth-chat .chat-history {
 .agent-thread:not(.has-bottom) .agent-thread-node.open:last-child::after {
   content: '';
   position: absolute;
-  /* -17px (was -15) nudges the terminating dot 2px further left so it
-     sits flush with the thread's left rail when the search node is
-     expanded. This is the "big glow dot at the bottom" the user sees
-     after a web_search step. */
-  left: -17px;
+  /* Centre the 6px dot on the rail: the rail sits at left:5px + 2px wide,
+     so its centre is 6px from the thread's left edge and the dot's left
+     edge belongs at 3px — i.e. 3px - padding-left. Keep this in step with
+     .agent-thread-dot and with the mobile padding override below. */
+  left: -19px;
   bottom: 5px;
   width: 6px;
   height: 6px;
@@ -9957,6 +9957,11 @@ body.fullwidth-chat .chat-history {
   .agent-thread-dot {
     left: -16px;
     top: 10px;
+  }
+  /* padding-left drops to 18px here, so the terminating dot needs its own
+     offset (3px - 18px) to stay centred on the rail. */
+  .agent-thread:not(.has-bottom) .agent-thread-node.open:last-child::after {
+    left: -15px;
   }
 }
 

--- a/tests/test_agent_thread_dot_alignment_css.py
+++ b/tests/test_agent_thread_dot_alignment_css.py
@@ -1,0 +1,105 @@
+"""Agent-thread timeline dots must stay centred on the vertical rail.
+
+Source-text assertions here are the narrow exception allowed by
+TESTING_STANDARD.md: the invariant is pure CSS geometry, and driving it at
+runtime would need a real layout engine, which the suite has no runner for.
+The test parses the declared pixel values and recomputes the centres rather
+than pinning literals, so retuning the spacing keeps it green — but moving a
+breakpoint's padding without moving both dot offsets turns it red.
+
+The thread's padding is restated once per breakpoint, and each breakpoint's
+overrides follow its own `.agent-thread` rule, so a rule's position in the
+file identifies the breakpoint it belongs to.
+"""
+
+import re
+from pathlib import Path
+
+
+CSS = (Path(__file__).resolve().parents[1] / "static" / "style.css").read_text(
+    encoding="utf-8"
+)
+
+THREAD = r"^[ \t]*\.agent-thread[ \t]*\{"
+RAIL = r"^[ \t]*\.agent-thread::before[ \t]*\{"
+STEP_DOT = r"^[ \t]*\.agent-thread-dot[ \t]*\{"
+END_DOT = (
+    r"^[ \t]*\.agent-thread:not\(\.has-bottom\) "
+    r"\.agent-thread-node\.open:last-child::after[ \t]*\{"
+)
+
+
+def _blocks(selector: str) -> list[tuple[int, str]]:
+    """(position, declaration block) for each rule using this exact selector."""
+    return [
+        (m.start(), CSS[m.end() : CSS.index("}", m.end())])
+        for m in re.finditer(selector, CSS, re.MULTILINE)
+    ]
+
+
+def _px(block: str, prop: str) -> float | None:
+    m = re.search(rf"(?:^|;|/)\s*{prop}\s*:\s*(-?[\d.]+)px", block)
+    return float(m.group(1)) if m else None
+
+
+def _padding_left(block: str) -> float | None:
+    explicit = _px(block, "padding-left")
+    if explicit is not None:
+        return explicit
+    shorthand = re.search(r"(?:^|;)\s*padding\s*:([^;]+);", block)
+    sides = shorthand.group(1).split() if shorthand else []
+    return float(sides[3].removesuffix("px")) if len(sides) == 4 else None
+
+
+def _breakpoints() -> list[tuple[float, int, int]]:
+    """(padding-left, window start, window end) for each declared breakpoint."""
+    threads = _blocks(THREAD)
+    assert threads, "no .agent-thread rule found"
+    bounds = [pos for pos, _ in threads] + [len(CSS)]
+    return [
+        (_padding_left(block), bounds[i], bounds[i + 1])
+        for i, (_, block) in enumerate(threads)
+    ]
+
+
+def _in_force(selector: str, prop: str, start: int, end: int, fallback):
+    """Value a breakpoint's window declares, else the one it inherits."""
+    declared = [_px(b, prop) for pos, b in _blocks(selector) if start <= pos < end]
+    values = [v for v in declared if v is not None]
+    return values[-1] if values else fallback
+
+
+def _centres() -> list[tuple[float, float, float]]:
+    rail = _blocks(RAIL)[0][1]
+    rail_centre = _px(rail, "left") + _px(rail, "width") / 2
+
+    base_step, base_end = _blocks(STEP_DOT)[0][1], _blocks(END_DOT)[0][1]
+    step_width, end_width = _px(base_step, "width"), _px(base_end, "width")
+
+    rows = []
+    for padding, start, end in _breakpoints():
+        step_left = _in_force(STEP_DOT, "left", start, end, _px(base_step, "left"))
+        end_left = _in_force(END_DOT, "left", start, end, _px(base_end, "left"))
+        rows.append(
+            (
+                rail_centre,
+                padding + step_left + step_width / 2,
+                padding + end_left + end_width / 2,
+            )
+        )
+    return rows
+
+
+def test_step_dots_are_centred_on_the_rail_at_every_breakpoint():
+    for index, (rail, step, _) in enumerate(_centres()):
+        assert step == rail, (
+            f"step dot at breakpoint {index} sits {step - rail}px off the rail"
+        )
+
+
+def test_terminating_dot_is_centred_on_the_rail_at_every_breakpoint():
+    for index, (rail, _, end) in enumerate(_centres()):
+        assert end == rail, (
+            f"terminating dot at breakpoint {index} sits {end - rail}px "
+            "off the rail"
+        )


### PR DESCRIPTION
## Summary

The glow dot that caps the agent thread's timeline used a single `left: -17px` at every breakpoint, but it is positioned from the thread's `padding-left`, which drops from 22px to 18px below 768px. The 6px dot therefore sat 2px right of the 2px rail on desktop and 2px left of it on mobile — a visible kink under an expanded last step. `.agent-thread-dot` already carries a per-breakpoint offset for exactly this reason; this gives the terminating dot the same treatment, derived from the rail rather than nudged by eye: the rail is `left: 5px` and 2px wide, so its centre is 6px from the thread's left edge and the dot's left edge belongs at `3px - padding-left` and makes Odysseus usable again.

Adds a test that recomputes each dot's centre per breakpoint from the declared values, so it stays green if the spacing is retuned but fails if a breakpoint moves the padding without moving both dots.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #6058

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run the app (`uvicorn app:app --port 7099`) and open a chat whose transcript ends with a tool step — a web search works — with no assistant message after it.
2. Click the step header to expand it. The glow dot appears at the bottom of the rail.
3. At a desktop width, check the dot is centred on the rail instead of sitting right of it.
4. Narrow the window below 768px and look again — before this change it jumped to the *left* of the rail.
5. To measure it rather than eyeball it, with the step expanded:

```js
const t = document.querySelector('.agent-thread');
const n = t.querySelector('.agent-thread-node');
const b = getComputedStyle(t, '::before'), a = getComputedStyle(n, '::after');
const rail = t.getBoundingClientRect().left + parseFloat(b.left) + parseFloat(b.width) / 2;
const dot = n.getBoundingClientRect().left + parseFloat(a.left) + parseFloat(a.width) / 2;
dot - rail;  // 0 after; +2 desktop / -2 mobile before
```

6. `./venv/bin/python -m pytest tests/test_agent_thread_dot_alignment_css.py` — 2 passed, and both fail on unmodified `dev`.

## Not verified

- Light theme not checked; the change is pure geometry, so it should be theme-independent.
- No live model round-trip — the tool event was seeded into a scratch session and rendered through the normal `/api/history` path, not produced by a real search.
- The streaming and `has-bottom` variants of the rail are untouched and were not re-checked.

## Visual / UI changes — REQUIRED if you touched anything that renders

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

No new values are introduced — the change only moves two existing offsets, and the dot keeps its `var(--red)` fill and existing box-shadow.

### Screenshots / clips

<img width="592" height="690" alt="compare-mobile" src="https://github.com/user-attachments/assets/a15d48f7-8ad0-4c30-aa22-16151147453f" />
