### PR TITLE
fix(ci): match the screenshot checkbox by wording, not emphasis

### DIFF
--- a/.github/scripts/check-pr-description.js
+++ b/.github/scripts/check-pr-description.js
@@ -96,7 +96,11 @@ module.exports = async ({ github, context, core }) => {
 
   const appRan = /- \[x\]\s+I actually ran the app\b/i.test(body);
   const appNotRun = /- \[x\]\s+I did not run the app\/runtime validation\b/i.test(body);
-  const screenshotChecked = /- \[x\]\s+\*\*Screenshot or short clip\*\*/i.test(body);
+  // Anchor on the wording, not the template's emphasis: a ticked box the author
+  // retyped without the surrounding ** renders identically on the PR page, so
+  // treating it as unchecked is invisible from their side. Matches the two
+  // attestations above, which already ignore formatting.
+  const screenshotChecked = /- \[x\]\s+[*_]{0,2}Screenshot or short clip[*_]{0,2}/i.test(body);
   const screenshotSection = section('Screenshots / clips');
   const hasVisualEvidence = /!\[[^\]]*\]\([^)]+\)|<(?:img|video|source)\b[^>]*(?:src|href)=|https?:\/\/[^\s)]+/i.test(screenshotSection);
   const evidenceGaps = [];

--- a/tests/test_pr_description_check.py
+++ b/tests/test_pr_description_check.py
@@ -169,6 +169,20 @@ def test_ui_checkbox_without_media_still_needs_visual_evidence():
     assert not any(call["method"] == "setFailed" for call in calls)
 
 
+def test_ticked_screenshot_box_counts_without_the_template_bolding():
+    body = _body(
+        app_ran=True,
+        screenshot=True,
+        media="https://github.com/user-attachments/assets/example",
+    ).replace("**Screenshot or short clip**", "Screenshot or short clip")
+
+    calls = _run_checker(["static/js/example.js"], body)
+
+    assert _added_labels(calls) == {"ready for review"}
+    assert not _comment(calls)
+    assert not any(call["method"] == "setFailed" for call in calls)
+
+
 def test_explicit_not_run_is_honest_but_not_ready():
     calls = _run_checker(
         ["services/example.py"],


### PR DESCRIPTION
## Summary

`check-pr-description.js` decided whether the screenshot attestation was ticked with a pattern that included the template's asterisks, so it only matched a body that kept the exact `**Screenshot or short clip**` rendering. A ticked box written any other way — plain text, `*italic*`, `__underscores__`, or the whole line bolded — read as unchecked, even though it renders identically on the PR page. The result was `ready for review` silently withheld and a bot comment claiming visual evidence was outstanding, with attached screenshots sitting right below it and `Check PR description` still green, since evidence gaps do not call `core.setFailed`. This anchors the match on the wording instead, which is what the two attestations three lines above already do.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #6071

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [x] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.
- [x] I did not run the app/runtime validation and stated that gap in **How to Test**. Leave this unchecked when the app-run box above is checked.

## How to Test

1. Check out the branch and run the focused suite — the new case is the one that matters:
   `python -m pytest tests/test_pr_description_check.py -q` → 16 passed.
2. Revert just the changed line in `.github/scripts/check-pr-description.js` and re-run. `test_ticked_screenshot_box_counts_without_the_template_bolding` fails: the checker adds `needs visual evidence` and comments, instead of `ready for review`.
3. For the other renderings, take `_body(app_ran=True, screenshot=True, media="https://github.com/user-attachments/assets/example")` from that module, swap the label for `Screenshot or short clip`, `*Screenshot or short clip*` or `__Screenshot or short clip__`, and call `_run_checker(["static/js/example.js"], body)`. All three come back `ready for review` here; all three came back `needs visual evidence` before.
4. Full suite on this branch: 5673 passed, 2 failed, 4 skipped. Both failures are the known macOS environment cases (`test_glob_confined_e2e`, `test_real_socket_falls_back_from_dead_first_to_live_second`) and reproduce identically on unmodified `dev`.

**Not verified**

- No live Actions run — this is the checker's logic under the node harness `tests/test_pr_description_check.py` already ships, not the workflow end-to-end.
- The app was not booted. The change is confined to a CI script and its test and never executes in the application, so a boot would not exercise it.
- The mirror case is deliberately untouched: bolding `**I actually ran the app**` still reads as unchecked on line 97, because that pattern carries no emphasis. One change per PR — it is written up in #6071.

## Visual / UI changes — REQUIRED if you touched anything that renders

Nothing renders — the diff is a CI script and a test.

- [x] **I am not an LLM agent submitting a bulk PR.**

### Screenshots / clips

Not applicable; no user-visible surface is touched.
