### PR TITLE
fix(cookbook): preserve local server environment profile

### DIFF
--- a/static/js/cookbook-hwfit.js
+++ b/static/js/cookbook-hwfit.js
@@ -1522,8 +1522,12 @@ function _syncHostFromScanDropdown() {
   if (!ss || ss.value == null) return _envState.remoteHost || '';
   let host = '';
   if (ss.value === 'local') {
+    const local = _serverByVal('local');
     _envState.remoteHost = '';
     _envState.remoteServerKey = '';
+    _envState.env = local?.env || 'none';
+    _envState.envPath = local?.envPath || '';
+    _envState.platform = local?.platform || _envState.hostPlatform || '';
   } else {
     const s = _serverByVal(ss.value);
     if (s) {
@@ -2318,8 +2322,12 @@ export function _hwfitInit() {
     // dropdown still showed odysseus. The user's selection must only change via
     // an explicit dropdown pick. Here we just refresh env/path if we can match
     // the current host; otherwise leave remoteHost untouched.
-    const sel = _serverByVal(_envState.remoteServerKey || _envState.remoteHost);
-    if (sel) { _envState.env = sel.env; _envState.envPath = sel.envPath; }
+    const sel = _serverByVal(_envState.remoteServerKey || _envState.remoteHost || 'local');
+    if (sel) {
+      _envState.env = sel.env || 'none';
+      _envState.envPath = sel.envPath || '';
+      _envState.platform = sel.platform || (!_envState.remoteHost ? (_envState.hostPlatform || '') : '');
+    }
     _persistEnvState();
   }
 
@@ -2494,8 +2502,23 @@ export function _hwfitInit() {
         // (inline — _applyServerSelection lives in cookbook.js and isn't imported here).
         const _dk = _envState.defaultServer;
         if (_dk) {
-          if (_dk === 'local') { _envState.remoteHost = ''; _envState.remoteServerKey = ''; _envState.env = 'none'; _envState.envPath = ''; _envState.platform = ''; }
-          else { const _s = _serverByVal(_dk); if (_s) { _envState.remoteHost = _s.host; _envState.remoteServerKey = _serverKey(_s); _envState.env = _s.env || 'none'; _envState.envPath = _s.envPath || ''; _envState.platform = _s.platform || ''; } }
+          if (_dk === 'local') {
+            const _local = _serverByVal('local');
+            _envState.remoteHost = '';
+            _envState.remoteServerKey = '';
+            _envState.env = _local?.env || 'none';
+            _envState.envPath = _local?.envPath || '';
+            _envState.platform = _local?.platform || _envState.hostPlatform || '';
+          } else {
+            const _s = _serverByVal(_dk);
+            if (_s) {
+              _envState.remoteHost = _s.host;
+              _envState.remoteServerKey = _serverKey(_s);
+              _envState.env = _s.env || 'none';
+              _envState.envPath = _s.envPath || '';
+              _envState.platform = _s.platform || '';
+            }
+          }
           _persistEnvState();
           document.querySelectorAll('#hwfit-server-select, #hwfit-dl-server, #hwfit-cache-server, #hwfit-deps-server').forEach(sel => {
             if (sel && sel.tagName === 'SELECT') sel.value = _currentServerValue();
@@ -2791,10 +2814,12 @@ export function _hwfitInit() {
     serverSelect.addEventListener('change', () => {
       const val = serverSelect.value;
       if (val === 'local') {
+        const local = _serverByVal('local');
         _envState.remoteHost = '';
         _envState.remoteServerKey = '';
-        _envState.env = 'none';
-        _envState.envPath = '';
+        _envState.env = local?.env || 'none';
+        _envState.envPath = local?.envPath || '';
+        _envState.platform = local?.platform || _envState.hostPlatform || '';
       } else {
         const s = _serverByVal(val);
         if (s) {

--- a/static/js/cookbook.js
+++ b/static/js/cookbook.js
@@ -138,8 +138,11 @@ export function _serverKey(s) {
 }
 
 export function _serverByVal(val) {
-  if (val == null || val === 'local' || val === '') return null;
+  if (val == null) return null;
   const raw = String(val);
+  if (raw === 'local' || raw === '') {
+    return _envState.servers.find(_isLocalEntry) || null;
+  }
   let s = _envState.servers.find(x => _serverKey(x) === raw);
   if (!s) s = _envState.servers.find(x => x.host === raw);
   if (!s) s = _envState.servers.find(x => x.name === raw);
@@ -1896,11 +1899,12 @@ async function _fetchDependencies() {
 
 function _applyServerSelection(val) {
   if (val === 'local') {
+    const local = _serverByVal('local');
     _envState.remoteHost = '';
     _envState.remoteServerKey = '';
-    _envState.env = 'none';
-    _envState.envPath = '';
-    _envState.platform = '';
+    _envState.env = local?.env || 'none';
+    _envState.envPath = local?.envPath || '';
+    _envState.platform = local?.platform || _envState.hostPlatform || '';
   } else {
     const s = _serverByVal(val);
     if (s) {
@@ -1919,7 +1923,7 @@ function _applyServerSelection(val) {
   const _want = _currentServerValue();
   document.querySelectorAll('#hwfit-server-select, #hwfit-dl-server, #hwfit-cache-server, #hwfit-deps-server').forEach(sel => {
     if (!sel || sel.tagName !== 'SELECT') return;
-    // Option values are host strings now ('local' for the local box).
+    // Option values are stable profile keys ('local' for the local box).
     sel.value = _want;
     // If the host isn't among this select's current options (stale options after
     // the server list changed), the browser leaves the box BLANK/grey even though
@@ -2045,26 +2049,23 @@ function _wireTabEvents(body) {
       servers.push({ name, host, port, env, envPath, color, modelDirs: dirs, downloadDir, platform });
     });
     _envState.servers = servers;
-    // Auto-default: when the user has configured EXACTLY ONE remote server
-    // and hasn't picked one yet, select it. Without this, the dropdown
-    // stays on "Local" so the eventual serve/scan/launch resolves to no
-    // remote host and the backend rejects the call with 403 (Forbidden),
-    // which read to the user as a permission bug.
-    if (!_envState.remoteHost) {
-      const remotes = servers.filter(s => !_isLocalEntry(s));
-      if (remotes.length === 1) {
-        _envState.remoteHost = remotes[0].host;
-        _envState.env = remotes[0].env || 'none';
-        _envState.envPath = remotes[0].envPath || '';
-      }
+    // Refresh the active profile from the just-read form. Local is a real
+    // profile too; treating an empty host as "no server" discarded its venv.
+    // Do not auto-select a lone remote here. An empty host means the user chose
+    // Local, while defaultServer handles intentional automatic selection.
+    const activeSrv = _envState.remoteHost
+      ? (_serverByVal(_envState.remoteServerKey || _envState.remoteHost)
+        || servers.find(s => s.host === _envState.remoteHost))
+      : _serverByVal('local');
+    if (activeSrv) {
+      _envState.env = activeSrv.env || 'none';
+      _envState.envPath = activeSrv.envPath || '';
+      _envState.platform = activeSrv.platform || (!_envState.remoteHost ? (_envState.hostPlatform || '') : '');
     }
-    const activeSrv = servers.find(s => s.host === _envState.remoteHost);
-    _envState.platform = activeSrv?.platform || '';
     localStorage.setItem('cookbook-last-state', JSON.stringify(_envStateForStorage()));
     _saveTasks(_loadTasks());
-    // Reflect the auto-default selection into every server dropdown so the
-    // UI matches the resolved host. Done in a microtask so the dropdowns
-    // exist by the time we set their .value.
+    // Reflect the active profile into every server dropdown. Done in a
+    // microtask so the dropdowns exist by the time we set their value.
     Promise.resolve().then(() => {
       const _want = _currentServerValue();
       document.querySelectorAll('#hwfit-server-select, #hwfit-dl-server, #hwfit-cache-server, #hwfit-deps-server').forEach(sel => {
@@ -2521,19 +2522,26 @@ function _wireTabEvents(body) {
       // downloads to the wrong server. The dropdown the user sees is the truth.
       const dlSrv = document.getElementById('hwfit-dl-server');
       const srvVal = dlSrv ? dlSrv.value : 'local';
-      let host = '';
-      if (srvVal !== 'local') {
-        host = _serverByVal(srvVal)?.host || '';
+      const _hsrv = _serverByVal(srvVal) || {};
+      const host = srvVal === 'local' ? '' : (_hsrv.host || '');
+      let env = _hsrv.env || 'none';
+      const envPath = _hsrv.envPath || '';
+      if ((!env || env === 'none') && envPath) {
+        env = /(?:^|[\\/])(?:\.?venv|env)(?:[\\/]|$)|[\\/]bin[\\/]activate$|[\\/]Scripts[\\/]Activate\.ps1$/i.test(envPath) ? 'venv' : env;
       }
-      const _hsrv = _envState.servers.find(sv => sv.host === host) || {};
-      let env = host ? (_hsrv.env || 'none') : _envState.env;
-      let envPath = host ? (_hsrv.envPath || '') : _envState.envPath;
       const payload = { repo_id: repo };
       if (ollamaName) payload.backend = 'ollama';
       if (autoInclude || pickerInclude) payload.include = autoInclude || pickerInclude;
       if (_envState.hfToken && !ollamaName) payload.hf_token = _envState.hfToken;
-      if (host) { payload.remote_host = host; const _sp3 = _getPort(host); if (_sp3) payload.ssh_port = _sp3; }
-      const srvPlatform = _getPlatform(host);
+      if (host) {
+        payload.remote_host = host;
+        payload.remote_server_key = _serverKey(_hsrv);
+        if (_hsrv.name) payload.remote_server_name = _hsrv.name;
+        const _sp3 = _hsrv.port || _getPort(host);
+        if (_sp3) payload.ssh_port = _sp3;
+      }
+      if (_hsrv.downloadDir) payload.local_dir = _hsrv.downloadDir;
+      const srvPlatform = _hsrv.platform || _getPlatform(host || 'local');
       if (srvPlatform) payload.platform = srvPlatform;
       if (srvPlatform === 'windows') {
         if (env === 'venv' && envPath) {
@@ -3031,6 +3039,12 @@ function _renderRecipes() {
   if (!_localSeen) {
     _es.servers.unshift({ host: '', env: _es.env || 'none', envPath: _es.envPath || '', modelDir: '~/.cache/huggingface/hub', platform: _envState.hostPlatform || '' });
   }
+  if (!_es.remoteHost) {
+    const local = _serverByVal('local');
+    _es.env = local?.env || 'none';
+    _es.envPath = local?.envPath || '';
+    _es.platform = local?.platform || _es.hostPlatform || '';
+  }
   if (_es.remoteHost && !_es.servers.some(s => s.host === _es.remoteHost)) {
     _es.servers.push({ host: _es.remoteHost, env: _es.env || 'none', envPath: _es.envPath || '', modelDir: '~/.cache/huggingface/hub' });
     _persistEnvState();
@@ -3395,7 +3409,12 @@ export async function open(opts) {
   if (_envState.defaultServer) {
     const _dk = _envState.defaultServer;
     if (_dk === 'local') {
-      _envState.remoteHost = ''; _envState.env = 'none'; _envState.envPath = ''; _envState.platform = '';
+      const _local = _serverByVal('local');
+      _envState.remoteHost = '';
+      _envState.remoteServerKey = '';
+      _envState.env = _local?.env || 'none';
+      _envState.envPath = _local?.envPath || '';
+      _envState.platform = _local?.platform || _envState.hostPlatform || '';
     } else {
       const _ds = (_envState.servers || []).find(s => s.host === _dk);
       if (_ds) { _envState.remoteHost = _ds.host; _envState.env = _ds.env || 'none'; _envState.envPath = _ds.envPath || ''; _envState.platform = _ds.platform || ''; }

--- a/static/js/cookbook.js
+++ b/static/js/cookbook.js
@@ -3037,7 +3037,19 @@ function _renderRecipes() {
     return true;
   });
   if (!_localSeen) {
-    _es.servers.unshift({ host: '', env: _es.env || 'none', envPath: _es.envPath || '', modelDir: '~/.cache/huggingface/hub', platform: _envState.hostPlatform || '' });
+    // A synthesized Local entry must use local-only defaults. When a remote
+    // server is the active context, _es.env/_es.envPath describe the REMOTE
+    // venv, so inheriting them here would make Local build/download/serve
+    // prefixes resolve the remote interpreter/path. Only carry the active env
+    // into Local when Local itself is the active context (no remote host).
+    const _localActive = !_es.remoteHost;
+    _es.servers.unshift({
+      host: '',
+      env: _localActive ? (_es.env || 'none') : 'none',
+      envPath: _localActive ? (_es.envPath || '') : '',
+      modelDir: '~/.cache/huggingface/hub',
+      platform: _envState.hostPlatform || '',
+    });
   }
   if (!_es.remoteHost) {
     const local = _serverByVal('local');

--- a/static/js/cookbookDownload.js
+++ b/static/js/cookbookDownload.js
@@ -489,7 +489,9 @@ export async function _runModelDownload(panel, model, backend, hostOverride) {
   let selectedServerKey = '';
   if (hostOverride !== undefined) {
     host = hostOverride || '';
-    selectedServer = host ? (_serverByVal?.(host) || (_envState.servers || []).find(s => s.host === host) || null) : null;
+    selectedServer = host
+      ? (_serverByVal?.(host) || (_envState.servers || []).find(s => s.host === host) || null)
+      : (_serverByVal?.('local') || null);
     selectedServerKey = selectedServer ? (typeof window.cookbookModule?._serverKey === 'function' ? window.cookbookModule._serverKey(selectedServer) : '') : '';
   } else {
     // No explicit host passed: resolve from the visible server dropdown rather
@@ -505,19 +507,23 @@ export async function _runModelDownload(panel, model, backend, hostOverride) {
       selectedServerKey = _ssv || '';
     } else if (ssEl && ssEl.value === 'local') {
       host = '';
+      selectedServer = _serverByVal?.('local') || null;
+      selectedServerKey = 'local';
     } else {
       host = _envState.remoteHost || '';
-      selectedServer = host ? ((_envState.servers || []).find(s => s.host === host) || _serverByVal?.(host) || null) : null;
+      selectedServer = host
+        ? ((_envState.servers || []).find(s => s.host === host) || _serverByVal?.(host) || null)
+        : (_serverByVal?.('local') || null);
     }
   }
-  const srv = selectedServer || _serverByVal?.(host) || {};
-  let env = host ? (srv.env || 'none') : (_envState.env || 'none');
-  const envPath = host ? (srv.envPath || '') : (_envState.envPath || '');
+  const srv = selectedServer || _serverByVal?.(host || 'local') || {};
+  let env = srv.env || 'none';
+  const envPath = srv.envPath || '';
   if ((!env || env === 'none') && envPath) {
-    env = /(?:^|\/)(?:\.?venv|env)(?:\/|$)|\/bin\/activate$/i.test(envPath) ? 'venv' : env;
+    env = /(?:^|[\\/])(?:\.?venv|env)(?:[\\/]|$)|[\\/]bin[\\/]activate$|[\\/]Scripts[\\/]Activate\.ps1$/i.test(envPath) ? 'venv' : env;
   }
-  const platform = host ? (srv.platform || '') : (_envState.platform || '');
-  const isWin = host ? (platform === 'windows') : _isWindows();
+  const platform = srv.platform || (host ? (_envState.platform || '') : (_envState.hostPlatform || _envState.platform || ''));
+  const isWin = platform ? platform === 'windows' : _isWindows();
 
   const payload = { repo_id: repo, backend };
   if (include) payload.include = include;

--- a/tests/test_cookbook_local_server_profile_js.py
+++ b/tests/test_cookbook_local_server_profile_js.py
@@ -1,0 +1,70 @@
+"""Regression guards for the Cookbook local server profile."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+COOKBOOK = (ROOT / "static/js/cookbook.js").read_text(encoding="utf-8")
+HWFIT = (ROOT / "static/js/cookbook-hwfit.js").read_text(encoding="utf-8")
+DOWNLOAD = (ROOT / "static/js/cookbookDownload.js").read_text(encoding="utf-8")
+
+
+def _between(source: str, start: str, end: str) -> str:
+    start_idx = source.index(start)
+    end_idx = source.index(end, start_idx)
+    return source[start_idx:end_idx]
+
+
+def test_local_dropdown_value_resolves_to_the_saved_server_profile():
+    resolver = _between(COOKBOOK, "export function _serverByVal(val)", "export function _selectedServer()")
+
+    assert "if (raw === 'local' || raw === '')" in resolver
+    assert "_envState.servers.find(_isLocalEntry)" in resolver
+    assert "val === 'local' || val === ''" not in resolver.split("const raw", 1)[0]
+
+
+def test_selecting_local_hydrates_env_path_instead_of_clearing_it():
+    selection = _between(COOKBOOK, "function _applyServerSelection(val)", "async function _refreshScanDownloadTarget()")
+    scan_selection = _between(HWFIT, "function _syncHostFromScanDropdown()", "// Minimum backend version")
+    dropdown_selection = _between(HWFIT, "// Server selector dropdown", "  _syncServerSelectColors();")
+
+    for source in (selection, scan_selection, dropdown_selection):
+        assert "_serverByVal('local')" in source
+        assert ".env || 'none'" in source
+        assert ".envPath || ''" in source
+
+    local_branch = selection.split("if (val === 'local')", 1)[1].split("} else", 1)[0]
+    assert "_envState.env = 'none'" not in local_branch
+    assert "_envState.envPath = ''" not in local_branch
+
+
+def test_settings_sync_persists_local_as_the_active_profile():
+    cookbook_sync = _between(COOKBOOK, "// Sync server form DOM", "// Wire server form inputs")
+    hwfit_sync = _between(HWFIT, "// Servers — sync changes", "async function _testServerConnection")
+
+    assert ": _serverByVal('local')" in cookbook_sync
+    assert "_envState.envPath = activeSrv.envPath || ''" in cookbook_sync
+    assert "remotes.length === 1" not in cookbook_sync
+    assert "_envState.remoteHost || 'local'" in hwfit_sync
+    assert "_envState.envPath = sel.envPath || ''" in hwfit_sync
+
+
+def test_direct_download_uses_the_visible_local_profile():
+    direct = _between(COOKBOOK, "const triggerDownload = async () =>", "dlBtn.addEventListener('click', triggerDownload)")
+
+    assert "const _hsrv = _serverByVal(srvVal) || {}" in direct
+    assert "let env = _hsrv.env || 'none'" in direct
+    assert "const envPath = _hsrv.envPath || ''" in direct
+    assert "const srvPlatform = _hsrv.platform || _getPlatform(host || 'local')" in direct
+    assert "payload.env_prefix" in direct
+    assert "host ? (_hsrv.env" not in direct
+
+
+def test_model_download_resolves_local_profile_before_building_payload():
+    model_download = _between(DOWNLOAD, "export async function _runModelDownload", "const payload = { repo_id: repo, backend }")
+
+    assert "_serverByVal?.('local')" in model_download
+    assert "_serverByVal?.(host || 'local')" in model_download
+    assert "let env = srv.env || 'none'" in model_download
+    assert "const envPath = srv.envPath || ''" in model_download
+    assert "host ? (srv.env" not in model_download

--- a/tests/test_cookbook_local_server_profile_js.py
+++ b/tests/test_cookbook_local_server_profile_js.py
@@ -68,3 +68,17 @@ def test_model_download_resolves_local_profile_before_building_payload():
     assert "let env = srv.env || 'none'" in model_download
     assert "const envPath = srv.envPath || ''" in model_download
     assert "host ? (srv.env" not in model_download
+
+
+def test_synthesized_local_entry_uses_local_only_defaults_under_active_remote():
+    # A missing Local entry is synthesized from local-only defaults. When a
+    # remote server is the active context, _es.env/_es.envPath describe the
+    # remote venv, so the synthetic Local entry must not inherit them — that
+    # would make Local build/download/serve resolve the remote interpreter/path.
+    synth = _between(COOKBOOK, "if (!_localSeen) {", "if (!_es.remoteHost) {")
+
+    assert "const _localActive = !_es.remoteHost" in synth
+    assert "env: _localActive ? (_es.env || 'none') : 'none'" in synth
+    assert "envPath: _localActive ? (_es.envPath || '') : ''" in synth
+    # The old unconditional inheritance of the active (possibly remote) env is gone.
+    assert "env: _es.env || 'none', envPath: _es.envPath || ''" not in synth

--- a/tests/test_cookbook_local_server_profile_js.py
+++ b/tests/test_cookbook_local_server_profile_js.py
@@ -1,6 +1,11 @@
 """Regression guards for the Cookbook local server profile."""
 
+import json
 from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -70,15 +75,72 @@ def test_model_download_resolves_local_profile_before_building_payload():
     assert "host ? (srv.env" not in model_download
 
 
-def test_synthesized_local_entry_uses_local_only_defaults_under_active_remote():
-    # A missing Local entry is synthesized from local-only defaults. When a
-    # remote server is the active context, _es.env/_es.envPath describe the
-    # remote venv, so the synthetic Local entry must not inherit them — that
-    # would make Local build/download/serve resolve the remote interpreter/path.
-    synth = _between(COOKBOOK, "if (!_localSeen) {", "if (!_es.remoteHost) {")
+def test_missing_local_active_remote_executes_local_only_transition():
+    if shutil.which("node") is None:
+        pytest.skip("node binary not on PATH")
 
-    assert "const _localActive = !_es.remoteHost" in synth
-    assert "env: _localActive ? (_es.env || 'none') : 'none'" in synth
-    assert "envPath: _localActive ? (_es.envPath || '') : ''" in synth
-    # The old unconditional inheritance of the active (possibly remote) env is gone.
-    assert "env: _es.env || 'none', envPath: _es.envPath || ''" not in synth
+    server_helpers = _between(
+        COOKBOOK,
+        "function _isLocalEntry(s)",
+        "const GEMMA4_THINKING_CHAT_TEMPLATE",
+    ).replace("export ", "")
+    selection = _between(
+        COOKBOOK,
+        "function _applyServerSelection(val)",
+        "async function _refreshScanDownloadTarget()",
+    )
+    synthesis = _between(
+        COOKBOOK,
+        "let _localSeen = false;",
+        "if (_es.remoteHost &&",
+    )
+    state = {
+        "remoteHost": "gpu.example",
+        "remoteServerKey": "srv:remote",
+        "env": "venv",
+        "envPath": "/remote/venv",
+        "platform": "linux",
+        "hostPlatform": "windows",
+        "servers": [{
+            "name": "Remote",
+            "host": "gpu.example",
+            "env": "venv",
+            "envPath": "/remote/venv",
+            "platform": "linux",
+        }],
+    }
+    script = f"""
+      const _envState = {json.dumps(state)};
+      const document = {{ querySelectorAll: () => [] }};
+      const _persistEnvState = () => {{}};
+      {server_helpers}
+      {selection}
+      const _es = _envState;
+      {synthesis}
+      const remoteBefore = JSON.stringify(_envState.servers.find(s => s.host === 'gpu.example'));
+      _applyServerSelection('local');
+      console.log(JSON.stringify({{
+        state: _envState,
+        local: _envState.servers.find(_isLocalEntry),
+        remoteUnchanged: remoteBefore === JSON.stringify(_envState.servers.find(s => s.host === 'gpu.example')),
+      }}));
+    """
+    proc = subprocess.run(
+        ["node", "--input-type=module"],
+        input=script,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    result = json.loads(proc.stdout.strip().splitlines()[-1])
+
+    assert result["local"]["env"] == "none"
+    assert result["local"]["envPath"] == ""
+    assert result["local"]["platform"] == "windows"
+    assert result["state"]["remoteHost"] == ""
+    assert result["state"]["remoteServerKey"] == ""
+    assert result["state"]["env"] == "none"
+    assert result["state"]["envPath"] == ""
+    assert result["state"]["platform"] == "windows"
+    assert result["remoteUnchanged"] is True


### PR DESCRIPTION
## Summary

Cookbook treated the local server's empty host as if no server profile existed, so selecting Local, reopening Cookbook, saving Settings, or starting a direct download could clear the saved venv path and platform. Legacy or partial state could also synthesize Local from the active remote profile and leak its venv into local actions.

This change treats Local as a real profile, hydrates it consistently across Cookbook and hardware-fit selectors, builds download payloads from the visible profile, and creates missing Local entries from local-only defaults.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release.

## Linked Issue

Part of #2710; related to #5691. Native-Windows Git Bash activation is handled by merged #5734.

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) - this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the Local-profile persistence and routing behavior end-to-end.
- [ ] I did not run the app/runtime validation and stated that gap in **How to Test**. Leave this unchecked when the app-run box above is checked.

## How to Test

1. Save Local with a Windows venv path and platform, then switch servers, save Settings, close Cookbook, and hard-reload.
2. Confirm Local retains its environment, path, platform, and default-server state.
3. Start a direct download and confirm it uses the visible Local profile.
4. Load legacy state with no Local entry and an active remote venv profile. Select Local and confirm it uses `env: none` with an empty path; local build, download, and serve actions must not contain the remote venv path.

Validation performed on native Windows:

- The existing isolated app run confirmed Local profile persistence after hard reload and routed a tiny download through the saved Local profile.
- The requested missing-Local/active-remote case now runs as an executable Node state-transition regression using the production synthesis and selection code.
- Focused local-profile tests: 12 passed.
- JavaScript syntax checks passed for `cookbook.js`, `cookbook-hwfit.js`, and `cookbookDownload.js`.

## Visual / UI changes - REQUIRED if you touched anything that renders

No layout, CSS, icon, typography, or component changes. The change preserves existing Local server fields and routes their values into existing actions.

- [x] **Screenshot or short clip** of the change in the running app, attached below. Mobile is unaffected.
- [x] **Style match**: no new styles, colors, fonts, spacing, or layout.
- [x] **No new component patterns.** The change uses the existing server profile and selector controls.
- [x] **I am not an LLM agent submitting a bulk PR.** This is a focused regression fix with targeted coverage.

### Screenshots / clips

![Local profile persisted after hard reload](https://raw.githubusercontent.com/gist/zoomdbz/d4146720d913e10eb69291610cf538d8/raw/48294d214fc1d2d92b1fbe89e029ec6e39130e9b/odysseus-pr-6106-local-profile-runtime.svg)

<!-- validation-evidence: native-windows-2026-09-09-final -->
