### PR TITLE
fix(tasks): scope action_tidy_research broken-file sweep to admins

### DIFF
--- a/src/builtin_actions.py
+++ b/src/builtin_actions.py
@@ -810,13 +810,27 @@ async def action_tidy_research(owner: str, **kwargs) -> Tuple[str, bool]:
 
     Research history lives entirely in data/deep_research/<id>.json and is NOT
     backed by chat-session rows — so a file must never be deleted just because
-    no chat session matches its id. Only prune files that fail to load."""
+    no chat session matches its id. Only prune files that fail to load.
+
+    A broken file has no readable owner stamp, so it cannot be matched against
+    `owner`. Clearing one is privileged: admins and the single-user operator
+    (AUTH_ENABLED=false) may, a regular user may not, and neither may anyone
+    during the pre-setup window before an admin exists.
+    """
     try:
         from pathlib import Path
         import json as _json
+        from src.tool_security import owner_is_admin_or_single_user
         research_dir = Path(DEEP_RESEARCH_DIR)
         if not research_dir.exists():
             raise TaskNoop("no research directory")
+        if not owner_is_admin_or_single_user(owner):
+            # Return before the glob rather than filtering inside the loop: the
+            # loop reports "none broken" off an empty `removed`, which reaches
+            # Activity as a false report to a user whose files it skipped, and a
+            # regular user need not read every owner's file to learn it may
+            # delete none of them.
+            raise TaskNoop("not permitted to remove unattributable research files")
         files = list(research_dir.glob("*.json"))
         removed = []
         for p in files:

--- a/tests/test_tidy_research_owner_scope.py
+++ b/tests/test_tidy_research_owner_scope.py
@@ -1,0 +1,159 @@
+"""Owner-scope tests for action_tidy_research.
+
+Broken research files (empty or unparseable JSON) have no readable owner
+stamp. The HTTP path and _find_owned_research_path treat parse failure as
+not-owned, so a regular user's tidy task must not unlink them. Clearing a
+corrupt record is a privileged act instead: admins, and the operator in
+single-user mode (AUTH_ENABLED=false), keep the janitor.
+
+Every case installs a fake AuthManager rather than relying on ambient state.
+Setting AUTH_ENABLED=true alone leaves is_configured False, so the admin check
+these tests exist to pin would never be reached.
+"""
+
+import json
+
+import pytest
+
+from src.builtin_actions import TaskNoop, action_tidy_research
+
+
+@pytest.fixture
+def research_dir(tmp_path, monkeypatch):
+    data_dir = tmp_path / "deep_research"
+    data_dir.mkdir()
+    monkeypatch.setattr("src.builtin_actions.DEEP_RESEARCH_DIR", str(data_dir))
+    return data_dir
+
+
+def _install_auth(monkeypatch, *, is_configured: bool):
+    """Auth enabled, with `root` as the only admin. `is_configured` False models
+    the pre-setup window, where no admin exists yet."""
+
+    import core.auth as core_auth
+
+    configured = is_configured
+
+    class FakeAuthManager:
+        is_configured = configured
+
+        def is_admin(self, user):
+            return user == "root"
+
+    monkeypatch.setenv("AUTH_ENABLED", "true")
+    monkeypatch.setattr(core_auth, "AuthManager", FakeAuthManager)
+
+
+@pytest.fixture
+def configured_auth(monkeypatch):
+    _install_auth(monkeypatch, is_configured=True)
+
+
+def _write(data_dir, name: str, text: str):
+    path = data_dir / f"{name}.json"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _write_owned(data_dir, name: str, owner: str):
+    return _write(data_dir, name, json.dumps({"owner": owner, "query": name}))
+
+
+@pytest.mark.asyncio
+async def test_configured_non_admin_skips_unparseable_and_empty_files(
+    research_dir, configured_auth
+):
+    alice = _write_owned(research_dir, "alice-ok", "alice")
+    bob = _write_owned(research_dir, "bob-ok", "bob")
+    empty = _write(research_dir, "broken-empty", "")
+    garbage = _write(research_dir, "broken-json", "{not json")
+    alice_txt = alice.read_text(encoding="utf-8")
+    bob_txt = bob.read_text(encoding="utf-8")
+
+    with pytest.raises(TaskNoop, match="not permitted"):
+        await action_tidy_research("alice")
+
+    assert alice.exists()
+    assert alice.read_text(encoding="utf-8") == alice_txt
+    assert bob.exists()
+    assert bob.read_text(encoding="utf-8") == bob_txt
+    assert empty.exists(), "empty file has no owner stamp; non-admin tidy must not unlink it"
+    assert garbage.exists(), "unparseable file has no owner stamp; non-admin tidy must not unlink it"
+
+
+@pytest.mark.asyncio
+async def test_configured_non_admin_skip_reason_does_not_claim_none_broken(
+    research_dir, configured_auth
+):
+    """The skip reason reaches Activity as `skipped -- <reason>`, so it must not
+    report a clean scan over files it declined to look at."""
+    _write(research_dir, "broken-empty", "")
+
+    with pytest.raises(TaskNoop) as excinfo:
+        await action_tidy_research("alice")
+
+    assert "none broken" not in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_configured_admin_still_removes_broken_files(research_dir, configured_auth):
+    valid = _write_owned(research_dir, "ok", "alice")
+    empty = _write(research_dir, "broken-empty", "   ")
+    garbage = _write(research_dir, "broken-json", "not-json")
+
+    message, ok = await action_tidy_research("root")
+
+    assert ok is True
+    assert "Removed 2" in message
+    assert valid.exists(), "admin sweep clears corrupt records, not valid ones"
+    assert not empty.exists()
+    assert not garbage.exists()
+
+
+@pytest.mark.asyncio
+async def test_pre_setup_denies_owner_who_would_be_admin_once_configured(
+    research_dir, monkeypatch
+):
+    """Auth on, no admin created yet: fail closed even for `root`.
+
+    The owner here is non-empty and would satisfy is_admin, so this fails if the
+    is_configured guard is removed. An empty owner would not discriminate -- it
+    is denied by the `owner and ...` short-circuit either way.
+    """
+    _install_auth(monkeypatch, is_configured=False)
+    empty = _write(research_dir, "broken-empty", "")
+    garbage = _write(research_dir, "broken-json", "{")
+
+    with pytest.raises(TaskNoop, match="not permitted"):
+        await action_tidy_research("root")
+
+    assert empty.exists()
+    assert garbage.exists()
+
+
+@pytest.mark.asyncio
+async def test_empty_owner_does_not_delete_broken_files(research_dir, configured_auth):
+    empty = _write(research_dir, "broken-empty", "")
+    garbage = _write(research_dir, "broken-json", "{")
+
+    with pytest.raises(TaskNoop, match="not permitted"):
+        await action_tidy_research("")
+
+    assert empty.exists()
+    assert garbage.exists()
+
+
+@pytest.mark.asyncio
+async def test_auth_disabled_still_removes_broken_files(research_dir, monkeypatch):
+    monkeypatch.setenv("AUTH_ENABLED", "false")
+    valid = _write_owned(research_dir, "ok", "alice")
+    empty = _write(research_dir, "broken-empty", "   ")
+    garbage = _write(research_dir, "broken-json", "not-json")
+
+    message, ok = await action_tidy_research("alice")
+
+    assert ok is True
+    assert "Removed 2" in message
+    assert valid.exists()
+    assert not empty.exists()
+    assert not garbage.exists()


### PR DESCRIPTION
## Summary

`action_tidy_research` takes an `owner` argument and never reads it. Every user gets a "Research Tidy" task created automatically, and running it sweeps `data/deep_research/` globally, unlinking every empty or unparseable file no matter who owned it. On a multi-user instance a regular user can delete other users' broken research records just by triggering their own housekeeping task.

A broken file has no readable owner stamp, so it can't be matched against `owner` the way `_find_owned_research_path` does. That's why the HTTP path and `manage_research` already treat a parse failure as not-owned. Clearing one is a privileged act rather than an ownership one, so this gates the sweep on the existing `owner_is_admin_or_single_user` helper instead of adding a second ownership rule next to the canonical one.

The check returns before the directory glob rather than filtering inside the loop. Filtering in the loop leaves `removed` empty and reports "none broken", and that string lands in Activity as the skipped-run reason, so the user whose files were skipped gets told there was nothing wrong with them.

Owner states, per the working rules on #4200:

| runtime state | `owner` | behaviour |
| --- | --- | --- |
| `AUTH_ENABLED=true`, no current user (`""` / `None`) | falsy | denied, nothing unlinked |
| `AUTH_ENABLED=true`, regular user | username | denied, nothing unlinked |
| `AUTH_ENABLED=true`, admin | username | sweeps broken files |
| `AUTH_ENABLED=true`, pre-setup (no admin yet) | any | denied, nothing unlinked |
| `AUTH_ENABLED=false`, no-login local operator | any | sweeps broken files |

A broken research file is effectively one of the legacy ownerless rows #4200 talks about. Only the admin or the local operator may clear one, never silently on a regular user's behalf. It doesn't move any file to a new owner or change what a valid record's `owner` field means.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Part of #4200

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

Boot an isolated instance with auth on, one admin and one regular user:

```bash
export ODYSSEUS_DATA_DIR=/tmp/ody-e2e AUTH_ENABLED=true
mkdir -p "$ODYSSEUS_DATA_DIR/deep_research"
./venv/bin/python -c "
from core.auth import AuthManager
AuthManager().setup('root','rootpass123!')
AuthManager().create_user('alice','alicepass123!',is_admin=False)"
./venv/bin/python -m uvicorn app:app --host 127.0.0.1 --port 7799
```

Seed two broken records and one valid record for each user:

```bash
cd "$ODYSSEUS_DATA_DIR/deep_research"
printf ''                              > broken-empty.json
printf '{not json'                     > broken-garbage.json
printf '{"owner":"alice","query":"x"}' > alice-valid.json
printf '{"owner":"root","query":"x"}'  > root-valid.json
```

Log in as `alice`, find her "Research Tidy" task in `GET /api/tasks`, and `POST /api/tasks/<id>/run`. Read the outcome back from `GET /api/tasks?include_last_run=true`.

On current `dev`:

```
status : success
result : Removed 2 broken research file(s) of 4
```

Both broken files are gone. A non-admin just deleted unattributable records out of the shared directory.

On this branch:

```
status : skipped
result : not permitted to remove unattributable research files
```

All four files are still there. Trigger the same task as `root` and you get `success` / `Removed 2 broken research file(s) of 4`, with both users' valid records untouched.

Tests:

```bash
./venv/bin/python -m pytest tests/test_tidy_research_owner_scope.py -q   # 6 passed
./venv/bin/python -m pytest tests/ -q -m area_security                   # 739 passed
```

Every one of the six is load-bearing. Forcing the gate permanently open fails four of them, forcing it permanently closed fails the other two, and deleting the `is_configured` pre-setup branch out of `owner_is_admin_or_single_user` fails `test_pre_setup_denies_owner_who_would_be_admin_once_configured`. The auth-enabled cases install a fake `AuthManager` rather than leaning on ambient state, because `AUTH_ENABLED=true` on its own leaves `is_configured` false and the admin check never gets reached.

## Notes for the reviewer

three things i left alone to keep this narrow, flagged rather than folded in:

- `BUILTIN_ACTION_INFO["tidy_research"]` still reads "Remove orphaned research files (sessions that were deleted)", which is behaviour the action's own docstring explicitly forbids.
- `TaskNoop`'s docstring says nothing appears in the Activity log, but the scheduler records a `skipped` row with the reason now.
- Every user still gets a `tidy_research` task auto-created, so non-admins on a multi-user instance will see a recurring "skipped" row from here on. Suppressing the auto-create for non-admins is a behaviour call, and it didn't belong inside a security fix.

i'm down to fold any of those into this PR or take them separately, whichever you'd rather.
