### PR TITLE
feat(security): add brokered sandbox egress

### DIFF
--- a/security/egress/Makefile
+++ b/security/egress/Makefile
@@ -1,22 +1,34 @@
 PYTHON ?= python3
-PYTHON_PATH := $(shell realpath "$$(command -v $(PYTHON))")
-INSTALL_DIR := /usr/local/libexec
-INSTALL_OWNER ?= root
-INSTALL_GROUP ?= root
-BROKER := odysseus_egress_broker.py
-BRIDGE := odysseus_egress_bridge.py
+PYTHON_PATH = $(shell realpath "$$(command -v $(PYTHON))")
+override SHELL := /bin/sh
+override .SHELLFLAGS := -eu -c
+override TRUSTED_PYTHON := $(firstword $(realpath /usr/local/bin/python3 /usr/bin/python3))
+override INSTALL_DIR := /usr/local/libexec
+override INSTALL_OWNER := root
+override INSTALL_GROUP := root
+override INSTALL_TOOL := /usr/bin/install
+override SED_TOOL := /usr/bin/sed
+override CHOWN_TOOL := /usr/bin/chown
+override CHMOD_TOOL := /usr/bin/chmod
+override BROKER := odysseus_egress_broker.py
+override BRIDGE := odysseus_egress_bridge.py
 
-.PHONY: check install
+.PHONY: check trusted-check install
 
 check:
 	test -n "$(PYTHON_PATH)" -a -x "$(PYTHON_PATH)"
 	$(PYTHON) -m py_compile $(BROKER) $(BRIDGE)
 
-install: check
-	install -d -o $(INSTALL_OWNER) -g $(INSTALL_GROUP) -m 0755 $(INSTALL_DIR)
-	install -o $(INSTALL_OWNER) -g $(INSTALL_GROUP) -m 0755 $(BROKER) $(INSTALL_DIR)/odysseus-egress-broker
-	install -o $(INSTALL_OWNER) -g $(INSTALL_GROUP) -m 0755 $(BRIDGE) $(INSTALL_DIR)/odysseus-egress-bridge
-	sed -i '1c\#!$(PYTHON_PATH) -I' $(INSTALL_DIR)/odysseus-egress-broker
-	sed -i '1c\#!$(PYTHON_PATH) -I' $(INSTALL_DIR)/odysseus-egress-bridge
-	chown $(INSTALL_OWNER):$(INSTALL_GROUP) $(INSTALL_DIR)/odysseus-egress-broker $(INSTALL_DIR)/odysseus-egress-bridge
-	chmod 0755 $(INSTALL_DIR)/odysseus-egress-broker $(INSTALL_DIR)/odysseus-egress-bridge
+trusted-check:
+	test -n "$(TRUSTED_PYTHON)" -a -x "$(TRUSTED_PYTHON)"
+	test -z "$$($(realpath /usr/bin/find) "$(TRUSTED_PYTHON)" -maxdepth 0 \( ! -type f -o ! -uid 0 -o -perm /022 -o -perm /6000 \) -print -quit)"
+	"$(TRUSTED_PYTHON)" -I -m py_compile $(BROKER) $(BRIDGE)
+
+install: trusted-check
+	$(INSTALL_TOOL) -d -o $(INSTALL_OWNER) -g $(INSTALL_GROUP) -m 0755 $(INSTALL_DIR)
+	$(INSTALL_TOOL) -o $(INSTALL_OWNER) -g $(INSTALL_GROUP) -m 0755 $(BROKER) $(INSTALL_DIR)/odysseus-egress-broker
+	$(INSTALL_TOOL) -o $(INSTALL_OWNER) -g $(INSTALL_GROUP) -m 0755 $(BRIDGE) $(INSTALL_DIR)/odysseus-egress-bridge
+	$(SED_TOOL) -i '1c\#!$(TRUSTED_PYTHON) -I' $(INSTALL_DIR)/odysseus-egress-broker
+	$(SED_TOOL) -i '1c\#!$(TRUSTED_PYTHON) -I' $(INSTALL_DIR)/odysseus-egress-bridge
+	$(CHOWN_TOOL) $(INSTALL_OWNER):$(INSTALL_GROUP) $(INSTALL_DIR)/odysseus-egress-broker $(INSTALL_DIR)/odysseus-egress-bridge
+	$(CHMOD_TOOL) 0755 $(INSTALL_DIR)/odysseus-egress-broker $(INSTALL_DIR)/odysseus-egress-bridge

--- a/security/egress/Makefile
+++ b/security/egress/Makefile
@@ -1,0 +1,22 @@
+PYTHON ?= python3
+PYTHON_PATH := $(shell realpath "$$(command -v $(PYTHON))")
+INSTALL_DIR := /usr/local/libexec
+INSTALL_OWNER ?= root
+INSTALL_GROUP ?= root
+BROKER := odysseus_egress_broker.py
+BRIDGE := odysseus_egress_bridge.py
+
+.PHONY: check install
+
+check:
+	test -n "$(PYTHON_PATH)" -a -x "$(PYTHON_PATH)"
+	$(PYTHON) -m py_compile $(BROKER) $(BRIDGE)
+
+install: check
+	install -d -o $(INSTALL_OWNER) -g $(INSTALL_GROUP) -m 0755 $(INSTALL_DIR)
+	install -o $(INSTALL_OWNER) -g $(INSTALL_GROUP) -m 0755 $(BROKER) $(INSTALL_DIR)/odysseus-egress-broker
+	install -o $(INSTALL_OWNER) -g $(INSTALL_GROUP) -m 0755 $(BRIDGE) $(INSTALL_DIR)/odysseus-egress-bridge
+	sed -i '1c\#!$(PYTHON_PATH) -I' $(INSTALL_DIR)/odysseus-egress-broker
+	sed -i '1c\#!$(PYTHON_PATH) -I' $(INSTALL_DIR)/odysseus-egress-bridge
+	chown $(INSTALL_OWNER):$(INSTALL_GROUP) $(INSTALL_DIR)/odysseus-egress-broker $(INSTALL_DIR)/odysseus-egress-bridge
+	chmod 0755 $(INSTALL_DIR)/odysseus-egress-broker $(INSTALL_DIR)/odysseus-egress-bridge

--- a/security/egress/README.md
+++ b/security/egress/README.md
@@ -19,7 +19,4 @@ connection lifetime, and total broker lifetime. It intentionally does not
 support arbitrary TCP, UDP, SSH, SOCKS, private destinations, or raw network
 sharing.
 
-Installation rewrites each helper's shebang to the absolute Python interpreter
-selected at build/install time and enables Python isolated mode. Runtime launch
-therefore never resolves a Python executable or imports user-site startup code
-through inherited or model-writable state.
+The production install target rewrites each helper's shebang to the first available interpreter in the fixed set `/usr/local/bin/python3` and `/usr/bin/python3`, requires that canonical interpreter to be a root-owned regular executable with no set-id or group/other write bits, enables Python isolated mode, and fixes the install path and ownership to `/usr/local/libexec` and `root:root`. Its interpreter, path, and ownership contract cannot be replaced through Make variables; the separate developer `check` target remains configurable. Runtime launch therefore never resolves a Python executable or imports user-site startup code through inherited or model-writable state.

--- a/security/egress/README.md
+++ b/security/egress/README.md
@@ -1,0 +1,25 @@
+# Brokered sandbox egress
+
+`odysseus-egress-broker` is a fixed-purpose parent for the trusted seccomp
+launcher. It owns a unique mode-0700 runtime directory and Unix socket outside
+Bubblewrap, injects that directory as a read-only mount, clears its environment,
+and resolves every requested destination itself.
+
+`odysseus-egress-bridge` runs after Bubblewrap has created a private network
+namespace and loaded the inner seccomp filter. It exposes only
+`127.0.0.1:3128` and forwards bytes to the mounted Unix socket. The payload can
+talk to the broker but cannot acquire the container's raw network namespace.
+
+The broker supports absolute-form HTTP requests to public TCP port 80 and
+HTTPS `CONNECT` to public TCP port 443. Every DNS answer must be globally
+routable; mixed public/private answers fail closed. It connects to the exact
+validated sockaddr, strips proxy authorization and hop-by-hop request headers,
+and bounds headers, HTTP bodies, tunnels, concurrent connections, idle time,
+connection lifetime, and total broker lifetime. It intentionally does not
+support arbitrary TCP, UDP, SSH, SOCKS, private destinations, or raw network
+sharing.
+
+Installation rewrites each helper's shebang to the absolute Python interpreter
+selected at build/install time and enables Python isolated mode. Runtime launch
+therefore never resolves a Python executable or imports user-site startup code
+through inherited or model-writable state.

--- a/security/egress/odysseus_egress_bridge.py
+++ b/security/egress/odysseus_egress_bridge.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Trusted loopback-to-Unix bridge inside a Bubblewrap network namespace."""
+
+from __future__ import annotations
+
+import os
+import signal
+import socket
+import subprocess
+import sys
+import threading
+import time
+from typing import Callable, Sequence
+
+
+BROKER_SOCKET = "/run/odysseus-egress/broker.sock"
+PROXY_HOST = "127.0.0.1"
+PROXY_PORT = 3128
+MAX_CONNECTIONS = 16
+COPY_BUFFER_BYTES = 64 * 1024
+IDLE_TIMEOUT_SECONDS = 60.0
+CONNECTION_LIFETIME_SECONDS = 15 * 60.0
+
+
+class BridgeError(RuntimeError):
+    """The trusted bridge could not be established safely."""
+
+
+def _copy(
+    source: socket.socket,
+    destination: socket.socket,
+    stop: threading.Event,
+    touch: Callable[[], None],
+    expired: Callable[[], bool],
+    *,
+    stop_after_eof: bool,
+) -> None:
+    try:
+        while not stop.is_set():
+            if expired():
+                stop.set()
+                break
+            try:
+                data = source.recv(COPY_BUFFER_BYTES)
+            except socket.timeout:
+                continue
+            if not data:
+                if stop_after_eof:
+                    stop.set()
+                break
+            destination.sendall(data)
+            touch()
+    except OSError:
+        stop.set()
+    finally:
+        try:
+            destination.shutdown(socket.SHUT_WR)
+        except OSError:
+            pass
+
+
+def _relay(
+    left: socket.socket,
+    right: socket.socket,
+    *,
+    idle_timeout: float = IDLE_TIMEOUT_SECONDS,
+    connection_lifetime: float = CONNECTION_LIFETIME_SECONDS,
+) -> None:
+    stop = threading.Event()
+    activity_lock = threading.Lock()
+    last_activity = [time.monotonic()]
+    deadline = time.monotonic() + connection_lifetime
+
+    def touch() -> None:
+        with activity_lock:
+            last_activity[0] = time.monotonic()
+
+    def expired() -> bool:
+        with activity_lock:
+            idle = time.monotonic() - last_activity[0] >= idle_timeout
+        return idle or time.monotonic() >= deadline
+
+    timeout = min(idle_timeout, 1.0)
+    left.settimeout(timeout)
+    right.settimeout(timeout)
+    upstream = threading.Thread(
+        target=_copy,
+        args=(left, right, stop, touch, expired),
+        kwargs={"stop_after_eof": False},
+        daemon=True,
+    )
+    downstream = threading.Thread(
+        target=_copy,
+        args=(right, left, stop, touch, expired),
+        kwargs={"stop_after_eof": True},
+        daemon=True,
+    )
+    upstream.start()
+    downstream.start()
+    while (upstream.is_alive() or downstream.is_alive()) and not stop.is_set():
+        if expired():
+            stop.set()
+            break
+        time.sleep(0.05)
+    if stop.is_set():
+        # Preserve any broker response already delivered to the client while
+        # interrupting the opposite read direction that would otherwise keep
+        # the slot alive after broker EOF.
+        try:
+            left.shutdown(socket.SHUT_RD)
+        except OSError:
+            pass
+        try:
+            right.shutdown(socket.SHUT_RDWR)
+        except OSError:
+            pass
+    upstream.join(timeout=1.0)
+    downstream.join(timeout=1.0)
+    left.close()
+    right.close()
+
+
+class LoopbackBridge:
+    def __init__(
+        self,
+        broker_socket: str = BROKER_SOCKET,
+        *,
+        host: str = PROXY_HOST,
+        port: int = PROXY_PORT,
+        max_connections: int = MAX_CONNECTIONS,
+        idle_timeout: float = IDLE_TIMEOUT_SECONDS,
+        connection_lifetime: float = CONNECTION_LIFETIME_SECONDS,
+    ) -> None:
+        if not os.path.isabs(broker_socket):
+            raise BridgeError("broker socket path must be absolute")
+        if idle_timeout <= 0 or connection_lifetime <= 0:
+            raise BridgeError("bridge time limits must be positive")
+        self.broker_socket = broker_socket
+        self.idle_timeout = idle_timeout
+        self.connection_lifetime = connection_lifetime
+        self.listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.listener.bind((host, port))
+        self.listener.listen(max_connections)
+        self.listener.settimeout(0.5)
+        self.stop = threading.Event()
+        self.slots = threading.BoundedSemaphore(max_connections)
+        self.accept_thread: threading.Thread | None = None
+        self.connections: list[threading.Thread] = []
+        self.connections_lock = threading.Lock()
+
+    @property
+    def address(self) -> tuple[str, int]:
+        host, port = self.listener.getsockname()[:2]
+        return str(host), int(port)
+
+    def verify_broker(self) -> None:
+        probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            probe.settimeout(2.0)
+            probe.connect(self.broker_socket)
+        except OSError as exc:
+            raise BridgeError("trusted egress broker is unavailable") from exc
+        finally:
+            probe.close()
+
+    def start(self) -> None:
+        self.verify_broker()
+        self.accept_thread = threading.Thread(target=self._accept, daemon=True)
+        self.accept_thread.start()
+
+    def _accept(self) -> None:
+        while not self.stop.is_set():
+            try:
+                client, _address = self.listener.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            if not self.slots.acquire(blocking=False):
+                client.close()
+                continue
+            thread = threading.Thread(
+                target=self._connect,
+                args=(client,),
+                daemon=True,
+            )
+            with self.connections_lock:
+                self.connections = [
+                    worker for worker in self.connections if worker.is_alive()
+                ]
+                thread.start()
+                self.connections.append(thread)
+
+    def _connect(self, client: socket.socket) -> None:
+        broker = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            broker.connect(self.broker_socket)
+        except OSError:
+            client.close()
+            broker.close()
+            self.slots.release()
+            return
+        try:
+            _relay(
+                client,
+                broker,
+                idle_timeout=self.idle_timeout,
+                connection_lifetime=self.connection_lifetime,
+            )
+        finally:
+            self.slots.release()
+
+    def close(self) -> None:
+        self.stop.set()
+        try:
+            self.listener.close()
+        except OSError:
+            pass
+        if self.accept_thread is not None:
+            self.accept_thread.join(timeout=1.0)
+        with self.connections_lock:
+            connections = list(self.connections)
+        for thread in connections:
+            thread.join(timeout=0.2)
+
+
+def _parse_command(arguments: Sequence[str]) -> list[str]:
+    if len(arguments) < 3 or arguments[0] != BROKER_SOCKET or arguments[1] != "--":
+        raise BridgeError("invalid trusted bridge arguments")
+    command = list(arguments[2:])
+    if not command or not os.path.isabs(command[0]):
+        raise BridgeError("trusted bridge requires an absolute payload executable")
+    return command
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    bridge: LoopbackBridge | None = None
+    child: subprocess.Popen[bytes] | None = None
+    try:
+        command = _parse_command(arguments)
+        bridge = LoopbackBridge()
+        bridge.start()
+        child = subprocess.Popen(command, close_fds=True)
+
+        def forward_signal(_signum: int, _frame: object) -> None:
+            if child is not None and child.poll() is None:
+                child.terminate()
+
+        signal.signal(signal.SIGTERM, forward_signal)
+        signal.signal(signal.SIGINT, forward_signal)
+        return int(child.wait())
+    except BridgeError as exc:
+        print(f"odysseus-egress-bridge: {exc}", file=sys.stderr)
+        return 64
+    except (OSError, subprocess.SubprocessError):
+        print("odysseus-egress-bridge: trusted bridge setup failed", file=sys.stderr)
+        if child is not None and child.poll() is None:
+            child.terminate()
+        return 70
+    finally:
+        if bridge is not None:
+            bridge.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/security/egress/odysseus_egress_broker.py
+++ b/security/egress/odysseus_egress_broker.py
@@ -504,7 +504,7 @@ def _serve_http(
     ):
         raise RequestError(400, "plain proxy requests require an absolute HTTP URL")
     host = parsed.hostname
-    port = parsed_port or 80
+    port = 80 if parsed_port is None else parsed_port
     if port != 80:
         raise RequestError(403, "plain HTTP proxying is limited to public TCP port 80")
 

--- a/security/egress/odysseus_egress_broker.py
+++ b/security/egress/odysseus_egress_broker.py
@@ -1,0 +1,774 @@
+#!/usr/bin/env python3
+"""Fixed-purpose public HTTP(S) egress broker for process sandboxes.
+
+The broker runs outside Bubblewrap with an empty environment.  A unique Unix
+socket is mounted read-only into one private network namespace, where the
+trusted loopback bridge exposes it as a conventional HTTP proxy.  The broker
+resolves every requested destination itself and connects only to globally
+routable addresses on TCP port 80 or 443.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+import re
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable, Iterable, Sequence
+from urllib.parse import urlsplit
+
+
+TRUSTED_LAUNCHER = "/usr/local/libexec/odysseus-seccomp-launcher"
+TRUSTED_BWRAP = "/usr/bin/bwrap"
+SANDBOX_RUNTIME_DIR = "/run/odysseus-egress"
+SANDBOX_SOCKET = f"{SANDBOX_RUNTIME_DIR}/broker.sock"
+
+MAX_CONNECTIONS = 16
+MAX_HEADER_BYTES = 64 * 1024
+MAX_HTTP_BODY_BYTES = 16 * 1024 * 1024
+MAX_TUNNEL_BYTES_PER_DIRECTION = 1024 * 1024 * 1024
+MAX_RESOLVED_TARGETS = 16
+CONNECT_TIMEOUT_SECONDS = 10.0
+HEADER_TIMEOUT_SECONDS = 10.0
+IDLE_TIMEOUT_SECONDS = 60.0
+CONNECTION_LIFETIME_SECONDS = 15 * 60.0
+BROKER_LIFETIME_SECONDS = 60 * 60.0
+
+_TOKEN = re.compile(rb"^[!#$%&'*+.^_`|~0-9A-Za-z-]+$")
+_HOP_BY_HOP = {
+    "connection",
+    "keep-alive",
+    "proxy-authorization",
+    "proxy-connection",
+    "te",
+    "trailer",
+    "upgrade",
+}
+_CONNECTION_PROTECTED_HEADERS = {
+    "content-length",
+    "expect",
+    "host",
+    "transfer-encoding",
+}
+_NAT64_WELL_KNOWN = ipaddress.ip_network("64:ff9b::/96")
+_NAT64_LOCAL_USE = ipaddress.ip_network("64:ff9b:1::/48")
+
+
+class BrokerError(RuntimeError):
+    """A fail-closed broker setup or destination-policy error."""
+
+
+class RequestError(BrokerError):
+    """A client request that the constrained proxy must reject."""
+
+    def __init__(self, status: int, reason: str):
+        super().__init__(reason)
+        self.status = status
+        self.reason = reason
+
+
+Resolver = Callable[..., Iterable[tuple]]
+Connector = Callable[[int, tuple, float], socket.socket]
+
+
+@dataclass(frozen=True)
+class PublicTarget:
+    family: int
+    sockaddr: tuple
+
+
+def _public_ip(value: object) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
+    if not isinstance(value, str):
+        raise BrokerError("destination did not resolve to an IP address")
+    try:
+        address = ipaddress.ip_address(value.split("%", 1)[0])
+    except ValueError as exc:
+        raise BrokerError("destination did not resolve to an IP address") from exc
+    if isinstance(address, ipaddress.IPv6Address) and address.ipv4_mapped is not None:
+        address = address.ipv4_mapped
+    if isinstance(address, ipaddress.IPv6Address):
+        if address in _NAT64_LOCAL_USE:
+            raise BrokerError("destination resolved to a non-public address")
+        if address in _NAT64_WELL_KNOWN:
+            embedded = ipaddress.IPv4Address(address.packed[-4:])
+            if (
+                not embedded.is_global
+                or embedded.is_multicast
+                or embedded.is_private
+                or embedded.is_loopback
+                or embedded.is_link_local
+                or embedded.is_reserved
+                or embedded.is_unspecified
+            ):
+                raise BrokerError("destination resolved to a non-public address")
+            return embedded
+    # is_global rejects loopback, RFC1918, link-local/metadata, CGNAT, ULA,
+    # multicast, unspecified, benchmarking, documentation, and reserved space.
+    if (
+        not address.is_global
+        or address.is_multicast
+        or address.is_private
+        or address.is_loopback
+        or address.is_link_local
+        or address.is_reserved
+        or address.is_unspecified
+    ):
+        raise BrokerError("destination resolved to a non-public address")
+    return address
+
+
+def resolve_public_targets(
+    host: str,
+    port: int,
+    *,
+    resolver: Resolver = socket.getaddrinfo,
+) -> list[PublicTarget]:
+    """Resolve once, reject mixed public/private answers, and retain IP tuples."""
+    if not isinstance(host, str) or not host or len(host) > 253 or "\x00" in host:
+        raise BrokerError("invalid destination host")
+    try:
+        answers = list(
+            resolver(
+                host,
+                port,
+                family=socket.AF_UNSPEC,
+                type=socket.SOCK_STREAM,
+                proto=socket.IPPROTO_TCP,
+            )
+        )
+    except (OSError, UnicodeError, ValueError) as exc:
+        raise BrokerError("destination resolution failed") from exc
+    if not answers:
+        raise BrokerError("destination resolution failed")
+
+    targets: list[PublicTarget] = []
+    seen: set[tuple[int, tuple]] = set()
+    too_many_targets = False
+    for answer in answers:
+        if not isinstance(answer, tuple) or len(answer) < 5:
+            raise BrokerError("destination resolution returned an invalid answer")
+        family, socket_type, _protocol, _canonical, sockaddr = answer[:5]
+        if family not in (socket.AF_INET, socket.AF_INET6):
+            raise BrokerError("destination resolution returned an unsupported family")
+        if socket_type not in (0, socket.SOCK_STREAM):
+            raise BrokerError("destination resolution returned an unsupported socket type")
+        if not isinstance(sockaddr, tuple) or len(sockaddr) < 2:
+            raise BrokerError("destination resolution returned an invalid address")
+        _public_ip(sockaddr[0])
+        normalized = (family, sockaddr)
+        if normalized not in seen:
+            if len(seen) >= MAX_RESOLVED_TARGETS:
+                too_many_targets = True
+                continue
+            seen.add(normalized)
+            targets.append(PublicTarget(family, sockaddr))
+    if too_many_targets:
+        raise BrokerError("destination resolved to too many addresses")
+    if not targets:
+        raise BrokerError("destination resolution failed")
+    return targets
+
+
+def _default_connector(family: int, sockaddr: tuple, timeout: float) -> socket.socket:
+    outbound = socket.socket(family, socket.SOCK_STREAM, socket.IPPROTO_TCP)
+    try:
+        outbound.settimeout(timeout)
+        outbound.connect(sockaddr)
+        return outbound
+    except Exception:
+        outbound.close()
+        raise
+
+
+def connect_public_target(
+    host: str,
+    port: int,
+    *,
+    resolver: Resolver = socket.getaddrinfo,
+    connector: Connector = _default_connector,
+) -> socket.socket:
+    """Connect to the exact approved sockaddr without a second name lookup."""
+    targets = resolve_public_targets(host, port, resolver=resolver)
+    for target in targets:
+        target_address = _public_ip(target.sockaddr[0])
+        target_port = int(target.sockaddr[1])
+        try:
+            outbound = connector(
+                target.family,
+                target.sockaddr,
+                CONNECT_TIMEOUT_SECONDS,
+            )
+        except OSError:
+            continue
+        try:
+            peer = outbound.getpeername()
+            if not isinstance(peer, tuple) or len(peer) < 2:
+                raise BrokerError("connected peer address is unavailable")
+            peer_address = _public_ip(peer[0])
+            if peer_address != target_address or int(peer[1]) != target_port:
+                raise BrokerError("connected peer does not match the approved target")
+        except Exception:
+            outbound.close()
+            continue
+        outbound.settimeout(IDLE_TIMEOUT_SECONDS)
+        return outbound
+    raise BrokerError("public destination connection failed")
+
+
+def _read_headers(client: socket.socket) -> tuple[bytes, bytes]:
+    client.settimeout(HEADER_TIMEOUT_SECONDS)
+    data = bytearray()
+    while True:
+        marker = data.find(b"\r\n\r\n")
+        if marker >= 0:
+            return bytes(data[:marker]), bytes(data[marker + 4:])
+        if len(data) >= MAX_HEADER_BYTES:
+            raise RequestError(431, "request headers too large")
+        chunk = client.recv(min(4096, MAX_HEADER_BYTES - len(data)))
+        if not chunk:
+            raise RequestError(400, "incomplete proxy request")
+        data.extend(chunk)
+
+
+def _parse_headers(block: bytes) -> tuple[str, str, str, list[tuple[str, str]]]:
+    try:
+        lines = block.split(b"\r\n")
+        request_line = lines[0].decode("ascii")
+    except (IndexError, UnicodeDecodeError) as exc:
+        raise RequestError(400, "invalid proxy request line") from exc
+    parts = request_line.split(" ")
+    if len(parts) != 3:
+        raise RequestError(400, "invalid proxy request line")
+    method, target, version = parts
+    if not _TOKEN.fullmatch(method.encode("ascii", errors="ignore")):
+        raise RequestError(400, "invalid HTTP method")
+    if version not in {"HTTP/1.0", "HTTP/1.1"}:
+        raise RequestError(400, "unsupported HTTP version")
+    if any(ord(character) < 0x21 or ord(character) == 0x7F for character in target):
+        raise RequestError(400, "invalid proxy destination")
+
+    headers: list[tuple[str, str]] = []
+    for raw in lines[1:]:
+        if not raw or raw[:1] in {b" ", b"\t"} or b":" not in raw:
+            raise RequestError(400, "invalid proxy request header")
+        name, value = raw.split(b":", 1)
+        if not _TOKEN.fullmatch(name):
+            raise RequestError(400, "invalid proxy request header")
+        try:
+            decoded_value = value.decode("iso-8859-1").strip()
+        except UnicodeDecodeError as exc:  # pragma: no cover - latin-1 is total
+            raise RequestError(400, "invalid proxy request header") from exc
+        if any(ord(character) < 0x20 or ord(character) == 0x7F for character in decoded_value):
+            raise RequestError(400, "invalid proxy request header")
+        headers.append((name.decode("ascii"), decoded_value))
+    return method, target, version, headers
+
+
+def _parse_authority(authority: str, *, default_port: int) -> tuple[str, int]:
+    if not authority or "@" in authority or any(char.isspace() for char in authority):
+        raise RequestError(400, "invalid proxy destination")
+    if authority.startswith("["):
+        end = authority.find("]")
+        if end <= 1:
+            raise RequestError(400, "invalid proxy destination")
+        host = authority[1:end]
+        suffix = authority[end + 1:]
+        if suffix:
+            if not suffix.startswith(":"):
+                raise RequestError(400, "invalid proxy destination")
+            port_text = suffix[1:]
+        else:
+            port_text = str(default_port)
+    else:
+        if authority.count(":") > 1:
+            raise RequestError(400, "IPv6 proxy destinations must be bracketed")
+        if ":" in authority:
+            host, port_text = authority.rsplit(":", 1)
+        else:
+            host, port_text = authority, str(default_port)
+    if not host or not port_text.isascii() or not port_text.isdigit():
+        raise RequestError(400, "invalid proxy destination")
+    port = int(port_text)
+    if not 1 <= port <= 65535:
+        raise RequestError(400, "invalid proxy destination port")
+    return host, port
+
+
+def _format_authority(host: str, port: int) -> str:
+    bracketed = f"[{host}]" if ":" in host and not host.startswith("[") else host
+    return f"{bracketed}:{port}"
+
+
+def _send_error(client: socket.socket, status: int, reason: str) -> None:
+    labels = {
+        400: "Bad Request",
+        403: "Forbidden",
+        431: "Request Header Fields Too Large",
+        502: "Bad Gateway",
+        503: "Service Unavailable",
+    }
+    label = labels.get(status, "Proxy Error")
+    body = f"{reason}\n".encode("utf-8", errors="replace")[:512]
+    response = (
+        f"HTTP/1.1 {status} {label}\r\n"
+        "Content-Type: text/plain\r\n"
+        f"Content-Length: {len(body)}\r\n"
+        "Connection: close\r\n\r\n"
+    ).encode("ascii") + body
+    try:
+        client.sendall(response)
+    except OSError:
+        pass
+
+
+def _relay(
+    client: socket.socket,
+    outbound: socket.socket,
+    *,
+    client_bytes_remaining: int | None,
+) -> None:
+    stop = threading.Event()
+    activity_lock = threading.Lock()
+    last_activity = [time.monotonic()]
+    deadline = time.monotonic() + CONNECTION_LIFETIME_SECONDS
+
+    def touch() -> None:
+        with activity_lock:
+            last_activity[0] = time.monotonic()
+
+    def idle_expired() -> bool:
+        with activity_lock:
+            return time.monotonic() - last_activity[0] >= IDLE_TIMEOUT_SECONDS
+
+    def pump(
+        source: socket.socket,
+        destination: socket.socket,
+        limit: int | None,
+        *,
+        stop_after_eof: bool,
+    ) -> None:
+        remaining = limit
+        try:
+            source.settimeout(min(IDLE_TIMEOUT_SECONDS, 5.0))
+            destination.settimeout(min(IDLE_TIMEOUT_SECONDS, 5.0))
+            while not stop.is_set() and time.monotonic() < deadline:
+                if remaining == 0:
+                    break
+                size = 64 * 1024 if remaining is None else min(64 * 1024, remaining)
+                try:
+                    data = source.recv(size)
+                except socket.timeout:
+                    if idle_expired():
+                        stop.set()
+                    continue
+                if not data:
+                    if stop_after_eof:
+                        stop.set()
+                    break
+                destination.sendall(data)
+                touch()
+                if remaining is not None:
+                    remaining -= len(data)
+            try:
+                destination.shutdown(socket.SHUT_WR)
+            except OSError:
+                pass
+        except OSError:
+            stop.set()
+
+    client_limit = (
+        MAX_TUNNEL_BYTES_PER_DIRECTION
+        if client_bytes_remaining is None
+        else client_bytes_remaining
+    )
+    upstream = threading.Thread(
+        target=pump,
+        args=(client, outbound, client_limit),
+        kwargs={"stop_after_eof": False},
+        daemon=True,
+    )
+    downstream = threading.Thread(
+        target=pump,
+        args=(outbound, client, MAX_TUNNEL_BYTES_PER_DIRECTION),
+        kwargs={"stop_after_eof": True},
+        daemon=True,
+    )
+    upstream.start()
+    downstream.start()
+    while (upstream.is_alive() or downstream.is_alive()) and not stop.is_set():
+        if time.monotonic() >= deadline or idle_expired():
+            stop.set()
+            break
+        time.sleep(0.05)
+    if stop.is_set():
+        for stream in (client, outbound):
+            try:
+                stream.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+    upstream.join(timeout=1.0)
+    downstream.join(timeout=1.0)
+
+
+def _single_header(headers: Sequence[tuple[str, str]], name: str) -> str | None:
+    values = [value for key, value in headers if key.casefold() == name]
+    if len(values) > 1:
+        raise RequestError(400, f"multiple {name} headers are not allowed")
+    return values[0] if values else None
+
+
+def _connection_options(headers: Sequence[tuple[str, str]]) -> set[str]:
+    """Parse hop-by-hop names without allowing request-framing removal."""
+    options: set[str] = set()
+    for name, value in headers:
+        if name.casefold() != "connection":
+            continue
+        for raw_option in value.split(","):
+            option = raw_option.strip()
+            if not option:
+                continue
+            try:
+                encoded = option.encode("ascii")
+            except UnicodeEncodeError as exc:
+                raise RequestError(400, "invalid Connection header") from exc
+            if not _TOKEN.fullmatch(encoded):
+                raise RequestError(400, "invalid Connection header")
+            options.add(option.casefold())
+    if options & _CONNECTION_PROTECTED_HEADERS:
+        raise RequestError(400, "Connection header cannot remove request framing")
+    return options
+
+
+def _serve_connect(
+    client: socket.socket,
+    target: str,
+    remainder: bytes,
+    *,
+    resolver: Resolver,
+    connector: Connector,
+) -> None:
+    host, port = _parse_authority(target, default_port=443)
+    if port != 443:
+        raise RequestError(403, "CONNECT is limited to public TCP port 443")
+    outbound = connect_public_target(
+        host,
+        port,
+        resolver=resolver,
+        connector=connector,
+    )
+    try:
+        client.sendall(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+        if len(remainder) > MAX_TUNNEL_BYTES_PER_DIRECTION:
+            raise RequestError(400, "tunnel preface too large")
+        if remainder:
+            outbound.sendall(remainder)
+        _relay(
+            client,
+            outbound,
+            client_bytes_remaining=MAX_TUNNEL_BYTES_PER_DIRECTION - len(remainder),
+        )
+    finally:
+        outbound.close()
+
+
+def _serve_http(
+    client: socket.socket,
+    method: str,
+    target: str,
+    version: str,
+    headers: Sequence[tuple[str, str]],
+    remainder: bytes,
+    *,
+    resolver: Resolver,
+    connector: Connector,
+) -> None:
+    try:
+        parsed = urlsplit(target)
+        parsed_port = parsed.port
+    except ValueError as exc:
+        raise RequestError(400, "invalid HTTP proxy destination") from exc
+    if (
+        parsed.scheme.casefold() != "http"
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.fragment
+    ):
+        raise RequestError(400, "plain proxy requests require an absolute HTTP URL")
+    host = parsed.hostname
+    port = parsed_port or 80
+    if port != 80:
+        raise RequestError(403, "plain HTTP proxying is limited to public TCP port 80")
+
+    host_header = _single_header(headers, "host")
+    if host_header is not None:
+        header_host, header_port = _parse_authority(host_header, default_port=80)
+        if header_host.rstrip(".").casefold() != host.rstrip(".").casefold() or header_port != port:
+            raise RequestError(400, "Host header does not match proxy destination")
+    if _single_header(headers, "expect") is not None:
+        raise RequestError(400, "Expect requests are not supported")
+    if _single_header(headers, "transfer-encoding") is not None:
+        raise RequestError(400, "streaming HTTP request bodies are not supported")
+    content_length = _single_header(headers, "content-length")
+    if content_length is None:
+        body_length = 0
+    elif not content_length.isascii() or not content_length.isdigit():
+        raise RequestError(400, "invalid Content-Length")
+    else:
+        body_length = int(content_length)
+    if body_length > MAX_HTTP_BODY_BYTES:
+        raise RequestError(400, "HTTP request body too large")
+    if len(remainder) > body_length:
+        raise RequestError(400, "pipelined proxy requests are not supported")
+    connection_tokens = _connection_options(headers)
+
+    outbound = connect_public_target(
+        host,
+        port,
+        resolver=resolver,
+        connector=connector,
+    )
+    try:
+        path = parsed.path or "/"
+        if parsed.query:
+            path = f"{path}?{parsed.query}"
+        forwarded = [f"{method} {path} {version}\r\n"]
+        forwarded.append(f"Host: {_format_authority(host, port)}\r\n")
+        for name, value in headers:
+            folded = name.casefold()
+            if folded == "host" or folded in _HOP_BY_HOP or folded in connection_tokens:
+                continue
+            forwarded.append(f"{name}: {value}\r\n")
+        forwarded.append("Connection: close\r\n\r\n")
+        outbound.sendall("".join(forwarded).encode("iso-8859-1") + remainder)
+        _relay(
+            client,
+            outbound,
+            client_bytes_remaining=body_length - len(remainder),
+        )
+    finally:
+        outbound.close()
+
+
+def serve_proxy_client(
+    client: socket.socket,
+    *,
+    resolver: Resolver = socket.getaddrinfo,
+    connector: Connector = _default_connector,
+) -> None:
+    try:
+        header_block, remainder = _read_headers(client)
+        method, target, version, headers = _parse_headers(header_block)
+        if method == "CONNECT":
+            _serve_connect(
+                client,
+                target,
+                remainder,
+                resolver=resolver,
+                connector=connector,
+            )
+        else:
+            _serve_http(
+                client,
+                method,
+                target,
+                version,
+                headers,
+                remainder,
+                resolver=resolver,
+                connector=connector,
+            )
+    except RequestError as exc:
+        _send_error(client, exc.status, exc.reason)
+    except BrokerError:
+        _send_error(client, 403, "destination blocked by sandbox egress policy")
+    except (OSError, UnicodeError, ValueError):
+        _send_error(client, 502, "public destination connection failed")
+    finally:
+        try:
+            client.close()
+        except OSError:
+            pass
+
+
+class BrokerServer:
+    def __init__(
+        self,
+        listener: socket.socket,
+        *,
+        resolver: Resolver = socket.getaddrinfo,
+        connector: Connector = _default_connector,
+        max_connections: int = MAX_CONNECTIONS,
+    ) -> None:
+        self.listener = listener
+        self.resolver = resolver
+        self.connector = connector
+        self.stop = threading.Event()
+        self.slots = threading.BoundedSemaphore(max_connections)
+        self.threads: list[threading.Thread] = []
+        self.threads_lock = threading.Lock()
+        self.accept_thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        self.listener.settimeout(0.5)
+        self.accept_thread = threading.Thread(target=self._accept, daemon=True)
+        self.accept_thread.start()
+
+    def _accept(self) -> None:
+        while not self.stop.is_set():
+            try:
+                client, _address = self.listener.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            if not self.slots.acquire(blocking=False):
+                _send_error(client, 503, "sandbox egress connection limit reached")
+                client.close()
+                continue
+            thread = threading.Thread(
+                target=self._handle,
+                args=(client,),
+                daemon=True,
+            )
+            with self.threads_lock:
+                self.threads = [worker for worker in self.threads if worker.is_alive()]
+                thread.start()
+                self.threads.append(thread)
+
+    def _handle(self, client: socket.socket) -> None:
+        try:
+            serve_proxy_client(
+                client,
+                resolver=self.resolver,
+                connector=self.connector,
+            )
+        finally:
+            self.slots.release()
+
+    def close(self) -> None:
+        self.stop.set()
+        try:
+            self.listener.close()
+        except OSError:
+            pass
+        if self.accept_thread is not None:
+            self.accept_thread.join(timeout=1.0)
+        with self.threads_lock:
+            threads = list(self.threads)
+        for thread in threads:
+            thread.join(timeout=0.2)
+
+
+def build_child_argv(arguments: Sequence[str], runtime_dir: str) -> list[str]:
+    """Validate the fixed launch chain and inject one read-only broker mount."""
+    if (
+        len(arguments) < 4
+        or arguments[0] != TRUSTED_LAUNCHER
+        or arguments[1] != TRUSTED_BWRAP
+    ):
+        raise BrokerError("invalid trusted sandbox launch chain")
+    try:
+        separator = arguments.index("--", 2)
+    except ValueError as exc:
+        raise BrokerError("invalid Bubblewrap arguments") from exc
+    setup = list(arguments[2:separator])
+    if setup.count("--unshare-net") != 1:
+        raise BrokerError("private network namespace is required")
+    if any(value == "--share-net" or value.startswith("--share-net=") for value in setup):
+        raise BrokerError("raw network sharing is forbidden")
+    if SANDBOX_RUNTIME_DIR in setup or SANDBOX_SOCKET in setup:
+        raise BrokerError("caller-supplied broker mounts are forbidden")
+    injected = [
+        "--dir",
+        "/run",
+        "--ro-bind",
+        runtime_dir,
+        SANDBOX_RUNTIME_DIR,
+    ]
+    return [*arguments[:separator], *injected, *arguments[separator:]]
+
+
+def _unix_listener(path: str) -> socket.socket:
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        listener.bind(path)
+        os.chmod(path, 0o600)
+        listener.listen(MAX_CONNECTIONS)
+        return listener
+    except Exception:
+        listener.close()
+        raise
+
+
+def _terminate(child: subprocess.Popen[bytes]) -> None:
+    if child.poll() is not None:
+        return
+    child.terminate()
+    try:
+        child.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        child.kill()
+        child.wait(timeout=5)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    # The broker never needs application configuration or credentials.  Clear
+    # them before opening the socket or starting any worker threads.
+    os.environ.clear()
+    runtime_dir: str | None = None
+    server: BrokerServer | None = None
+    child: subprocess.Popen[bytes] | None = None
+    try:
+        runtime_dir = tempfile.mkdtemp(prefix="odysseus-egress-", dir="/tmp")
+        os.chmod(runtime_dir, 0o700)
+        socket_path = os.path.join(runtime_dir, "broker.sock")
+        listener = _unix_listener(socket_path)
+        server = BrokerServer(listener)
+        server.start()
+        child_argv = build_child_argv(arguments, runtime_dir)
+        child = subprocess.Popen(child_argv, env={}, close_fds=True)
+
+        def forward_signal(_signum: int, _frame: object) -> None:
+            if child is not None and child.poll() is None:
+                child.terminate()
+
+        signal.signal(signal.SIGTERM, forward_signal)
+        signal.signal(signal.SIGINT, forward_signal)
+        deadline = time.monotonic() + BROKER_LIFETIME_SECONDS
+        while child.poll() is None and time.monotonic() < deadline:
+            time.sleep(0.1)
+        if child.poll() is None:
+            print(
+                "odysseus-egress-broker: sandbox network lifetime exceeded",
+                file=sys.stderr,
+            )
+            _terminate(child)
+            return 72
+        return int(child.returncode or 0)
+    except BrokerError as exc:
+        print(f"odysseus-egress-broker: {exc}", file=sys.stderr)
+        return 64
+    except (OSError, subprocess.SubprocessError):
+        print("odysseus-egress-broker: trusted broker setup failed", file=sys.stderr)
+        if child is not None:
+            _terminate(child)
+        return 70
+    finally:
+        if server is not None:
+            server.close()
+        if runtime_dir is not None:
+            shutil.rmtree(runtime_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_egress_broker.py
+++ b/tests/test_egress_broker.py
@@ -599,6 +599,31 @@ def test_broker_and_bridge_limits_are_explicit_and_consistent():
     )
 
 
+def test_egress_makefile_keeps_trusted_install_contract():
+    makefile = (
+        Path(__file__).resolve().parents[1] / "security" / "egress" / "Makefile"
+    ).read_text(encoding="utf-8")
+
+    assert "INSTALL_OWNER ?= root" in makefile
+    assert "INSTALL_GROUP ?= root" in makefile
+    assert (
+        'PYTHON_PATH := $(shell realpath "$$(command -v $(PYTHON))")' in makefile
+    )
+    assert "sed -i '1c\\#!$(PYTHON_PATH) -I'" in makefile
+    assert (
+        "install -o $(INSTALL_OWNER) -g $(INSTALL_GROUP) -m 0755" in makefile
+    )
+    assert (
+        "chown $(INSTALL_OWNER):$(INSTALL_GROUP) "
+        "$(INSTALL_DIR)/odysseus-egress-broker "
+        "$(INSTALL_DIR)/odysseus-egress-bridge" in makefile
+    )
+    assert (
+        "chmod 0755 $(INSTALL_DIR)/odysseus-egress-broker "
+        "$(INSTALL_DIR)/odysseus-egress-bridge" in makefile
+    )
+
+
 def test_multiple_simultaneous_connect_tunnels_work_within_bounds(tmp_path):
     origins = []
     origin_threads = []

--- a/tests/test_egress_broker.py
+++ b/tests/test_egress_broker.py
@@ -1,0 +1,902 @@
+"""Deterministic coverage for the public-only sandbox HTTP(S) broker."""
+
+from __future__ import annotations
+
+import datetime
+import os
+import shutil
+import socket
+import ssl
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from security.egress import odysseus_egress_bridge as bridge
+from security.egress import odysseus_egress_broker as broker
+
+
+PUBLIC_V4 = "93.184.216.34"
+PUBLIC_V6 = "2606:2800:220:1:248:1893:25c8:1946"
+
+
+def _resolver(*addresses: str):
+    def resolve(_host, port, **_kwargs):
+        answers = []
+        for address in addresses:
+            if ":" in address:
+                answers.append(
+                    (
+                        socket.AF_INET6,
+                        socket.SOCK_STREAM,
+                        socket.IPPROTO_TCP,
+                        "",
+                        (address, port, 0, 0),
+                    )
+                )
+            else:
+                answers.append(
+                    (
+                        socket.AF_INET,
+                        socket.SOCK_STREAM,
+                        socket.IPPROTO_TCP,
+                        "",
+                        (address, port),
+                    )
+                )
+        return answers
+
+    return resolve
+
+
+class _PublicPeerSocket:
+    """Delegate I/O to a socketpair while reporting a validated public peer."""
+
+    def __init__(self, stream: socket.socket, peer=(PUBLIC_V4, 443)):
+        self.stream = stream
+        self.peer = peer
+
+    def getpeername(self):
+        return self.peer
+
+    def __getattr__(self, name):
+        return getattr(self.stream, name)
+
+
+def _read_all(stream: socket.socket) -> bytes:
+    chunks = []
+    while True:
+        data = stream.recv(65536)
+        if not data:
+            return b"".join(chunks)
+        chunks.append(data)
+
+
+class _Transport:
+    def __init__(
+        self,
+        tmp_path,
+        connector,
+        *,
+        resolver=None,
+        max_connections=broker.MAX_CONNECTIONS,
+    ):
+        socket_path = tmp_path / "transport.sock"
+        self.listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.listener.bind(str(socket_path))
+        self.listener.listen(max_connections)
+        self.server = broker.BrokerServer(
+            self.listener,
+            resolver=resolver or _resolver(PUBLIC_V4),
+            connector=connector,
+            max_connections=max_connections,
+        )
+        self.server.start()
+        self.bridge = bridge.LoopbackBridge(str(socket_path), port=0)
+        self.bridge.start()
+
+    @property
+    def proxy_url(self):
+        host, port = self.bridge.address
+        return f"http://{host}:{port}"
+
+    def close(self):
+        self.bridge.close()
+        self.server.close()
+
+
+@pytest.mark.parametrize(
+    "address",
+    [
+        "127.0.0.1",
+        "10.0.0.1",
+        "172.16.0.1",
+        "192.168.1.1",
+        "100.64.0.1",
+        "169.254.169.254",
+        "192.0.2.1",
+        "198.18.0.1",
+        "224.0.0.1",
+        "::1",
+        "fe80::1",
+        "fc00::1",
+        "ff02::1",
+        "::ffff:169.254.169.254",
+        "64:ff9b::a9fe:a9fe",
+        "64:ff9b::a00:1",
+    ],
+)
+def test_non_public_destinations_are_rejected(address):
+    with pytest.raises(broker.BrokerError, match="non-public"):
+        broker.resolve_public_targets(
+            "blocked.example",
+            443,
+            resolver=_resolver(address),
+        )
+
+
+def test_public_ipv4_and_ipv6_destinations_are_allowed():
+    targets = broker.resolve_public_targets(
+        "public.example",
+        443,
+        resolver=_resolver(PUBLIC_V4, PUBLIC_V6),
+    )
+
+    assert [target.sockaddr[0] for target in targets] == [PUBLIC_V4, PUBLIC_V6]
+
+
+def test_nat64_allows_only_an_embedded_public_ipv4_destination():
+    target = "64:ff9b::808:808"
+
+    targets = broker.resolve_public_targets(
+        "public-via-nat64.example",
+        443,
+        resolver=_resolver(target),
+    )
+
+    assert [item.sockaddr[0] for item in targets] == [target]
+
+
+def test_mixed_public_private_dns_answer_fails_closed():
+    with pytest.raises(broker.BrokerError, match="non-public"):
+        broker.resolve_public_targets(
+            "rebind.example",
+            443,
+            resolver=_resolver(PUBLIC_V4, "127.0.0.1"),
+        )
+
+
+def test_excessive_dns_answer_set_fails_closed():
+    addresses = [f"8.8.8.{index}" for index in range(1, 18)]
+
+    with pytest.raises(broker.BrokerError, match="too many"):
+        broker.resolve_public_targets(
+            "wide.example",
+            443,
+            resolver=_resolver(*addresses),
+        )
+
+
+def test_connected_peer_is_revalidated():
+    local, remote = socket.socketpair()
+
+    def connector(_family, _sockaddr, _timeout):
+        return _PublicPeerSocket(local, peer=("127.0.0.1", 443))
+
+    try:
+        with pytest.raises(broker.BrokerError, match="connection failed"):
+            broker.connect_public_target(
+                "public.example",
+                443,
+                resolver=_resolver(PUBLIC_V4),
+                connector=connector,
+            )
+    finally:
+        remote.close()
+
+
+def test_connected_peer_must_match_the_resolved_target():
+    local, remote = socket.socketpair()
+
+    def connector(_family, _sockaddr, _timeout):
+        return _PublicPeerSocket(local, peer=("1.1.1.1", 443))
+
+    try:
+        with pytest.raises(broker.BrokerError, match="connection failed"):
+            broker.connect_public_target(
+                "public.example",
+                443,
+                resolver=_resolver(PUBLIC_V4),
+                connector=connector,
+            )
+    finally:
+        local.close()
+        remote.close()
+
+
+def test_https_connect_reaches_only_validated_public_target():
+    client, broker_side = socket.socketpair()
+    outbound, origin = socket.socketpair()
+    resolver_calls = []
+
+    def resolver(host, port, **kwargs):
+        resolver_calls.append((host, port, kwargs))
+        return _resolver(PUBLIC_V4)(host, port, **kwargs)
+
+    def connector(_family, sockaddr, _timeout):
+        assert sockaddr == (PUBLIC_V4, 443)
+        return _PublicPeerSocket(outbound)
+
+    worker = threading.Thread(
+        target=broker.serve_proxy_client,
+        args=(broker_side,),
+        kwargs={"resolver": resolver, "connector": connector},
+    )
+    worker.start()
+    client.settimeout(2)
+    client.sendall(
+        b"CONNECT public.example:443 HTTP/1.1\r\n"
+        b"Host: public.example:443\r\n\r\n"
+    )
+    assert client.recv(4096) == b"HTTP/1.1 200 Connection Established\r\n\r\n"
+    client.sendall(b"encrypted request")
+    assert origin.recv(4096) == b"encrypted request"
+    origin.sendall(b"encrypted response")
+    origin.shutdown(socket.SHUT_WR)
+    assert client.recv(4096) == b"encrypted response"
+    client.close()
+    origin.close()
+    worker.join(timeout=2)
+
+    assert not worker.is_alive()
+    assert len(resolver_calls) == 1
+
+
+def test_plain_http_is_rewritten_and_proxy_credentials_are_stripped():
+    client, broker_side = socket.socketpair()
+    outbound, origin = socket.socketpair()
+    received = []
+
+    def connector(_family, sockaddr, _timeout):
+        assert sockaddr == (PUBLIC_V4, 80)
+        return _PublicPeerSocket(outbound, peer=(PUBLIC_V4, 80))
+
+    def origin_server():
+        received.append(origin.recv(65536))
+        origin.sendall(
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok"
+        )
+        origin.shutdown(socket.SHUT_WR)
+
+    upstream = threading.Thread(target=origin_server)
+    worker = threading.Thread(
+        target=broker.serve_proxy_client,
+        args=(broker_side,),
+        kwargs={
+            "resolver": _resolver(PUBLIC_V4),
+            "connector": connector,
+        },
+    )
+    upstream.start()
+    worker.start()
+    client.sendall(
+        b"GET http://public.example/package.tgz?x=1 HTTP/1.1\r\n"
+        b"Host: public.example\r\n"
+        b"Proxy-Authorization: Basic must-not-forward\r\n"
+        b"Connection: keep-alive\r\n\r\n"
+    )
+    client.shutdown(socket.SHUT_WR)
+    response = _read_all(client)
+    client.close()
+    worker.join(timeout=2)
+    upstream.join(timeout=2)
+    origin.close()
+
+    assert response.endswith(b"\r\n\r\nok")
+    request = received[0]
+    assert request.startswith(b"GET /package.tgz?x=1 HTTP/1.1\r\n")
+    assert b"Host: public.example:80\r\n" in request
+    assert b"Proxy-Authorization" not in request
+    assert b"Connection: close\r\n" in request
+
+
+def test_connection_header_cannot_remove_content_length_framing():
+    client, broker_side = socket.socketpair()
+    outbound, origin = socket.socketpair()
+    connector_calls = []
+
+    def connector(_family, _sockaddr, _timeout):
+        connector_calls.append(True)
+        return _PublicPeerSocket(outbound, peer=(PUBLIC_V4, 80))
+
+    worker = threading.Thread(
+        target=broker.serve_proxy_client,
+        args=(broker_side,),
+        kwargs={
+            "resolver": _resolver(PUBLIC_V4),
+            "connector": connector,
+        },
+    )
+    worker.start()
+    client.settimeout(2)
+    client.sendall(
+        b"POST http://public.example/upload HTTP/1.1\r\n"
+        b"Host: public.example\r\n"
+        b"Content-Length: 4\r\n"
+        b"Connection: content-length\r\n\r\nbody"
+    )
+    client.shutdown(socket.SHUT_WR)
+    response = client.recv(4096)
+    client.close()
+    origin.close()
+    worker.join(timeout=2)
+
+    assert b" 400 " in response
+    assert connector_calls == []
+    assert not worker.is_alive()
+
+
+@pytest.mark.parametrize(
+    "raw_request",
+    [
+        b"CONNECT public.example:80 HTTP/1.1\r\nHost: public.example\r\n\r\n",
+        b"CONNECT public.example:22 HTTP/1.1\r\nHost: public.example\r\n\r\n",
+        b"GET http://public.example:8080/ HTTP/1.1\r\nHost: public.example:8080\r\n\r\n",
+        b"GET https://public.example/ HTTP/1.1\r\nHost: public.example\r\n\r\n",
+    ],
+)
+def test_only_http_80_and_https_connect_443_are_allowed(raw_request):
+    client, broker_side = socket.socketpair()
+    worker = threading.Thread(
+        target=broker.serve_proxy_client,
+        args=(broker_side,),
+        kwargs={"resolver": lambda *_args, **_kwargs: pytest.fail("DNS must not run")},
+    )
+    worker.start()
+    client.sendall(raw_request)
+    client.shutdown(socket.SHUT_WR)
+    response = _read_all(client)
+    client.close()
+    worker.join(timeout=2)
+
+    assert b" 403 " in response or b" 400 " in response
+
+
+def test_each_new_connection_resolves_again():
+    calls = []
+
+    def resolver(host, port, **kwargs):
+        calls.append((host, port))
+        return _resolver(PUBLIC_V4)(host, port, **kwargs)
+
+    for _index in range(2):
+        client, broker_side = socket.socketpair()
+        outbound, origin = socket.socketpair()
+
+        def connector(_family, _sockaddr, _timeout, stream=outbound):
+            return _PublicPeerSocket(stream)
+
+        worker = threading.Thread(
+            target=broker.serve_proxy_client,
+            args=(broker_side,),
+            kwargs={"resolver": resolver, "connector": connector},
+        )
+        worker.start()
+        client.sendall(b"CONNECT public.example:443 HTTP/1.1\r\n\r\n")
+        assert b" 200 " in client.recv(4096)
+        client.close()
+        origin.close()
+        worker.join(timeout=2)
+
+    assert calls == [("public.example", 443), ("public.example", 443)]
+
+
+def test_broker_wrapper_injects_one_read_only_runtime_mount():
+    arguments = [
+        broker.TRUSTED_LAUNCHER,
+        broker.TRUSTED_BWRAP,
+        "--unshare-net",
+        "--clearenv",
+        "--",
+        "/bin/true",
+    ]
+
+    child = broker.build_child_argv(arguments, "/tmp/trusted-runtime")
+
+    assert child[:4] == [
+        broker.TRUSTED_LAUNCHER,
+        broker.TRUSTED_BWRAP,
+        "--unshare-net",
+        "--clearenv",
+    ]
+    assert child.count("--unshare-net") == 1
+    assert "--share-net" not in child
+    separator = child.index("--")
+    assert child[separator - 5:separator] == [
+        "--dir",
+        "/run",
+        "--ro-bind",
+        "/tmp/trusted-runtime",
+        broker.SANDBOX_RUNTIME_DIR,
+    ]
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        [broker.TRUSTED_LAUNCHER, broker.TRUSTED_BWRAP, "--share-net", "--", "/bin/true"],
+        [broker.TRUSTED_LAUNCHER, broker.TRUSTED_BWRAP, "--", "/bin/true"],
+        ["/bin/true", broker.TRUSTED_BWRAP, "--unshare-net", "--", "/bin/true"],
+    ],
+)
+def test_broker_wrapper_rejects_raw_or_invalid_launch_chains(arguments):
+    with pytest.raises(broker.BrokerError):
+        broker.build_child_argv(arguments, "/tmp/trusted-runtime")
+
+
+def test_broker_failure_does_not_print_commands_or_environment():
+    secret = "broker-must-not-log-this-secret"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            str(Path(broker.__file__)),
+            "/bin/false",
+            broker.TRUSTED_BWRAP,
+            "--unshare-net",
+            "--",
+            "/bin/echo",
+            secret,
+        ],
+        env={"API_TOKEN": secret},
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=False,
+    )
+
+    assert completed.returncode == 64
+    assert secret not in completed.stdout
+    assert secret not in completed.stderr
+
+
+def test_bridge_refuses_to_launch_without_the_mounted_broker(tmp_path):
+    missing = tmp_path / "missing.sock"
+    proxy = bridge.LoopbackBridge(str(missing), port=0)
+
+    with pytest.raises(bridge.BridgeError, match="unavailable"):
+        proxy.start()
+
+    proxy.close()
+
+
+def test_loopback_bridge_forwards_to_the_mounted_unix_socket(tmp_path):
+    socket_path = tmp_path / "broker.sock"
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    listener.bind(str(socket_path))
+    listener.listen(4)
+    stop = threading.Event()
+
+    def echo_server():
+        while not stop.is_set():
+            connection, _address = listener.accept()
+            data = connection.recv(4096)
+            if data:
+                connection.sendall(data.upper())
+            connection.close()
+            if data:
+                return
+
+    echo = threading.Thread(target=echo_server)
+    echo.start()
+    proxy = bridge.LoopbackBridge(str(socket_path), port=0)
+    proxy.start()
+    client = socket.create_connection(proxy.address, timeout=2)
+    client.sendall(b"brokered")
+    client.shutdown(socket.SHUT_WR)
+    assert client.recv(4096) == b"BROKERED"
+    client.close()
+    proxy.close()
+    stop.set()
+    listener.close()
+    echo.join(timeout=2)
+
+
+def test_loopback_bridge_releases_a_slot_when_the_broker_closes_first(tmp_path):
+    socket_path = tmp_path / "broker.sock"
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    listener.bind(str(socket_path))
+    listener.listen(2)
+
+    def close_connections():
+        for _index in range(2):
+            connection, _address = listener.accept()
+            connection.close()
+
+    closer = threading.Thread(target=close_connections)
+    closer.start()
+    proxy = bridge.LoopbackBridge(str(socket_path), port=0, max_connections=1)
+    proxy.start()
+    client = socket.create_connection(proxy.address, timeout=2)
+
+    deadline = time.monotonic() + 2
+    connection_thread = None
+    while connection_thread is None and time.monotonic() < deadline:
+        with proxy.connections_lock:
+            if proxy.connections:
+                connection_thread = proxy.connections[0]
+        if connection_thread is None:
+            time.sleep(0.01)
+    assert connection_thread is not None
+    connection_thread.join(timeout=1)
+    released_before_client_close = not connection_thread.is_alive()
+
+    client.close()
+    proxy.close()
+    listener.close()
+    closer.join(timeout=2)
+
+    assert released_before_client_close
+    assert not closer.is_alive()
+
+
+def test_loopback_bridge_closes_when_its_connection_bound_is_full(tmp_path):
+    socket_path = tmp_path / "broker.sock"
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    listener.bind(str(socket_path))
+    listener.listen(1)
+    accepted = []
+
+    def hold_connection():
+        probe, _address = listener.accept()
+        probe.close()
+        connection, _address = listener.accept()
+        accepted.append(connection)
+        connection.recv(1)
+
+    holder = threading.Thread(target=hold_connection)
+    holder.start()
+    proxy = bridge.LoopbackBridge(str(socket_path), port=0, max_connections=1)
+    proxy.start()
+    first = socket.create_connection(proxy.address, timeout=2)
+    first.sendall(b"x")
+
+    deadline = time.monotonic() + 2
+    while not accepted and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert accepted
+    rejected = socket.create_connection(proxy.address, timeout=2)
+    rejected.sendall(b"GET http://public.example/ HTTP/1.1\r\n\r\n")
+    try:
+        response = rejected.recv(4096)
+    except ConnectionResetError:
+        response = b""
+
+    rejected.close()
+    first.close()
+    accepted[0].close()
+    proxy.close()
+    listener.close()
+    holder.join(timeout=2)
+
+    assert response == b""
+    assert not holder.is_alive()
+
+
+def test_broker_and_bridge_limits_are_explicit_and_consistent():
+    assert broker.MAX_CONNECTIONS == bridge.MAX_CONNECTIONS == 16
+    assert broker.MAX_HEADER_BYTES == 64 * 1024
+    assert broker.MAX_HTTP_BODY_BYTES == 16 * 1024 * 1024
+    assert broker.MAX_RESOLVED_TARGETS == 16
+    assert broker.IDLE_TIMEOUT_SECONDS == bridge.IDLE_TIMEOUT_SECONDS > 0
+    assert (
+        broker.CONNECTION_LIFETIME_SECONDS
+        == bridge.CONNECTION_LIFETIME_SECONDS
+        < broker.BROKER_LIFETIME_SECONDS
+    )
+
+
+def test_multiple_simultaneous_connect_tunnels_work_within_bounds(tmp_path):
+    origins = []
+    origin_threads = []
+
+    def connector(_family, _sockaddr, _timeout):
+        outbound, origin = socket.socketpair()
+        origins.append(origin)
+
+        def echo():
+            data = origin.recv(4096)
+            origin.sendall(data.upper())
+            origin.shutdown(socket.SHUT_WR)
+
+        thread = threading.Thread(target=echo)
+        thread.start()
+        origin_threads.append(thread)
+        return _PublicPeerSocket(outbound)
+
+    transport = _Transport(tmp_path, connector, max_connections=4)
+    results = []
+
+    def request(payload):
+        client = socket.create_connection(transport.bridge.address, timeout=2)
+        client.sendall(b"CONNECT public.example:443 HTTP/1.1\r\n\r\n")
+        assert b" 200 " in client.recv(4096)
+        client.sendall(payload)
+        client.shutdown(socket.SHUT_WR)
+        results.append(_read_all(client))
+        client.close()
+
+    clients = [
+        threading.Thread(target=request, args=(b"first",)),
+        threading.Thread(target=request, args=(b"second",)),
+    ]
+    for client in clients:
+        client.start()
+    for client in clients:
+        client.join(timeout=3)
+    transport.close()
+    for origin in origins:
+        origin.close()
+    for thread in origin_threads:
+        thread.join(timeout=2)
+
+    assert sorted(results) == [b"FIRST", b"SECOND"]
+    assert all(not client.is_alive() for client in clients)
+
+
+def test_broker_rejects_connections_above_the_per_process_bound(tmp_path):
+    origins = []
+
+    def connector(_family, _sockaddr, _timeout):
+        outbound, origin = socket.socketpair()
+        origins.append(origin)
+        return _PublicPeerSocket(outbound)
+
+    transport = _Transport(tmp_path, connector, max_connections=2)
+    clients = []
+    for _index in range(2):
+        client = socket.create_connection(transport.bridge.address, timeout=2)
+        client.sendall(b"CONNECT public.example:443 HTTP/1.1\r\n\r\n")
+        assert b" 200 " in client.recv(4096)
+        clients.append(client)
+
+    rejected = socket.create_connection(transport.bridge.address, timeout=2)
+    rejected.sendall(b"CONNECT public.example:443 HTTP/1.1\r\n\r\n")
+    try:
+        response = rejected.recv(4096)
+    except ConnectionResetError:
+        response = b""
+    rejected.close()
+    for client in clients:
+        client.close()
+    for origin in origins:
+        origin.close()
+    transport.close()
+
+    # An overloaded broker may close with unread request bytes after its
+    # best-effort 503, which is observed as either the response or EOF. The
+    # authority invariant is that no additional outbound connection is made.
+    assert response == b"" or b" 503 " in response
+    assert len(origins) == 2
+
+
+@pytest.mark.skipif(shutil.which("npm") is None, reason="npm is unavailable")
+def test_npm_reads_a_package_document_through_standard_proxy_variables(tmp_path):
+    body = (
+        b'{"name":"odysseus-fake","dist-tags":{"latest":"1.0.0"},'
+        b'"versions":{"1.0.0":{"name":"odysseus-fake","version":"1.0.0"}}}'
+    )
+    origin_threads = []
+
+    def connector(_family, _sockaddr, _timeout):
+        outbound, origin = socket.socketpair()
+
+        def serve():
+            request = origin.recv(65536)
+            assert request.startswith(b"GET /odysseus-fake HTTP/1.1\r\n")
+            origin.sendall(
+                b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"
+                + f"Content-Length: {len(body)}\r\nConnection: close\r\n\r\n".encode()
+                + body
+            )
+            origin.shutdown(socket.SHUT_WR)
+            origin.close()
+
+        thread = threading.Thread(target=serve)
+        thread.start()
+        origin_threads.append(thread)
+        return _PublicPeerSocket(outbound, peer=(PUBLIC_V4, 80))
+
+    transport = _Transport(tmp_path, connector)
+    proxy_environment = {
+        "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+        "HOME": str(tmp_path / "home"),
+        "npm_config_cache": str(tmp_path / "npm-cache"),
+        "HTTP_PROXY": transport.proxy_url,
+        "HTTPS_PROXY": transport.proxy_url,
+        "http_proxy": transport.proxy_url,
+        "https_proxy": transport.proxy_url,
+    }
+    completed = subprocess.run(
+        [
+            "npm",
+            "view",
+            "odysseus-fake",
+            "version",
+            "--registry=http://public.example/",
+            "--fetch-retries=0",
+            "--fetch-timeout=5000",
+            "--json",
+        ],
+        env=proxy_environment,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+    transport.close()
+    for thread in origin_threads:
+        thread.join(timeout=2)
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip().strip('"') == "1.0.0"
+    assert "NO_PROXY" not in proxy_environment
+    assert "no_proxy" not in proxy_environment
+
+
+@pytest.mark.skipif(shutil.which("curl") is None, reason="curl is unavailable")
+def test_redirect_to_loopback_is_revalidated_and_blocked(tmp_path):
+    connector_calls = []
+
+    def resolver(host, port, **kwargs):
+        address = PUBLIC_V4 if host == "public.example" else host
+        return _resolver(address)(host, port, **kwargs)
+
+    def connector(_family, _sockaddr, _timeout):
+        connector_calls.append(True)
+        outbound, origin = socket.socketpair()
+
+        def redirect():
+            origin.recv(65536)
+            origin.sendall(
+                b"HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1/\r\n"
+                b"Content-Length: 0\r\nConnection: close\r\n\r\n"
+            )
+            origin.shutdown(socket.SHUT_WR)
+            origin.close()
+
+        threading.Thread(target=redirect).start()
+        return _PublicPeerSocket(outbound, peer=(PUBLIC_V4, 80))
+
+    transport = _Transport(tmp_path, connector, resolver=resolver)
+    completed = subprocess.run(
+        [
+            "curl",
+            "--silent",
+            "--show-error",
+            "--fail",
+            "--location",
+            "--proxy",
+            transport.proxy_url,
+            "--noproxy",
+            "",
+            "http://public.example/start",
+        ],
+        env={"PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin")},
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    transport.close()
+
+    assert completed.returncode != 0
+    assert len(connector_calls) == 1
+
+
+@pytest.mark.skipif(shutil.which("curl") is None, reason="curl is unavailable")
+def test_https_connect_preserves_end_to_end_ca_validation(tmp_path):
+    cryptography = pytest.importorskip("cryptography")
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import NameOID
+
+    assert cryptography
+    now = datetime.datetime.now(datetime.timezone.utc)
+    ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    ca_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Odysseus test CA")])
+    ca_cert = (
+        x509.CertificateBuilder()
+        .subject_name(ca_name)
+        .issuer_name(ca_name)
+        .public_key(ca_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=1))
+        .not_valid_after(now + datetime.timedelta(days=1))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=0), critical=True)
+        .sign(ca_key, hashes.SHA256())
+    )
+    server_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    server_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "public.example")])
+    server_cert = (
+        x509.CertificateBuilder()
+        .subject_name(server_name)
+        .issuer_name(ca_name)
+        .public_key(server_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=1))
+        .not_valid_after(now + datetime.timedelta(days=1))
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName("public.example")]),
+            critical=False,
+        )
+        .sign(ca_key, hashes.SHA256())
+    )
+    ca_path = tmp_path / "ca.pem"
+    cert_path = tmp_path / "server.pem"
+    key_path = tmp_path / "server-key.pem"
+    ca_path.write_bytes(ca_cert.public_bytes(serialization.Encoding.PEM))
+    cert_path.write_bytes(server_cert.public_bytes(serialization.Encoding.PEM))
+    key_path.write_bytes(
+        server_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        )
+    )
+
+    tls_listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    tls_listener.bind(("127.0.0.1", 0))
+    tls_listener.listen(1)
+    tls_address = tls_listener.getsockname()
+    tls_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    tls_context.load_cert_chain(cert_path, key_path)
+
+    def tls_server():
+        raw, _address = tls_listener.accept()
+        with tls_context.wrap_socket(raw, server_side=True) as secured:
+            assert secured.recv(65536).startswith(b"GET / HTTP/1.1\r\n")
+            secured.sendall(
+                b"HTTP/1.1 200 OK\r\nContent-Length: 6\r\n"
+                b"Connection: close\r\n\r\nsecure"
+            )
+
+    server_thread = threading.Thread(target=tls_server)
+    server_thread.start()
+
+    def connector(_family, _sockaddr, timeout):
+        stream = socket.create_connection(tls_address, timeout=timeout)
+        return _PublicPeerSocket(stream)
+
+    transport = _Transport(tmp_path, connector)
+    completed = subprocess.run(
+        [
+            "curl",
+            "--silent",
+            "--show-error",
+            "--fail",
+            "--proxy",
+            transport.proxy_url,
+            "--noproxy",
+            "",
+            "--cacert",
+            str(ca_path),
+            "https://public.example/",
+        ],
+        env={"PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin")},
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+    transport.close()
+    tls_listener.close()
+    server_thread.join(timeout=2)
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout == "secure"
+    assert not server_thread.is_alive()

--- a/tests/test_egress_broker.py
+++ b/tests/test_egress_broker.py
@@ -344,6 +344,7 @@ def test_connection_header_cannot_remove_content_length_framing():
     [
         b"CONNECT public.example:80 HTTP/1.1\r\nHost: public.example\r\n\r\n",
         b"CONNECT public.example:22 HTTP/1.1\r\nHost: public.example\r\n\r\n",
+        b"GET http://public.example:0/ HTTP/1.1\r\nHost: public.example:0\r\n\r\n",
         b"GET http://public.example:8080/ HTTP/1.1\r\nHost: public.example:8080\r\n\r\n",
         b"GET https://public.example/ HTTP/1.1\r\nHost: public.example\r\n\r\n",
     ],
@@ -604,24 +605,77 @@ def test_egress_makefile_keeps_trusted_install_contract():
         Path(__file__).resolve().parents[1] / "security" / "egress" / "Makefile"
     ).read_text(encoding="utf-8")
 
-    assert "INSTALL_OWNER ?= root" in makefile
-    assert "INSTALL_GROUP ?= root" in makefile
     assert (
-        'PYTHON_PATH := $(shell realpath "$$(command -v $(PYTHON))")' in makefile
+        "override TRUSTED_PYTHON := "
+        "$(firstword $(realpath /usr/local/bin/python3 /usr/bin/python3))"
+        in makefile
     )
-    assert "sed -i '1c\\#!$(PYTHON_PATH) -I'" in makefile
+    assert "override INSTALL_DIR := /usr/local/libexec" in makefile
+    assert "override INSTALL_OWNER := root" in makefile
+    assert "override INSTALL_GROUP := root" in makefile
+    assert "override SHELL := /bin/sh" in makefile
+    assert "override .SHELLFLAGS := -eu -c" in makefile
+    assert "override BROKER := odysseus_egress_broker.py" in makefile
+    assert "override BRIDGE := odysseus_egress_bridge.py" in makefile
+    for tool in ("install", "sed", "chown", "chmod"):
+        assert f"override {tool.upper()}_TOOL := /usr/bin/{tool}" in makefile
     assert (
-        "install -o $(INSTALL_OWNER) -g $(INSTALL_GROUP) -m 0755" in makefile
+        'PYTHON_PATH = $(shell realpath "$$(command -v $(PYTHON))")' in makefile
     )
+    assert "install: trusted-check" in makefile
     assert (
-        "chown $(INSTALL_OWNER):$(INSTALL_GROUP) "
+        "! -type f -o ! -uid 0 -o -perm /022 -o -perm /6000" in makefile
+    )
+    assert '"$(TRUSTED_PYTHON)" -I -m py_compile' in makefile
+    assert "$(SED_TOOL) -i '1c\\#!$(TRUSTED_PYTHON) -I'" in makefile
+    assert "$(INSTALL_TOOL) -o $(INSTALL_OWNER) -g $(INSTALL_GROUP) -m 0755" in makefile
+    assert (
+        "$(CHOWN_TOOL) $(INSTALL_OWNER):$(INSTALL_GROUP) "
         "$(INSTALL_DIR)/odysseus-egress-broker "
         "$(INSTALL_DIR)/odysseus-egress-bridge" in makefile
     )
     assert (
-        "chmod 0755 $(INSTALL_DIR)/odysseus-egress-broker "
+        "$(CHMOD_TOOL) 0755 $(INSTALL_DIR)/odysseus-egress-broker "
         "$(INSTALL_DIR)/odysseus-egress-bridge" in makefile
     )
+
+
+def test_egress_production_install_rejects_make_variable_overrides(tmp_path):
+    egress_dir = Path(__file__).resolve().parents[1] / "security" / "egress"
+    evaluation_marker = tmp_path / "attacker-python-was-evaluated"
+    completed = subprocess.run(
+        [
+            "make",
+            "--directory",
+            str(egress_dir),
+            "--dry-run",
+            "install",
+            f"PYTHON=$(shell touch {evaluation_marker})",
+            "TRUSTED_PYTHON=/tmp/attacker-python",
+            "INSTALL_DIR=/tmp/attacker-bin",
+            "INSTALL_OWNER=nobody",
+            "INSTALL_GROUP=nogroup",
+            "BROKER=/tmp/attacker-broker",
+            "BRIDGE=/tmp/attacker-bridge",
+            "INSTALL_TOOL=/tmp/attacker-install",
+            "SED_TOOL=/tmp/attacker-sed",
+            "CHOWN_TOOL=/tmp/attacker-chown",
+            "CHMOD_TOOL=/tmp/attacker-chmod",
+            "SHELL=/tmp/attacker-shell",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert not evaluation_marker.exists()
+    assert "/tmp/attacker" not in completed.stdout
+    assert "/usr/bin/install -d -o root -g root -m 0755 /usr/local/libexec" in completed.stdout
+    assert "odysseus_egress_broker.py" in completed.stdout
+    assert "odysseus_egress_bridge.py" in completed.stdout
+    assert "-I -m py_compile" in completed.stdout
 
 
 def test_multiple_simultaneous_connect_tunnels_work_within_bounds(tmp_path):


### PR DESCRIPTION
## Summary

This PR extracts the trusted HTTP(S) egress transport from [#5818](https://github.com/odysseus-dev/odysseus/pull/5818) into a focused, independently reviewable security slice. It adds the broker and loopback bridge, public-address and reconnect validation, bounded HTTP and CONNECT handling, proxy credential/header scrubbing, TLS/CA-preserving tunneling, concurrency and lifetime limits, and broker/bridge lifecycle tests. It intentionally excludes Docker/Compose installation, AppArmor and boot checks, application network-profile propagation, and process-execution wiring. The launch chain depends at runtime on the seccomp substrate tracked by [#6114](https://github.com/odysseus-dev/odysseus/issues/6114) and implemented by [PR #6119](https://github.com/odysseus-dev/odysseus/pull/6119).

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #6115

Depends on [PR #6119](https://github.com/odysseus-dev/odysseus/pull/6119) for the trusted seccomp substrate.

Part of #6091

Part of #5815

Related to and supersedes the corresponding egress slice of [#5818](https://github.com/odysseus-dev/odysseus/pull/5818).

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [x] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.
- [x] I did not run the app/runtime validation and stated that gap in **How to Test**. Leave this unchecked when the app-run box above is checked.

## How to Test

1. Run `python3 -m pytest -q tests/test_egress_broker.py` through the secretless review runner; this produced 46 passing tests covering address filtering, DNS/reconnect behavior, HTTP and CONNECT policy, redirects, TLS/CA handling, proxy-variable scrubbing, bridge lifecycle, concurrency, failure handling, and the independent Makefile trust contract for root/group defaults, absolute interpreter resolution, isolated `-I` shebang rewriting, and root-owned `0755` installation.
2. Run `make -C security/egress check` through the secretless review runner; this passed Python compilation for both trusted helpers.
3. Review the five changed paths as the broker/bridge transport boundary only. Docker/Compose installation, AppArmor/boot behavior, application network-profile propagation, process wiring, and full app/runtime execution were not run in this slice and remain follow-up work.

## Visual / UI changes — REQUIRED if you touched anything that renders

This slice changes no UI or rendering behavior.

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** This coordinated multi-PR split intentionally leaves this bulk-submission attestation unchecked.

### Screenshots / clips

Not applicable: this PR contains no UI or visual changes.
