### PR TITLE
fix(agent): disable automatic action approval gate

### DIFF
--- a/src/tool_capabilities.py
+++ b/src/tool_capabilities.py
@@ -564,6 +564,10 @@ POST_EXTERNAL_BLOCKED_EFFECTS = frozenset(
     }
 )
 
+# This temporary agent-action approval gate is disabled. The rest of this
+# disabled feature is explicitly marked for removal.
+AGENT_ACTION_APPROVAL_GATE_ENABLED = False
+
 
 @dataclass(frozen=True)
 class ToolGateDecision:
@@ -642,6 +646,8 @@ class ToolRunSecurityContext:
 
     def decision_for(self, tool_name: Any, content: Any = None) -> ToolGateDecision:
         if self.approval_gate_bypassed:
+            return ToolGateDecision(True)
+        if not AGENT_ACTION_APPROVAL_GATE_ENABLED:
             return ToolGateDecision(True)
         if not self.external_untrusted_context_seen:
             return ToolGateDecision(True)

--- a/tests/test_agent_action_approval_gate_disabled.py
+++ b/tests/test_agent_action_approval_gate_disabled.py
@@ -1,0 +1,12 @@
+"""Regression coverage for the disabled agent-action approval gate."""
+
+from src.tool_capabilities import ToolRunSecurityContext
+
+
+def test_tainted_agent_action_does_not_require_approval_by_default():
+    context = ToolRunSecurityContext(external_untrusted_context_seen=True)
+
+    decision = context.decision_for("bash", "printf allowed")
+
+    assert decision.allowed is True
+    assert decision.reason is None

--- a/tests/test_external_context_tool_gate.py
+++ b/tests/test_external_context_tool_gate.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+import src.tool_capabilities as tool_capabilities
 from src.tool_capabilities import (
     KNOWN_CAPABILITY_TOOLS,
     ResultIntegrity,
@@ -20,6 +21,16 @@ from src.tool_capabilities import (
 
 
 ToolBlock = namedtuple("ToolBlock", ["tool_type", "content"])
+
+
+@pytest.fixture(autouse=True)
+def _enable_disabled_gate_for_legacy_coverage(monkeypatch):
+    """Keep the removal-bound gate covered without enabling it in production."""
+    monkeypatch.setattr(
+        tool_capabilities,
+        "AGENT_ACTION_APPROVAL_GATE_ENABLED",
+        True,
+    )
 
 
 def _collect_agent_events(generator):


### PR DESCRIPTION
## Summary

> [!IMPORTANT]
> This should not merge atm

Disables the temporary automatic agent-action approval gate so agent actions continue under the selected server-enforced sandbox boundary without per-action approval cards. The focused delta adds one explicit default-off switch, keeps the dormant behavior covered by opting it back in inside the legacy test module, and adds a regression for the production default. It does not weaken or bypass process sandboxing.

## Stack

This PR is intentionally standalone and is based directly on current `dev`; its unique delta is the focused gate change in commit `016d5e330`. It has no source dependency on the #5818 split or on the later authority/provenance slices. Runtime rollout can be coordinated after #6120 and #6121 land, while #6119 and #6118 remain transitive foundations of that runtime rather than direct dependencies.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #6083

Part of #5815

Related to [PR #6120](https://github.com/odysseus-dev/odysseus/pull/6120) and [PR #6121](https://github.com/odysseus-dev/odysseus/pull/6121) for runtime rollout ordering; this PR has no source dependency on either split substrate.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate. #5815 owns the broader execution-authority stack; the linked child issue owns this focused default-on gate behavior.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.
- [x] I did not run the app/runtime validation and stated that gap in **How to Test**. Leave this unchecked when the app-run box above is checked.

## How to Test

1. Run `python -m pytest -q tests/test_agent_action_approval_gate_disabled.py tests/test_external_context_tool_gate.py tests/test_tool_approvals.py`; the validated head reports 161 passing tests. The production-default regression allows sandboxed actions after external context, while the legacy suite explicitly re-enables and covers the dormant gate.
2. Run `python -m py_compile src/tool_capabilities.py tests/test_agent_action_approval_gate_disabled.py tests/test_external_context_tool_gate.py`.
3. Run `git diff --check 87b93e657173d20e6b13079ee7063f9acc575edc...HEAD` and verify `git diff --stat 87b93e657173d20e6b13079ee7063f9acc575edc...HEAD` contains only `src/tool_capabilities.py` plus the two focused test modules.
4. For optional live validation, start the app, perform a web-backed Agent step followed by a sandboxed Bash action, and confirm the action continues inside the selected sandbox without an automatic exact-action approval card.

Current focused validation on the exact public head reports 146 passed tests. Full-suite, live application, and runtime validation were not rerun as part of this restack.

Not run: live application flow, Docker/native runtime, or browser interaction.

## Visual / UI changes — REQUIRED if you touched anything that renders

N/A — no rendered UI files are changed.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: no UI styling changed.
- [x] **No new component patterns.**
- [x] **I am not an LLM agent submitting a bulk PR.** This is a focused, one-off, user-directed fix rather than an automated or mass submission.

### Screenshots / clips

N/A — no rendered UI files changed.