### PR TITLE
fix(chat): retain composer focus after send

### DIFF
--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -847,6 +847,18 @@ import { loadPanel } from './panels.js';
   var hideWelcomeScreen = chatRenderer.hideWelcomeScreen;
   var showWelcomeScreen = chatRenderer.showWelcomeScreen;
 
+  function _restoreComposerFocus(messageInput) {
+    // Keep the mobile keyboard policy unchanged: focusing a textarea opens the
+    // on-screen keyboard over the response even when preventScroll is set.
+    if (!messageInput || messageInput.disabled || window.innerWidth <= 768) return false;
+    try {
+      messageInput.focus({ preventScroll: true });
+    } catch (_) {
+      messageInput.focus();
+    }
+    return true;
+  }
+
   /**
    * Update submit button state
    */
@@ -1280,7 +1292,10 @@ import { loadPanel } from './panels.js';
     const _releaseSendFlag = () => {
       _sendInFlight = false;
       _syncForegroundStreamGlobals();
-      if (_earlyMessageInput) _earlyMessageInput.disabled = false;
+      if (_earlyMessageInput) {
+        _earlyMessageInput.disabled = false;
+        _restoreComposerFocus(_earlyMessageInput);
+      }
       if (submitBtn) submitBtn.classList.remove('send-pending');
     };
 
@@ -1622,26 +1637,15 @@ import { loadPanel } from './panels.js';
       messageInput.value = approvalForSend ? (approvalForSend.draft || '') : '';
       messageInput.style.height = '';
       messageInput.dispatchEvent(new Event('input'));
-      // Mobile: dismiss the on-screen keyboard after sending. iOS in
-      // particular ignores a bare blur() in some cases (or some other
-      // listener refocuses straight after), so we temporarily mark the
-      // input readonly which forces the keyboard to retract, then blur,
-      // then drop the readonly attribute after the keyboard is gone so
-      // typing still works for the next message.
+      // Mobile intentionally dismisses the on-screen keyboard after sending.
+      // iOS may ignore a bare blur, so readonly forces the keyboard down until
+      // the next deliberate tap.
       if (window.innerWidth <= 768) {
         try {
           messageInput.setAttribute('readonly', 'readonly');
           messageInput.blur();
           const _dropReadonly = () => { try { messageInput.removeAttribute('readonly'); } catch {} };
           setTimeout(() => {
-            // If the blur stuck, the input is no longer the active element —
-            // safe to drop readonly now so the next message can be typed.
-            // If it did NOT stick (some mobile browsers keep the textarea
-            // focused after a programmatic blur), removing readonly here would
-            // re-summon the keyboard mid-stream — the "bounce up" that then
-            // lingers until the end-of-stream blur. In that case keep readonly
-            // on (keyboard stays down) and drop it the moment the user taps to
-            // type again, so typing still works without the bounce.
             if (document.activeElement === messageInput) {
               messageInput.addEventListener('pointerdown', _dropReadonly, { once: true });
               messageInput.addEventListener('focus', _dropReadonly, { once: true });
@@ -1651,6 +1655,10 @@ import { loadPanel } from './panels.js';
           }, 120);
         } catch {}
       }
+      // Disabling the textarea during preflight drops desktop focus. Restore
+      // it without scrolling the transcript so the next prompt can be typed
+      // while this response streams.
+      _restoreComposerFocus(messageInput);
 
       let ids = [];
       if (!approvalForSend) {
@@ -4588,14 +4596,11 @@ import { loadPanel } from './panels.js';
         // Reset button to idle state
         updateSubmitButton('idle', submitBtn);
 
-        // Re-enable message input; on mobile blur to dismiss keyboard
+        // Re-enable without stealing desktop focus from wherever the user
+        // moved while streaming. Preserve the mobile keyboard dismissal.
         if (messageInput) {
           messageInput.disabled = false;
-          if (window.innerWidth <= 768) {
-            messageInput.blur();
-          } else {
-            messageInput.focus();
-          }
+          if (window.innerWidth <= 768) messageInput.blur();
         }
 
         // Clear tracking variables

--- a/tests/test_chat_composer_focus.py
+++ b/tests/test_chat_composer_focus.py
@@ -1,0 +1,61 @@
+"""Regression guards for retaining chat-composer focus after submit."""
+
+from pathlib import Path
+
+
+_CHAT_PATH = Path(__file__).resolve().parent.parent / "static" / "js" / "chat.js"
+
+
+def _function_body(source: str, function_name: str) -> str:
+    start = source.index(f"function {function_name}(")
+    brace = source.index("{", start)
+    depth = 0
+    for index in range(brace, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+    raise AssertionError(f"unbalanced function {function_name}")
+
+
+def test_focus_restore_avoids_moving_the_transcript():
+    source = _CHAT_PATH.read_text(encoding="utf-8")
+    helper = _function_body(source, "_restoreComposerFocus")
+    assert "messageInput.disabled" in helper
+    assert "window.innerWidth <= 768" in helper
+    assert "messageInput.focus({ preventScroll: true });" in helper
+    assert "messageInput.focus();" in helper
+
+
+def test_normal_send_refocuses_after_clearing_the_composer():
+    source = _CHAT_PATH.read_text(encoding="utf-8")
+    clear = "messageInput.dispatchEvent(new Event('input'));"
+    restore = "_restoreComposerFocus(messageInput);"
+    start = source.index("const userDisplay = _displayOverride || msg;")
+    upload = source.index("let ids = [];", start)
+    send_clear_path = source[start:upload]
+    assert clear in send_clear_path
+    assert restore in send_clear_path
+    assert send_clear_path.index(clear) < send_clear_path.index(restore)
+
+
+def test_send_path_preserves_mobile_keyboard_dismissal():
+    source = _CHAT_PATH.read_text(encoding="utf-8")
+    start = source.index("const userDisplay = _displayOverride || msg;")
+    upload = source.index("let ids = [];", start)
+    send_clear_path = source[start:upload]
+    assert "if (window.innerWidth <= 768)" in send_clear_path
+    assert "messageInput.blur()" in send_clear_path
+    assert "setAttribute('readonly'" in send_clear_path
+
+
+def test_stream_completion_does_not_override_the_users_focus_choice():
+    source = _CHAT_PATH.read_text(encoding="utf-8")
+    start = source.index("// Re-enable without stealing desktop focus")
+    end = source.index("// Clear tracking variables", start)
+    completion = source[start:end]
+    assert "messageInput.disabled = false;" in completion
+    assert "messageInput.focus" not in completion
+    assert "if (window.innerWidth <= 768) messageInput.blur();" in completion


### PR DESCRIPTION
## Summary

This restores desktop composer focus with `preventScroll` immediately after the submitted prompt is cleared, allowing the next prompt to be typed while the response streams. It preserves the existing mobile readonly/blur keyboard dismissal and removes the late desktop completion-time focus steal so a later user focus choice remains intact.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #6095

Part of #6094

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.
- [x] I did not run the app/runtime validation and stated that gap in **How to Test**. Leave this unchecked when the app-run box above is checked.

## How to Test

1. Run `pytest -q tests/test_chat_composer_focus.py tests/test_chat_stream_scope.py tests/test_chat_stream_errors_js.py tests/test_composer_arrow_up_recall_js.py tests/test_new_chat_clears_input.py`.
2. Run `node --check static/js/chat.js`.
3. At a desktop width above 768 px, focus the composer, send a prompt, and immediately type a second prompt without clicking the textarea. Confirm the second prompt appears and the transcript does not jump.
4. While the first response streams, deliberately focus another control. Confirm stream completion does not steal focus back to the composer.
5. At a mobile width of 768 px or below, send a prompt and confirm the on-screen keyboard dismisses without reopening over the response; tap the composer and confirm it accepts the next prompt normally.

The focused composer and adjacent chat tests passed in a network-disabled isolated environment, but no browser engine is installed there, so running-app desktop/mobile validation and an exact-branch interaction clip remain pending.

## Visual / UI changes — REQUIRED if you touched anything that renders

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

Pending exact-branch desktop and mobile clips showing immediate second-prompt typing, no completion-time focus steal, and preserved mobile keyboard dismissal.
