### PR TITLE
fix(models): show API models by default

### DIFF
--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -1351,14 +1351,14 @@ def _legacy_visible_api_models(ep) -> List[str]:
 def _picker_models_for_endpoint(ep, base_url: str, kind: str):
     """Return model IDs that should appear in the picker for an endpoint.
 
-    API providers expose remote inventory from /v1/models. Treat that cache as
-    inventory, not approval: only manually pinned API models should appear in
-    the picker. Local/self-hosted endpoints keep the older hide-list behavior.
+    API providers expose remote inventory from /v1/models. Default to that
+    visible inventory until an explicit pinned-model allow-list is saved.
+    Local/self-hosted endpoints keep the older hide-list behavior.
     """
     pinned = _normalize_model_ids(getattr(ep, "pinned_models", None))
     if _picker_requires_pinning(base_url, kind):
         if not _has_explicit_pinned_models(ep):
-            pinned = _legacy_visible_api_models(ep) if _hidden_model_ids(ep) else []
+            pinned = _legacy_visible_api_models(ep)
         return pinned, pinned
     return _visible_models(
         _cached_model_ids(ep),

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -1107,7 +1107,7 @@ def test_get_api_models_marks_picker_as_pinned_only(monkeypatch):
     assert by_id["anthropic/claude-sonnet-4"]["is_pinned"] is False
 
 
-def test_get_fresh_api_models_does_not_mark_cached_inventory_as_pinned(monkeypatch):
+def test_get_fresh_api_models_marks_cached_inventory_as_pinned(monkeypatch):
     ep = _make_endpoint(
         base_url="https://api.example.test/v1",
         cached_models=json.dumps(["openai/gpt-image-1", "anthropic/claude-sonnet-4"]),
@@ -1125,7 +1125,7 @@ def test_get_fresh_api_models_does_not_mark_cached_inventory_as_pinned(monkeypat
         "anthropic/claude-sonnet-4",
     ]
     assert all(row["picker_requires_pinning"] is True for row in result)
-    assert all(row["is_pinned"] is False for row in result)
+    assert all(row["is_pinned"] is True for row in result)
 
 
 def test_get_legacy_api_models_preserves_hidden_selection_as_pinned(monkeypatch):
@@ -1307,7 +1307,7 @@ def test_list_model_endpoints_returns_key_fingerprint(monkeypatch):
     assert result[1]["api_key_fingerprint"] == ""
 
 
-def test_list_api_endpoint_reports_inventory_count_when_none_pinned(monkeypatch):
+def test_list_api_endpoint_defaults_inventory_to_visible_when_none_pinned(monkeypatch):
     ep = _make_endpoint(
         base_url="https://api.example.test/v1",
         cached_models=json.dumps(["openai/gpt-image-1", "anthropic/claude-sonnet-4"]),
@@ -1320,10 +1320,29 @@ def test_list_api_endpoint_reports_inventory_count_when_none_pinned(monkeypatch)
 
     result = endpoint(_PinnedFakeRequest())
 
-    assert result[0]["models"] == []
+    assert result[0]["models"] == [
+        "openai/gpt-image-1",
+        "anthropic/claude-sonnet-4",
+    ]
+    assert result[0]["pinned_models"] == result[0]["models"]
     assert result[0]["model_count"] == 2
     assert result[0]["picker_requires_pinning"] is True
     assert result[0]["status"] == "online"
+
+
+def test_api_picker_preserves_explicit_empty_selection():
+    ep = _make_endpoint(
+        base_url="https://api.example.test/v1",
+        cached_models=json.dumps(["openai/gpt-image-1", "anthropic/claude-sonnet-4"]),
+        pinned_models=json.dumps([]),
+    )
+
+    models, pinned = model_routes._picker_models_for_endpoint(
+        ep, ep.base_url, ep.endpoint_kind
+    )
+
+    assert models == []
+    assert pinned == []
 
 
 def test_list_api_endpoint_returns_pinned_picker_models(monkeypatch):
@@ -1808,7 +1827,7 @@ def test_api_models_openrouter_uses_pinned_models_not_hidden(monkeypatch):
     assert result["items"][0]["models"] == ["openai/gpt-image-1"]
 
 
-def test_api_models_openrouter_derives_legacy_visible_models(monkeypatch):
+def test_api_models_openrouter_defaults_cached_models_visible(monkeypatch):
     row = _route_ep(
         "openrouter",
         "https://openrouter.ai/api/v1",
@@ -1816,7 +1835,6 @@ def test_api_models_openrouter_derives_legacy_visible_models(monkeypatch):
         pinned_models=None,
         api_key="fake-key",
     )
-    row.hidden_models = json.dumps(["m2"])
     db = _RouteDb([row])
     router = model_routes.setup_model_routes(model_discovery=None)
 
@@ -1829,7 +1847,7 @@ def test_api_models_openrouter_derives_legacy_visible_models(monkeypatch):
     result = _route_endpoint(router, "/api/models")(_route_request())
 
     assert result["items"][0]["endpoint_name"] == "openrouter"
-    assert result["items"][0]["models"] == ["m1", "m3"]
+    assert result["items"][0]["models"] == ["m1", "m2", "m3"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Default API endpoints to their cached visible model catalog when no `pinned_models` selection has been saved. This is a direct policy follow-up to #6087: Settings and `/api/models` continue using the same picker-state calculation, while an explicitly saved empty selection still means that no models are enabled.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

No issue — direct follow-up to #6087.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.
- [ ] I did not run the app/runtime validation and stated that gap in **How to Test**. Leave this unchecked when the app-run box above is checked.

## How to Test

1. Run `python -m pytest -q tests/test_model_routes.py`; the validated branch reports 166 passing tests with one existing SQLAlchemy deprecation warning.
2. Start the app with an isolated data directory and an API endpoint whose model catalog returns `m1` and `m2`; before saving a model selection, confirm `/api/models` exposes both models and `/api/model-endpoints/{id}/models` reports both as pinned.
3. Save `{"pinned_models":[]}` through the endpoint-model PATCH route and confirm `/api/models` exposes no models for that endpoint.

The live smoke ran the actual app with auth and built-in MCP disabled against an isolated local provider, exercising endpoint creation, `/api/models`, the Settings model response, and the explicit-empty PATCH transition. `python -m py_compile routes/model_routes.py` and `git diff --check` also pass.

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable: no static, template, style, or rendering files changed. Existing Settings and picker surfaces receive the revised backend default state.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

N/A — no rendering code changed.
