### PR TITLE
fix(chat): keep streamed activity in view

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -330,7 +330,13 @@ function initializeEventListeners() {
   el('chat-history').addEventListener('scroll', uiModule.debounce(() => {
     const box = el('chat-history');
     const atBottom = box.scrollHeight - box.scrollTop - box.clientHeight < 80;
-    uiModule.setAutoScroll(atBottom);
+    if (atBottom) {
+      uiModule.setAutoScroll(true);
+    } else if (!uiModule.isAutoScrollAnimating()) {
+      // A scrollbar drag or keyboard scroll has no wheel/touch signal. Do not
+      // mistake frames from our own smooth scroll for user intent.
+      uiModule.setAutoScroll(false);
+    }
   }, 100));
   // Close all footer popups immediately on any scroll
   el('chat-history').addEventListener('scroll', () => {

--- a/static/index.html
+++ b/static/index.html
@@ -1340,17 +1340,27 @@
 
     bottomBtn.addEventListener('click', () => {
       cancelAutoScroll();
-      const target = container.scrollHeight - container.clientHeight;
+      if (window.uiModule && window.uiModule.setAutoScroll && window.uiModule.scrollHistory) {
+        window.uiModule.setAutoScroll(true);
+        window.uiModule.scrollHistory();
+        return;
+      }
       _scrollingToBottom = true;
       function step() {
         if (!_scrollingToBottom) return;
+        const target = container.scrollHeight - container.clientHeight;
         const diff = target - container.scrollTop;
         if (diff <= 8) { container.scrollTop = target; _scrollingToBottom = false; return; }
         container.scrollTop += diff * 0.2;
         _scrollRaf = requestAnimationFrame(step);
       }
       step();
-      _scrollTimeout = setTimeout(() => { if (_scrollingToBottom) { container.scrollTop = target; _scrollingToBottom = false; } }, 1500);
+      _scrollTimeout = setTimeout(() => {
+        if (_scrollingToBottom) {
+          container.scrollTop = container.scrollHeight - container.clientHeight;
+          _scrollingToBottom = false;
+        }
+      }, 1500);
     });
     new ResizeObserver(reposition).observe(chatBar);
     new MutationObserver(update).observe(container, {childList:true, subtree:true});

--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -2318,13 +2318,13 @@ import { loadPanel } from './panels.js';
 
       // Auto-show thinking spinner after text stops streaming
       let _textPauseTimer = null;
-      function _scheduleThinkingSpinner() {
+      function _scheduleThinkingSpinner(delayMs = 400) {
         if (_textPauseTimer) clearTimeout(_textPauseTimer);
         _textPauseTimer = setTimeout(() => {
           if (!document.querySelector('.agent-thinking-dots') && isStreaming) {
             _showThinkingSpinner(_thinkingLabel());
           }
-        }, 400);
+        }, delayMs);
       }
       _cancelThinkingTimer = () => {
         if (_textPauseTimer) { clearTimeout(_textPauseTimer); _textPauseTimer = null; }
@@ -3759,9 +3759,11 @@ import { loadPanel } from './panels.js';
                   });
                 }
 
-                // Schedule a thinking spinner between tool rounds (short delay so
-                // agent_step in the same SSE chunk can cancel it before it shows)
-                _scheduleThinkingSpinner();
+                // Put the next assistant activity bubble at the transcript
+                // bottom as soon as a tool settles. If agent_step is already
+                // queued in this SSE batch it cancels this zero-delay task and
+                // creates the normal continuation bubble instead.
+                _scheduleThinkingSpinner(0);
                 uiModule.scrollHistory();
 
               } else if (json.type === 'doc_stream_open') {

--- a/static/js/chatAutoScroll.js
+++ b/static/js/chatAutoScroll.js
@@ -1,0 +1,67 @@
+// Chat transcript auto-scroll state. Kept DOM-light so streaming callers can
+// share one animation without dropping later height changes from tool cards.
+
+export function createChatAutoScroller({
+  getBox = () => document.getElementById('chat-history'),
+  requestFrame = (callback) => requestAnimationFrame(callback),
+  cancelFrame = (frameId) => cancelAnimationFrame(frameId),
+  isCompactViewport = () => window.innerWidth <= 768,
+} = {}) {
+  let enabled = true;
+  let frameId = null;
+  let box = null;
+
+  function resolveBox() {
+    if (!box || !box.isConnected) box = getBox();
+    return box;
+  }
+
+  function step() {
+    frameId = null;
+    const targetBox = resolveBox();
+    if (!targetBox || !enabled) return;
+
+    // Recalculate on every frame. A tool card, progress tail, or reply bubble
+    // can grow while this animation is already in flight.
+    const target = Math.max(0, targetBox.scrollHeight - targetBox.clientHeight);
+    const current = targetBox.scrollTop;
+    const diff = target - current;
+    if (Math.abs(diff) <= 1) {
+      targetBox.scrollTop = target;
+      return;
+    }
+
+    const factor = isCompactViewport() ? 0.4 : 0.2;
+    targetBox.scrollTop = current + diff * factor;
+    frameId = requestFrame(step);
+  }
+
+  function scroll() {
+    if (!enabled || !resolveBox() || frameId !== null) return;
+    frameId = requestFrame(step);
+  }
+
+  function scrollInstant() {
+    const targetBox = resolveBox();
+    if (!targetBox) return;
+    targetBox.scrollTop = Math.max(0, targetBox.scrollHeight - targetBox.clientHeight);
+  }
+
+  function setEnabled(nextEnabled) {
+    enabled = !!nextEnabled;
+    if (!enabled && frameId !== null) {
+      cancelFrame(frameId);
+      frameId = null;
+    }
+  }
+
+  return {
+    scroll,
+    scrollInstant,
+    setEnabled,
+    isEnabled: () => enabled,
+    isAnimating: () => frameId !== null,
+  };
+}
+
+export default createChatAutoScroller;

--- a/static/js/chatAutoScroll.js
+++ b/static/js/chatAutoScroll.js
@@ -25,14 +25,22 @@ export function createChatAutoScroller({
     if (enabled) setEnabled(false);
   }
 
+  function handleContentLoad() {
+    if (enabled) scroll();
+  }
+
   function resolveBox() {
     if (!box || !box.isConnected) {
       if (box && box.removeEventListener) {
         box.removeEventListener('scroll', handleBoxScroll);
+        box.removeEventListener('load', handleContentLoad, true);
       }
       box = getBox();
       if (box && box.addEventListener) {
         box.addEventListener('scroll', handleBoxScroll, { passive: true });
+        // Descendant image/media load events do not bubble, so capture them.
+        // If auto-follow is still enabled, restart after late height growth.
+        box.addEventListener('load', handleContentLoad, true);
       }
     }
     return box;

--- a/static/js/chatAutoScroll.js
+++ b/static/js/chatAutoScroll.js
@@ -10,10 +10,37 @@ export function createChatAutoScroller({
   let enabled = true;
   let frameId = null;
   let box = null;
+  let expectedScrollTop = null;
+
+  function handleBoxScroll() {
+    if (!box) return;
+    if (
+      expectedScrollTop !== null
+      && Math.abs(box.scrollTop - expectedScrollTop) <= 1
+    ) {
+      expectedScrollTop = null;
+      return;
+    }
+    expectedScrollTop = null;
+    if (enabled) setEnabled(false);
+  }
 
   function resolveBox() {
-    if (!box || !box.isConnected) box = getBox();
+    if (!box || !box.isConnected) {
+      if (box && box.removeEventListener) {
+        box.removeEventListener('scroll', handleBoxScroll);
+      }
+      box = getBox();
+      if (box && box.addEventListener) {
+        box.addEventListener('scroll', handleBoxScroll, { passive: true });
+      }
+    }
     return box;
+  }
+
+  function writeScrollTop(targetBox, nextScrollTop) {
+    expectedScrollTop = nextScrollTop;
+    targetBox.scrollTop = nextScrollTop;
   }
 
   function step() {
@@ -27,12 +54,12 @@ export function createChatAutoScroller({
     const current = targetBox.scrollTop;
     const diff = target - current;
     if (Math.abs(diff) <= 1) {
-      targetBox.scrollTop = target;
+      writeScrollTop(targetBox, target);
       return;
     }
 
     const factor = isCompactViewport() ? 0.4 : 0.2;
-    targetBox.scrollTop = current + diff * factor;
+    writeScrollTop(targetBox, current + diff * factor);
     frameId = requestFrame(step);
   }
 
@@ -44,11 +71,15 @@ export function createChatAutoScroller({
   function scrollInstant() {
     const targetBox = resolveBox();
     if (!targetBox) return;
-    targetBox.scrollTop = Math.max(0, targetBox.scrollHeight - targetBox.clientHeight);
+    writeScrollTop(
+      targetBox,
+      Math.max(0, targetBox.scrollHeight - targetBox.clientHeight),
+    );
   }
 
   function setEnabled(nextEnabled) {
     enabled = !!nextEnabled;
+    if (!enabled) expectedScrollTop = null;
     if (!enabled && frameId !== null) {
       cancelFrame(frameId);
       frameId = null;

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -9,18 +9,16 @@ import * as Modals from './modalManager.js';
 import spinnerModule from './spinner.js';
 import { registerMenuDismiss, dismissTopMenu, dismissOrRemove } from './escMenuStack.js';
 import { nextToolWindowZ, topToolWindowZ } from './toolWindowZOrder.js';
+import { createChatAutoScroller } from './chatAutoScroll.js';
 
 let toastEl = null;
-let autoScrollEnabled = true;
 let hoveredToggleCard = null;
 let hoveredToggleWindow = null;
 let hoveredDockChip = null;
 let _lastPointerClientX = null;
 let _lastPointerClientY = null;
 
-// Smooth scroll state
-let _scrollRafId = null;
-let _scrollBox = null;
+const _chatAutoScroller = createChatAutoScroller();
 
 function _isTextEditingTarget(target) {
   const el = target && target.nodeType === 1 ? target : target?.parentElement;
@@ -450,49 +448,10 @@ export function showError(msg) {
 }
 
 /**
- * Smooth-scroll chat history to bottom using rAF lerp.
- * Throttled during streaming so it doesn't fight user scrolling.
+ * Smooth-scroll chat history to bottom using the shared rAF controller.
  */
-let _scrollThrottleTimer = null;
 export function scrollHistory() {
-  if (!autoScrollEnabled) return;
-  if (!_scrollBox) {
-    _scrollBox = document.getElementById('chat-history');
-  }
-  // Throttle: only start a new scroll animation every 500ms
-  if (_scrollThrottleTimer) return;
-  _scrollThrottleTimer = setTimeout(() => { _scrollThrottleTimer = null; }, 500);
-  if (!_scrollRafId) {
-    _scrollRafId = requestAnimationFrame(_smoothScrollStep);
-  }
-}
-
-function _smoothScrollStep() {
-  const box = _scrollBox;
-  if (!box || !autoScrollEnabled) {
-    _scrollRafId = null;
-    return;
-  }
-  const target = box.scrollHeight - box.clientHeight;
-  const current = box.scrollTop;
-  const diff = target - current;
-
-  // If user scrolled up significantly, don't force them down
-  if (diff > 300) {
-    _scrollRafId = null;
-    return;
-  }
-
-  if (diff <= 1) {
-    box.scrollTop = target;
-    _scrollRafId = null;
-    return;
-  }
-
-  // Lerp: gentle catch-up
-  const factor = window.innerWidth <= 768 ? 0.4 : 0.2;
-  box.scrollTop = current + diff * factor;
-  _scrollRafId = requestAnimationFrame(_smoothScrollStep);
+  _chatAutoScroller.scroll();
 }
 
 /**
@@ -500,26 +459,25 @@ function _smoothScrollStep() {
  * like loading history or switching sessions.
  */
 export function scrollHistoryInstant() {
-  if (!_scrollBox) {
-    _scrollBox = document.getElementById('chat-history');
-  }
-  if (_scrollBox) {
-    _scrollBox.scrollTop = _scrollBox.scrollHeight;
-  }
+  _chatAutoScroller.scrollInstant();
 }
 
 /**
  * Enable/disable auto-scroll
  */
 export function setAutoScroll(enabled) {
-  autoScrollEnabled = enabled;
+  _chatAutoScroller.setEnabled(enabled);
 }
 
 /**
  * Get auto-scroll state
  */
 export function getAutoScroll() {
-  return autoScrollEnabled;
+  return _chatAutoScroller.isEnabled();
+}
+
+export function isAutoScrollAnimating() {
+  return _chatAutoScroller.isAnimating();
 }
 
 /**
@@ -865,6 +823,7 @@ const uiModule = {
   scrollHistoryInstant,
   setAutoScroll,
   getAutoScroll,
+  isAutoScrollAnimating,
   autoResize,
   debounce,
   el,

--- a/static/style.css
+++ b/static/style.css
@@ -1912,7 +1912,7 @@ body.bg-pattern-sparkles {
       min-height:0;
       --chat-max: 800px;
       padding-left: max(0px, calc((100% - var(--chat-max)) / 2));
-      padding-right: max(12px, calc((100% - var(--chat-max)) / 2 + 12px));
+      padding-right: max(0px, calc((100% - var(--chat-max)) / 2));
     }
     .chat-history > * {
       flex: 0 0 auto;

--- a/static/sw.js
+++ b/static/sw.js
@@ -7,7 +7,7 @@
 //   - Other static assets (images/fonts/libs): cache-first with bg refresh.
 //   - API / non-GET: never cached.
 // Bump CACHE_NAME whenever the precache list or SW logic changes.
-const CACHE_NAME = 'odysseus-v380-shared-config-image-editor-lazy-katex-mermaid';
+const CACHE_NAME = 'odysseus-v381-chat-auto-scroll';
 
 // KaTeX resolves these from its own stylesheet, so caching the CSS without them
 // gives offline math fallback glyphs instead of proper typesetting.
@@ -44,6 +44,7 @@ const PRECACHE = [
   '/static/js/storage.js',
   '/static/js/appConfig.js',
   '/static/js/ui.js',
+  '/static/js/chatAutoScroll.js',
   '/static/js/markdown.js',
   '/static/js/dragSort.js',
   '/static/js/sessions.js',

--- a/tests/test_chat_auto_scroll_js.py
+++ b/tests/test_chat_auto_scroll_js.py
@@ -1,0 +1,150 @@
+"""Exercise the transcript auto-scroll controller with a manually pumped frame clock."""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+_REPO = Path(__file__).resolve().parent.parent
+_MODULE_URL = (_REPO / "static" / "js" / "chatAutoScroll.js").as_uri()
+_HAS_NODE = shutil.which("node") is not None
+
+
+_HARNESS = r"""
+import { createChatAutoScroller } from 'MODULE_URL';
+
+function makeCase({ scrollHeight, clientHeight, scrollTop = 0, compact = false }) {
+  const frames = new Map();
+  let nextFrame = 1;
+  const box = { scrollHeight, clientHeight, scrollTop, isConnected: true };
+  const scroller = createChatAutoScroller({
+    getBox: () => box,
+    requestFrame(callback) {
+      const id = nextFrame++;
+      frames.set(id, callback);
+      return id;
+    },
+    cancelFrame(id) { frames.delete(id); },
+    isCompactViewport: () => compact,
+  });
+  return {
+    box,
+    scroller,
+    pump(limit = 200) {
+      let count = 0;
+      while (frames.size && count < limit) {
+        const current = [...frames.entries()];
+        frames.clear();
+        for (const [, callback] of current) callback();
+        count += 1;
+      }
+      return count;
+    },
+    pending: () => frames.size,
+  };
+}
+
+const results = {};
+
+{
+  const c = makeCase({ scrollHeight: 1600, clientHeight: 500 });
+  c.scroller.scroll();
+  const frames = c.pump();
+  results.largeGap = { scrollTop: c.box.scrollTop, frames, pending: c.pending() };
+}
+
+{
+  const c = makeCase({ scrollHeight: 900, clientHeight: 500 });
+  c.scroller.scroll();
+  c.pump(2);
+  c.box.scrollHeight = 1800;
+  const framesAfterGrowth = c.pump();
+  results.dynamicGrowth = { scrollTop: c.box.scrollTop, framesAfterGrowth, pending: c.pending() };
+}
+
+{
+  const c = makeCase({ scrollHeight: 1600, clientHeight: 500 });
+  c.scroller.scroll();
+  c.pump(2);
+  const beforeDisable = c.box.scrollTop;
+  c.scroller.setEnabled(false);
+  c.pump();
+  results.disabled = {
+    beforeDisable,
+    afterDisable: c.box.scrollTop,
+    enabled: c.scroller.isEnabled(),
+    animating: c.scroller.isAnimating(),
+  };
+}
+
+console.log(JSON.stringify(results));
+""".replace("MODULE_URL", _MODULE_URL)
+
+
+def _run_harness() -> dict:
+    proc = subprocess.run(
+        ["node", "--input-type=module"],
+        input=_HARNESS,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        cwd=str(_REPO),
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_large_stream_growth_reaches_bottom_without_a_distance_cutoff():
+    result = _run_harness()["largeGap"]
+    assert result["scrollTop"] == pytest.approx(1100, abs=1)
+    assert result["frames"] > 1
+    assert result["pending"] == 0
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_inflight_scroll_tracks_tool_card_and_reply_growth():
+    result = _run_harness()["dynamicGrowth"]
+    assert result["scrollTop"] == pytest.approx(1300, abs=1)
+    assert result["framesAfterGrowth"] > 1
+    assert result["pending"] == 0
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_user_scroll_disable_cancels_the_active_animation():
+    result = _run_harness()["disabled"]
+    assert result["afterDisable"] == result["beforeDisable"]
+    assert result["enabled"] is False
+    assert result["animating"] is False
+
+
+def test_tool_completion_schedules_the_next_activity_bubble_without_delay():
+    source = (_REPO / "static" / "js" / "chat.js").read_text(encoding="utf-8")
+    tool_output = source.split("} else if (json.type === 'tool_output') {", 1)[1].split(
+        "} else if (json.type === 'doc_stream_open') {", 1
+    )[0]
+    assert "_scheduleThinkingSpinner(0);" in tool_output
+
+
+def test_programmatic_scroll_frames_do_not_turn_off_auto_scroll():
+    source = (_REPO / "static" / "app.js").read_text(encoding="utf-8")
+    handler = source.split("// Scrolling", 1)[1].split(
+        "// Close all footer popups", 1
+    )[0]
+    assert "else if (!uiModule.isAutoScrollAnimating())" in handler
+
+
+def test_history_and_composer_use_the_same_horizontal_track():
+    css = (_REPO / "static" / "style.css").read_text(encoding="utf-8")
+    history = css.split(".chat-history {", 1)[1].split("}", 1)[0]
+    assert "padding-left: max(0px, calc((100% - var(--chat-max)) / 2));" in history
+    assert "padding-right: max(0px, calc((100% - var(--chat-max)) / 2));" in history
+
+
+def test_auto_scroll_module_is_available_in_the_offline_app_shell():
+    service_worker = (_REPO / "static" / "sw.js").read_text(encoding="utf-8")
+    assert "'/static/js/chatAutoScroll.js'," in service_worker


### PR DESCRIPTION
## Summary

This replaces the throttled, distance-limited transcript scroller with one shared controller that follows live height growth, ignores its own programmatic scroll frames, and keeps the next assistant activity state visible as soon as a tool completes. It also aligns the transcript with the composer track, makes the scroll-bottom control follow later growth, and precaches the new browser module for offline reloads.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #6096

Part of #6094

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.
- [x] I did not run the app/runtime validation and stated that gap in **How to Test**. Leave this unchecked when the app-run box above is checked.

## How to Test

1. Run `pytest -q tests/test_chat_auto_scroll_js.py tests/test_chat_stream_scope.py tests/test_live_thinking_chat_integration.py tests/test_live_thinking_scheduler_js.py tests/test_modal_dock_composer_clearance.py tests/test_agent_thread_dot_alignment_css.py tests/test_chat_stream_errors_js.py tests/test_chat_model_provenance_js.py tests/test_chat_tool_screenshot_xss.py tests/test_composer_arrow_up_recall_js.py tests/test_new_chat_clears_input.py tests/test_web_search_tool_icon_js.py`.
2. Run `node --check static/app.js && node --check static/js/ui.js && node --check static/js/chat.js && node --check static/js/chatAutoScroll.js && node --check static/sw.js`.
3. In an Agent chat, remain at the bottom and run a file/tool request whose result expands by more than one viewport. Confirm the outer transcript continues to the live bottom and a normal assistant activity indicator appears immediately after tool completion.
4. Scroll up with the mouse wheel, keyboard, scrollbar, and touch gesture while a response streams. Confirm the app respects that opt-out, then use the scroll-bottom control and confirm it follows later content growth.
5. Compare the transcript and composer tracks at desktop width, then reload once with the service worker active and confirm the new module loads without a missing-resource error.

The focused controller and integration tests passed in a network-disabled isolated environment, but no browser engine is installed there, so running-app desktop/mobile validation and exact-branch visual evidence remain pending.

## Visual / UI changes — REQUIRED if you touched anything that renders

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

Pending an exact-branch desktop clip showing large tool-output growth, the immediate continuation state, manual scroll-up opt-out, and the aligned composer/transcript track. The prior clip on #5972 demonstrates the old symptom but is not evidence for this candidate branch.
