### PR TITLE
fix(models): align API model checkbox state

### DIFF
--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -2342,9 +2342,7 @@ def setup_model_routes(model_discovery):
                 else:
                     response.headers["X-Model-Refresh-Status"] = "failed"
                     response.headers["X-Model-Refresh-Warning"] = "Model refresh failed or returned no models; kept cached models."
-            pinned = _normalize_model_ids(getattr(ep, "pinned_models", None))
-            if picker_requires_pinning and not _has_explicit_pinned_models(ep):
-                pinned = _legacy_visible_api_models(ep)
+            _, pinned = _picker_models_for_endpoint(ep, base, kind)
             pinned_set = set(pinned)
             return [
                 {

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -1107,6 +1107,47 @@ def test_get_api_models_marks_picker_as_pinned_only(monkeypatch):
     assert by_id["anthropic/claude-sonnet-4"]["is_pinned"] is False
 
 
+def test_get_fresh_api_models_does_not_mark_cached_inventory_as_pinned(monkeypatch):
+    ep = _make_endpoint(
+        base_url="https://api.example.test/v1",
+        cached_models=json.dumps(["openai/gpt-image-1", "anthropic/claude-sonnet-4"]),
+        pinned_models=None,
+    )
+    db = _PinnedFakeDb([ep])
+    monkeypatch.setattr(model_routes, "SessionLocal", lambda: db)
+    monkeypatch.setattr(model_routes, "require_admin", lambda request: None)
+    endpoint = _get_route("/api/model-endpoints/{ep_id}/models", "GET")
+
+    result = endpoint("ep1", _PinnedFakeRequest(), SimpleNamespace(headers={}))
+
+    assert [row["id"] for row in result] == [
+        "openai/gpt-image-1",
+        "anthropic/claude-sonnet-4",
+    ]
+    assert all(row["picker_requires_pinning"] is True for row in result)
+    assert all(row["is_pinned"] is False for row in result)
+
+
+def test_get_legacy_api_models_preserves_hidden_selection_as_pinned(monkeypatch):
+    ep = _make_endpoint(
+        base_url="https://api.example.test/v1",
+        cached_models=json.dumps(["m1", "m2", "m3"]),
+        hidden_models=json.dumps(["m2"]),
+        pinned_models=None,
+    )
+    db = _PinnedFakeDb([ep])
+    monkeypatch.setattr(model_routes, "SessionLocal", lambda: db)
+    monkeypatch.setattr(model_routes, "require_admin", lambda request: None)
+    endpoint = _get_route("/api/model-endpoints/{ep_id}/models", "GET")
+
+    result = endpoint("ep1", _PinnedFakeRequest(), SimpleNamespace(headers={}))
+
+    by_id = {row["id"]: row for row in result}
+    assert by_id["m1"]["is_pinned"] is True
+    assert by_id["m2"]["is_pinned"] is False
+    assert by_id["m3"]["is_pinned"] is True
+
+
 def test_reprobe_preserves_pinned_models(monkeypatch):
     ep = _make_endpoint(pinned_models=json.dumps(["deploy-1"]))
     db = _PinnedFakeDb([ep])


### PR DESCRIPTION
## Summary

Make the Settings endpoint-model response use the same authoritative allow-list calculation as `/api/models`. Fresh API inventory now renders unchecked until a model is explicitly pinned, while saved pins, explicit empty selections, legacy `hidden_models` state, and local endpoint hide-list behavior keep their existing semantics. This removes the state where Settings shows every cached API model enabled while the chat model picker sees none.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #6086

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.
- [ ] I did not run the app/runtime validation and stated that gap in **How to Test**. Leave this unchecked when the app-run box above is checked.

## How to Test

1. Run `python -m pytest -q tests/test_model_routes.py`; the validated head reports 165 passing tests with one existing SQLAlchemy deprecation warning.
2. Start the app with an API/proxy endpoint that has cached model IDs, no `pinned_models`, and no legacy `hidden_models`; open Settings → Added Models and confirm its inventory is present but every checkbox is unchecked, while the endpoint summary and chat picker report zero enabled models.
3. Check one model and reload both Settings and the chat model picker; confirm the saved model remains checked and is the only model exposed by `/api/models`.
4. Repeat with a legacy API endpoint that has cached models plus a nonempty `hidden_models` list and no explicit pins; confirm the previously visible models remain checked. Confirm a local/self-hosted endpoint still uses its existing hide-list behavior.

The application smoke used an isolated SQLite database, started the real app on loopback, verified fresh cached API inventory was unchecked, saved `m1` through the PATCH route, and confirmed both the Settings read and `/api/models` exposed exactly `m1`. Changed-file compilation and `git diff --check` also pass.

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable: no static, template, style, or rendering files changed. The existing Settings UI now receives the correct persisted checkbox state from its backend response.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

N/A — no rendering code changed.
