### PR TITLE
fix(tests): skip SearXNG migration tests on Windows

### DIFF
--- a/scripts/migrate_searxng_settings.py
+++ b/scripts/migrate_searxng_settings.py
@@ -122,22 +122,24 @@ def migrate_settings(path: Path) -> bool:
     try:
         # chmod before chown: the Compose cap set is `cap_drop: ALL` plus
         # CHOWN/SETGID/SETUID/DAC_OVERRIDE, with no FOWNER. Once the temporary
-        # file belongs to searxng:searxng — which every retained settings file
-        # does, because searxng's entrypoint chowns /etc/searxng — root can no
+        # file belongs to searxng:searxng -- which every retained settings file
+        # does, because searxng's entrypoint chowns /etc/searxng -- root can no
         # longer chmod it and the migration dies with EPERM.
         os.fchmod(fd, stat.S_IMODE(source_stat.st_mode))
-        os.fchown(fd, source_stat.st_uid, source_stat.st_gid)
+        if sys.platform != "win32":
+            os.fchown(fd, source_stat.st_uid, source_stat.st_gid)
         with os.fdopen(fd, "wb") as handle:
             fd = -1
             handle.write(updated)
             handle.flush()
             os.fsync(handle.fileno())
         os.replace(temporary, path)
-        directory_fd = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
-        try:
-            os.fsync(directory_fd)
-        finally:
-            os.close(directory_fd)
+        if sys.platform != "win32":
+            directory_fd = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
     finally:
         if fd >= 0:
             os.close(fd)

--- a/tests/test_searxng_settings_migration.py
+++ b/tests/test_searxng_settings_migration.py
@@ -8,6 +8,14 @@ from pathlib import Path
 import pytest
 import yaml
 
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "SearXNG settings migration relies on POSIX-only os.fchown and "
+        "os.O_DIRECTORY; the migration script runs only inside the Linux "
+        "SearXNG container and is not exercised on native Windows."
+    ),
+)
 
 ROOT = Path(__file__).resolve().parent.parent
 MIGRATION = ROOT / "scripts" / "migrate_searxng_settings.py"


### PR DESCRIPTION
## Summary

Guard the two POSIX-only calls in `scripts/migrate_searxng_settings.py` (`os.fchown` and `os.O_DIRECTORY`) behind `sys.platform != "win32"` checks, and add a module-level `pytestmark` to skip all tests in `tests/test_searxng_settings_migration.py` on Windows. The migration runs exclusively inside the Linux SearXNG container; the POSIX ownership and directory-fsync guarantees are preserved on all Linux paths.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #6067.

## Type of Change

- [x] Bug fix (non-breaking -- fixes a confirmed issue)
- [ ] New feature (non-breaking -- adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) -- this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above -- no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.
- [ ] I did not run the app/runtime validation and stated that gap in **How to Test**. Leave this unchecked when the app-run box above is checked.

## How to Test

1. Run `python -m pytest -q tests/test_searxng_settings_migration.py` on Linux/macOS: all tests should pass as before.
2. On Windows: `python -c "import importlib.util; spec = importlib.util.spec_from_file_location('m', 'scripts/migrate_searxng_settings.py'); m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)"`; it should import without AttributeError.
3. Verify the pytestmark skip: `python -m pytest tests/test_searxng_settings_migration.py --collect-only` on Windows shows all tests as skipped with the platform reason.

The POSIX ownership (`fchown`) and directory-fsync (`O_DIRECTORY`) paths remain intact on non-Windows systems. On macOS the migration was verified to correctly insert `use_default_settings: true` and preserve mode 0o640 on a temp file. `python -m py_compile scripts/migrate_searxng_settings.py` and `git diff --check` pass.

## Visual / UI changes -- REQUIRED if you touched anything that renders

Not applicable: no static, template, style, or rendering files changed.

- [ ] Screenshot or short clip of the change in the running app, attached below.
- [ ] Style match: the change uses Odysseus's existing visual language.
- [ ] No new component patterns.
- [x] I am not an LLM agent submitting a bulk PR.

### Screenshots / clips

N/A, no rendering code changed.

## Runtime validation (2026-08-26)

- **macOS:** `python -m pytest tests/test_searxng_settings_migration.py` passes (27 tests), and `python -m py_compile scripts/migrate_searxng_settings.py` is clean.
- **Linux, the script's real runtime:** I executed this branch's script inside the pinned `searxng/searxng:2026.5.31-7159b8aed` image via `/usr/local/searxng/.venv/bin/python` against a retained operator `settings.yml`. It exits 0, inserts `use_default_settings: true`, and exercises the POSIX `fchown` / `O_DIRECTORY` paths. I also ran the full `docker compose up -d searxng` path on this branch with a pre-seeded retained file: the migration log line appears and SearXNG boots healthy. (`format=json` still returns 403 on this branch; that is issue #6066, addressed separately in #6136, not a regression from this change.)
- **Windows guard:** simulated by setting `sys.platform = "win32"` and exec'ing the module. It imports cleanly where the pre-fix script raised `AttributeError`. To be clear, this is a simulation on macOS rather than a real Windows box; the test-file skip is a declarative `pytestmark` skipif on the same condition.