### PR TITLE
fix(docker): pip-install CUDA 13 toolkit for llama.cpp GPU build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,28 @@ COPY --from=realesrgan-wheels /wheels/ /tmp/odysseus-wheels/
 RUN pip install --no-cache-dir --no-deps /tmp/odysseus-wheels/*.whl \
     && rm -rf /tmp/odysseus-wheels
 
+RUN pip install --no-cache-dir \
+    nvidia-cuda-nvcc==13.3.73 \
+    nvidia-cuda-runtime==13.3.29 \
+    nvidia-cublas==13.3.0.5 \
+    nvidia-cuda-nvrtc==13.3.33 \
+    nvidia-cuda-cccl==13.3.3.4.1
+
+RUN CUDA_PIP=/usr/local/lib/python3.14/site-packages/nvidia/cu13 \
+    && mkdir -p /usr/local/cuda \
+    && ln -s "${CUDA_PIP}/bin" /usr/local/cuda/bin \
+    && ln -s "${CUDA_PIP}/include" /usr/local/cuda/include \
+    && ln -s "${CUDA_PIP}/lib" /usr/local/cuda/lib \
+    && ln -s "${CUDA_PIP}/lib" /usr/local/cuda/lib64 \
+    && ln -s libcudart.so.13 "${CUDA_PIP}/lib/libcudart.so" \
+    && ln -s libcublas.so.13 "${CUDA_PIP}/lib/libcublas.so" \
+    && ln -s libnvrtc.so.13 "${CUDA_PIP}/lib/libnvrtc.so"
+
+ENV CUDA_HOME=/usr/local/cuda
+ENV CUDAToolkit_ROOT=/usr/local/cuda
+ENV PATH=/usr/local/cuda/bin:${PATH}
+ENV LD_LIBRARY_PATH=/usr/local/cuda/lib:${LD_LIBRARY_PATH}
+
 # Copy app code
 COPY . .
 

--- a/routes/cookbook_helpers.py
+++ b/routes/cookbook_helpers.py
@@ -1009,7 +1009,7 @@ def _append_llama_cpp_linux_accel_build_lines(runner_lines: list[str]) -> None:
     runner_lines.append('      }')
     runner_lines.append('      if _odysseus_has_cudart; then')
     runner_lines.append('        echo "[odysseus] CUDA nvcc + cudart found — building llama-server with CUDA (GPU) support..."')
-    runner_lines.append('        cmake -B build -DCMAKE_BUILD_TYPE=Release -DGGML_CUDA=ON && cmake --build build -j"$NPROC" --target llama-server && ln -sf ~/llama.cpp/build/bin/llama-server ~/bin/llama-server')
+    runner_lines.append('        cmake -B build -DCMAKE_BUILD_TYPE=Release -DGGML_CUDA=ON -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc -DCUDAToolkit_ROOT=/usr/local/cuda && cmake --build build -j"$NPROC" --target llama-server && ln -sf ~/llama.cpp/build/bin/llama-server ~/bin/llama-server')
     runner_lines.append('      else')
     runner_lines.append('        echo "[odysseus] WARNING: nvcc found but CUDA runtime (libcudart.so) is not visible — building llama-server for CPU only."')
     runner_lines.append('        echo "[odysseus]   GPU inference will not be available for this llama.cpp build."')

--- a/tests/test_cookbook_helpers.py
+++ b/tests/test_cookbook_helpers.py
@@ -636,7 +636,7 @@ def test_llama_cpp_linux_bootstrap_prefers_rocm_before_cuda():
     assert script.index("mkdir -p ~/bin") < script.index("cd ~/llama.cpp")
     assert 'command -v hipconfig &>/dev/null || [ -d /opt/rocm ] || [ -n "$ROCM_PATH" ] || [ -n "$HIP_PATH" ]' in script
     assert 'cmake -B build -DCMAKE_BUILD_TYPE=Release -DGGML_HIP=ON' in script
-    assert 'cmake -B build -DCMAKE_BUILD_TYPE=Release -DGGML_CUDA=ON' in script
+    assert 'cmake -B build -DCMAKE_BUILD_TYPE=Release -DGGML_CUDA=ON -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc -DCUDAToolkit_ROOT=/usr/local/cuda' in script
     assert script.index('DGGML_HIP=ON') < script.index('DGGML_CUDA=ON')
     assert 'ROCm/HIP detected — building llama-server with HIP support' in script
 
@@ -666,7 +666,7 @@ def test_llama_cpp_linux_bootstrap_cuda_cmake_present_when_cudart_found():
     _append_llama_cpp_linux_accel_build_lines(runner_lines)
     script = "\n".join(runner_lines)
 
-    assert 'cmake -B build -DCMAKE_BUILD_TYPE=Release -DGGML_CUDA=ON' in script
+    assert 'cmake -B build -DCMAKE_BUILD_TYPE=Release -DGGML_CUDA=ON -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc -DCUDAToolkit_ROOT=/usr/local/cuda' in script
     assert 'CUDA nvcc + cudart found' in script
 
 


### PR DESCRIPTION
## Summary
- The base image has no `nvcc`, so the llama.cpp bootstrap always fell back to a CPU-only `llama-server` build even on CUDA-capable hosts.
- Install the `nvidia-cuda-nvcc`/`nvidia-cuda-runtime`/`nvidia-cublas`/`nvidia-cuda-nvrtc`/`nvidia-cuda-cccl` pip wheels in the Dockerfile and symlink them under `/usr/local/cuda` (with `libcudart.so`/`libcublas.so`/`libnvrtc.so` aliases and `CUDA_HOME`/`PATH`/`LD_LIBRARY_PATH` set) so the toolkit is discoverable at build time.
- Point the llama.cpp CUDA CMake invocation at that toolkit explicitly via `-DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc -DCUDAToolkit_ROOT=/usr/local/cuda` so `GGML_CUDA=ON` reliably finds `nvcc` instead of depending on `PATH` alone.

Duplication: https://github.com/odysseus-dev/odysseus/pull/6051 tries to solve a very similar problem, but solves it differently. A maintainer can decide which solution is preferable. Mine relies on linux repos, theirs relies on curl, but mine needs to hardcode the version of the libraries while theirs does not. 

## Linked Issue

#6076

Fixes #6076

https://github.com/odysseus-dev/odysseus/issues/6076

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate. Note that  https://github.com/odysseus-dev/odysseus/issues/5606 has a similar problem.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.


## Type of Change
- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Test plan
- [x] `pytest tests/test_cookbook_helpers.py` — 68 passed, 1 skipped


## How to Test

1. docker compose build odysseus
2. docker compose -f docker-compose.gpu-nvidia.yml up -d
3. connect to localhost:7000 via browser
4. click cookbook
5. choose any small enough model, download it
6. change the setting from CPU to GPU on an nvidia card
7. This would have crashed before, works now. Tested with Qwen3.5-9b