### PR TITLE
fix(cookbook): stop Windows serve by listening port owner

### DIFF
--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -144,8 +144,83 @@ def _append_venv_nvidia_library_path_lines(lines: list[str], *, cmd: str = "") -
 
 
 def _serve_port_from_cmd(cmd: str) -> str:
-    m = re.search(r"--port(?:=|\s+)(\d+)", cmd or "")
-    return m.group(1) if m else ""
+    command = cmd or ""
+    for pattern in (
+        r"--port(?:=|\s+)(\d+)",
+        r"(?:^|\s)-p(?:=|\s+)(\d+)",
+        r"OLLAMA_HOST\s*=\s*(?:['\"])?(?:\[[^\]]+\]|[^:\s'\"]+):(\d+)(?:['\"])?",
+    ):
+        match = re.search(pattern, command, re.IGNORECASE)
+        if match:
+            return match.group(1)
+    if re.search(r"\bollama\s+serve\b", command, re.IGNORECASE):
+        return "11434"
+    if re.search(r"\bdocker\s+exec\s+(?:ollama-rocm|ollama-test)\b", command, re.IGNORECASE):
+        return "11434"
+    return ""
+
+
+def _serve_launch_result(
+    *, session_id: str, remote: str | None, endpoint_id: str | None, cmd: str
+) -> dict:
+    """Return the exact launch metadata the browser must persist for Stop."""
+    runtime_port = _serve_port_from_cmd(cmd)
+    return {
+        "ok": True,
+        "session_id": session_id,
+        "remote": remote or "local",
+        "endpoint_id": endpoint_id,
+        "effective_cmd": cmd,
+        "runtime_port": int(runtime_port) if runtime_port else None,
+    }
+
+
+def _windows_serve_command_lines(cmd: str) -> list[str]:
+    """Translate the validated canonical Ollama bind prefix for PowerShell.
+
+    The response keeps the POSIX-style ``OLLAMA_HOST=... ollama serve`` form so
+    restart can safely submit it through the normal command validator. Only the
+    generated remote-Windows runner needs PowerShell assignment syntax.
+    """
+    command = (cmd or "").strip()
+    match = re.fullmatch(
+        r"OLLAMA_HOST\s*=\s*(['\"]?)([^\s'\"]+)\1\s+(ollama\s+serve(?:\s+.*)?)",
+        command,
+        re.IGNORECASE,
+    )
+    if not match:
+        return [command]
+    return [
+        f"$env:OLLAMA_HOST = '{_ps_squote(match.group(2))}'",
+        match.group(3),
+    ]
+
+
+def _remote_ollama_port_probe_command(
+    start_port: int,
+    max_offset: int,
+    *,
+    is_windows: bool,
+) -> str:
+    """Build the target-shell command used to choose an unused Ollama port."""
+    probe_values = [start_port + i for i in range(max_offset + 1)]
+    if is_windows:
+        import base64
+        ps = (
+            "$used = @([System.Net.NetworkInformation.IPGlobalProperties]::"
+            "GetIPGlobalProperties().GetActiveTcpListeners() | "
+            "ForEach-Object { $_.Port }); "
+            f"foreach ($p in @({','.join(str(p) for p in probe_values)})) {{ "
+            "if ($used -notcontains $p) { Write-Output $p; exit 0 } }; exit 1"
+        )
+        encoded = base64.b64encode(ps.encode("utf-16le")).decode("ascii")
+        return f"powershell -NoProfile -NonInteractive -EncodedCommand {encoded}"
+    probe_ports = " ".join(str(p) for p in probe_values)
+    return (
+        f"for p in {probe_ports}; do "
+        "if ! (exec 3<>/dev/tcp/127.0.0.1/$p) 2>/dev/null; then "
+        "echo $p; exit 0; fi; exec 3<&-; exec 3>&-; done; exit 1"
+    )
 
 
 def _append_openai_port_preflight_lines(lines: list[str], *, cmd: str, expected_model: str) -> None:
@@ -1524,9 +1599,9 @@ def setup_cookbook_routes() -> APIRouter:
         from core.database import SessionLocal, ModelEndpoint
         from src.settings import load_settings, save_settings
 
-        # Parse port from command (--port NNNN), default 8100 for diffusion_server
-        port_match = re.search(r'--port\s+(\d+)', req.cmd)
-        port = int(port_match.group(1)) if port_match else 8100
+        # Use the same parser as task persistence and stop verification.
+        parsed_port = _serve_port_from_cmd(req.cmd)
+        port = int(parsed_port) if parsed_port else 8100
 
         # Determine host
         if remote:
@@ -1593,7 +1668,12 @@ def setup_cookbook_routes() -> APIRouter:
             db.close()
 
     def _pick_free_port_for_ollama(
-        remote: str | None, ssh_port: str | None, start_port: int, max_offset: int
+        remote: str | None,
+        ssh_port: str | None,
+        start_port: int,
+        max_offset: int,
+        *,
+        is_windows: bool = False,
     ) -> int | None:
         """Return the first free port in [start_port, start_port+max_offset] on
         the target host. Used to pick a real bind for `ollama serve` so we
@@ -1601,8 +1681,9 @@ def setup_cookbook_routes() -> APIRouter:
         Cookbook Stop button can't kill."""
         import socket
         if remote:
-            # Probe over SSH. Bash's /dev/tcp gives a portable "is anything
-            # listening" check without requiring ss/netstat/nmap.
+            # Probe over SSH. Remote Windows uses a PowerShell/.NET listener
+            # query; POSIX targets use Bash's /dev/tcp without requiring
+            # ss/netstat/nmap.
             ssh_base = ["ssh", "-o", "ConnectTimeout=4", "-o", "StrictHostKeyChecking=no"]
             if ssh_port and str(ssh_port) != "22":
                 try:
@@ -1616,11 +1697,10 @@ def setup_cookbook_routes() -> APIRouter:
                 return None
             if not host_arg:
                 return None
-            probe_ports = " ".join(str(start_port + i) for i in range(max_offset + 1))
-            script = (
-                f"for p in {probe_ports}; do "
-                "if ! (exec 3<>/dev/tcp/127.0.0.1/$p) 2>/dev/null; then "
-                "echo $p; exit 0; fi; exec 3<&-; exec 3>&-; done; exit 1"
+            script = _remote_ollama_port_probe_command(
+                start_port,
+                max_offset,
+                is_windows=is_windows,
             )
             try:
                 import subprocess
@@ -1774,26 +1854,10 @@ def setup_cookbook_routes() -> APIRouter:
         import re
         from core.database import SessionLocal, ModelEndpoint
 
-        # Port: ordered fallbacks so we match whatever the user actually
-        # asked for, not a hardcoded default:
-        #   1. explicit `--port N`  (vllm / sglang / llama-server)
-        #   2. `OLLAMA_HOST=host:port`  (the way Ollama specifies its bind)
-        #   3. fallback by backend (11434 ollama / 8080 llama.cpp)
-        # Previously the OLLAMA_HOST form was silently ignored and we
-        # registered every Ollama endpoint at 11434 — even if the user
-        # set OLLAMA_HOST=0.0.0.0:11435 to avoid colliding with an
-        # existing systemd Ollama, the registered endpoint pointed at
-        # the OLD port and showed as offline.
-        port_match = re.search(r'--port\s+(\d+)', req.cmd)
-        ollama_host_match = re.search(r'OLLAMA_HOST=[^\s]*?:(\d+)', req.cmd)
-        if port_match:
-            port = int(port_match.group(1))
-        elif ollama_host_match:
-            port = int(ollama_host_match.group(1))
-        elif "ollama" in req.cmd:
-            port = 11434
-        else:
-            port = 8080  # llama.cpp's llama-server default — the Apple Silicon path
+        # Task persistence, endpoint registration, and Stop must agree on the
+        # effective port, including --port=, -p, and OLLAMA_HOST forms.
+        parsed_port = _serve_port_from_cmd(req.cmd)
+        port = int(parsed_port) if parsed_port else 8080
 
         # Determine host. The cookbook tmux for `local=true` serves runs INSIDE
         # the odysseus container — so the right URL for the in-container
@@ -2047,9 +2111,15 @@ def setup_cookbook_routes() -> APIRouter:
             _ollama_bind_host = "0.0.0.0" if remote else "127.0.0.1"
             _ollama_chosen_port = _pick_free_port_for_ollama(
                 remote, req.ssh_port, start_port=11434, max_offset=10,
+                is_windows=is_windows,
             )
-            if _ollama_chosen_port:
-                req.cmd = f"OLLAMA_HOST={_ollama_bind_host}:{_ollama_chosen_port} {req.cmd}"
+            if not _ollama_chosen_port:
+                return {
+                    "ok": False,
+                    "error": "No free Ollama serve port was found in 11434-11444.",
+                    "session_id": session_id,
+                }
+            req.cmd = f"OLLAMA_HOST={_ollama_bind_host}:{_ollama_chosen_port} {req.cmd}"
         # LOCAL execution on a native-Windows host never uses tmux (detached
         # process path below), regardless of the UI-supplied platform.
         local_windows = IS_WINDOWS and not remote
@@ -2110,7 +2180,7 @@ def setup_cookbook_routes() -> APIRouter:
             elif "vllm" in req.cmd:
                 ps_lines.append('Write-Host "ERROR: vLLM is not supported on Windows. Use Ollama or llama.cpp instead."')
                 ps_lines.append('exit 1')
-            ps_lines.append(req.cmd)
+            ps_lines.extend(_windows_serve_command_lines(req.cmd))
             if is_pip_install:
                 ps_lines.append('if ($LASTEXITCODE -eq 0) { Write-Host ""; Write-Host "DOWNLOAD_OK" }')
             ps_lines.append('Write-Host ""')
@@ -2297,22 +2367,12 @@ def setup_cookbook_routes() -> APIRouter:
                     req.cmd,
                     default_host=_ollama_default_host,
                 )
-                # Always launch a fresh ollama under tmux so Stop reliably
-                # kills it. If the requested port is busy (e.g. a systemd
-                # ollama on 11434), scan upward for a free one rather than
-                # silently reattaching to an external service that Stop
-                # can't reach.
+                # The backend selected this exact free port before building the
+                # runner and returns it to the browser. Do not scan again here:
+                # a second choice would make the persisted stop metadata stale.
+                # A bind race should fail the launch instead of moving silently.
                 runner_lines.append(f'ODYSSEUS_OLLAMA_HOST={_bash_squote(_ollama_host)}')
                 runner_lines.append(f'ODYSSEUS_OLLAMA_PORT="{_ollama_port}"')
-                runner_lines.append('for _ody_off in 0 1 2 3 4 5 6 7 8 9; do')
-                runner_lines.append('  _ody_try_port=$((ODYSSEUS_OLLAMA_PORT + _ody_off))')
-                runner_lines.append('  if ! (exec 3<>/dev/tcp/127.0.0.1/$_ody_try_port) 2>/dev/null; then')
-                runner_lines.append('    exec 3<&-; exec 3>&-')
-                runner_lines.append('    ODYSSEUS_OLLAMA_PORT="$_ody_try_port"')
-                runner_lines.append('    break')
-                runner_lines.append('  fi')
-                runner_lines.append('  exec 3<&-; exec 3>&-')
-                runner_lines.append('done')
                 runner_lines.append('if ! command -v ollama &>/dev/null; then')
                 # Single-quoted on purpose: backticks inside a double-quoted
                 # echo are command substitution, and this line used to run the
@@ -2825,8 +2885,12 @@ def setup_cookbook_routes() -> APIRouter:
         except Exception:
             pass
 
-        return {"ok": True, "session_id": session_id, "remote": remote or "local",
-                "endpoint_id": endpoint_id}
+        return _serve_launch_result(
+            session_id=session_id,
+            remote=remote,
+            endpoint_id=endpoint_id,
+            cmd=req.cmd,
+        )
 
     # ── Server setup (install deps on remote) ──
 

--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -183,16 +183,45 @@ def _windows_serve_command_lines(cmd: str) -> list[str]:
     generated remote-Windows runner needs PowerShell assignment syntax.
     """
     command = (cmd or "").strip()
-    match = re.fullmatch(
-        r"OLLAMA_HOST\s*=\s*(['\"]?)([^\s'\"]+)\1\s+(ollama\s+serve(?:\s+.*)?)",
-        command,
-        re.IGNORECASE,
-    )
-    if not match:
+    env_name = "OLLAMA_HOST"
+    if command[: len(env_name)].upper() != env_name:
+        return [command]
+
+    remainder = command[len(env_name) :].lstrip()
+    if not remainder.startswith("="):
+        return [command]
+    remainder = remainder[1:].lstrip()
+    if not remainder:
+        return [command]
+
+    if remainder[0] in {"'", '"'}:
+        quote = remainder[0]
+        value_end = remainder.find(quote, 1)
+        if value_end < 0:
+            return [command]
+        host = remainder[1:value_end]
+        serve_command = remainder[value_end + 1 :].strip()
+    else:
+        value_end = next(
+            (index for index, char in enumerate(remainder) if char.isspace()),
+            len(remainder),
+        )
+        host = remainder[:value_end]
+        serve_command = remainder[value_end:].strip()
+
+    serve_parts = serve_command.split(None, 2)
+    if (
+        not host
+        or "'" in host
+        or '"' in host
+        or len(serve_parts) < 2
+        or serve_parts[0].lower() != "ollama"
+        or serve_parts[1].lower() != "serve"
+    ):
         return [command]
     return [
-        f"$env:OLLAMA_HOST = '{_ps_squote(match.group(2))}'",
-        match.group(3),
+        f"$env:OLLAMA_HOST = '{_ps_squote(host)}'",
+        serve_command,
     ]
 
 

--- a/src/builtin_actions.py
+++ b/src/builtin_actions.py
@@ -3254,13 +3254,19 @@ async def action_cookbook_serve(
          if isinstance(s, dict) and (s.get("host") == host or s.get("name") == host)),
         {},
     )
+    task_ssh_port = str(srv.get("port") or srv.get("sshPort") or cfg.get("ssh_port") or "")
+    task_platform = str(
+        srv.get("platform")
+        or cfg.get("platform")
+        or ("windows" if IS_WINDOWS and not host else "linux")
+    ).strip().lower()
     if srv.get("env") == "venv" and srv.get("envPath"):
         body["env_prefix"] = f"source {srv['envPath']}/bin/activate"
     elif srv.get("env") == "conda" and srv.get("envPath"):
         body["env_prefix"] = f"conda activate {srv['envPath']}"
     if srv.get("hfToken"): body["hf_token"] = srv["hfToken"]
-    if srv.get("port"): body["ssh_port"] = str(srv["port"])
-    if srv.get("platform"): body["platform"] = srv["platform"]
+    if task_ssh_port: body["ssh_port"] = task_ssh_port
+    if task_platform: body["platform"] = task_platform
 
     try:
         async with httpx.AsyncClient(timeout=30) as client:
@@ -3274,6 +3280,17 @@ async def action_cookbook_serve(
 
     sid = data.get("session_id") or ""
     endpoint_id = data.get("endpoint_id") or ""
+    raw_effective_cmd = data.get("effective_cmd")
+    effective_cmd = raw_effective_cmd.strip() if isinstance(raw_effective_cmd, str) else ""
+    if not effective_cmd:
+        effective_cmd = cmd
+    runtime_port = None
+    try:
+        candidate_port = int(data.get("runtime_port"))
+        if 1 <= candidate_port <= 65535:
+            runtime_port = candidate_port
+    except (TypeError, ValueError):
+        pass
     # Scheduled serves are usually meant to become the active local model for
     # chat/tools while their time window is open. Persist both endpoint and
     # model so task/utility/default resolution does not keep routing to a stale
@@ -3339,13 +3356,11 @@ async def action_cookbook_serve(
             )
             if existing is None:
                 display_name = repo_id.split("/")[-1] if "/" in repo_id else repo_id
-                ssh_port = str(srv.get("port") or cfg.get("ssh_port") or "")
-                platform = str(srv.get("platform") or cfg.get("platform") or "linux")
                 placeholder = (
                     f"Launched by scheduled task {task_name!r} — waiting for tmux output…\n"
                     f"  session: {sid}\n"
                     f"  target:  {host or 'local'}\n"
-                    f"  cmd:     {cmd[:200]}{'…' if len(cmd) > 200 else ''}"
+                    f"  cmd:     {effective_cmd[:200]}{'…' if len(effective_cmd) > 200 else ''}"
                 )
                 existing = {
                     "id": sid,
@@ -3356,14 +3371,29 @@ async def action_cookbook_serve(
                     "status": "running",
                     "output": placeholder,
                     "ts": int(_time.time() * 1000),
-                    "payload": {"repo_id": repo_id, "remote_host": host or "", "_cmd": cmd},
+                    "payload": {"repo_id": repo_id, "remote_host": host or "", "_cmd": effective_cmd},
                     "remoteHost": host or "",
-                    "sshPort": ssh_port or "",
-                    "platform": platform or "linux",
+                    "sshPort": task_ssh_port,
+                    "platform": task_platform or "linux",
                     "_serveReady": False,
                     "_endpointAdded": bool(endpoint_id),
                 }
                 tasks.append(existing)
+            task_payload = existing.get("payload") if isinstance(existing.get("payload"), dict) else {}
+            task_payload.update({
+                "repo_id": repo_id,
+                "remote_host": host or "",
+                "_cmd": effective_cmd,
+                "platform": task_platform or "linux",
+            })
+            if task_ssh_port:
+                task_payload["ssh_port"] = task_ssh_port
+            if runtime_port is not None:
+                task_payload["runtime_port"] = str(runtime_port)
+            existing["payload"] = task_payload
+            existing["remoteHost"] = host or ""
+            existing["sshPort"] = task_ssh_port
+            existing["platform"] = task_platform or "linux"
             # Stamp ownership + end-at on the task entry.
             existing["_scheduledByTask"] = task_name or ""
             existing["_scheduledByOwner"] = owner or ""

--- a/src/tools/cookbook.py
+++ b/src/tools/cookbook.py
@@ -180,8 +180,13 @@ async def _cookbook_env_for_host(host: str) -> Dict[str, Any]:
 
     env_kind = per_host.get("env") or env_root.get("env") or "none"
     env_path = per_host.get("envPath") or env_root.get("envPath") or ""
-    platform = per_host.get("platform") or env_root.get("platform") or "linux"
-    ssh_port = per_host.get("sshPort") or env_root.get("sshPort") or ""
+    platform = (
+        per_host.get("platform")
+        or (env_root.get("hostPlatform") if not host else "")
+        or env_root.get("platform")
+        or "linux"
+    )
+    ssh_port = per_host.get("sshPort") or per_host.get("port") or env_root.get("sshPort") or ""
 
     env_prefix = ""
     if env_kind == "venv" and env_path:
@@ -213,21 +218,38 @@ def _infer_serve_port(cmd: str) -> int:
     """Infer likely listen port from a serve command."""
     if not cmd:
         return 8080
-    m = re.search(r"--port\\s+(\\d+)", cmd)
-    if m:
-        try:
-            return int(m.group(1))
-        except Exception:
-            pass
-    m = re.search(r"OLLAMA_HOST=[^\\s]*?:(\\d+)", cmd)
-    if m:
-        try:
-            return int(m.group(1))
-        except Exception:
-            pass
-    if "ollama" in cmd:
+    for pattern in (
+        r"--port(?:=|\s+)(\d+)",
+        r"(?:^|\s)-p(?:=|\s+)(\d+)",
+        r"OLLAMA_HOST\s*=\s*(?:['\"])?(?:\[[^\]]+\]|[^:\s'\"]+):(\d+)(?:['\"])?",
+    ):
+        match = re.search(pattern, cmd, re.IGNORECASE)
+        if match:
+            port = int(match.group(1))
+            if 1 <= port <= 65535:
+                return port
+    if re.search(r"\bollama\s+serve\b", cmd, re.IGNORECASE):
+        return 11434
+    if re.search(r"\bdocker\s+exec\s+(?:ollama-rocm|ollama-test)\b", cmd, re.IGNORECASE):
         return 11434
     return 8080
+
+
+def _serve_response_metadata(data: Dict[str, Any], fallback_cmd: str) -> tuple[str, Optional[int]]:
+    """Return server-authoritative launch metadata with safe fallbacks."""
+    raw_cmd = data.get("effective_cmd")
+    effective_cmd = raw_cmd.strip() if isinstance(raw_cmd, str) else ""
+    if not effective_cmd:
+        effective_cmd = (fallback_cmd or "").strip()
+
+    runtime_port: Optional[int] = None
+    try:
+        candidate = int(data.get("runtime_port"))
+        if 1 <= candidate <= 65535:
+            runtime_port = candidate
+    except (TypeError, ValueError):
+        pass
+    return effective_cmd, runtime_port
 
 
 def _infer_serve_host(host: str | None) -> tuple[str, bool]:
@@ -243,12 +265,13 @@ async def _ensure_served_endpoint(
     model: str,
     cmd: str,
     host: str | None,
+    runtime_port: int | None = None,
 ) -> Dict[str, Any]:
     """Register/fetch a model endpoint for a running serve session."""
     from src.tool_implementations import _internal_headers, _INTERNAL_BASE  # shared, lives in facade
     import httpx
     endpoint_host, container_local = _infer_serve_host(host)
-    port = _infer_serve_port(cmd)
+    port = runtime_port if runtime_port is not None else _infer_serve_port(cmd)
     base_url = f"http://{endpoint_host}:{port}/v1"
     short_name = model.split("/")[-1] if "/" in model else model
     is_image = "diffusion_server.py" in (cmd or "") or "mlx_image_server.py" in (cmd or "")
@@ -293,6 +316,9 @@ async def _cookbook_register_task(
     *,
     endpoint_added: bool = False,
     endpoint_id: str = "",
+    runtime_port: int | None = None,
+    platform: str = "",
+    ssh_port: str = "",
 ) -> bool:
     """Append a task entry to cookbook_state.json after the agent
     launches via /api/model/serve or /api/model/download. The route
@@ -330,6 +356,17 @@ async def _cookbook_register_task(
         f"  target:  {target}{(cmd.split() or [''])[0] if cmd else ''}\n"
         f"  cmd:     {cmd[:200]}{'…' if len(cmd) > 200 else ''}"
     )
+    task_payload = {
+        "repo_id": model,
+        "remote_host": host or "",
+        "_cmd": cmd,
+    }
+    if runtime_port is not None:
+        task_payload["runtime_port"] = str(runtime_port)
+    if platform:
+        task_payload["platform"] = platform
+    if ssh_port:
+        task_payload["ssh_port"] = str(ssh_port)
     tasks.append({
         "id": session_id,
         "sessionId": session_id,
@@ -339,10 +376,10 @@ async def _cookbook_register_task(
         "status": "running",
         "output": placeholder,
         "ts": int(_time.time() * 1000),
-        "payload": {"repo_id": model, "remote_host": host or "", "_cmd": cmd},
+        "payload": task_payload,
         "remoteHost": host or "",
-        "sshPort": "",
-        "platform": "linux",
+        "sshPort": str(ssh_port or ""),
+        "platform": platform or "linux",
         "_serveReady": False,
         "_endpointAdded": bool(endpoint_added),
         "_endpointId": endpoint_id or "",
@@ -735,16 +772,25 @@ async def do_serve_model(content: str, owner: Optional[str] = None) -> Dict:
         if data.get("ok"):
             sid = data.get("session_id", "?")
             endpoint_id = data.get("endpoint_id") or ""
+            effective_cmd, runtime_port = _serve_response_metadata(data, cmd)
             if endpoint_id:
                 endpoint_added = True
             else:
-                endpoint_meta = await _ensure_served_endpoint(model=repo_id, cmd=cmd, host=host)
+                endpoint_meta = await _ensure_served_endpoint(
+                    model=repo_id,
+                    cmd=effective_cmd,
+                    host=host,
+                    runtime_port=runtime_port,
+                )
                 endpoint_added = bool(endpoint_meta.get("added"))
                 endpoint_id = endpoint_meta.get("endpoint_id", "") or endpoint_id
             registered = await _cookbook_register_task(
                 session_id=sid, model=repo_id,
-                host=host, cmd=cmd, task_type="serve",
+                host=host, cmd=effective_cmd, task_type="serve",
                 endpoint_added=endpoint_added, endpoint_id=endpoint_id or "",
+                runtime_port=runtime_port,
+                platform=env_cfg.get("platform") or "",
+                ssh_port=str(env_cfg.get("ssh_port") or ""),
             )
             note = "" if registered else " (state-write failed — task may not show in UI)"
             where = host or "local"
@@ -761,6 +807,8 @@ async def do_serve_model(content: str, owner: Optional[str] = None) -> Dict:
                 "phase": "running",
                 "host": host,
                 "endpoint_id": endpoint_id,
+                "effective_cmd": effective_cmd,
+                "runtime_port": runtime_port,
                 "log_path": log_path,
                 "next_tools": [
                     {"name": "list_served_models", "arguments": {}},
@@ -1516,19 +1564,36 @@ async def do_serve_preset(content: str, owner: Optional[str] = None) -> Dict:
         if data.get("ok"):
             sid = data.get("session_id", "?")
             endpoint_id = data.get("endpoint_id") or ""
+            effective_cmd, runtime_port = _serve_response_metadata(data, cmd)
             if endpoint_id:
                 endpoint_added = True
             else:
-                endpoint_meta = await _ensure_served_endpoint(model=repo_id, cmd=cmd, host=host)
+                endpoint_meta = await _ensure_served_endpoint(
+                    model=repo_id,
+                    cmd=effective_cmd,
+                    host=host,
+                    runtime_port=runtime_port,
+                )
                 endpoint_added = bool(endpoint_meta.get("added"))
                 endpoint_id = endpoint_meta.get("endpoint_id", "") or endpoint_id
             registered = await _cookbook_register_task(
                 session_id=sid, model=repo_id, host=host,
-                cmd=cmd, task_type="serve",
+                cmd=effective_cmd, task_type="serve",
                 endpoint_added=endpoint_added, endpoint_id=endpoint_id or "",
+                runtime_port=runtime_port,
+                platform=env_cfg.get("platform") or "",
+                ssh_port=str(env_cfg.get("ssh_port") or ""),
             )
             note = "" if registered else " (state-write failed — task may not show in UI)"
-            return {"output": f"Launched preset {chosen.get('name')!r}: {repo_id} on {host or 'local'} (session: {sid}){note}", "session_id": sid, "host": host, "endpoint_id": endpoint_id, "exit_code": 0}
+            return {
+                "output": f"Launched preset {chosen.get('name')!r}: {repo_id} on {host or 'local'} (session: {sid}){note}",
+                "session_id": sid,
+                "host": host,
+                "endpoint_id": endpoint_id,
+                "effective_cmd": effective_cmd,
+                "runtime_port": runtime_port,
+                "exit_code": 0,
+            }
         return {"error": data.get("error", "Serve failed"), "exit_code": 1}
     except Exception as e:
         return {"error": str(e), "exit_code": 1}

--- a/static/js/cookbook-hwfit.js
+++ b/static/js/cookbook-hwfit.js
@@ -34,7 +34,8 @@ import {
 } from './cookbook.js';
 import uiModule from './ui.js';
 import spinnerModule from './spinner.js';
-import { _loadTasks, _tmuxGracefulKill, _nextAvailablePort, _taskPort } from './cookbookRunning.js';
+import { _loadTasks, _nextAvailablePort, _taskPort, _stopTaskFromElement } from './cookbookRunning.js';
+import { withEffectiveServeMetadata } from './cookbookPorts.js';
 import { openCookbookDependencies } from './cookbook-diagnosis.js';
 
 // Map a serve-backend code (vllm / sglang / llamacpp / mlx) → the package name
@@ -1730,23 +1731,25 @@ export function _expandModelRow(row, modelData) {
           } else {
             quickRunBtn.disabled = true;
             quickRunBtn.textContent = 'Stopping…';
+            let _stopFailed = false;
             for (const t of _clashing) {
               try {
                 const _taskEl = document.querySelector(`.cookbook-task[data-task-id="${t.sessionId}"]`);
-                const _stopBtn = _taskEl?.querySelector('.cookbook-task-action-stop');
-                if (_stopBtn) {
-                  _stopBtn.click();
-                } else {
-                  await fetch('/api/shell/exec', {
-                    method: 'POST',
-                    credentials: 'same-origin',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ command: _tmuxGracefulKill(t) }),
-                  });
+                if (!await _stopTaskFromElement(_taskEl, t, { showFailure: false })) {
+                  _stopFailed = true;
+                  break;
                 }
-              } catch (_killErr) { /* best-effort */ }
+              } catch (_killErr) {
+                _stopFailed = true;
+                break;
               }
-            await new Promise(r => setTimeout(r, 2500));
+            }
+            if (_stopFailed) {
+              quickRunBtn.disabled = false;
+              quickRunBtn.textContent = 'Run';
+              uiModule.showToast(`Launch aborted: the existing server on port ${_qrPort} could not be confirmed stopped.`, 'error');
+              return;
+            }
           }
         }
       } catch (_e) { /* best-effort */ }
@@ -1950,7 +1953,15 @@ export function _expandModelRow(row, modelData) {
         const data = await res.json();
         if (data.ok) {
           const shortName = modelData.name.split('/').pop();
-          _addTask(data.session_id, shortName, 'serve', { _cmd: cmd, model: modelData.name, backend: runBackend, remote_host: host });
+          const taskPayload = withEffectiveServeMetadata({
+            repo_id: modelData.name,
+            model: modelData.name,
+            backend: runBackend,
+            remote_host: host,
+            ssh_port: (_srv && _srv.port) || undefined,
+            platform: _envState.platform || undefined,
+          }, data, cmd);
+          _addTask(data.session_id, shortName, 'serve', taskPayload);
           _renderRunningTab();
           uiModule.showToast(`Launching ${shortName}...`);
           // Switch to Running tab

--- a/static/js/cookbook.js
+++ b/static/js/cookbook.js
@@ -309,9 +309,15 @@ export function _getPlatform(hostOrTask) {
   if (hostOrTask === 'local') return _envState.hostPlatform || '';
   if (!hostOrTask) return _envState.remoteHost ? (_envState.platform || '') : (_envState.hostPlatform || '');
   if (typeof hostOrTask === 'object') {
+    // Persisted tasks carry the platform used at launch. Prefer that value,
+    // especially for local tasks: after a reload the volatile hardware probe
+    // may not have repopulated hostPlatform yet. Falling through here used to
+    // route a Windows detached process through the POSIX tmux stop command,
+    // then the UI removed the card while llama-server kept running.
+    const taskPlatform = hostOrTask.platform || hostOrTask.payload?.platform || '';
     const taskHost = hostOrTask.remoteServerKey || hostOrTask.remoteHost || '';
-    if (!taskHost || taskHost === 'local') return _envState.hostPlatform || '';
-    return hostOrTask.platform || _getPlatform(taskHost);
+    if (!taskHost || taskHost === 'local') return taskPlatform || _envState.hostPlatform || '';
+    return taskPlatform || _getPlatform(taskHost);
   }
   const selected = hostOrTask === _envState.remoteHost ? _selectedServer() : null;
   const srv = selected || _serverByVal(hostOrTask);

--- a/static/js/cookbookPorts.js
+++ b/static/js/cookbookPorts.js
@@ -1,12 +1,45 @@
 // Pure port helpers extracted so they're unit-testable without the
 // browser-bound rest of cookbookRunning.js (issue #4507 follow-up).
 
-// Read the port out of a serve launch command. Handles --port 8000,
-// --port=8000, -p 8000, and -p=8000. Returns '' when none is present.
+// Read an explicitly requested port out of a serve launch command. Handles
+// --port/-p and OLLAMA_HOST forms. Returns '' when the backend should choose.
 export function portOf(cmd) {
   const s = cmd || '';
-  const m = s.match(/--port[=\s]+(\d+)/) || s.match(/(?:^|\s)-p[=\s]+(\d+)/);
+  const m = s.match(/--port[=\s]+(\d+)/)
+    || s.match(/(?:^|\s)-p[=\s]+(\d+)/)
+    || s.match(/OLLAMA_HOST\s*=\s*(?:['"])?(?:\[[^\]]+\]|[^:\s'"]+):(\d+)(?:['"])?/i);
   return m ? m[1] : '';
+}
+
+// Resolve the effective port persisted with a running serve task. The backend
+// value wins because it may have selected a free Ollama port after the browser
+// submitted the launch command.
+export function taskServePort(task) {
+  const persisted = task?.payload?.runtime_port ?? task?.payload?.port ?? task?.port;
+  if (persisted != null && /^\d+$/.test(String(persisted))) return String(persisted);
+  const cmd = task?.payload?._cmd || '';
+  const explicit = portOf(cmd);
+  if (explicit) return explicit;
+  if (/\bollama\s+serve\b/i.test(cmd)) return '11434';
+  if (/\bdocker\s+exec\s+(?:ollama-rocm|ollama-test)\b/i.test(cmd)) return '11434';
+  return '';
+}
+
+// Merge server-authoritative launch metadata into the browser task payload.
+// The server may normalize the command and choose a different port, so saving
+// only the pre-request command leaves Stop looking at the wrong process.
+export function withEffectiveServeMetadata(payload, response, fallbackCmd = '') {
+  const next = { ...(payload || {}) };
+  const rawCmd = response?.effective_cmd ?? response?.cmd;
+  const responseCmd = typeof rawCmd === 'string' ? rawCmd.trim() : '';
+  const cmd = responseCmd || String(fallbackCmd || '').trim();
+  if (cmd) next._cmd = cmd;
+  const rawPort = response?.runtime_port ?? response?.port;
+  const port = Number(rawPort);
+  if (rawPort != null && Number.isInteger(port) && port > 0 && port <= 65535) {
+    next.runtime_port = String(port);
+  }
+  return next;
 }
 
 // Lowest free port >= start that isn't in usedPorts (array or Set of

--- a/static/js/cookbookRunning.js
+++ b/static/js/cookbookRunning.js
@@ -1575,13 +1575,15 @@ async function _retryTask(el, task) {
   if (el && el._abort) el._abort.abort();
   const badge = el?.querySelector('.cookbook-task-status');
   if (badge) { badge.textContent = 'restarting...'; badge.className = 'cookbook-task-status'; }
-  try {
-    await fetch('/api/shell/exec', {
-      method: 'POST', credentials: 'same-origin',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ command: _tmuxGracefulKill(task) }),
-    });
-  } catch {}
+  // Route the kill through the verified stop: never relaunch into a still-bound
+  // port or drop the retry handle when the old process is not confirmed gone.
+  if (!(await _stopTaskSession(task))) {
+    const priorStatus = task.status || 'running';
+    if (badge) { badge.textContent = _statusLabel(priorStatus, task.type); badge.className = `cookbook-task-status cookbook-task-${priorStatus}`; }
+    _updateTask(task.sessionId, { status: priorStatus });
+    uiModule.showToast('Restart aborted: the previous process could not be confirmed stopped. The task was kept so you can retry.', 'error');
+    return;
+  }
   if (task.payload) {
     if (task.type === 'serve' && task.payload._cmd) {
       _removeTask(task.sessionId);
@@ -1667,6 +1669,19 @@ function _guardServeRetry(panel, taskEl) {
   return true;
 }
 
+// Reverse _guardServeRetry: re-enable the panel and clear the retry flag so the
+// user can try again after a remediation was aborted (e.g. the previous process
+// could not be confirmed stopped).
+function _unguardServeRetry(panel, taskEl) {
+  if (taskEl) delete taskEl.dataset.retrying;
+  if (!panel) return;
+  panel.querySelectorAll('button').forEach(b => {
+    b.disabled = false;
+    b.style.opacity = '';
+    b.style.pointerEvents = '';
+  });
+}
+
 export async function _serveAutoFix(panel, envVar) {
   const taskEl = panel.closest('.cookbook-task');
   if (!taskEl) return;
@@ -1676,14 +1691,11 @@ export async function _serveAutoFix(panel, envVar) {
   if (!task || !task.payload) return;
   if (!_guardServeRetry(panel, taskEl)) return;
 
-  const killCmd = _tmuxCmd(task, `kill-session -t ${taskId}`);
-  try {
-    await fetch('/api/shell/exec', {
-      method: 'POST', credentials: 'same-origin',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ command: killCmd }),
-    });
-  } catch {}
+  if (!(await _stopTaskSession(task))) {
+    _unguardServeRetry(panel, taskEl);
+    uiModule.showToast('Retry aborted: the previous server could not be confirmed stopped. The task was kept so you can retry.', 'error');
+    return;
+  }
 
   _animateOutThenRemove(taskEl, taskId);
 
@@ -1740,13 +1752,11 @@ export async function _serveAutoRetryReplace(panel, flag, value) {
   if (!task || !task.payload || !task.payload._cmd) return;
   if (!_guardServeRetry(panel, taskEl)) return;
 
-  try {
-    await fetch('/api/shell/exec', {
-      method: 'POST', credentials: 'same-origin',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ command: _tmuxCmd(task, `kill-session -t ${taskId}`) }),
-    });
-  } catch {}
+  if (!(await _stopTaskSession(task))) {
+    _unguardServeRetry(panel, taskEl);
+    uiModule.showToast('Retry aborted: the previous server could not be confirmed stopped. The task was kept so you can retry.', 'error');
+    return;
+  }
 
   _animateOutThenRemove(taskEl, taskId);
 
@@ -1782,13 +1792,11 @@ export async function _serveAutoRetryRemove(panel, flag) {
   if (!task || !task.payload || !task.payload._cmd) return;
   if (!_guardServeRetry(panel, taskEl)) return;
 
-  try {
-    await fetch('/api/shell/exec', {
-      method: 'POST', credentials: 'same-origin',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ command: _tmuxCmd(task, `kill-session -t ${taskId}`) }),
-    });
-  } catch {}
+  if (!(await _stopTaskSession(task))) {
+    _unguardServeRetry(panel, taskEl);
+    uiModule.showToast('Retry aborted: the previous server could not be confirmed stopped. The task was kept so you can retry.', 'error');
+    return;
+  }
 
   _animateOutThenRemove(taskEl, taskId);
 
@@ -1815,13 +1823,11 @@ export async function _serveAutoRetry(panel, flag) {
   if (!task || !task.payload || !task.payload._cmd) return;
   if (!_guardServeRetry(panel, taskEl)) return;
 
-  try {
-    await fetch('/api/shell/exec', {
-      method: 'POST', credentials: 'same-origin',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ command: _tmuxCmd(task, `kill-session -t ${taskId}`) }),
-    });
-  } catch {}
+  if (!(await _stopTaskSession(task))) {
+    _unguardServeRetry(panel, taskEl);
+    uiModule.showToast('Retry aborted: the previous server could not be confirmed stopped. The task was kept so you can retry.', 'error');
+    return;
+  }
 
   _animateOutThenRemove(taskEl, taskId);
 
@@ -2036,17 +2042,16 @@ export async function _launchServeTask(shortName, repo, cmd, fields, hostOverrid
   const _replaceTaskId = fields?._replaceTaskId || '';
   const _launchAnyway = !!targetMeta?.launchAnyway;
   if (_replaceTaskId) {
-    try {
-      const _old = _loadTasks().find(t => t.sessionId === _replaceTaskId);
-      if (_old && _old.type === 'serve') {
-        await fetch('/api/shell/exec', {
-          method: 'POST', credentials: 'same-origin',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ command: _tmuxGracefulKill(_old) }),
-        });
-        _removeTask(_old.sessionId);
+    const _old = _loadTasks().find(t => t.sessionId === _replaceTaskId);
+    if (_old && _old.type === 'serve') {
+      // Verify the old server is actually gone before relaunching — otherwise a
+      // failed cleanup relaunches into a still-bound port and orphans the GPU.
+      if (!(await _stopTaskSession(_old))) {
+        uiModule.showToast('Launch aborted: the existing server could not be confirmed stopped. It was kept to avoid a port collision.', 'error');
+        return;
       }
-    } catch {}
+      _removeTask(_old.sessionId);
+    }
   }
   // Replace any serve already targeting this same host:port — you can't run two
   // servers on one port, so re-serving (or retrying) should stop & remove the
@@ -2060,13 +2065,10 @@ export async function _launchServeTask(shortName, repo, cmd, fields, hostOverrid
         if (_t.type !== 'serve' || !_t.payload || !_t.payload._cmd) continue;
         const _tm = _t.payload._cmd.match(/--port[=\s]+(\d+)/) || _t.payload._cmd.match(/(?:^|\s)-p[=\s]+(\d+)/);
         if ((_tm ? _tm[1] : '') === _newPort && (_t.remoteHost || '') === _host) {
-          try {
-            await fetch('/api/shell/exec', {
-              method: 'POST', credentials: 'same-origin',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ command: _tmuxGracefulKill(_t) }),
-            });
-          } catch {}
+          if (!(await _stopTaskSession(_t))) {
+            uiModule.showToast(`Launch aborted: an existing server on port ${_newPort} could not be confirmed stopped.`, 'error');
+            return;
+          }
           _removeTask(_t.sessionId);
         }
       }
@@ -3470,13 +3472,12 @@ async function _reconnectTask(el, task) {
               badge.textContent = _startupStalled ? '0% stall — retrying' : 'stale — restarting';
               badge.className = 'cookbook-task-status cookbook-task-error';
               _showCookbookNotif(true);
-              try {
-                await fetch('/api/shell/exec', {
-                  method: 'POST', credentials: 'same-origin',
-                  headers: { 'Content-Type': 'application/json' },
-                  body: JSON.stringify({ command: _tmuxCmd(task, `kill-session -t ${task.sessionId}`) }),
-                });
-              } catch {}
+              if (!(await _stopTaskSession(task))) {
+                badge.textContent = 'stale — stop unconfirmed';
+                badge.className = 'cookbook-task-status cookbook-task-error';
+                _showCookbookNotif(true);
+                break;
+              }
               try {
                 // Reuse original payload so the full repo_id (e.g. "Qwen/Qwen3.5-...")
                 // is preserved — rebuilding from task.repo/task.name drops the org prefix.
@@ -3585,13 +3586,11 @@ async function _reconnectTask(el, task) {
                 badge.className = 'cookbook-task-status cookbook-task-running';
                 uiModule.showToast(`Download interrupted — retrying (${_dlN + 1}/${_DL_MAX_AUTO_RETRY}), resumes where it stopped…`, 6000);
                 const _p = task.payload, _nm = task.name;
-                try {
-                  await fetch('/api/shell/exec', {
-                    method: 'POST', credentials: 'same-origin',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ command: _tmuxCmd(task, `kill-session -t ${task.sessionId}`) }),
-                  });
-                } catch {}
+                if (!(await _stopTaskSession(task))) {
+                  badge.textContent = 'interrupted — stop unconfirmed';
+                  badge.className = 'cookbook-task-status cookbook-task-error';
+                  break;
+                }
                 _removeTask(task.sessionId);
                 setTimeout(() => { _retryDownload(_nm, _p); }, 8000);
                 break;

--- a/static/js/cookbookRunning.js
+++ b/static/js/cookbookRunning.js
@@ -1062,14 +1062,31 @@ function _winSessionStopTreePs(task) {
   const sid = task.sessionId;
   const pidPath = `(Join-Path $env:TEMP '${sessionDir}\\${sid}.pid')`;
   const artifactPath = `(Join-Path $env:TEMP '${sessionDir}\\${sid}.*')`;
-  // Capture the full Win32 tree before killing anything. taskkill /T follows
-  // native Windows process relationships more reliably than recursive
-  // Stop-Process through Git Bash. Trying every captured PID also covers the
-  // case where the recorded wrapper exited but llama-server still points at
-  // that former parent. Keep the PID and logs when any process survives so the
-  // UI can retry instead of losing its only handle to the live GPU process.
-  const stopTree = `$targets = [System.Collections.Generic.List[int]]::new(); function Add-Tree([int]$Id) { Get-CimInstance Win32_Process -Filter ('ParentProcessId = ' + $Id) -ErrorAction SilentlyContinue | ForEach-Object { Add-Tree ([int]$_.ProcessId) }; if (-not $targets.Contains($Id)) { $targets.Add($Id) } }`;
-  return `${stopTree}; $p = Get-Content ${pidPath} -ErrorAction SilentlyContinue; if ($p -notmatch '^\\d+$') { Write-Error 'Missing Windows session PID'; exit 1 }; Add-Tree ([int]$p); foreach ($target in @($targets)) { if (Get-Process -Id $target -ErrorAction SilentlyContinue) { & taskkill.exe /PID $target /T /F 2>$null | Out-Null } }; Start-Sleep -Milliseconds 250; $alive = @($targets | Where-Object { Get-Process -Id $_ -ErrorAction SilentlyContinue }); if ($alive.Count -gt 0) { Write-Error ('Processes still alive: ' + ($alive -join ',')); exit 1 }; Remove-Item ${artifactPath} -Force -ErrorAction SilentlyContinue; exit 0`;
+  // The LISTENING serve port is the source of truth for "is the model still
+  // up", not the recorded PID. That PID is only a Git Bash wrapper in the
+  // launch chain, never llama-server.exe itself: a native binary started
+  // through the bash runner (or a ~/bin shim that `exec`s it) is reparented
+  // into a separate Win32 subtree, so a tree walk from the wrapper PID can miss
+  // the live GPU process and then wrongly report a clean stop. Kill the port
+  // owner first (that is the real server), fold in the recorded wrapper tree to
+  // clean up logs/children, then verify against the port — never the wrapper
+  // alone. Keep the PID/artifacts while the port stays bound so the UI retries
+  // instead of losing its only handle to the live GPU process.
+  const portMatch = task?.payload?._cmd?.match(/--port[=\s]+(\d+)/);
+  const port = portMatch ? portMatch[1] : '';
+  const addTree = `$targets = [System.Collections.Generic.List[int]]::new(); function Add-Tree([int]$Id) { if ($Id -le 0) { return }; Get-CimInstance Win32_Process -Filter ('ParentProcessId = ' + $Id) -ErrorAction SilentlyContinue | ForEach-Object { Add-Tree ([int]$_.ProcessId) }; if (-not $targets.Contains($Id)) { $targets.Add($Id) } }`;
+  const portOwners = port
+    ? `$port = ${port}; foreach ($o in @(Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue | Select-Object -ExpandProperty OwningProcess | Sort-Object -Unique)) { Add-Tree ([int]$o) }; `
+    : `$port = 0; `;
+  const recordedPid = `$p = Get-Content ${pidPath} -ErrorAction SilentlyContinue; if ($p -match '^\\d+$') { Add-Tree ([int]$p) }; `;
+  const portBound = `($port -gt 0 -and @(Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue).Count -gt 0)`;
+  return `${addTree}; ${portOwners}${recordedPid}`
+    + `if ($targets.Count -eq 0) { if ($port -le 0) { Write-Error 'No serve port or recorded PID to stop'; exit 1 }; if (${portBound}) { Write-Error ('Serve port ' + $port + ' bound but owner unresolved'); exit 1 }; Remove-Item ${artifactPath} -Force -ErrorAction SilentlyContinue; exit 0 }; `
+    + `foreach ($target in @($targets)) { if (Get-Process -Id $target -ErrorAction SilentlyContinue) { & taskkill.exe /PID $target /T /F 2>$null | Out-Null } }; `
+    + `Start-Sleep -Milliseconds 250; `
+    + `if (${portBound}) { Write-Error ('Serve port ' + $port + ' still bound after kill'); exit 1 }; `
+    + `$alive = @($targets | Where-Object { Get-Process -Id $_ -ErrorAction SilentlyContinue }); if ($alive.Count -gt 0) { Write-Error ('Processes still alive: ' + ($alive -join ',')); exit 1 }; `
+    + `Remove-Item ${artifactPath} -Force -ErrorAction SilentlyContinue; exit 0`;
 }
 
 export function _tmuxGracefulKill(task) {

--- a/static/js/cookbookRunning.js
+++ b/static/js/cookbookRunning.js
@@ -1058,12 +1058,18 @@ function _winPowerShellCmd(task, ps) {
 
 function _winSessionStopTreePs(task) {
   const host = _taskRemoteHost(task);
-  const sd = host ? '$env:TEMP\\odysseus-sessions' : '$env:TEMP\\odysseus-tmux';
+  const sessionDir = host ? 'odysseus-sessions' : 'odysseus-tmux';
   const sid = task.sessionId;
-  const stopTree = `function Stop-Tree([int]$Id) { Get-CimInstance Win32_Process -Filter ('ParentProcessId = ' + $Id) -ErrorAction SilentlyContinue | ForEach-Object { Stop-Tree ([int]$_.ProcessId) }; Stop-Process -Id $Id -Force -ErrorAction SilentlyContinue }`;
-  return host
-    ? `${stopTree}; $p = Get-Content '${sd}\\${sid}.pid' -ErrorAction SilentlyContinue; if ($p -match '^\\d+$') { Stop-Tree ([int]$p) }; Remove-Item '${sd}\\${sid}.*' -Force -ErrorAction SilentlyContinue`
-    : `${stopTree}; $p = Get-Content (Join-Path $env:TEMP 'odysseus-tmux\\${sid}.pid') -ErrorAction SilentlyContinue; if ($p -match '^\\d+$') { Stop-Tree ([int]$p) }; Remove-Item (Join-Path $env:TEMP 'odysseus-tmux\\${sid}.*') -Force -ErrorAction SilentlyContinue`;
+  const pidPath = `(Join-Path $env:TEMP '${sessionDir}\\${sid}.pid')`;
+  const artifactPath = `(Join-Path $env:TEMP '${sessionDir}\\${sid}.*')`;
+  // Capture the full Win32 tree before killing anything. taskkill /T follows
+  // native Windows process relationships more reliably than recursive
+  // Stop-Process through Git Bash. Trying every captured PID also covers the
+  // case where the recorded wrapper exited but llama-server still points at
+  // that former parent. Keep the PID and logs when any process survives so the
+  // UI can retry instead of losing its only handle to the live GPU process.
+  const stopTree = `$targets = [System.Collections.Generic.List[int]]::new(); function Add-Tree([int]$Id) { Get-CimInstance Win32_Process -Filter ('ParentProcessId = ' + $Id) -ErrorAction SilentlyContinue | ForEach-Object { Add-Tree ([int]$_.ProcessId) }; if (-not $targets.Contains($Id)) { $targets.Add($Id) } }`;
+  return `${stopTree}; $p = Get-Content ${pidPath} -ErrorAction SilentlyContinue; if ($p -notmatch '^\\d+$') { Write-Error 'Missing Windows session PID'; exit 1 }; Add-Tree ([int]$p); foreach ($target in @($targets)) { if (Get-Process -Id $target -ErrorAction SilentlyContinue) { & taskkill.exe /PID $target /T /F 2>$null | Out-Null } }; Start-Sleep -Milliseconds 250; $alive = @($targets | Where-Object { Get-Process -Id $_ -ErrorAction SilentlyContinue }); if ($alive.Count -gt 0) { Write-Error ('Processes still alive: ' + ($alive -join ',')); exit 1 }; Remove-Item ${artifactPath} -Force -ErrorAction SilentlyContinue; exit 0`;
 }
 
 export function _tmuxGracefulKill(task) {
@@ -1078,13 +1084,54 @@ export function _tmuxGracefulKill(task) {
   return `tmux send-keys -t ${task.sessionId} C-c 2>/dev/null; sleep 2; tmux kill-session -t ${task.sessionId} 2>/dev/null`;
 }
 
+async function _stopTaskSession(task) {
+  let commandOk = false;
+  try {
+    const response = await fetch('/api/shell/exec', {
+      method: 'POST', credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ command: _tmuxGracefulKill(task) }),
+    });
+    if (!response.ok) return false;
+    const result = await response.json();
+    commandOk = result?.exit_code === undefined || Number(result.exit_code) === 0;
+  } catch (_) {
+    return false;
+  }
+
+  if (!task?.sessionId) return commandOk;
+
+  let probeKnown = false;
+  let stillAlive = false;
+  try {
+    const probe = await fetch('/api/shell/exec', {
+      method: 'POST', credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ command: _tmuxCmd(task, `has-session -t ${task.sessionId}`) }),
+    });
+    if (probe.ok) {
+      const result = await probe.json();
+      probeKnown = true;
+      // has-session exits 0 while the session PID/process still exists.
+      stillAlive = Number(result?.exit_code ?? 0) === 0;
+    }
+  } catch (_) { /* fall back to the stop command result */ }
+
+  if (stillAlive) return false;
+  // The Windows helper verifies every captured process before returning 0 and
+  // deliberately keeps the PID file on failure. A missing PID file makes the
+  // follow-up probe look dead, so never let that override a failed helper.
+  if (_isWindows(task) && !commandOk) return false;
+  return probeKnown || commandOk;
+}
+
 // Force-kill escalation: SIGKILL the tmux pane's owning PID and any children,
 // then nuke the session. Use AFTER the graceful kill when the process is
 // still detected — vLLM sometimes ignores SIGINT during model init, and a
 // stuck CUDA context can survive `tmux kill-session` alone.
 export function _tmuxForceKill(task) {
   if (_isWindows(task)) {
-    // Windows graceful path already does Stop-Process -Force, so the same
+    // Windows graceful path already does taskkill /T /F, so the same
     // command serves as the "force" variant.
     return _tmuxGracefulKill(task);
   }
@@ -2875,13 +2922,8 @@ export function _renderRunningTab() {
       if (el._abort) el._abort.abort();
       const badge = el.querySelector('.cookbook-task-status');
       if (badge) { badge.textContent = 'stopping...'; badge.className = 'cookbook-task-status cookbook-task-stopping'; }
-      el.dataset.status = 'stopped';
       _updateTask(task.sessionId, { _userStopped: true });
       const outputText = el.querySelector('.cookbook-output-pre')?.textContent || task.output || '';
-      // Drop the model endpoint so the picker stops listing it.
-      if (task.type === 'serve' && task.payload) {
-        _removeEndpointByUrl(_endpointUrlForTask(task, outputText));
-      }
       const ollamaUnload = _ollamaUnloadCommand(task, outputText);
       if (ollamaUnload) {
         try {
@@ -2892,16 +2934,23 @@ export function _renderRunningTab() {
           });
         } catch {}
       }
-      // Gracefully stop (C-c, then kill the session) so it's fully down...
-      try {
-        await fetch('/api/shell/exec', {
-          method: 'POST', credentials: 'same-origin',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ command: _tmuxGracefulKill(task) }),
-        });
-      } catch {}
-      // ...then smoothly fade/slide the card out and auto-remove it — no manual
-      // ⋮ → Remove needed.
+      const stopped = await _stopTaskSession(task);
+      if (!stopped) {
+        const priorStatus = task.status || 'running';
+        el.dataset.status = priorStatus;
+        _updateTask(task.sessionId, { _userStopped: false, status: priorStatus });
+        if (badge) {
+          badge.textContent = _statusLabel(priorStatus, task.type);
+          badge.className = `cookbook-task-status cookbook-task-${priorStatus}`;
+        }
+        uiModule.showToast('Stop failed: process exit was not confirmed. The task was kept so you can retry.', 'error');
+        return;
+      }
+      el.dataset.status = 'stopped';
+      if (task.type === 'serve' && task.payload) {
+        _removeEndpointByUrl(_endpointUrlForTask(task, outputText));
+      }
+      // Only remove the card after the process/session is confirmed gone.
       _animateOutThenRemove(el, task.sessionId);
     });
 
@@ -2912,7 +2961,6 @@ export function _renderRunningTab() {
     // row disappeared from the UI.
     el.querySelector('.cookbook-task-action-kill').addEventListener('click', async () => {
       const outputText = el.querySelector('.cookbook-output-pre')?.textContent || task.output || '';
-      const isLive = task.type === 'serve' && ['running', 'ready', 'loading', 'warming', 'starting'].includes(task.status || '');
       const ollamaUnload = _ollamaUnloadCommand(task, outputText);
       if (ollamaUnload) {
         try {
@@ -2923,37 +2971,9 @@ export function _renderRunningTab() {
           });
         } catch (_) { /* unload best-effort */ }
       }
-      let killOk = true;
-      try {
-        const r = await fetch('/api/shell/exec', {
-          method: 'POST', credentials: 'same-origin',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ command: _tmuxGracefulKill(task) }),
-        });
-        if (r.ok) {
-          const out = await r.json();
-          // Don't trust exit_code alone — tmux kill returns 0 even when
-          // there was nothing to kill. Verify the session is actually gone.
-          if (task.sessionId && isLive) {
-            try {
-              const probe = await fetch('/api/shell/exec', {
-                method: 'POST', credentials: 'same-origin',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ command: _tmuxCmd(task, `has-session -t ${task.sessionId}`) }),
-              });
-              if (probe.ok) {
-                const pj = await probe.json();
-                // has-session exits 0 when session STILL exists; non-zero = gone.
-                if ((pj.exit_code || 0) === 0) killOk = false;
-              }
-            } catch (_) { /* probe best-effort; trust kill */ }
-          }
-        } else {
-          killOk = false;
-        }
-      } catch (_) { killOk = false; }
+      const killOk = await _stopTaskSession(task);
       if (!killOk) {
-        try { uiModule.showToast('Kill failed — session may still be running. Check `tmux ls` on the server.', 'error'); } catch (_) {}
+        try { uiModule.showToast('Kill failed: process exit was not confirmed. The task was kept so you can retry.', 'error'); } catch (_) {}
         return;  // leave the row so the user can retry
       }
       if (task.type === 'serve' && task.payload) {

--- a/static/js/cookbookRunning.js
+++ b/static/js/cookbookRunning.js
@@ -1056,35 +1056,83 @@ function _winPowerShellCmd(task, ps) {
   return `ssh ${_sshPrefix(_getPort(task))}${host} ${_shQuote(command)}`;
 }
 
+// Resolve the serve port for a task. Prefers an authoritative runtime port
+// persisted by the backend, then the supported command forms — `--port`, `-p`,
+// `OLLAMA_HOST=host:port`, and the Ollama default — so `-p` and Ollama serves
+// are verified rather than silently skipped. Returns '' when unknown so callers
+// fail closed instead of reporting an unverifiable stop as clean.
+function _taskServePort(task) {
+  const persisted = task?.payload?.port ?? task?.port;
+  if (persisted != null && /^\d+$/.test(String(persisted))) return String(persisted);
+  const cmd = task?.payload?._cmd || '';
+  let m = cmd.match(/--port[=\s]+(\d+)/) || cmd.match(/(?:^|\s)-p[=\s]+(\d+)/);
+  if (m) return m[1];
+  m = cmd.match(/OLLAMA_HOST=[^\s'"]*?:(\d+)/i);
+  if (m) return m[1];
+  if (/\bollama\s+serve\b/i.test(cmd)) return '11434';
+  return '';
+}
+
+// A distinctive token the genuine server's Win32 command line must contain,
+// used to prove a port listener actually belongs to this task before
+// force-killing it. The model file/name is far more specific than the port,
+// which can be stale, reused, or backend-reassigned. '' means no reliable
+// identity, so the port owner is treated as unproven and not killed.
+function _taskProcessIdentity(task) {
+  const cmd = task?.payload?._cmd || '';
+  let m = cmd.match(/([^\s"'\\/]+\.gguf)/i);
+  if (m) return m[1];
+  m = cmd.match(/--model[=\s]+"?([^"\s]+)"?/);
+  if (m) {
+    const seg = m[1].split(/[\\/]/).pop();
+    if (seg && seg.length >= 4) return seg;
+  }
+  m = cmd.match(/\bollama\s+run\s+([^\s'"]+)/i);
+  if (m) return m[1];
+  return '';
+}
+
+// PowerShell single-quoted string literal (doubles embedded quotes).
+function _psLit(value) {
+  return `'${String(value ?? '').replace(/'/g, "''")}'`;
+}
+
 function _winSessionStopTreePs(task) {
   const host = _taskRemoteHost(task);
   const sessionDir = host ? 'odysseus-sessions' : 'odysseus-tmux';
   const sid = task.sessionId;
   const pidPath = `(Join-Path $env:TEMP '${sessionDir}\\${sid}.pid')`;
   const artifactPath = `(Join-Path $env:TEMP '${sessionDir}\\${sid}.*')`;
-  // The LISTENING serve port is the source of truth for "is the model still
-  // up", not the recorded PID. That PID is only a Git Bash wrapper in the
-  // launch chain, never llama-server.exe itself: a native binary started
-  // through the bash runner (or a ~/bin shim that `exec`s it) is reparented
-  // into a separate Win32 subtree, so a tree walk from the wrapper PID can miss
-  // the live GPU process and then wrongly report a clean stop. Kill the port
-  // owner first (that is the real server), fold in the recorded wrapper tree to
-  // clean up logs/children, then verify against the port — never the wrapper
-  // alone. Keep the PID/artifacts while the port stays bound so the UI retries
-  // instead of losing its only handle to the live GPU process.
-  const portMatch = task?.payload?._cmd?.match(/--port[=\s]+(\d+)/);
-  const port = portMatch ? portMatch[1] : '';
+  // The recorded PID is only a Git Bash wrapper in the launch chain, never
+  // llama-server.exe itself: a native binary started through the bash runner
+  // (or a ~/bin shim that `exec`s it) is reparented into a separate Win32
+  // subtree, so a tree walk from the wrapper PID can miss the live GPU process.
+  // The authoritative signal is the LISTENING serve port — but its owner is
+  // killed only after its command line is proven to belong to this task
+  // (identity match), so a stale task or a reused port can never take down an
+  // unrelated service. A bound port whose owner cannot be proven ours fails
+  // closed and keeps the task so the UI can retry, while a task with no live
+  // process or listener is cleaned up so Remove can clear a dead row.
+  const isServe = task?.type === 'serve';
+  const port = _taskServePort(task);
+  const portLit = /^\d+$/.test(port) ? port : '0';
+  const idLit = _psLit(_taskProcessIdentity(task));
   const addTree = `$targets = [System.Collections.Generic.List[int]]::new(); function Add-Tree([int]$Id) { if ($Id -le 0) { return }; Get-CimInstance Win32_Process -Filter ('ParentProcessId = ' + $Id) -ErrorAction SilentlyContinue | ForEach-Object { Add-Tree ([int]$_.ProcessId) }; if (-not $targets.Contains($Id)) { $targets.Add($Id) } }`;
-  const portOwners = port
-    ? `$port = ${port}; foreach ($o in @(Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue | Select-Object -ExpandProperty OwningProcess | Sort-Object -Unique)) { Add-Tree ([int]$o) }; `
-    : `$port = 0; `;
-  const recordedPid = `$p = Get-Content ${pidPath} -ErrorAction SilentlyContinue; if ($p -match '^\\d+$') { Add-Tree ([int]$p) }; `;
-  const portBound = `($port -gt 0 -and @(Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue).Count -gt 0)`;
-  return `${addTree}; ${portOwners}${recordedPid}`
-    + `if ($targets.Count -eq 0) { if ($port -le 0) { Write-Error 'No serve port or recorded PID to stop'; exit 1 }; if (${portBound}) { Write-Error ('Serve port ' + $port + ' bound but owner unresolved'); exit 1 }; Remove-Item ${artifactPath} -Force -ErrorAction SilentlyContinue; exit 0 }; `
+  const ownedFn = `$identity = ${idLit}; function Test-Owned([int]$Id) { if ($Id -le 0 -or $identity -eq '') { return $false }; $cl = (Get-CimInstance Win32_Process -Filter ('ProcessId = ' + $Id) -ErrorAction SilentlyContinue).CommandLine; if ($null -eq $cl) { return $false }; return $cl.ToLower().Contains($identity.ToLower()) }`;
+  const listenersFn = `function Get-Listeners([int]$Prt) { $r = [System.Collections.Generic.List[int]]::new(); if ($Prt -le 0) { return ,$r }; foreach ($o in @(Get-NetTCPConnection -LocalPort $Prt -State Listen -ErrorAction SilentlyContinue | Select-Object -ExpandProperty OwningProcess | Sort-Object -Unique)) { if ([int]$o -gt 0) { $r.Add([int]$o) } }; return ,$r }`;
+  return `${addTree}; ${ownedFn}; ${listenersFn}; `
+    + `$port = ${portLit}; $isServe = ${isServe ? '$true' : '$false'}; `
+    + `$p = Get-Content ${pidPath} -ErrorAction SilentlyContinue; if ($p -match '^\\d+$') { Add-Tree ([int]$p) }; `
+    + `$unverified = $false; foreach ($o in @(Get-Listeners $port)) { if (Test-Owned $o) { Add-Tree $o } else { $unverified = $true } }; `
+    + `if ($targets.Count -eq 0) { `
+    +   `if ($unverified) { Write-Error ('Serve port ' + $port + ' bound by an unverified process; refusing to force-kill'); exit 1 }; `
+    +   `if ($isServe -and $port -le 0) { Write-Error 'Serve task has no resolvable port; cannot verify shutdown'; exit 1 }; `
+    +   `Remove-Item ${artifactPath} -Force -ErrorAction SilentlyContinue; exit 0 `
+    + `}; `
     + `foreach ($target in @($targets)) { if (Get-Process -Id $target -ErrorAction SilentlyContinue) { & taskkill.exe /PID $target /T /F 2>$null | Out-Null } }; `
     + `Start-Sleep -Milliseconds 250; `
-    + `if (${portBound}) { Write-Error ('Serve port ' + $port + ' still bound after kill'); exit 1 }; `
+    + `$stillOwned = $false; foreach ($o in @(Get-Listeners $port)) { if (Test-Owned $o) { $stillOwned = $true } }; `
+    + `if ($stillOwned) { Write-Error ('Serve port ' + $port + ' still held by a task process after kill'); exit 1 }; `
     + `$alive = @($targets | Where-Object { Get-Process -Id $_ -ErrorAction SilentlyContinue }); if ($alive.Count -gt 0) { Write-Error ('Processes still alive: ' + ($alive -join ',')); exit 1 }; `
     + `Remove-Item ${artifactPath} -Force -ErrorAction SilentlyContinue; exit 0`;
 }

--- a/static/js/cookbookRunning.js
+++ b/static/js/cookbookRunning.js
@@ -8,7 +8,12 @@ import uiModule from './ui.js';
 import { _diagnose, _showDiagnosis, _clearDiagnosis } from './cookbook-diagnosis.js';
 import { registerMenuDismiss } from './escMenuStack.js';
 import { computeProgressSignal } from './cookbookProgressSignal.js';
-import { portOf, nextFreePort } from './cookbookPorts.js';
+import {
+  portOf,
+  nextFreePort,
+  taskServePort,
+  withEffectiveServeMetadata,
+} from './cookbookPorts.js';
 import { topPortalZ } from './toolWindowZOrder.js';
 
 // Human-friendly badge label for a task's internal status. Avoids surfacing
@@ -298,7 +303,7 @@ function _taskHostLabel(task) {
 }
 
 function _taskPort(task) {
-  return portOf(task?.payload?._cmd || '');
+  return taskServePort(task);
 }
 
 function _buildCrashReport(task, outputText) {
@@ -514,7 +519,7 @@ function _nextAvailablePort() {
   const presets = _loadPresets();
   const usedPorts = new Set();
   tasks.forEach(t => {
-    if (t.type === 'serve' && (t.status === 'running' || t.status === 'queued')) {
+    if (t.type === 'serve' && (_isStoppableTask(t) || t.status === 'queued' || t._serveReady)) {
       const p = _taskPort(t);
       if (p) usedPorts.add(parseInt(p));
     }
@@ -1031,9 +1036,7 @@ function _winSessionCmd(task, tmuxArgs) {
     return _winPowerShellCmd(task, ps);
   }
   if (tmuxArgs.includes('has-session')) {
-    const ps = host
-      ? `$p = Get-Content '${sd}\\${sid}.pid' -ErrorAction SilentlyContinue; if ($p) { Get-Process -Id $p -ErrorAction SilentlyContinue | Out-Null; if ($?) { exit 0 } else { exit 1 } } else { exit 1 }`
-      : `$p = Get-Content (Join-Path $env:TEMP 'odysseus-tmux\\${sid}.pid') -ErrorAction SilentlyContinue; if ($p) { Get-Process -Id $p -ErrorAction SilentlyContinue | Out-Null; if ($?) { exit 0 } else { exit 1 } } else { exit 1 }`;
+    const ps = _winSessionRootProofPs(task);
     return _winPowerShellCmd(task, ps);
   }
   if (tmuxArgs.includes('kill-session')) {
@@ -1062,15 +1065,7 @@ function _winPowerShellCmd(task, ps) {
 // are verified rather than silently skipped. Returns '' when unknown so callers
 // fail closed instead of reporting an unverifiable stop as clean.
 function _taskServePort(task) {
-  const persisted = task?.payload?.port ?? task?.port;
-  if (persisted != null && /^\d+$/.test(String(persisted))) return String(persisted);
-  const cmd = task?.payload?._cmd || '';
-  let m = cmd.match(/--port[=\s]+(\d+)/) || cmd.match(/(?:^|\s)-p[=\s]+(\d+)/);
-  if (m) return m[1];
-  m = cmd.match(/OLLAMA_HOST=[^\s'"]*?:(\d+)/i);
-  if (m) return m[1];
-  if (/\bollama\s+serve\b/i.test(cmd)) return '11434';
-  return '';
+  return taskServePort(task);
 }
 
 // A distinctive token the genuine server's Win32 command line must contain,
@@ -1080,16 +1075,51 @@ function _taskServePort(task) {
 // identity, so the port owner is treated as unproven and not killed.
 function _taskProcessIdentity(task) {
   const cmd = task?.payload?._cmd || '';
-  let m = cmd.match(/([^\s"'\\/]+\.gguf)/i);
-  if (m) return m[1];
-  m = cmd.match(/--model[=\s]+"?([^"\s]+)"?/);
+  const stableToken = (value) => {
+    const seg = String(value || '').split(/[\\/]/).pop();
+    if (!seg || seg.length < 4 || /[?*$()[\]{}]/.test(seg)) return '';
+    return seg;
+  };
+  let m = cmd.match(/--model(?:-path|-id)?[=\s]+"?([^"\s]+)"?/i);
   if (m) {
-    const seg = m[1].split(/[\\/]/).pop();
-    if (seg && seg.length >= 4) return seg;
+    const token = stableToken(m[1]);
+    if (token) return token;
   }
+  m = cmd.match(/([^\s"'\\/]+\.gguf)/i);
+  if (m) {
+    const token = stableToken(m[1]);
+    if (token) return token;
+  }
+  m = cmd.match(/\bvllm\s+serve\s+([^\s'"]+)/i);
+  if (m) return m[1];
   m = cmd.match(/\bollama\s+run\s+([^\s'"]+)/i);
   if (m) return m[1];
+  const repo = String(task?.payload?.repo_id || task?.modelId || '').trim();
+  if (repo.length >= 4) return repo;
   return '';
+}
+
+function _taskProcessEngine(task) {
+  const cmd = task?.payload?._cmd || '';
+  if (/\bollama\s+serve\b/i.test(cmd)) return 'ollama';
+  if (/\bllama-server(?:\.exe)?\b/i.test(cmd) || /\bllama_cpp\.server\b/i.test(cmd)) return 'llama';
+  return '';
+}
+
+function _taskOwnsServeListener(task) {
+  if (task?.type !== 'serve') return false;
+  const cmd = task?.payload?._cmd || '';
+  const repo = String(task?.payload?.repo_id || '');
+  // Dependency repair and pip maintenance use the serve launcher only to get
+  // a tracked background session. They never own a network listener.
+  if (task?.payload?._dep || /^pip(?:-|\s|$)/i.test(repo)
+    || /\b(?:python3?|py)(?:\.exe)?\s+-m\s+pip\s+(?:install|uninstall)\b/i.test(cmd)
+    || /\b(?:pip3?(?:\.exe)?|uv(?:\.exe)?\s+pip)\s+(?:install|uninstall)\b/i.test(cmd)) return false;
+  // These commands attach a short-lived tracked wrapper to an existing Ollama
+  // daemon. Stopping the task must not kill that shared daemon or require its
+  // port to become unbound.
+  return !/\bdocker\s+exec\s+(?:ollama-rocm|ollama-test)\b/i.test(cmd)
+    && !/\bollama\s+run\b/i.test(cmd);
 }
 
 // PowerShell single-quoted string literal (doubles embedded quotes).
@@ -1097,49 +1127,71 @@ function _psLit(value) {
   return `'${String(value ?? '').replace(/'/g, "''")}'`;
 }
 
-function _winSessionStopTreePs(task) {
+function _winSessionRootProofPs(task) {
   const host = _taskRemoteHost(task);
   const sessionDir = host ? 'odysseus-sessions' : 'odysseus-tmux';
   const sid = task.sessionId;
   const pidPath = `(Join-Path $env:TEMP '${sessionDir}\\${sid}.pid')`;
-  const artifactPath = `(Join-Path $env:TEMP '${sessionDir}\\${sid}.*')`;
+  const marker = _psLit(sid);
+  return `$sessionMarker = ${marker}; $p = Get-Content ${pidPath} -ErrorAction SilentlyContinue; if ($p -notmatch '^\\d+$') { exit 1 }; $proc = Get-CimInstance Win32_Process -Filter ('ProcessId = ' + [int]$p) -ErrorAction SilentlyContinue; if ($null -eq $proc -or $null -eq $proc.CommandLine) { exit 1 }; $lower = $proc.CommandLine.ToLower(); if ($lower.Contains(($sessionMarker + '.sh').ToLower()) -or $lower.Contains(($sessionMarker + '_run.sh').ToLower()) -or $lower.Contains(($sessionMarker + '.cmd').ToLower()) -or $lower.Contains(($sessionMarker + '_run.ps1').ToLower())) { exit 0 }; exit 1`;
+}
+
+function _winSessionStopTreePs(task, { allowDeadServeCleanup = false } = {}) {
+  const host = _taskRemoteHost(task);
+  const sessionDir = host ? 'odysseus-sessions' : 'odysseus-tmux';
+  const sid = task.sessionId;
+  const pidPath = `(Join-Path $env:TEMP '${sessionDir}\\${sid}.pid')`;
+  // Launchers use both "<session>.*" (pid/log/wrapper) and
+  // "<session>_*" (the actual _run.sh/_run.ps1 script).
+  const artifactPaths = `@((Join-Path $env:TEMP '${sessionDir}\\${sid}.*'), (Join-Path $env:TEMP '${sessionDir}\\${sid}_*'))`;
   // The recorded PID is only a Git Bash wrapper in the launch chain, never
   // llama-server.exe itself: a native binary started through the bash runner
   // (or a ~/bin shim that `exec`s it) is reparented into a separate Win32
   // subtree, so a tree walk from the wrapper PID can miss the live GPU process.
-  // The authoritative signal is the LISTENING serve port — but its owner is
-  // killed only after its command line is proven to belong to this task
-  // (identity match), so a stale task or a reused port can never take down an
-  // unrelated service. A bound port whose owner cannot be proven ours fails
-  // closed and keeps the task so the UI can retry, while a task with no live
-  // process or listener is cleaned up so Remove can clear a dead row.
-  const isServe = task?.type === 'serve';
+  // We prove ownership twice: the process command line must identify this
+  // model/engine, and its Win32 ancestry must contain this session's runner
+  // artifact. The ancestry scan also finds a matching process before it opens
+  // the port, including the separate Git Bash subtree that caused the original
+  // GPU leak. Ambiguous listeners/PIDs fail closed and keep the task.
+  const isServe = _taskOwnsServeListener(task);
+  const allowDead = !!allowDeadServeCleanup;
   const port = _taskServePort(task);
   const portLit = /^\d+$/.test(port) ? port : '0';
   const idLit = _psLit(_taskProcessIdentity(task));
+  const engineLit = _psLit(_taskProcessEngine(task));
+  const sessionLit = _psLit(sid);
   const addTree = `$targets = [System.Collections.Generic.List[int]]::new(); function Add-Tree([int]$Id) { if ($Id -le 0) { return }; Get-CimInstance Win32_Process -Filter ('ParentProcessId = ' + $Id) -ErrorAction SilentlyContinue | ForEach-Object { Add-Tree ([int]$_.ProcessId) }; if (-not $targets.Contains($Id)) { $targets.Add($Id) } }`;
-  const ownedFn = `$identity = ${idLit}; function Test-Owned([int]$Id) { if ($Id -le 0 -or $identity -eq '') { return $false }; $cl = (Get-CimInstance Win32_Process -Filter ('ProcessId = ' + $Id) -ErrorAction SilentlyContinue).CommandLine; if ($null -eq $cl) { return $false }; return $cl.ToLower().Contains($identity.ToLower()) }`;
-  const listenersFn = `function Get-Listeners([int]$Prt) { $r = [System.Collections.Generic.List[int]]::new(); if ($Prt -le 0) { return ,$r }; foreach ($o in @(Get-NetTCPConnection -LocalPort $Prt -State Listen -ErrorAction SilentlyContinue | Select-Object -ExpandProperty OwningProcess | Sort-Object -Unique)) { if ([int]$o -gt 0) { $r.Add([int]$o) } }; return ,$r }`;
-  return `${addTree}; ${ownedFn}; ${listenersFn}; `
-    + `$port = ${portLit}; $isServe = ${isServe ? '$true' : '$false'}; `
-    + `$p = Get-Content ${pidPath} -ErrorAction SilentlyContinue; if ($p -match '^\\d+$') { Add-Tree ([int]$p) }; `
-    + `$unverified = $false; foreach ($o in @(Get-Listeners $port)) { if (Test-Owned $o) { Add-Tree $o } else { $unverified = $true } }; `
-    + `if ($targets.Count -eq 0) { `
-    +   `if ($unverified) { Write-Error ('Serve port ' + $port + ' bound by an unverified process; refusing to force-kill'); exit 1 }; `
-    +   `if ($isServe -and $port -le 0) { Write-Error 'Serve task has no resolvable port; cannot verify shutdown'; exit 1 }; `
-    +   `Remove-Item ${artifactPath} -Force -ErrorAction SilentlyContinue; exit 0 `
-    + `}; `
-    + `foreach ($target in @($targets)) { if (Get-Process -Id $target -ErrorAction SilentlyContinue) { & taskkill.exe /PID $target /T /F 2>$null | Out-Null } }; `
-    + `Start-Sleep -Milliseconds 250; `
-    + `$stillOwned = $false; foreach ($o in @(Get-Listeners $port)) { if (Test-Owned $o) { $stillOwned = $true } }; `
-    + `if ($stillOwned) { Write-Error ('Serve port ' + $port + ' still held by a task process after kill'); exit 1 }; `
-    + `$alive = @($targets | Where-Object { Get-Process -Id $_ -ErrorAction SilentlyContinue }); if ($alive.Count -gt 0) { Write-Error ('Processes still alive: ' + ($alive -join ',')); exit 1 }; `
-    + `Remove-Item ${artifactPath} -Force -ErrorAction SilentlyContinue; exit 0`;
+  const ownedFn = `$identity = ${idLit}; $engine = ${engineLit}; function Test-Owned([int]$Id, $Process = $null) { if ($Id -le 0) { return $false }; $proc = $Process; if ($null -eq $proc) { $proc = Get-CimInstance Win32_Process -Filter ('ProcessId = ' + $Id) -ErrorAction SilentlyContinue }; if ($null -eq $proc -or $null -eq $proc.CommandLine) { return $false }; if (@('powershell.exe','pwsh.exe','cmd.exe','bash.exe','sh.exe','ssh.exe') -contains $proc.Name.ToLower()) { return $false }; $cl = $proc.CommandLine; if ($identity -ne '' -and $cl.ToLower().Contains($identity.ToLower())) { return $true }; if ($engine -eq 'ollama' -and $proc.Name -ieq 'ollama.exe' -and $cl -match '(?i)(?:^|\\s)serve(?:\\s|$)') { return $true }; if ($engine -eq 'llama' -and ($proc.Name -ieq 'llama-server.exe' -or $proc.Name -ieq 'llama-server' -or $cl -match '(?i)(?:^|\\s)llama-server(?:\\.exe)?(?:\\s|$)' -or $cl -match '(?i)(?:^|\\s)-m\\s+llama_cpp\\.server(?:\\s|$)')) { return $true }; return $false }`;
+  const sessionFn = `$sessionMarker = ${sessionLit}; function Test-SessionRoot([int]$Id) { if ($Id -le 0 -or $sessionMarker -eq '') { return $false }; $cl = (Get-CimInstance Win32_Process -Filter ('ProcessId = ' + $Id) -ErrorAction SilentlyContinue).CommandLine; if ($null -eq $cl) { return $false }; $lower = $cl.ToLower(); return $lower.Contains(($sessionMarker + '.sh').ToLower()) -or $lower.Contains(($sessionMarker + '_run.sh').ToLower()) -or $lower.Contains(($sessionMarker + '.cmd').ToLower()) -or $lower.Contains(($sessionMarker + '_run.ps1').ToLower()) }`;
+  const lineageFn = `function Get-SessionRoot([int]$Id) { $seen = [System.Collections.Generic.HashSet[int]]::new(); $cur = $Id; for ($i = 0; $i -lt 64 -and $cur -gt 0 -and $seen.Add($cur); $i++) { if (Test-SessionRoot $cur) { return [int]$cur }; $proc = Get-CimInstance Win32_Process -Filter ('ProcessId = ' + $cur) -ErrorAction SilentlyContinue; if ($null -eq $proc -or [int]$proc.ParentProcessId -eq $cur) { return 0 }; $cur = [int]$proc.ParentProcessId }; return 0 }`;
+  const listenersFn = `function Get-Listeners([int]$Prt) { if ($Prt -le 0) { return }; try { $net = @(Get-NetTCPConnection -LocalPort $Prt -State Listen -ErrorAction Stop | Select-Object -ExpandProperty OwningProcess | Sort-Object -Unique); foreach ($id in $net) { if ([int]$id -gt 0) { [int]$id } }; return } catch {}; try { $rows = @(& netstat.exe -ano -p TCP 2>$null); if ($LASTEXITCODE -ne 0) { throw 'netstat failed' }; foreach ($line in $rows) { $parts = @(($line -split '\\s+') | Where-Object { $_ }); if ($parts.Count -ge 5 -and $parts[0] -eq 'TCP' -and $parts[1] -match (':' + $Prt + '$') -and $parts[2] -match ':0$' -and $parts[4] -match '^\\d+$') { [int]$parts[4] } } } catch { $script:listenerQueryOk = $false } }`;
+  return `${addTree}; ${ownedFn}; ${sessionFn}; ${lineageFn}; ${listenersFn}; `
+      + `$port = ${portLit}; $isServe = ${isServe ? '$true' : '$false'}; `
+      + `$allowDeadServeCleanup = ${allowDead ? '$true' : '$false'}; `
+      + `if ($isServe -and $port -le 0) { Write-Error 'Serve task has no resolvable port; cannot verify shutdown'; exit 1 }; `
+      + `$unsafePid = $false; $sessionRootVerified = $false; $p = Get-Content ${pidPath} -ErrorAction SilentlyContinue; if ($p -match '^\\d+$') { $pidProc = Get-CimInstance Win32_Process -Filter ('ProcessId = ' + [int]$p) -ErrorAction SilentlyContinue; if ($null -ne $pidProc) { if (Test-SessionRoot ([int]$p)) { $sessionRootVerified = $true; Add-Tree ([int]$p) } else { $unsafePid = $true } } }; `
+      + `$script:processQueryOk = $true; if ($isServe) { try { $processes = @(Get-CimInstance Win32_Process -ErrorAction Stop) } catch { $script:processQueryOk = $false; $processes = @() }; if (-not $processQueryOk) { Write-Error 'Could not inspect Windows processes; refusing an unverifiable stop'; exit 1 }; foreach ($candidate in $processes) { if (Test-Owned ([int]$candidate.ProcessId) $candidate) { $root = Get-SessionRoot ([int]$candidate.ProcessId); if ($root -gt 0) { Add-Tree $root; Add-Tree ([int]$candidate.ProcessId) } } } }; `
+      + `$script:listenerQueryOk = $true; $listeners = @(); if ($isServe) { $listeners = @(Get-Listeners $port); if (-not $listenerQueryOk) { Write-Error ('Could not inspect serve port ' + $port + '; refusing an unverifiable stop'); exit 1 } }; `
+      + `$unverified = $false; foreach ($o in $listeners) { $root = Get-SessionRoot ([int]$o); if ((Test-Owned ([int]$o)) -and $root -gt 0) { Add-Tree $root; Add-Tree ([int]$o) } else { $unverified = $true } }; `
+      + `if ($unsafePid) { Write-Error 'Recorded task PID belongs to an unverified process; refusing to force-kill'; exit 1 }; `
+      + `if ($unverified) { Write-Error ('Serve port ' + $port + ' is bound by an unverified process; refusing to force-kill'); exit 1 }; `
+      + `if ($targets.Count -eq 0) { `
+      +   `if ($isServe -and -not $allowDeadServeCleanup) { Write-Error 'No verified session root or listener was found; refusing an unverifiable serve cleanup'; exit 1 }; `
+      +   `$artifacts = ${artifactPaths}; Remove-Item -Path $artifacts -Force -ErrorAction SilentlyContinue; exit 0 `
+      + `}; `
+      + `foreach ($target in @($targets)) { if (Get-Process -Id $target -ErrorAction SilentlyContinue) { & taskkill.exe /PID $target /T /F 2>$null | Out-Null } }; `
+      + `Start-Sleep -Milliseconds 250; `
+      + `$script:listenerQueryOk = $true; $remainingListeners = @(); if ($isServe) { $remainingListeners = @(Get-Listeners $port); if (-not $listenerQueryOk) { Write-Error ('Could not verify serve port ' + $port + ' after kill'); exit 1 }; if ($remainingListeners.Count -gt 0) { Write-Error ('Serve port ' + $port + ' is still bound after kill'); exit 1 } }; `
+      + `$alive = @($targets | Where-Object { Get-Process -Id $_ -ErrorAction SilentlyContinue }); if ($alive.Count -gt 0) { Write-Error ('Processes still alive: ' + ($alive -join ',')); exit 1 }; `
+      // Check only matching processes still rooted in this session. Another
+      // valid task may serve the same model/engine on a different port.
+      + `if ($isServe) { try { $remainingOwned = @(Get-CimInstance Win32_Process -ErrorAction Stop | Where-Object { (Test-Owned ([int]$_.ProcessId) $_) -and (Get-SessionRoot ([int]$_.ProcessId)) -gt 0 }) } catch { Write-Error 'Could not verify model processes after kill'; exit 1 }; if ($remainingOwned.Count -gt 0) { Write-Error ('Matching model process still exists after kill: ' + (($remainingOwned | Select-Object -ExpandProperty ProcessId) -join ',')); exit 1 } }; `
+      + `$artifacts = ${artifactPaths}; Remove-Item -Path $artifacts -Force -ErrorAction SilentlyContinue; exit 0`;
 }
 
-export function _tmuxGracefulKill(task) {
+export function _tmuxGracefulKill(task, options = {}) {
   if (_isWindows(task)) {
-    const ps = _winSessionStopTreePs(task);
+    const ps = _winSessionStopTreePs(task, options);
     return _winPowerShellCmd(task, ps);
   }
   const host = _taskRemoteHost(task);
@@ -1149,13 +1201,13 @@ export function _tmuxGracefulKill(task) {
   return `tmux send-keys -t ${task.sessionId} C-c 2>/dev/null; sleep 2; tmux kill-session -t ${task.sessionId} 2>/dev/null`;
 }
 
-async function _stopTaskSession(task) {
+async function _stopTaskSession(task, { allowDeadServeCleanup = false } = {}) {
   let commandOk = false;
   try {
     const response = await fetch('/api/shell/exec', {
       method: 'POST', credentials: 'same-origin',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ command: _tmuxGracefulKill(task) }),
+      body: JSON.stringify({ command: _tmuxGracefulKill(task, { allowDeadServeCleanup }) }),
     });
     if (!response.ok) return false;
     const result = await response.json();
@@ -1188,6 +1240,73 @@ async function _stopTaskSession(task) {
   // follow-up probe look dead, so never let that override a failed helper.
   if (_isWindows(task) && !commandOk) return false;
   return probeKnown || commandOk;
+}
+
+async function _stopTaskFromElement(el, task, { showFailure = true } = {}) {
+  if (!task) return false;
+  // Abort reconnect before the shell writes a failure marker; otherwise a
+  // user-requested stop can race the download auto-retry path.
+  if (el?._abort) el._abort.abort();
+  const badge = el?.querySelector?.('.cookbook-task-status') || null;
+  if (badge) {
+    badge.textContent = 'stopping...';
+    badge.className = 'cookbook-task-status cookbook-task-stopping';
+  }
+  _updateTask(task.sessionId, { _userStopped: true });
+  const outputText = el?.querySelector?.('.cookbook-output-pre')?.textContent || task.output || '';
+  const ollamaUnload = _ollamaUnloadCommand(task, outputText);
+  // A direct `ollama serve` owns its daemon and the verified stop below kills
+  // it. Sidecar/`ollama run` tasks share an external daemon, so unload only
+  // after proving this exact tracked session is still live. A stale task must
+  // never send keep_alive:0 to a new service that reused its saved port.
+  if (ollamaUnload && !_taskOwnsServeListener(task) && await _taskSessionOwnershipConfirmed(task)) {
+    try {
+      await fetch('/api/shell/exec', {
+        method: 'POST', credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ command: ollamaUnload }),
+      });
+    } catch {}
+  }
+  const stopped = await _stopTaskSession(task, {
+    allowDeadServeCleanup: task.type === 'serve' && _canClearTask(task),
+  });
+  if (!stopped) {
+    const priorStatus = task.status || 'running';
+    if (el?.dataset) el.dataset.status = priorStatus;
+    _updateTask(task.sessionId, { _userStopped: false, status: priorStatus });
+    if (badge) {
+      badge.textContent = _statusLabel(priorStatus, task.type);
+      badge.className = `cookbook-task-status cookbook-task-${priorStatus}`;
+    }
+    if (showFailure) {
+      uiModule.showToast('Stop failed: process exit was not confirmed. The task was kept so you can retry.', 'error');
+    }
+    return false;
+  }
+  if (el?.dataset) el.dataset.status = 'stopped';
+  if (task.type === 'serve' && task.payload) {
+    _removeEndpointByUrl(_endpointUrlForTask(task, outputText));
+  }
+  if (el) _animateOutThenRemove(el, task.sessionId);
+  else _removeTask(task.sessionId);
+  return true;
+}
+
+async function _taskSessionOwnershipConfirmed(task) {
+  if (!task?.sessionId) return false;
+  try {
+    const response = await fetch('/api/shell/exec', {
+      method: 'POST', credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ command: _tmuxCmd(task, `has-session -t ${task.sessionId}`) }),
+    });
+    if (!response.ok) return false;
+    const result = await response.json();
+    return Number(result?.exit_code ?? 1) === 0;
+  } catch (_) {
+    return false;
+  }
 }
 
 // Force-kill escalation: SIGKILL the tmux pane's owning PID and any children,
@@ -1247,9 +1366,7 @@ function _ollamaBaseUrlForTask(task, outputText = '') {
   const out = String(outputText || '');
   const ready = out.match(/Ollama API ready on port\s+\d+:\s*(http:\/\/[^\s]+)/i);
   if (ready) return ready[1].replace(/\/+$/, '');
-  const cmd = String(task?.payload?._cmd || '');
-  const host = cmd.match(/OLLAMA_HOST=([^\s]+)/)?.[1] || '';
-  const port = host.match(/:(\d+)$/)?.[1] || '11434';
+  const port = _taskServePort(task) || '11434';
   return `http://127.0.0.1:${port}`;
 }
 
@@ -1276,8 +1393,7 @@ function _endpointUrlForTask(task, outputText = '') {
     return _ollamaBaseUrlForTask(task, outputText) + '/v1';
   }
   const host = _connectHostFromRemote(_taskRemoteHost(task));
-  const portMatch = task.payload?._cmd?.match(/--port\s+(\d+)/);
-  const port = portMatch ? portMatch[1] : '8000';
+  const port = _taskServePort(task) || '8000';
   return `http://${host}:${port}/v1`;
 }
 
@@ -1365,8 +1481,7 @@ function _redactPresetForStorage(preset) {
 
 function _saveTaskAsPreset(task, label) {
   const host = task.remoteHost || 'localhost';
-  const portMatch = task.payload?._cmd?.match(/--port\s+(\d+)/);
-  const port = portMatch ? portMatch[1] : '8000';
+  const port = _taskServePort(task) || '8000';
   const presets = _loadPresets();
   if (presets.some(p => p.cmd === task.payload._cmd)) return false;
   presets.push(_redactPresetForStorage({ name: task.name, model: task.payload.repo_id, backend: 'vllm', host, port, cmd: task.payload._cmd, remoteHost: task.remoteHost || '', label: label || task.name, ..._presetEnvFields(task) }));
@@ -1419,8 +1534,7 @@ function _autoSaveWorkingConfig(task) {
   // Respect the per-model cap the manual save flow uses (max 5).
   if (_presetsForModelLocal(presets, model).length >= 5) { task._autoSaved = true; return; }
   const host = task.remoteHost || 'localhost';
-  const portMatch = cmd.match(/--port[=\s]+(\d+)/);
-  const port = portMatch ? portMatch[1] : '8000';
+  const port = _taskServePort(task) || '8000';
   presets.push(_redactPresetForStorage({
     name: task.name, model, backend: 'vllm', host, port,
     cmd, remoteHost: task.remoteHost || '',
@@ -2058,13 +2172,14 @@ export async function _launchServeTask(shortName, repo, cmd, fields, hostOverrid
   // old one instead of leaving a dead duplicate behind. (The retry buttons
   // already removed their own task, so this is a no-op for them.)
   if (!_launchAnyway) try {
-    const _pm = cmd.match(/--port[=\s]+(\d+)/) || cmd.match(/(?:^|\s)-p[=\s]+(\d+)/);
-    const _newPort = _pm ? _pm[1] : '';
+    // Only replace a task when the submitted command explicitly targets its
+    // port. Bare `ollama serve` lets the backend choose a free 11434-11444
+    // port, so treating it as 11434 here could stop an unrelated live task.
+    const _newPort = portOf(cmd);
     if (_newPort) {
       for (const _t of _loadTasks()) {
         if (_t.type !== 'serve' || !_t.payload || !_t.payload._cmd) continue;
-        const _tm = _t.payload._cmd.match(/--port[=\s]+(\d+)/) || _t.payload._cmd.match(/(?:^|\s)-p[=\s]+(\d+)/);
-        if ((_tm ? _tm[1] : '') === _newPort && (_t.remoteHost || '') === _host) {
+        if (_taskServePort(_t) === _newPort && (_t.remoteHost || '') === _host) {
           if (!(await _stopTaskSession(_t))) {
             uiModule.showToast(`Launch aborted: an existing server on port ${_newPort} could not be confirmed stopped.`, 'error');
             return;
@@ -2136,7 +2251,7 @@ export async function _launchServeTask(shortName, repo, cmd, fields, hostOverrid
     // _fields = the exact structured serve-form values used for this launch,
     // so the "Edit / relaunch" button can re-open the Serve panel pre-filled
     // with these precise settings (not just the last-used-for-repo state).
-    const payload = { repo_id: repo, remote_host: _host || undefined, remote_server_key: _serverMetaKey || undefined, remote_server_name: _serverMetaName || undefined, ssh_port: _sp || undefined, _cmd: cmd, _fields: fields || undefined, _env: _usedEnv, _envPath: _usedEnvPath, _gpus: _usedGpus };
+    const payload = withEffectiveServeMetadata({ repo_id: repo, remote_host: _host || undefined, remote_server_key: _serverMetaKey || undefined, remote_server_name: _serverMetaName || undefined, ssh_port: _sp || undefined, _fields: fields || undefined, _env: _usedEnv, _envPath: _usedEnvPath, _gpus: _usedGpus }, data, cmd);
     _addTask(data.session_id, shortName, 'serve', payload);
     uiModule.showToast(`Serving ${shortName}...`);
     // Auto-register may have enabled an existing (offline) endpoint for this
@@ -2366,54 +2481,44 @@ export function _renderRunningTab() {
         return;
       }
       if (!await window.styledConfirm(`Clear ${toRemove.length} finished task${toRemove.length === 1 ? '' : 's'} on ${_serverName(host)}?`, { confirmText: 'Clear' })) return;
-      toRemove.forEach(t => _tombstoneTask(t.sessionId));
-      const remaining = allTasks.filter(t => _taskServerKey(t) !== host || !_canClearTask(t));
-      _saveTasks(remaining);
-      // Fade/slide each finished card out (same exit as the per-card clear)
-      // instead of yanking them instantly.
-      toRemove.forEach(t => {
+      let clearedCount = 0;
+      for (const t of toRemove) {
         const el = document.querySelector(`.cookbook-task[data-task-id="${t.sessionId}"]`);
-        if (el) {
-          if (el._abort) el._abort.abort();
-          if (el._uptimeInterval) clearInterval(el._uptimeInterval);
-          el.style.transition = 'opacity 0.35s ease, transform 0.35s ease';
-          el.style.opacity = '0';
-          el.style.transform = 'translateX(-10px)';
-        }
-      });
-      // After the animation, remove the cards and tidy up the now-empty section.
-      setTimeout(() => {
-        toRemove.forEach(t => document.querySelector(`.cookbook-task[data-task-id="${t.sessionId}"]`)?.remove());
-        // If this server's section is now empty (only finished tasks lived here),
-        // remove the whole section so its header/title doesn't linger.
-        const _sk = (host || 'local').replace(/[^a-zA-Z0-9-]/g, '_');
-        const _sec = group.querySelector(`.cookbook-server-section-${_sk}`);
-        if (_sec && !_sec.querySelector('.cookbook-task')) _sec.remove();
-        if (!remaining.length) _renderRunningTab();
-      }, 360);
+        if (await _stopTaskFromElement(el, t, { showFailure: false })) clearedCount += 1;
+      }
+      const failedCount = toRemove.length - clearedCount;
+      if (failedCount) {
+        uiModule.showToast(`Cleared ${clearedCount}; ${failedCount} could not be confirmed dead and ${failedCount === 1 ? 'was' : 'were'} kept.`, 'error');
+      }
     });
   });
 
-  // Wire "Stop all" buttons — stop every running task on that server.
+  // Wire "Stop all" buttons — stop every live task on that server. Ready
+  // serves still own their GPU process even though the monitor promoted their
+  // status from running.
   group.querySelectorAll('[data-stop-server]').forEach(btn => {
     if (btn._bound) return;
     btn._bound = true;
     btn.addEventListener('click', async (e) => {
       e.stopPropagation();  // don't toggle the section collapse
       const host = btn.dataset.stopServer;
-      const running = _loadTasks().filter(t => _taskServerKey(t) === host && t.status === 'running');
+      const running = _loadTasks().filter(t => _taskServerKey(t) === host && _isStoppableTask(t));
       if (!running.length) { uiModule.showToast(`Nothing running on ${_serverName(host)}`); return; }
       if (!await window.styledConfirm(`Stop ${running.length} running task${running.length > 1 ? 's' : ''} on ${_serverName(host)}?`, { confirmText: 'Stop all' })) return;
-      // Mark every task as user-stopped BEFORE firing the kills so that the
+      // Mark every task as user-stopped BEFORE starting the kills so that the
       // download auto-retry logic never restarts a task the user just stopped.
       running.forEach(t => _updateTask(t.sessionId, { _userStopped: true }));
-      // Reuse each task's own Stop action so it does the full teardown
-      // (send C-c, drop the endpoint, mark stopped) consistently.
-      running.forEach(t => {
+      let stoppedCount = 0;
+      for (const t of running) {
         const el = document.querySelector(`.cookbook-task[data-task-id="${t.sessionId}"]`);
-        el?.querySelector('.cookbook-task-action-stop')?.click();
-      });
-      uiModule.showToast(`Stopped ${running.length} task${running.length > 1 ? 's' : ''} on ${_serverName(host)}`);
+        if (await _stopTaskFromElement(el, t, { showFailure: false })) stoppedCount += 1;
+      }
+      const failedCount = running.length - stoppedCount;
+      if (failedCount) {
+        uiModule.showToast(`Stopped ${stoppedCount}; ${failedCount} could not be confirmed and ${failedCount === 1 ? 'was' : 'were'} kept.`, 'error');
+      } else {
+        uiModule.showToast(`Stopped ${stoppedCount} task${stoppedCount > 1 ? 's' : ''} on ${_serverName(host)}`);
+      }
     });
   });
 
@@ -2606,7 +2711,7 @@ export function _renderRunningTab() {
     // morphs to a red ✕ on hover (see CSS).
     const _clearChk = el.querySelector('.cookbook-task-check');
     if (_clearChk) {
-      _clearChk.addEventListener('click', (e) => {
+      _clearChk.addEventListener('click', async (e) => {
         e.stopPropagation();
         // If the output still shows an active shard line, the task isn't
         // actually finished — clicking is "reconnect" (flip back to running
@@ -2632,16 +2737,9 @@ export function _renderRunningTab() {
           _renderRunningTab();
           return;
         }
-        // Otherwise: real clear. Kill the tmux session as belt-and-suspenders,
-        // then animate out + remove the row.
-        try {
-          fetch('/api/shell/exec', {
-            method: 'POST', credentials: 'same-origin',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ command: _tmuxCmd(task, `kill-session -t ${task.sessionId}`) }),
-          }).catch(() => {});
-        } catch {}
-        _animateOutThenRemove(el, task.sessionId);
+        // Otherwise, verify the terminal task has no live/ambiguous process
+        // before dropping the last retry handle from the UI.
+        await _stopTaskFromElement(el, task);
       });
     }
 
@@ -2763,8 +2861,7 @@ export function _renderRunningTab() {
         if (task.type === 'serve' && task.payload?._cmd) {
           items.push({ group: 'endpoint', label: 'Register endpoint', action: 'register-endpoint', custom: async () => {
             const host = _connectHostFromRemote(task.remoteHost);
-            const portMatch = task.payload?._cmd?.match(/--port\s+(\d+)/);
-            const port = portMatch ? portMatch[1] : '8000';
+            const port = _taskServePort(task) || '8000';
             const baseUrl = `http://${host}:${port}/v1`;
             try {
               // Check existing first — offer to overwrite if present
@@ -2983,80 +3080,13 @@ export function _renderRunningTab() {
 
     // Wire stop
     el.querySelector('.cookbook-task-action-stop').addEventListener('click', async () => {
-      // Abort the reconnect loop before sending kill so that a DOWNLOAD_FAILED
-      // marker written by the shell wrapper (on SIGINT/non-zero exit) cannot
-      // trigger an auto-retry after a manual stop.
-      if (el._abort) el._abort.abort();
-      const badge = el.querySelector('.cookbook-task-status');
-      if (badge) { badge.textContent = 'stopping...'; badge.className = 'cookbook-task-status cookbook-task-stopping'; }
-      _updateTask(task.sessionId, { _userStopped: true });
-      const outputText = el.querySelector('.cookbook-output-pre')?.textContent || task.output || '';
-      const ollamaUnload = _ollamaUnloadCommand(task, outputText);
-      if (ollamaUnload) {
-        try {
-          await fetch('/api/shell/exec', {
-            method: 'POST', credentials: 'same-origin',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ command: ollamaUnload }),
-          });
-        } catch {}
-      }
-      const stopped = await _stopTaskSession(task);
-      if (!stopped) {
-        const priorStatus = task.status || 'running';
-        el.dataset.status = priorStatus;
-        _updateTask(task.sessionId, { _userStopped: false, status: priorStatus });
-        if (badge) {
-          badge.textContent = _statusLabel(priorStatus, task.type);
-          badge.className = `cookbook-task-status cookbook-task-${priorStatus}`;
-        }
-        uiModule.showToast('Stop failed: process exit was not confirmed. The task was kept so you can retry.', 'error');
-        return;
-      }
-      el.dataset.status = 'stopped';
-      if (task.type === 'serve' && task.payload) {
-        _removeEndpointByUrl(_endpointUrlForTask(task, outputText));
-      }
-      // Only remove the card after the process/session is confirmed gone.
-      _animateOutThenRemove(el, task.sessionId);
+      await _stopTaskFromElement(el, task);
     });
 
-    // Wire kill — awaits the SSH/tmux kill and verifies the session is
-    // actually gone before removing the row. Previously fire-and-forget,
-    // which meant a failed kill (wrong remoteHost, SSH error, tmux server
-    // already exited) silently left the live serve running while the
-    // row disappeared from the UI.
+    // Wire kill through the same abort, ownership, and verified-stop path as
+    // Stop. This prevents reconnect/auto-retry from racing a user removal.
     el.querySelector('.cookbook-task-action-kill').addEventListener('click', async () => {
-      const outputText = el.querySelector('.cookbook-output-pre')?.textContent || task.output || '';
-      const ollamaUnload = _ollamaUnloadCommand(task, outputText);
-      if (ollamaUnload) {
-        try {
-          await fetch('/api/shell/exec', {
-            method: 'POST', credentials: 'same-origin',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ command: ollamaUnload }),
-          });
-        } catch (_) { /* unload best-effort */ }
-      }
-      const killOk = await _stopTaskSession(task);
-      if (!killOk) {
-        try { uiModule.showToast('Kill failed: process exit was not confirmed. The task was kept so you can retry.', 'error'); } catch (_) {}
-        return;  // leave the row so the user can retry
-      }
-      if (task.type === 'serve' && task.payload) {
-        const endpointUrl = _endpointUrlForTask(task, outputText);
-        _removeEndpointByUrl(endpointUrl);
-        const modelName = task.payload.model || task.name || '';
-        if (modelName) {
-          fetch('/api/model-endpoints', { credentials: 'same-origin' })
-            .then(r => r.json())
-            .then(eps => {
-              const ep = eps.find(e => e.name === modelName || e.base_url === endpointUrl);
-              if (ep) fetch(`/api/model-endpoints/${ep.id}`, { method: 'DELETE', credentials: 'same-origin' }).then(() => _refreshModelsAfterEndpointChange());
-            }).catch(() => {});
-        }
-      }
-      _animateOutThenRemove(el, task.sessionId);
+      if (!await _stopTaskFromElement(el, task)) return;
     });
 
     // Wire retry
@@ -3698,13 +3728,11 @@ async function _reconnectTask(el, task) {
         if (task.type === 'serve' && !task._endpointAdded && !task._endpointAddInFlight && task._serveReady) {
           task._endpointAddInFlight = true;
           let host = _connectHostFromRemote(task.remoteHost);
-          const portMatch = task.payload?._cmd?.match(/--port[=\s]+(\d+)/)
-            || task.payload?._cmd?.match(/(?:^|\s)-p[=\s]+(\d+)/)
-            || snapshot.match(/Uvicorn running on\D*?:(\d+)/i)
+          const portMatch = snapshot.match(/Uvicorn running on\D*?:(\d+)/i)
             || snapshot.match(/running on\D*?:(\d+)/i)
             || snapshot.match(/listening on\D*?:(\d+)/i)
             || snapshot.match(/port[:=\s]+(\d+)/i);
-          let port = portMatch ? portMatch[1] : '8000';
+          let port = _taskServePort(task) || (portMatch ? portMatch[1] : '8000');
           let baseUrl = `http://${host}:${port}/v1`;
           const ollamaUrlMatch = snapshot.match(/Ollama API ready on port\s+\d+:\s*(http:\/\/[^\s]+)/i);
           if (ollamaUrlMatch) {
@@ -3831,13 +3859,19 @@ const BG_LEADER_KEY = 'odysseus-cookbook-bg-leader';
 const BG_LEADER_ID = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
 const BG_LEADER_TTL_MS = 15000;
 
+function _isStoppableTask(task) {
+  return !!task && (
+    task.status === 'running'
+    || task.status === 'ready'
+    || _downloadOutputLooksActive(task)
+  );
+}
+
 function _hasLiveTasks(tasks = null) {
   const list = tasks || _loadTasks();
   return list.some(t =>
-    t.status === 'running'
+    _isStoppableTask(t)
     || t.status === 'queued'
-    || t.status === 'ready'
-    || _downloadOutputLooksActive(t)
   );
 }
 
@@ -3928,8 +3962,7 @@ async function _checkServeReachability() {
     ]);
     for (const task of serveTasks) {
       const host = _connectHostFromRemote(task.remoteHost);
-      const portMatch = task.payload?._cmd?.match(/--port\s+(\d+)/);
-      const port = portMatch ? portMatch[1] : '8000';
+      const port = _taskServePort(task) || '8000';
       const baseUrl = `http://${host}:${port}/v1`;
       const ep = (eps || []).find(e => e.base_url === baseUrl);
       if (!ep) continue;                       // not registered yet — can't judge
@@ -4355,9 +4388,7 @@ async function _pollBackgroundStatus() {
       const localTask = localTasks.find(lt => lt.sessionId === t.session_id);
 
       let host = _connectHostFromRemote(localTask?.remoteHost || t.remote);
-      const portMatch = localTask?.payload?._cmd?.match(/--port\s+(\d+)/)
-        || localTask?.payload?._cmd?.match(/OLLAMA_HOST=[^\s:]+:(\d+)/);
-      let port = portMatch ? portMatch[1] : '8000';
+      let port = _taskServePort(localTask) || '8000';
       let baseUrl = `http://${host}:${port}/v1`;
       const snapshot = t.output || localTask?.output || '';
       const ollamaUrlMatch = snapshot.match(/Ollama API ready on port\s+\d+:\s*(http:\/\/[^\s]+)/i);
@@ -4516,4 +4547,4 @@ export function initRunning(shared) {
 }
 
 // Also export _retryDownload and _nextAvailablePort for use by other modules
-export { _retryDownload, _nextAvailablePort, _processQueue, _taskPort };
+export { _retryDownload, _nextAvailablePort, _processQueue, _taskPort, _stopTaskFromElement };

--- a/tests/test_builtin_actions_cookbook_serve_state.py
+++ b/tests/test_builtin_actions_cookbook_serve_state.py
@@ -10,7 +10,12 @@ class _FakeServeResponse:
     content = b"{}"
 
     def json(self):
-        return {"ok": True, "session_id": "tmux-123"}
+        return {
+            "ok": True,
+            "session_id": "tmux-123",
+            "effective_cmd": "OLLAMA_HOST=0.0.0.0:11437 ollama serve",
+            "runtime_port": 11437,
+        }
 
 
 async def _fake_post(self, *_args, **_kwargs):
@@ -31,7 +36,7 @@ async def _run_scheduled_serve(tmp_path, monkeypatch, server):
         task_name="test-serve",
         command=json.dumps({
             "repo_id": "org/model",
-            "cmd": "llama-server --port 8080",
+            "cmd": "ollama serve",
             "host": "gpu-box",
             "end_after_min": 30,
         }),
@@ -54,7 +59,15 @@ async def test_scheduled_serve_preserves_server_ssh_port_and_platform(tmp_path, 
     assert task["sshPort"] == "2222"
     assert task["platform"] == "windows"
     assert task["remoteHost"] == "gpu-box"
-    assert task["payload"]["_cmd"] == "llama-server --port 8080"
+    assert task["payload"] == {
+        "repo_id": "org/model",
+        "remote_host": "gpu-box",
+        "_cmd": "OLLAMA_HOST=0.0.0.0:11437 ollama serve",
+        "platform": "windows",
+        "ssh_port": "2222",
+        "runtime_port": "11437",
+    }
+    assert "OLLAMA_HOST=0.0.0.0:11437 ollama serve" in task["output"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_cookbook_helpers.py
+++ b/tests/test_cookbook_helpers.py
@@ -794,9 +794,11 @@ def test_local_windows_download_pid_tracks_inner_bash_and_stop_kills_tree():
     assert "/proc/$$/winpid" in routes_src
     assert "pid_ready_path.touch()" in routes_src
     assert '\\"$$\\" > {pp}' not in routes_src
-    assert "function Stop-Tree([int]$Id)" in running_src
+    assert "function Add-Tree([int]$Id)" in running_src
     assert "('ParentProcessId = ' + $Id)" in running_src
-    assert "Stop-Tree ([int]$p)" in running_src
+    assert "Add-Tree ([int]$p)" in running_src
+    assert "taskkill.exe /PID $target /T /F" in running_src
+    assert "$alive.Count -gt 0" in running_src
 
 
 def test_llama_cpp_rebuild_cmd_runs_clean_on_a_fresh_home(tmp_path):

--- a/tests/test_cookbook_helpers.py
+++ b/tests/test_cookbook_helpers.py
@@ -1,4 +1,5 @@
 import json
+import base64
 import os
 import subprocess
 import sys
@@ -6,6 +7,12 @@ from pathlib import Path
 
 import pytest
 from fastapi import HTTPException
+from routes.cookbook_routes import (
+    _serve_launch_result,
+    _serve_port_from_cmd,
+    _remote_ollama_port_probe_command,
+    _windows_serve_command_lines,
+)
 
 from routes.cookbook_helpers import (
     _cached_model_scan_script,
@@ -656,6 +663,67 @@ def test_model_serve_normalizes_llama_cpp_python_cache_types_after_validation():
     assert "req.cmd = _validate_serve_cmd(req.cmd) or \"\"" in src
     assert "req.cmd = _normalize_llama_cpp_python_cache_types(req.cmd) or \"\"" in src
     assert src.index("_validate_serve_cmd(req.cmd)") < src.index("_normalize_llama_cpp_python_cache_types(req.cmd)")
+
+
+@pytest.mark.parametrize(
+    ("cmd", "expected"),
+    [
+        ("vllm serve org/model --port 8000", "8000"),
+        ("llama-server --port=8001 --model model.gguf", "8001"),
+        ("llama-server -p 8002 --model model.gguf", "8002"),
+        ("llama-server -p=8003 --model model.gguf", "8003"),
+        ("OLLAMA_HOST=127.0.0.1:11435 ollama serve", "11435"),
+        ("OLLAMA_HOST='[::1]:11436' ollama serve", "11436"),
+        ("$env:OLLAMA_HOST = '0.0.0.0:11437'; ollama serve", "11437"),
+        ("ollama serve", "11434"),
+        ("docker exec ollama-rocm ollama show llama3", "11434"),
+        ("python -m pip install package", ""),
+    ],
+)
+def test_serve_port_from_cmd_handles_all_supported_forms(cmd, expected):
+    assert _serve_port_from_cmd(cmd) == expected
+
+
+def test_serve_launch_result_returns_authoritative_ollama_metadata():
+    result = _serve_launch_result(
+        session_id="serve-abc12345",
+        remote=None,
+        endpoint_id="local-abc12345",
+        cmd="OLLAMA_HOST=127.0.0.1:11437 ollama serve",
+    )
+
+    assert result == {
+        "ok": True,
+        "session_id": "serve-abc12345",
+        "remote": "local",
+        "endpoint_id": "local-abc12345",
+        "effective_cmd": "OLLAMA_HOST=127.0.0.1:11437 ollama serve",
+        "runtime_port": 11437,
+    }
+
+
+def test_windows_ollama_runner_keeps_effective_command_replay_safe():
+    effective_cmd = "OLLAMA_HOST=0.0.0.0:11437 ollama serve"
+
+    assert _windows_serve_command_lines(effective_cmd) == [
+        "$env:OLLAMA_HOST = '0.0.0.0:11437'",
+        "ollama serve",
+    ]
+    assert _validate_serve_cmd(effective_cmd) == effective_cmd
+
+
+def test_remote_ollama_port_probe_uses_the_target_platform_shell():
+    windows = _remote_ollama_port_probe_command(11434, 2, is_windows=True)
+    encoded = windows.rsplit(" ", 1)[-1]
+    decoded = base64.b64decode(encoded).decode("utf-16le")
+
+    assert windows.startswith("powershell -NoProfile -NonInteractive -EncodedCommand ")
+    assert "GetActiveTcpListeners" in decoded
+    assert "@(11434,11435,11436)" in decoded
+
+    posix = _remote_ollama_port_probe_command(11434, 1, is_windows=False)
+    assert "/dev/tcp/127.0.0.1/$p" in posix
+    assert "for p in 11434 11435" in posix
 
 
 def test_ollama_serve_defaults_to_loopback_bind():

--- a/tests/test_cookbook_helpers.py
+++ b/tests/test_cookbook_helpers.py
@@ -712,6 +712,12 @@ def test_windows_ollama_runner_keeps_effective_command_replay_safe():
     assert _validate_serve_cmd(effective_cmd) == effective_cmd
 
 
+def test_windows_ollama_runner_rejects_unclosed_host_quote_without_regex_backtracking():
+    effective_cmd = "OLLAMA_HOST=" + "!'" * 10_000 + " ollama serve"
+
+    assert _windows_serve_command_lines(effective_cmd) == [effective_cmd]
+
+
 def test_remote_ollama_port_probe_uses_the_target_platform_shell():
     windows = _remote_ollama_port_probe_command(11434, 2, is_windows=True)
     encoded = windows.rsplit(" ", 1)[-1]

--- a/tests/test_cookbook_port_parsing_js.py
+++ b/tests/test_cookbook_port_parsing_js.py
@@ -17,7 +17,8 @@ _HAS_NODE = shutil.which("node") is not None
 
 def _run(expr):
     js = (
-        f"import {{ portOf, nextFreePort }} from '{_HELPER.as_posix()}';"
+        f"import {{ portOf, nextFreePort, taskServePort, withEffectiveServeMetadata }} "
+        f"from '{_HELPER.as_uri()}';"
         f"console.log(JSON.stringify({expr}));"
     )
     proc = subprocess.run(
@@ -34,6 +35,9 @@ def test_port_of_handles_all_forms():
     assert _run("portOf('x --port=8001')") == "8001"
     assert _run("portOf('llama-server -p 8002')") == "8002"
     assert _run("portOf('llama-server -p=8003')") == "8003"
+    assert _run("portOf(\"OLLAMA_HOST='127.0.0.1:11435' ollama serve\")") == "11435"
+    assert _run("portOf(\"$env:OLLAMA_HOST = '[::1]:11436'; ollama serve\")") == "11436"
+    assert _run("portOf('ollama serve')") == ""
     assert _run("portOf('serve with no port flag')") == ""
 
 
@@ -51,3 +55,50 @@ def test_clash_outcome_same_port_flagged_different_ignored():
     # the guard's predicate is portOf(cmd) === target
     assert _run("portOf('m --port 8000') === '8000'") is True
     assert _run("portOf('m --port 8001') === '8000'") is False
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_task_serve_port_prefers_runtime_and_handles_ollama_forms():
+    assert _run(
+        "taskServePort({payload:{runtime_port:'11437',_cmd:'ollama serve'}})"
+    ) == "11437"
+    assert _run(
+        "taskServePort({payload:{port:9000,_cmd:'m --port 8000'}})"
+    ) == "9000"
+    assert _run(
+        "taskServePort({payload:{_cmd:\"OLLAMA_HOST='127.0.0.1:11435' ollama serve\"}})"
+    ) == "11435"
+    assert _run(
+        "taskServePort({payload:{_cmd:\"OLLAMA_HOST='[::1]:11436' ollama serve\"}})"
+    ) == "11436"
+    assert _run(
+        "taskServePort({payload:{_cmd:\"$env:OLLAMA_HOST = '0.0.0.0:11437'; ollama serve\"}})"
+    ) == "11437"
+    assert _run("taskServePort({payload:{_cmd:'ollama serve'}})") == "11434"
+    assert _run(
+        "taskServePort({payload:{_cmd:'docker exec ollama-rocm ollama show llama3'}})"
+    ) == "11434"
+    assert _run("taskServePort({payload:{_cmd:'serve with no port'}})") == ""
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_effective_serve_metadata_overrides_stale_browser_command():
+    merged = _run(
+        "withEffectiveServeMetadata("
+        "{repo_id:'org/model'},"
+        "{effective_cmd:'OLLAMA_HOST=127.0.0.1:11437 ollama serve',runtime_port:11437},"
+        "'ollama serve')"
+    )
+    assert merged == {
+        "repo_id": "org/model",
+        "_cmd": "OLLAMA_HOST=127.0.0.1:11437 ollama serve",
+        "runtime_port": "11437",
+    }
+
+    fallback = _run(
+        "withEffectiveServeMetadata({repo_id:'org/model'},{},'llama-server -p 8080')"
+    )
+    assert fallback == {
+        "repo_id": "org/model",
+        "_cmd": "llama-server -p 8080",
+    }

--- a/tests/test_cookbook_tool_serve_metadata.py
+++ b/tests/test_cookbook_tool_serve_metadata.py
@@ -1,0 +1,173 @@
+import json
+
+import httpx
+import pytest
+
+from src.tools import cookbook
+
+
+class _FakeResponse:
+    def __init__(self, data, status_code=200):
+        self._data = data
+        self.status_code = status_code
+        self.headers = {"content-type": "application/json"}
+
+    def json(self):
+        return self._data
+
+
+@pytest.mark.parametrize(
+    ("cmd", "expected"),
+    [
+        ("llama-server --port=8001", 8001),
+        ("llama-server -p 8002", 8002),
+        ("OLLAMA_HOST='[::1]:11436' ollama serve", 11436),
+        ("$env:OLLAMA_HOST = '0.0.0.0:11437'; ollama serve", 11437),
+        ("ollama serve", 11434),
+        ("docker exec ollama-test ollama-import org/model model 8192 model.gguf", 11434),
+    ],
+)
+def test_infer_serve_port_matches_backend_command_forms(cmd, expected):
+    assert cookbook._infer_serve_port(cmd) == expected
+
+
+def _install_http_fake(monkeypatch, *, state, serve_response):
+    writes = []
+    endpoint_requests = []
+
+    class _FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url, **kwargs):
+            assert url.endswith("/api/cookbook/state")
+            return _FakeResponse(state)
+
+        async def post(self, url, **kwargs):
+            if url.endswith("/api/model/serve"):
+                return _FakeResponse(serve_response)
+            if url.endswith("/api/model-endpoints"):
+                endpoint_requests.append(kwargs.get("data"))
+                return _FakeResponse({"id": "endpoint-fallback"})
+            if url.endswith("/api/cookbook/state"):
+                writes.append(kwargs.get("json"))
+                return _FakeResponse({"ok": True})
+            raise AssertionError(f"Unexpected POST {url}")
+
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeAsyncClient)
+    return writes, endpoint_requests
+
+
+@pytest.mark.asyncio
+async def test_serve_model_persists_backend_effective_metadata(monkeypatch):
+    effective_cmd = "OLLAMA_HOST=0.0.0.0:11437 ollama serve"
+    writes, endpoint_requests = _install_http_fake(
+        monkeypatch,
+        state={},
+        serve_response={
+            "ok": True,
+            "session_id": "serve-agent",
+            "effective_cmd": effective_cmd,
+            "runtime_port": 11437,
+        },
+    )
+
+    async def _resolve(host):
+        return host
+
+    async def _env(_host):
+        return {"platform": "windows", "ssh_port": "2222"}
+
+    monkeypatch.setattr(cookbook, "_resolve_cookbook_host", _resolve)
+    monkeypatch.setattr(cookbook, "_cookbook_env_for_host", _env)
+
+    result = await cookbook.do_serve_model(json.dumps({
+        "repo_id": "org/model",
+        "cmd": "ollama serve",
+        "host": "gpu-box",
+    }))
+
+    assert result["exit_code"] == 0
+    assert result["effective_cmd"] == effective_cmd
+    assert result["runtime_port"] == 11437
+    assert endpoint_requests[0]["base_url"] == "http://gpu-box:11437/v1"
+    task = writes[-1]["tasks"][0]
+    assert task["payload"] == {
+        "repo_id": "org/model",
+        "remote_host": "gpu-box",
+        "_cmd": effective_cmd,
+        "runtime_port": "11437",
+        "platform": "windows",
+        "ssh_port": "2222",
+    }
+    assert task["sshPort"] == "2222"
+    assert task["platform"] == "windows"
+
+
+@pytest.mark.asyncio
+async def test_serve_preset_persists_backend_effective_metadata(monkeypatch):
+    effective_cmd = "OLLAMA_HOST=0.0.0.0:11438 ollama serve"
+    state = {
+        "presets": [{
+            "name": "ollama-model",
+            "model": "org/model",
+            "host": "gpu-box",
+            "cmd": "ollama serve",
+        }]
+    }
+    writes, _ = _install_http_fake(
+        monkeypatch,
+        state=state,
+        serve_response={
+            "ok": True,
+            "session_id": "serve-preset",
+            "endpoint_id": "endpoint-route",
+            "effective_cmd": effective_cmd,
+            "runtime_port": 11438,
+        },
+    )
+
+    async def _env(_host):
+        return {"platform": "windows", "ssh_port": "2200"}
+
+    monkeypatch.setattr(cookbook, "_cookbook_env_for_host", _env)
+
+    result = await cookbook.do_serve_preset(json.dumps({"name": "ollama-model"}))
+
+    assert result["exit_code"] == 0
+    assert result["effective_cmd"] == effective_cmd
+    assert result["runtime_port"] == 11438
+    task = writes[-1]["tasks"][0]
+    assert task["payload"]["_cmd"] == effective_cmd
+    assert task["payload"]["runtime_port"] == "11438"
+    assert task["sshPort"] == "2200"
+    assert task["platform"] == "windows"
+
+
+@pytest.mark.asyncio
+async def test_env_lookup_uses_local_host_platform_and_server_port(monkeypatch):
+    state = {
+        "env": {
+            "hostPlatform": "windows",
+            "servers": [{
+                "host": "gpu-box",
+                "platform": "windows",
+                "port": "2222",
+            }],
+        }
+    }
+    _install_http_fake(monkeypatch, state=state, serve_response={})
+    monkeypatch.setattr("routes.cookbook_helpers.load_stored_hf_token", lambda: "")
+
+    local = await cookbook._cookbook_env_for_host("")
+    remote = await cookbook._cookbook_env_for_host("gpu-box")
+
+    assert local["platform"] == "windows"
+    assert remote["platform"] == "windows"
+    assert remote["ssh_port"] == "2222"

--- a/tests/test_cookbook_windows_stop_tree_js.py
+++ b/tests/test_cookbook_windows_stop_tree_js.py
@@ -26,7 +26,18 @@ def test_windows_graceful_kill_uses_verified_native_process_tree_helper():
     assert "taskkill.exe /PID $target /T /F" in helper
     assert "$alive.Count -gt 0" in helper
     assert "exit 1" in helper
-    assert helper.index("$alive.Count -gt 0") < helper.index("Remove-Item")
+    # Final artifact cleanup happens only after the liveness verification.
+    assert helper.index("$alive.Count -gt 0") < helper.rindex("Remove-Item")
+    # The listening owner of the serve port is the real llama-server.exe, not
+    # the recorded Git Bash wrapper, so it is the authoritative kill target and
+    # is resolved before the wrapper-PID fallback is folded in.
+    assert "task?.payload?._cmd?.match(/--port" in helper
+    assert "Get-NetTCPConnection -LocalPort $port -State Listen" in helper
+    assert "Select-Object -ExpandProperty OwningProcess" in helper
+    assert helper.index("Get-NetTCPConnection") < helper.index("Get-Content")
+    # Verification is against the port: a still-bound serve port fails the stop
+    # even when the recorded wrapper PID is already dead.
+    assert "still bound after kill" in helper
     assert "${_shQuote(command)}" in wrapper
     assert "_winSessionStopTreePs(task)" in win_session
     assert "_winPowerShellCmd(task, ps)" in win_session
@@ -48,6 +59,9 @@ def test_remote_windows_stop_tree_payload_survives_shell_parsing():
         "Get-CimInstance Win32_Process -Filter ('ParentProcessId = ' + $Id) "
         "-ErrorAction SilentlyContinue | ForEach-Object { Add-Tree ([int]$_.ProcessId) }; "
         "if (-not $targets.Contains($Id)) { $targets.Add($Id) } }; "
+        "$port = 8000; foreach ($o in @(Get-NetTCPConnection -LocalPort $port -State Listen "
+        "-ErrorAction SilentlyContinue | Select-Object -ExpandProperty OwningProcess "
+        "| Sort-Object -Unique)) { Add-Tree ([int]$o) }; "
         "$p = Get-Content '$env:TEMP\\odysseus-sessions\\serve_abc.pid' "
         "-ErrorAction SilentlyContinue; "
         "Add-Tree ([int]$p); "
@@ -64,6 +78,9 @@ def test_remote_windows_stop_tree_payload_survives_shell_parsing():
     assert "$env:TEMP" in argv[-1]
     assert "$p" in argv[-1]
     assert "taskkill.exe /PID $target /T /F" in argv[-1]
+    # The pipe-heavy port-owner lookup must survive SSH single-quoting + shlex.
+    assert "Get-NetTCPConnection -LocalPort $port -State Listen" in argv[-1]
+    assert "Select-Object -ExpandProperty OwningProcess | Sort-Object -Unique" in argv[-1]
 
 
 def test_persisted_local_task_platform_drives_windows_stop_routing():

--- a/tests/test_cookbook_windows_stop_tree_js.py
+++ b/tests/test_cookbook_windows_stop_tree_js.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 RUNNING_JS = ROOT / "static" / "js" / "cookbookRunning.js"
+COOKBOOK_JS = ROOT / "static" / "js" / "cookbook.js"
 
 
 def _between(source, start, end):
@@ -12,16 +13,20 @@ def _between(source, start, end):
     return source[start_idx:end_idx]
 
 
-def test_windows_graceful_kill_reuses_recursive_stop_tree_helper():
+def test_windows_graceful_kill_uses_verified_native_process_tree_helper():
     source = RUNNING_JS.read_text(encoding="utf-8")
     wrapper = _between(source, "function _winPowerShellCmd(task, ps)", "function _winSessionStopTreePs(task)")
     helper = _between(source, "function _winSessionStopTreePs(task)", "function _tmuxGracefulKill(task)")
     graceful = _between(source, "function _tmuxGracefulKill(task)", "function _shQuote(value)")
     win_session = _between(source, "function _winSessionCmd(task, tmuxArgs)", "function _winPowerShellCmd(task, ps)")
 
-    assert "function Stop-Tree([int]$Id)" in helper
+    assert "function Add-Tree([int]$Id)" in helper
     assert "('ParentProcessId = ' + $Id)" in helper
-    assert "Stop-Tree ([int]$p)" in helper
+    assert "Add-Tree ([int]$p)" in helper
+    assert "taskkill.exe /PID $target /T /F" in helper
+    assert "$alive.Count -gt 0" in helper
+    assert "exit 1" in helper
+    assert helper.index("$alive.Count -gt 0") < helper.index("Remove-Item")
     assert "${_shQuote(command)}" in wrapper
     assert "_winSessionStopTreePs(task)" in win_session
     assert "_winPowerShellCmd(task, ps)" in win_session
@@ -38,13 +43,15 @@ def _posix_quote(value):
 
 def test_remote_windows_stop_tree_payload_survives_shell_parsing():
     ps = (
-        "function Stop-Tree([int]$Id) { "
+        "$targets = [System.Collections.Generic.List[int]]::new(); "
+        "function Add-Tree([int]$Id) { "
         "Get-CimInstance Win32_Process -Filter ('ParentProcessId = ' + $Id) "
-        "-ErrorAction SilentlyContinue | ForEach-Object { Stop-Tree ([int]$_.ProcessId) }; "
-        "Stop-Process -Id $Id -Force -ErrorAction SilentlyContinue }; "
+        "-ErrorAction SilentlyContinue | ForEach-Object { Add-Tree ([int]$_.ProcessId) }; "
+        "if (-not $targets.Contains($Id)) { $targets.Add($Id) } }; "
         "$p = Get-Content '$env:TEMP\\odysseus-sessions\\serve_abc.pid' "
         "-ErrorAction SilentlyContinue; "
-        "if ($p -match '^\\d+$') { Stop-Tree ([int]$p) }"
+        "Add-Tree ([int]$p); "
+        "foreach ($target in @($targets)) { & taskkill.exe /PID $target /T /F }"
     )
     remote_command = f'powershell -Command "{ps}"'
     shell_command = f"ssh -p 2222 winbox {_posix_quote(remote_command)}"
@@ -56,3 +63,26 @@ def test_remote_windows_stop_tree_payload_survives_shell_parsing():
     assert "$_.ProcessId" in argv[-1]
     assert "$env:TEMP" in argv[-1]
     assert "$p" in argv[-1]
+    assert "taskkill.exe /PID $target /T /F" in argv[-1]
+
+
+def test_persisted_local_task_platform_drives_windows_stop_routing():
+    source = COOKBOOK_JS.read_text(encoding="utf-8")
+    platform = _between(source, "export function _getPlatform(hostOrTask)", "export function _isWindows(hostOrTask)")
+
+    assert "hostOrTask.platform || hostOrTask.payload?.platform" in platform
+    assert "return taskPlatform || _envState.hostPlatform || ''" in platform
+
+
+def test_stop_keeps_task_and_endpoint_until_process_exit_is_confirmed():
+    source = RUNNING_JS.read_text(encoding="utf-8")
+    helper = _between(source, "async function _stopTaskSession(task)", "// Force-kill escalation")
+    stop_handler = _between(source, "// Wire stop", "// Wire kill")
+
+    assert "commandOk = result?.exit_code === undefined || Number(result.exit_code) === 0" in helper
+    assert "if (_isWindows(task) && !commandOk) return false" in helper
+    assert "const stopped = await _stopTaskSession(task)" in stop_handler
+    assert "if (!stopped)" in stop_handler
+    assert "process exit was not confirmed" in stop_handler
+    assert stop_handler.index("if (!stopped)") < stop_handler.index("_removeEndpointByUrl")
+    assert stop_handler.index("if (!stopped)") < stop_handler.index("_animateOutThenRemove")

--- a/tests/test_cookbook_windows_stop_tree_js.py
+++ b/tests/test_cookbook_windows_stop_tree_js.py
@@ -19,7 +19,10 @@ def test_windows_graceful_kill_uses_verified_native_process_tree_helper():
     helper = _between(source, "function _winSessionStopTreePs(task)", "function _tmuxGracefulKill(task)")
     graceful = _between(source, "function _tmuxGracefulKill(task)", "function _shQuote(value)")
     win_session = _between(source, "function _winSessionCmd(task, tmuxArgs)", "function _winPowerShellCmd(task, ps)")
+    port_helper = _between(source, "function _taskServePort(task)", "function _taskProcessIdentity(task)")
+    identity_helper = _between(source, "function _taskProcessIdentity(task)", "function _psLit(value)")
 
+    # Native process-tree walk + force kill retained.
     assert "function Add-Tree([int]$Id)" in helper
     assert "('ParentProcessId = ' + $Id)" in helper
     assert "Add-Tree ([int]$p)" in helper
@@ -28,16 +31,37 @@ def test_windows_graceful_kill_uses_verified_native_process_tree_helper():
     assert "exit 1" in helper
     # Final artifact cleanup happens only after the liveness verification.
     assert helper.index("$alive.Count -gt 0") < helper.rindex("Remove-Item")
-    # The listening owner of the serve port is the real llama-server.exe, not
-    # the recorded Git Bash wrapper, so it is the authoritative kill target and
-    # is resolved before the wrapper-PID fallback is folded in.
-    assert "task?.payload?._cmd?.match(/--port" in helper
-    assert "Get-NetTCPConnection -LocalPort $port -State Listen" in helper
+
+    # Ownership binding: a port listener is force-killed only once its command
+    # line is proven to belong to this task (identity match), and it is proven
+    # before any kill runs. A bound port whose owner cannot be proven ours fails
+    # closed and retains the task instead of killing an unrelated service.
+    assert "function Test-Owned([int]$Id)" in helper
+    assert ".CommandLine" in helper
+    assert "refusing to force-kill" in helper
+    assert helper.index("Test-Owned") < helper.index("taskkill.exe")
+    assert "Get-NetTCPConnection -LocalPort $Prt -State Listen" in helper
     assert "Select-Object -ExpandProperty OwningProcess" in helper
-    assert helper.index("Get-NetTCPConnection") < helper.index("Get-Content")
-    # Verification is against the port: a still-bound serve port fails the stop
-    # even when the recorded wrapper PID is already dead.
-    assert "still bound after kill" in helper
+    # Verification is scoped to an owned process still holding the port, not the
+    # wrapper alone.
+    assert "still held by a task process after kill" in helper
+    # A genuinely dead task (no owned listener, no live PID) cleans up and exits
+    # 0 so Remove can clear the row; a serve task with no resolvable port fails
+    # closed rather than reporting an unverifiable stop as clean.
+    assert "cannot verify shutdown" in helper
+    assert helper.index("refusing to force-kill") < helper.index("Remove-Item")
+
+    # Port resolution covers -p and Ollama forms (not just --port) and prefers a
+    # backend-persisted authoritative port; identity keys off the model file/name.
+    assert "task?.payload?.port ?? task?.port" in port_helper
+    assert "--port" in port_helper
+    assert "-p[=\\s]+" in port_helper
+    assert "OLLAMA_HOST" in port_helper
+    assert "11434" in port_helper
+    assert ".gguf" in identity_helper
+    assert "--model" in identity_helper
+
+    # Routing unchanged.
     assert "${_shQuote(command)}" in wrapper
     assert "_winSessionStopTreePs(task)" in win_session
     assert "_winPowerShellCmd(task, ps)" in win_session

--- a/tests/test_cookbook_windows_stop_tree_js.py
+++ b/tests/test_cookbook_windows_stop_tree_js.py
@@ -127,3 +127,29 @@ def test_stop_keeps_task_and_endpoint_until_process_exit_is_confirmed():
     assert "process exit was not confirmed" in stop_handler
     assert stop_handler.index("if (!stopped)") < stop_handler.index("_removeEndpointByUrl")
     assert stop_handler.index("if (!stopped)") < stop_handler.index("_animateOutThenRemove")
+
+
+def test_remediation_paths_route_through_verified_stop():
+    # Restart, serve auto-fix/retry, download auto-retry, and same-port replace
+    # must gate the relaunch on the verified stop result and retain the task when
+    # termination is not confirmed — never kill-and-relaunch into a bound port.
+    source = RUNNING_JS.read_text(encoding="utf-8")
+    retry = _between(source, "async function _retryTask(el, task)", "async function _retryDownload(")
+    autofix = _between(source, "export async function _serveAutoFix(", "async function _openServeEditForTask(")
+    launch = _between(source, "if (_replaceTaskId) {", "// Capture the env + GPU pin")
+
+    # Restart/retry verifies the stop and bails on failure, no direct kill.
+    assert "await _stopTaskSession(task)" in retry
+    assert "Restart aborted" in retry
+    assert "_tmuxGracefulKill(task)" not in retry
+
+    # Serve auto-fix gates the relaunch and re-enables the panel on failure.
+    assert "await _stopTaskSession(task)" in autofix
+    assert "_unguardServeRetry(panel, taskEl)" in autofix
+    assert "_tmuxCmd(task, `kill-session" not in autofix
+
+    # Launch-time replace of the old / same-port server verifies before relaunch.
+    assert "await _stopTaskSession(_old)" in launch
+    assert "await _stopTaskSession(_t)" in launch
+    assert "_tmuxGracefulKill(_old)" not in launch
+    assert "_tmuxGracefulKill(_t)" not in launch

--- a/tests/test_cookbook_windows_stop_tree_js.py
+++ b/tests/test_cookbook_windows_stop_tree_js.py
@@ -1,10 +1,22 @@
+import json
+import os
 import shlex
+import shutil
+import socket
+import subprocess
+import sys
+import uuid
 from pathlib import Path
+
+import pytest
 
 
 ROOT = Path(__file__).resolve().parents[1]
 RUNNING_JS = ROOT / "static" / "js" / "cookbookRunning.js"
 COOKBOOK_JS = ROOT / "static" / "js" / "cookbook.js"
+PORTS_JS = ROOT / "static" / "js" / "cookbookPorts.js"
+_HAS_NODE = shutil.which("node") is not None
+_POWERSHELL = shutil.which("powershell")
 
 
 def _between(source, start, end):
@@ -13,11 +25,149 @@ def _between(source, start, end):
     return source[start_idx:end_idx]
 
 
+def _generated_stop_ps(task, options=None):
+    source = RUNNING_JS.read_text(encoding="utf-8")
+    identity = _between(
+        source,
+        "function _taskProcessIdentity(task)",
+        "function _psLit(value)",
+    )
+    literal = _between(
+        source,
+        "function _psLit(value)",
+        "function _winSessionStopTreePs(",
+    )
+    helper = _between(
+        source,
+        "function _winSessionStopTreePs(",
+        "export function _tmuxGracefulKill(",
+    )
+    script = f"""
+      import {{ taskServePort }} from {json.dumps(PORTS_JS.as_uri())};
+      const _taskServePort = taskServePort;
+      const _taskRemoteHost = task => task.remoteHost || task?.payload?.remote_host || '';
+      {identity}
+      {literal}
+      {helper}
+      console.log(JSON.stringify(_winSessionStopTreePs({json.dumps(task)}, {json.dumps(options or {})})));
+    """
+    proc = subprocess.run(
+        ["node", "--input-type=module"],
+        input=script,
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+def _start_listener(identity):
+    code = (
+        "import socket,time; "
+        "s=socket.socket(); s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1); "
+        "s.bind(('127.0.0.1',0)); s.listen(); "
+        "print(s.getsockname()[1],flush=True); time.sleep(120)"
+    )
+    proc = subprocess.Popen(
+        [sys.executable, "-c", code, identity],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    port = int(proc.stdout.readline().strip())
+    return proc, port
+
+
+def _start_wrapper(session_dir, sid, identity=""):
+    script = session_dir / f"{sid}.cmd"
+    marker_arg = f" {identity}" if identity else ""
+    script.write_text(
+        f'@"{sys.executable}" -c "import time; time.sleep(120)"{marker_arg}\r\n',
+        encoding="utf-8",
+    )
+    return subprocess.Popen(
+        [os.environ.get("ComSpec", "cmd.exe"), "/d", "/c", str(script)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def _start_powershell_wrapper(session_dir, sid, identity):
+    script = session_dir / f"{sid}_run.ps1"
+    script.write_text(
+        f"& '{sys.executable}' -u -c 'import time; print(314159, flush=True); time.sleep(120)' '{identity}'\r\n",
+        encoding="utf-8",
+    )
+    wrapper = subprocess.Popen(
+        [_POWERSHELL, "-NoProfile", "-NonInteractive", "-File", str(script)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    ready = wrapper.stdout.readline().strip()
+    if ready != "314159":
+        stderr = wrapper.stderr.read()
+        _stop_process(wrapper)
+        raise RuntimeError(f"PowerShell child did not start: {ready!r} {stderr!r}")
+    return wrapper
+
+
+def _start_powershell_listener_wrapper(session_dir, sid, identity):
+    script = session_dir / f"{sid}_run.ps1"
+    code = (
+        "import socket,time; "
+        "s=socket.socket(); s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1); "
+        "s.bind(('127.0.0.1',0)); s.listen(); "
+        "print(s.getsockname()[1],flush=True); time.sleep(120)"
+    )
+    script.write_text(
+        f'& \'{sys.executable}\' -c "{code}" \'{identity}\'\r\n',
+        encoding="utf-8",
+    )
+    wrapper = subprocess.Popen(
+        [_POWERSHELL, "-NoProfile", "-NonInteractive", "-File", str(script)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    port = int(wrapper.stdout.readline().strip())
+    return wrapper, port
+
+
+def _stop_process(proc):
+    if proc is None:
+        return
+    if proc.poll() is not None:
+        return
+    if os.name == "nt":
+        subprocess.run(
+            ["taskkill.exe", "/PID", str(proc.pid), "/T", "/F"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+    else:
+        proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5)
+
+
+def _remove_session_artifacts(session_dir, sid):
+    for pattern in (f"{sid}.*", f"{sid}_*"):
+        for artifact in session_dir.glob(pattern):
+            artifact.unlink(missing_ok=True)
+
+
 def test_windows_graceful_kill_uses_verified_native_process_tree_helper():
     source = RUNNING_JS.read_text(encoding="utf-8")
-    wrapper = _between(source, "function _winPowerShellCmd(task, ps)", "function _winSessionStopTreePs(task)")
-    helper = _between(source, "function _winSessionStopTreePs(task)", "function _tmuxGracefulKill(task)")
-    graceful = _between(source, "function _tmuxGracefulKill(task)", "function _shQuote(value)")
+    wrapper = _between(source, "function _winPowerShellCmd(task, ps)", "function _winSessionStopTreePs(")
+    helper = _between(source, "function _winSessionStopTreePs(", "function _tmuxGracefulKill(")
+    graceful = _between(source, "function _tmuxGracefulKill(", "function _shQuote(value)")
     win_session = _between(source, "function _winSessionCmd(task, tmuxArgs)", "function _winPowerShellCmd(task, ps)")
     port_helper = _between(source, "function _taskServePort(task)", "function _taskProcessIdentity(task)")
     identity_helper = _between(source, "function _taskProcessIdentity(task)", "function _psLit(value)")
@@ -36,28 +186,32 @@ def test_windows_graceful_kill_uses_verified_native_process_tree_helper():
     # line is proven to belong to this task (identity match), and it is proven
     # before any kill runs. A bound port whose owner cannot be proven ours fails
     # closed and retains the task instead of killing an unrelated service.
-    assert "function Test-Owned([int]$Id)" in helper
+    assert "function Test-Owned([int]$Id," in helper
     assert ".CommandLine" in helper
     assert "refusing to force-kill" in helper
     assert helper.index("Test-Owned") < helper.index("taskkill.exe")
     assert "Get-NetTCPConnection -LocalPort $Prt -State Listen" in helper
     assert "Select-Object -ExpandProperty OwningProcess" in helper
-    # Verification is scoped to an owned process still holding the port, not the
-    # wrapper alone.
-    assert "still held by a task process after kill" in helper
+    assert "function Test-SessionRoot([int]$Id)" in helper
+    assert "function Get-SessionRoot([int]$Id)" in helper
+    assert "(Test-Owned ([int]$o)) -and $root -gt 0" in helper
+    assert "if (Test-SessionRoot ([int]$p))" in helper
+    assert "(Test-SessionRoot ([int]$p)) -or (Test-Owned" not in helper
+    assert "$unsafePid" in helper
+    assert "netstat.exe -ano -p TCP" in helper
+    assert "$remainingListeners.Count -gt 0" in helper
+    assert helper.index("if ($unverified)") < helper.index("taskkill.exe")
     # A genuinely dead task (no owned listener, no live PID) cleans up and exits
     # 0 so Remove can clear the row; a serve task with no resolvable port fails
     # closed rather than reporting an unverifiable stop as clean.
     assert "cannot verify shutdown" in helper
+    assert "$allowDeadServeCleanup" in helper
+    assert "Matching model process still exists after kill" in helper
     assert helper.index("refusing to force-kill") < helper.index("Remove-Item")
 
     # Port resolution covers -p and Ollama forms (not just --port) and prefers a
     # backend-persisted authoritative port; identity keys off the model file/name.
-    assert "task?.payload?.port ?? task?.port" in port_helper
-    assert "--port" in port_helper
-    assert "-p[=\\s]+" in port_helper
-    assert "OLLAMA_HOST" in port_helper
-    assert "11434" in port_helper
+    assert "return taskServePort(task)" in port_helper
     assert ".gguf" in identity_helper
     assert "--model" in identity_helper
 
@@ -65,7 +219,7 @@ def test_windows_graceful_kill_uses_verified_native_process_tree_helper():
     assert "${_shQuote(command)}" in wrapper
     assert "_winSessionStopTreePs(task)" in win_session
     assert "_winPowerShellCmd(task, ps)" in win_session
-    assert "_winSessionStopTreePs(task)" in graceful
+    assert "_winSessionStopTreePs(task, options)" in graceful
     assert "_winPowerShellCmd(task, ps)" in graceful
     assert "Stop-Process -Id $p -Force" not in graceful
     assert '-Filter "ParentProcessId = $Id"' not in helper
@@ -77,20 +231,14 @@ def _posix_quote(value):
 
 
 def test_remote_windows_stop_tree_payload_survives_shell_parsing():
-    ps = (
-        "$targets = [System.Collections.Generic.List[int]]::new(); "
-        "function Add-Tree([int]$Id) { "
-        "Get-CimInstance Win32_Process -Filter ('ParentProcessId = ' + $Id) "
-        "-ErrorAction SilentlyContinue | ForEach-Object { Add-Tree ([int]$_.ProcessId) }; "
-        "if (-not $targets.Contains($Id)) { $targets.Add($Id) } }; "
-        "$port = 8000; foreach ($o in @(Get-NetTCPConnection -LocalPort $port -State Listen "
-        "-ErrorAction SilentlyContinue | Select-Object -ExpandProperty OwningProcess "
-        "| Sort-Object -Unique)) { Add-Tree ([int]$o) }; "
-        "$p = Get-Content '$env:TEMP\\odysseus-sessions\\serve_abc.pid' "
-        "-ErrorAction SilentlyContinue; "
-        "Add-Tree ([int]$p); "
-        "foreach ($target in @($targets)) { & taskkill.exe /PID $target /T /F }"
-    )
+    if not _HAS_NODE:
+        pytest.skip("node binary not on PATH")
+    ps = _generated_stop_ps({
+        "sessionId": "serve_abc",
+        "type": "serve",
+        "remoteHost": "winbox",
+        "payload": {"_cmd": "llama-server --model model.gguf --port 8000"},
+    })
     remote_command = f'powershell -Command "{ps}"'
     shell_command = f"ssh -p 2222 winbox {_posix_quote(remote_command)}"
 
@@ -103,8 +251,389 @@ def test_remote_windows_stop_tree_payload_survives_shell_parsing():
     assert "$p" in argv[-1]
     assert "taskkill.exe /PID $target /T /F" in argv[-1]
     # The pipe-heavy port-owner lookup must survive SSH single-quoting + shlex.
-    assert "Get-NetTCPConnection -LocalPort $port -State Listen" in argv[-1]
-    assert "Select-Object -ExpandProperty OwningProcess | Sort-Object -Unique" in argv[-1]
+    assert "Get-NetTCPConnection -LocalPort $Prt -State Listen" in argv[-1]
+    assert "Select-Object -ExpandProperty OwningProcess" in argv[-1]
+
+
+@pytest.mark.skipif(
+    os.name != "nt" or not _HAS_NODE or not _POWERSHELL,
+    reason="native Windows, node, and Windows PowerShell are required",
+)
+def test_generated_windows_stop_refuses_unverified_listener_with_live_wrapper():
+    sid = f"serve-test-{uuid.uuid4().hex[:8]}"
+    listener, port = _start_listener("unrelated-listener")
+    session_dir = Path(os.environ["TEMP"]) / "odysseus-tmux"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    wrapper = _start_wrapper(session_dir, sid)
+    pid_path = session_dir / f"{sid}.pid"
+    log_path = session_dir / f"{sid}.log"
+    pid_path.write_text(str(wrapper.pid), encoding="utf-8")
+    log_path.write_text("validation", encoding="utf-8")
+    try:
+        ps = _generated_stop_ps({
+            "sessionId": sid,
+            "type": "serve",
+            "payload": {"_cmd": f"llama-server --model expected-{sid}.gguf --port {port}"},
+        })
+        result = subprocess.run(
+            [_POWERSHELL, "-NoProfile", "-NonInteractive", "-Command", ps],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode != 0
+        assert "unverified process" in (result.stderr + result.stdout)
+        assert listener.poll() is None
+        assert wrapper.poll() is None
+        assert pid_path.exists()
+        assert log_path.exists()
+    finally:
+        _stop_process(listener)
+        _stop_process(wrapper)
+        _remove_session_artifacts(session_dir, sid)
+
+
+@pytest.mark.skipif(
+    os.name != "nt" or not _HAS_NODE or not _POWERSHELL,
+    reason="native Windows, node, and Windows PowerShell are required",
+)
+def test_generated_windows_stop_kills_verified_listener_and_wrapper():
+    sid = f"serve-test-{uuid.uuid4().hex[:8]}"
+    identity = f"owned-{sid}.gguf"
+    session_dir = Path(os.environ["TEMP"]) / "odysseus-tmux"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    wrapper, port = _start_powershell_listener_wrapper(session_dir, sid, identity)
+    pid_path = session_dir / f"{sid}.pid"
+    log_path = session_dir / f"{sid}.log"
+    pid_path.write_text(str(wrapper.pid), encoding="utf-8")
+    log_path.write_text("validation", encoding="utf-8")
+    try:
+        ps = _generated_stop_ps({
+            "sessionId": sid,
+            "type": "serve",
+            "payload": {"_cmd": f"llama-server --model {identity} --port {port}"},
+        })
+        result = subprocess.run(
+            [_POWERSHELL, "-NoProfile", "-NonInteractive", "-Command", ps],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, result.stderr + result.stdout
+        wrapper.wait(timeout=10)
+        assert not pid_path.exists()
+        assert not log_path.exists()
+        assert not (session_dir / f"{sid}_run.ps1").exists()
+        with socket.socket() as probe:
+            probe.settimeout(1)
+            assert probe.connect_ex(("127.0.0.1", port)) != 0
+    finally:
+        _stop_process(wrapper)
+        _remove_session_artifacts(session_dir, sid)
+
+
+@pytest.mark.skipif(
+    os.name != "nt" or not _HAS_NODE or not _POWERSHELL,
+    reason="native Windows, node, and Windows PowerShell are required",
+)
+def test_generated_windows_stop_ignores_same_model_in_another_session():
+    sid = f"serve-test-{uuid.uuid4().hex[:8]}"
+    other_sid = f"serve-test-{uuid.uuid4().hex[:8]}"
+    identity = f"shared-{uuid.uuid4().hex[:8]}.gguf"
+    session_dir = Path(os.environ["TEMP"]) / "odysseus-tmux"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    wrapper, port = _start_powershell_listener_wrapper(session_dir, sid, identity)
+    other_wrapper, other_port = _start_powershell_listener_wrapper(
+        session_dir, other_sid, identity
+    )
+    (session_dir / f"{sid}.pid").write_text(str(wrapper.pid), encoding="utf-8")
+    (session_dir / f"{other_sid}.pid").write_text(
+        str(other_wrapper.pid), encoding="utf-8"
+    )
+    try:
+        ps = _generated_stop_ps({
+            "sessionId": sid,
+            "type": "serve",
+            "payload": {"_cmd": f"llama-server --model {identity} --port {port}"},
+        })
+        result = subprocess.run(
+            [_POWERSHELL, "-NoProfile", "-NonInteractive", "-Command", ps],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, result.stderr + result.stdout
+        wrapper.wait(timeout=10)
+        assert other_wrapper.poll() is None
+        with socket.socket() as probe:
+            probe.settimeout(1)
+            assert probe.connect_ex(("127.0.0.1", other_port)) == 0
+    finally:
+        _stop_process(wrapper)
+        _stop_process(other_wrapper)
+        _remove_session_artifacts(session_dir, sid)
+        _remove_session_artifacts(session_dir, other_sid)
+
+
+@pytest.mark.skipif(
+    os.name != "nt" or not _HAS_NODE or not _POWERSHELL,
+    reason="native Windows, node, and Windows PowerShell are required",
+)
+def test_generated_windows_stop_owns_dynamic_gguf_by_llama_engine_and_session():
+    sid = f"serve-test-{uuid.uuid4().hex[:8]}"
+    session_dir = Path(os.environ["TEMP"]) / "odysseus-tmux"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    wrapper, port = _start_powershell_listener_wrapper(
+        session_dir, sid, "llama-server"
+    )
+    pid_path = session_dir / f"{sid}.pid"
+    pid_path.write_text(str(wrapper.pid), encoding="utf-8")
+    snapshots = '"$HOME/.cache/huggingface/hub/models--org--model/snapshots"'
+    dynamic_cmd = (
+        f"MODEL_FILE=$({{ find {snapshots} -name '*-00001-of-*.gguf' 2>/dev/null | sort; "
+        f"find {snapshots} -name '*.gguf' 2>/dev/null | sort; }} | head -1) && "
+        f'llama-server --model "$MODEL_FILE" --host 0.0.0.0 --port {port}'
+    )
+    try:
+        ps = _generated_stop_ps({
+            "sessionId": sid,
+            "type": "serve",
+            "payload": {"_cmd": dynamic_cmd},
+        })
+        result = subprocess.run(
+            [_POWERSHELL, "-NoProfile", "-NonInteractive", "-Command", ps],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, result.stderr + result.stdout
+        wrapper.wait(timeout=10)
+        assert not pid_path.exists()
+    finally:
+        _stop_process(wrapper)
+        _remove_session_artifacts(session_dir, sid)
+
+
+@pytest.mark.parametrize("reuse_listener_as_recorded_pid", [False, True])
+@pytest.mark.skipif(
+    os.name != "nt" or not _HAS_NODE or not _POWERSHELL,
+    reason="native Windows, node, and Windows PowerShell are required",
+)
+def test_generated_windows_stop_refuses_matching_replacement_without_session_root(
+    reuse_listener_as_recorded_pid,
+):
+    sid = f"serve-test-{uuid.uuid4().hex[:8]}"
+    identity = f"owned-{sid}.gguf"
+    listener, port = _start_listener(identity)
+    session_dir = Path(os.environ["TEMP"]) / "odysseus-tmux"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    pid_path = session_dir / f"{sid}.pid"
+    log_path = session_dir / f"{sid}.log"
+    if reuse_listener_as_recorded_pid:
+        pid_path.write_text(str(listener.pid), encoding="utf-8")
+    log_path.write_text("validation", encoding="utf-8")
+    try:
+        ps = _generated_stop_ps({
+            "sessionId": sid,
+            "type": "serve",
+            "payload": {"_cmd": f"llama-server --model {identity} --port {port}"},
+        })
+        result = subprocess.run(
+            [_POWERSHELL, "-NoProfile", "-NonInteractive", "-Command", ps],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode != 0
+        assert "refusing" in (result.stderr + result.stdout)
+        assert listener.poll() is None
+        assert log_path.exists()
+    finally:
+        _stop_process(listener)
+        _remove_session_artifacts(session_dir, sid)
+
+
+@pytest.mark.skipif(
+    os.name != "nt" or not _HAS_NODE or not _POWERSHELL,
+    reason="native Windows, node, and Windows PowerShell are required",
+)
+def test_generated_windows_stop_only_cleans_dead_serve_when_remove_allows_it():
+    sid = f"serve-test-{uuid.uuid4().hex[:8]}"
+    session_dir = Path(os.environ["TEMP"]) / "odysseus-tmux"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    log_path = session_dir / f"{sid}.log"
+    log_path.write_text("terminal", encoding="utf-8")
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+    task = {
+        "sessionId": sid,
+        "type": "serve",
+        "status": "error",
+        "payload": {"_cmd": f"llama-server --model dead-{sid}.gguf --port {port}"},
+    }
+    try:
+        refused = subprocess.run(
+            [_POWERSHELL, "-NoProfile", "-NonInteractive", "-Command", _generated_stop_ps(task)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert refused.returncode != 0
+        assert log_path.exists()
+
+        removed = subprocess.run(
+            [
+                _POWERSHELL,
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                _generated_stop_ps(task, {"allowDeadServeCleanup": True}),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert removed.returncode == 0, removed.stderr + removed.stdout
+        assert not log_path.exists()
+    finally:
+        _remove_session_artifacts(session_dir, sid)
+
+
+@pytest.mark.skipif(
+    os.name != "nt" or not _HAS_NODE or not _POWERSHELL,
+    reason="native Windows, node, and Windows PowerShell are required",
+)
+def test_generated_windows_stop_finds_matching_prebind_process_in_sibling_runner_tree():
+    sid = f"serve-test-{uuid.uuid4().hex[:8]}"
+    identity = f"prebind-{sid}.gguf"
+    session_dir = Path(os.environ["TEMP"]) / "odysseus-tmux"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    recorded_wrapper = _start_wrapper(session_dir, sid)
+    sibling_wrapper = None
+    try:
+        sibling_wrapper = _start_powershell_wrapper(session_dir, sid, identity)
+        pid_path = session_dir / f"{sid}.pid"
+        pid_path.write_text(str(recorded_wrapper.pid), encoding="utf-8")
+        with socket.socket() as probe:
+            probe.bind(("127.0.0.1", 0))
+            unused_port = probe.getsockname()[1]
+        ps = _generated_stop_ps({
+            "sessionId": sid,
+            "type": "serve",
+            "payload": {"_cmd": f"llama-server --model {identity} --port {unused_port}"},
+        })
+        result = subprocess.run(
+            [_POWERSHELL, "-NoProfile", "-NonInteractive", "-Command", ps],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, result.stderr + result.stdout
+        recorded_wrapper.wait(timeout=10)
+        sibling_wrapper.wait(timeout=10)
+        assert not pid_path.exists()
+        assert not (session_dir / f"{sid}_run.ps1").exists()
+    finally:
+        _stop_process(recorded_wrapper)
+        _stop_process(sibling_wrapper)
+        _remove_session_artifacts(session_dir, sid)
+
+
+@pytest.mark.skipif(
+    os.name != "nt" or not _HAS_NODE or not _POWERSHELL,
+    reason="native Windows, node, and Windows PowerShell are required",
+)
+def test_generated_windows_stop_keeps_shared_ollama_listener_and_kills_only_wrapper():
+    sid = f"serve-test-{uuid.uuid4().hex[:8]}"
+    listener, port = _start_listener("shared-ollama-daemon")
+    session_dir = Path(os.environ["TEMP"]) / "odysseus-tmux"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    wrapper = _start_wrapper(session_dir, sid)
+    pid_path = session_dir / f"{sid}.pid"
+    pid_path.write_text(str(wrapper.pid), encoding="utf-8")
+    try:
+        ps = _generated_stop_ps({
+            "sessionId": sid,
+            "type": "serve",
+            "payload": {
+                "_cmd": "docker exec ollama-rocm ollama show llama3",
+                "runtime_port": str(port),
+            },
+        })
+        result = subprocess.run(
+            [_POWERSHELL, "-NoProfile", "-NonInteractive", "-Command", ps],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, result.stderr + result.stdout
+        wrapper.wait(timeout=10)
+        assert listener.poll() is None
+        assert not pid_path.exists()
+    finally:
+        _stop_process(listener)
+        _stop_process(wrapper)
+        _remove_session_artifacts(session_dir, sid)
+
+
+@pytest.mark.skipif(
+    os.name != "nt" or not _HAS_NODE or not _POWERSHELL,
+    reason="native Windows, node, and Windows PowerShell are required",
+)
+def test_generated_windows_stop_refuses_serve_with_unknown_port():
+    sid = f"serve-test-{uuid.uuid4().hex[:8]}"
+    ps = _generated_stop_ps({
+        "sessionId": sid,
+        "type": "serve",
+        "payload": {"_cmd": "python custom_server.py", "repo_id": "org/model"},
+    })
+    result = subprocess.run(
+        [_POWERSHELL, "-NoProfile", "-NonInteractive", "-Command", ps],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode != 0
+    assert "no resolvable port" in (result.stderr + result.stdout)
+
+
+@pytest.mark.skipif(
+    os.name != "nt" or not _HAS_NODE or not _POWERSHELL,
+    reason="native Windows, node, and Windows PowerShell are required",
+)
+def test_generated_windows_stop_clears_pip_maintenance_without_a_port():
+    sid = f"serve-test-{uuid.uuid4().hex[:8]}"
+    session_dir = Path(os.environ["TEMP"]) / "odysseus-tmux"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    wrapper = _start_wrapper(session_dir, sid)
+    pid_path = session_dir / f"{sid}.pid"
+    log_path = session_dir / f"{sid}.log"
+    pid_path.write_text(str(wrapper.pid), encoding="utf-8")
+    log_path.write_text("validation", encoding="utf-8")
+    try:
+        ps = _generated_stop_ps({
+            "sessionId": sid,
+            "type": "serve",
+            "payload": {
+                "repo_id": "pip-update",
+                "_cmd": "python -m pip install -U vllm transformers",
+            },
+        })
+        result = subprocess.run(
+            [_POWERSHELL, "-NoProfile", "-NonInteractive", "-Command", ps],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, result.stderr + result.stdout
+        wrapper.wait(timeout=10)
+        assert not pid_path.exists()
+        assert not log_path.exists()
+    finally:
+        _stop_process(wrapper)
+        _remove_session_artifacts(session_dir, sid)
 
 
 def test_persisted_local_task_platform_drives_windows_stop_routing():
@@ -117,16 +646,50 @@ def test_persisted_local_task_platform_drives_windows_stop_routing():
 
 def test_stop_keeps_task_and_endpoint_until_process_exit_is_confirmed():
     source = RUNNING_JS.read_text(encoding="utf-8")
-    helper = _between(source, "async function _stopTaskSession(task)", "// Force-kill escalation")
+    helper = _between(source, "async function _stopTaskSession(", "// Force-kill escalation")
+    stop_helper = _between(source, "async function _stopTaskFromElement", "// Force-kill escalation")
     stop_handler = _between(source, "// Wire stop", "// Wire kill")
 
     assert "commandOk = result?.exit_code === undefined || Number(result.exit_code) === 0" in helper
     assert "if (_isWindows(task) && !commandOk) return false" in helper
-    assert "const stopped = await _stopTaskSession(task)" in stop_handler
-    assert "if (!stopped)" in stop_handler
-    assert "process exit was not confirmed" in stop_handler
-    assert stop_handler.index("if (!stopped)") < stop_handler.index("_removeEndpointByUrl")
-    assert stop_handler.index("if (!stopped)") < stop_handler.index("_animateOutThenRemove")
+    assert "const stopped = await _stopTaskSession(task," in stop_helper
+    assert "if (!stopped)" in stop_helper
+    assert "process exit was not confirmed" in stop_helper
+    assert "await _taskSessionOwnershipConfirmed(task)" in stop_helper
+    assert stop_helper.index("if (!stopped)") < stop_helper.index("_removeEndpointByUrl")
+    assert stop_helper.index("if (!stopped)") < stop_helper.index("_animateOutThenRemove")
+    assert "await _stopTaskFromElement(el, task)" in stop_handler
+
+    kill_handler = _between(source, "// Wire kill", "// Wire retry")
+    assert "await _stopTaskFromElement(el, task)" in kill_handler
+    assert "_ollamaUnloadCommand" not in kill_handler
+    assert "/api/model-endpoints" not in kill_handler
+    assert "eps.find" not in kill_handler
+
+
+def test_stop_all_awaits_each_verified_result_before_reporting_success():
+    source = RUNNING_JS.read_text(encoding="utf-8")
+    stop_all = _between(source, '// Wire "Stop all" buttons', "// Section collapse/expand")
+
+    assert "await _stopTaskFromElement" in stop_all
+    assert "_isStoppableTask(t)" in stop_all
+    assert "failedCount" in stop_all
+    assert "could not be confirmed" in stop_all
+    assert ".click()" not in stop_all
+
+    live_predicate = _between(source, "function _isStoppableTask", "function _hasLiveTasks")
+    assert "task.status === 'ready'" in live_predicate
+
+
+def test_hardware_fit_collision_waits_for_verified_stop_result():
+    source = (ROOT / "static" / "js" / "cookbook-hwfit.js").read_text(encoding="utf-8")
+    quick_run = _between(source, "// ─── Pre-launch: stop colliding serves", "// -- Launch")
+
+    assert "await _stopTaskFromElement" in quick_run
+    assert "could not be confirmed stopped" in quick_run
+    assert "_stopBtn.click()" not in quick_run
+    assert "_tmuxGracefulKill" not in quick_run
+    assert "setTimeout(r, 2500)" not in quick_run
 
 
 def test_remediation_paths_route_through_verified_stop():


### PR DESCRIPTION
## Summary

On native Windows, Cookbook could remove a serve task while the real model process remained alive and held GPU memory. The recorded PID can belong to a Git Bash or PowerShell wrapper, while the native server lives in a separate Win32 subtree.

This change binds shutdown to the task's session lineage, model or server identity, and authoritative runtime port. It kills only verified targets, checks that captured processes exited and owned ports closed, and keeps the task and endpoint when ownership or shutdown cannot be proven. Backend-selected Ollama ports and normalized commands are persisted for browser, tool, and scheduled launches. Stop All, retry, replacement, hardware-fit, Clear, and Kill now use the same verified path.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release.

## Linked Issue

Part of #3995; related to #4571

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) - this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the change works end-to-end.
- [ ] I did not run the app/runtime validation and stated that gap in **How to Test**. Leave this unchecked when the app-run box above is checked.

## How to Test

1. On native Windows, launch a local llama.cpp or Ollama serve from Cookbook.
2. Reload the page and use Stop and remove, Kill, or Stop All.
3. Confirm the verified wrapper and server processes exit, the owned port closes, and only then the task, endpoint, and session artifacts disappear.
4. Reuse the saved port with an unrelated listener; confirm Cookbook refuses the stop and keeps the task.
5. Run the same model in two tracked sessions on different ports; confirm stopping one leaves the other running.
6. Clear a finished pip-maintenance task; confirm it clears without requiring a serve port.

Validation performed on native Windows:

- The existing authenticated GUI validation confirmed the real Stop and remove path removed the tracked wrapper tree and task state; the rejected-stop path retained the task and artifacts.
- Native PowerShell regressions exercised verified and unrelated listeners, stale PID reuse, a pre-bind process in a sibling runner tree, same-model sessions on different ports, dynamic GGUF commands, shared Ollama listeners, dead-task removal, unknown ports, and pip maintenance.
- Focused automated checks: 129 passed across the final non-native selection and changed native cases.
- JavaScript syntax, Python syntax, and whitespace checks passed.
- Final cleanup found no tagged validation process or session artifact. No model server or GPU process was used for the final regression run.

## Visual / UI changes - REQUIRED if you touched anything that renders

No layout, CSS, icon, typography, or component changes. Failed or ambiguous stops keep the existing task card and use the existing error toast.

- [x] **Screenshot or short clip** of the change in the running app, attached below. Mobile is unaffected.
- [x] **Style match**: no new styles, colors, fonts, spacing, or layout.
- [x] **No new component patterns.** The change reuses the existing task card, status badge, and toast.
- [x] **I am not an LLM agent submitting a bulk PR.** This is a focused fix for a reproduced Windows process-lifecycle bug.

### Screenshots / clips

![Native Windows process-tree stop validation](https://raw.githubusercontent.com/gist/zoomdbz/7eb5f25e704231f46f931c2b73ef9755/raw/ff6581bcebc69531823b21cf84b97692129a148f/odysseus-pr-6105-windows-stop-runtime.svg)

<!-- validation-evidence: native-windows-2026-09-09-final -->
