### PR TITLE
fix(agent): drop the empty assistant turn from an approved-action replay

### DIFF
--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -3081,10 +3081,17 @@ def _append_tool_results(
             messages.append(result_message)
     else:
         tool_output_text = "\n\n".join(tool_results)
-        msg = {"role": "assistant", "content": round_response}
-        if round_reasoning:
-            msg["reasoning_content"] = round_reasoning
-        messages.append(msg)
+        # An approved-action replay injects the sealed tool result with no
+        # assistant prose for that round, which used to append an assistant turn
+        # whose content was "". Anthropic's Messages API rejects a non-final
+        # assistant message with empty content (HTTP 400), so the resumed turn
+        # died before the model saw the result. A turn carrying neither prose nor
+        # reasoning has nothing to say to any provider, so skip it entirely.
+        if round_response.strip() or round_reasoning:
+            msg = {"role": "assistant", "content": round_response}
+            if round_reasoning:
+                msg["reasoning_content"] = round_reasoning
+            messages.append(msg)
         # Tool output (shell/python stdout, file reads, fetched pages, email
         # bodies, MCP results) is sourced from outside the server. Wrap it as
         # untrusted data so prompt-injection inside a tool result is treated as

--- a/tests/test_approved_replay_message_shape.py
+++ b/tests/test_approved_replay_message_shape.py
@@ -1,0 +1,100 @@
+"""Regression coverage for the assistant turn an approved-action replay appends.
+
+Anthropic's Messages API rejects a non-final assistant message whose content is
+empty, so the resumed turn after a tool approval used to fail before the model
+ever saw the sealed result. The replay injects its result with no assistant
+prose for that round, which is the only path that produced such a turn.
+"""
+
+import src.llm_core as llm_core
+from src.agent_loop import _append_tool_results
+
+_RESULT = "bash: ok\nhello"
+_RECORD = {
+    "tool_name": "bash",
+    "content": "printf hello",
+    "result": {"output": "hello", "exit_code": 0},
+    "text": _RESULT,
+}
+
+
+def _replay_messages(round_response="", round_reasoning=""):
+    """Mirror the approved-action injection in stream_agent_loop."""
+    messages = [
+        {"role": "system", "content": "system preface"},
+        {"role": "user", "content": "run the command and summarise it"},
+    ]
+    _append_tool_results(
+        messages,
+        round_response,
+        [],
+        [_RESULT],
+        [_RESULT],
+        False,
+        0,
+        round_reasoning=round_reasoning,
+        tool_result_records=[_RECORD],
+    )
+    return messages
+
+
+def _empty_assistant_turns(messages):
+    return [
+        index
+        for index, message in enumerate(messages)
+        if message.get("role") == "assistant"
+        and not str(message.get("content") or "").strip()
+        and not message.get("tool_calls")
+    ]
+
+
+def test_replay_appends_no_empty_assistant_turn():
+    assert _empty_assistant_turns(_replay_messages()) == []
+
+
+def test_replay_payload_is_a_single_non_empty_user_turn_for_anthropic():
+    # Asserting the whole sequence rather than scanning a slice: once the empty
+    # spacer is gone the payload is one message, so a "no offenders in
+    # chat[:-1]" check would pass without inspecting anything.
+    sanitized = llm_core._sanitize_llm_messages(_replay_messages())
+    payload = llm_core._build_anthropic_payload(
+        "claude-sonnet-5", sanitized, 0.2, 512
+    )
+    chat = payload["messages"]
+    assert [message["role"] for message in chat] == ["user"]
+    assert all(str(message.get("content") or "").strip() for message in chat)
+
+
+def test_replay_merges_tool_output_after_the_request_with_its_fence_intact():
+    # Dropping the empty assistant turn leaves two adjacent user messages, which
+    # the sanitizer merges. Pin that shape: the tool output must still sit
+    # behind its untrusted fence and must not precede the operator's request.
+    sanitized = llm_core._sanitize_llm_messages(_replay_messages())
+    user_turns = [m for m in sanitized if m.get("role") == "user"]
+    assert len(user_turns) == 1
+    merged = user_turns[0]["content"]
+    assert merged.index("run the command") < merged.index("UNTRUSTED SOURCE DATA")
+    assert merged.index("UNTRUSTED SOURCE DATA") < merged.index("hello")
+
+
+def test_a_round_with_prose_still_appends_its_assistant_turn():
+    messages = _replay_messages(round_response="running that now")
+    assistants = [m for m in messages if m.get("role") == "assistant"]
+    assert [m["content"] for m in assistants] == ["running that now"]
+
+
+def test_reasoning_only_round_keeps_its_carrier_and_its_known_empty_content():
+    """Characterises the one empty-content turn this change deliberately leaves.
+
+    A round with reasoning and no prose still appends its carrier, and that
+    carrier's content is still "", which Anthropic would still reject. Dropping
+    it would lose the reasoning DeepSeek thinking mode requires on the next
+    request, and the approval replay never takes this path because it passes no
+    reasoning. Left alone on purpose; this test makes the gap visible instead of
+    silent, and should be updated by whoever closes it.
+    """
+    messages = _replay_messages(round_reasoning="thinking about it")
+    assistants = [m for m in messages if m.get("role") == "assistant"]
+    assert len(assistants) == 1
+    assert assistants[0].get("reasoning_content") == "thinking about it"
+    assert assistants[0]["content"] == ""


### PR DESCRIPTION
## Summary

The approved-action replay appends the sealed tool result with no assistant prose for that round, which made `_append_tool_results` append an assistant turn whose content was `""`. Anthropic's Messages API rejects a non-final assistant message with empty content, so a resumed turn after a tool approval failed at the provider before the model saw the result. A turn carrying neither prose nor reasoning has nothing to say to any provider, so it is no longer appended.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #6123

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app and verified the change works end-to-end.
- [x] I did not run the app/runtime validation and stated that gap in **How to Test**.

## How to Test

```bash
python -m pytest -q tests/test_approved_replay_message_shape.py
```

All five pass on this branch. Reverting `src/agent_loop.py` to `dev` and rerunning fails three of them, so they pin the bug rather than the fix.

Regression sweep, same venv:

```bash
python -m pytest -q tests/test_agent_loop.py tests/test_native_tool_result_threading.py \
  tests/test_llm_core_ollama.py tests/test_llm_core_sanitize_tool_calls.py \
  tests/test_tool_output_prompt_injection.py tests/test_external_context_tool_gate.py \
  tests/test_foreground_model_routing.py
```

332 passed. Full suite (`python -m pytest -q`): 5760 passed, 6 failed. The same 6 fail on stock `dev` on this host, so they are not from this change:

```
tests/test_cookbook_docker_access.py::test_container_opt_in_with_unix_socket_is_allowed
tests/test_integration_api_call_ssrf.py::test_real_socket_falls_back_from_dead_first_to_live_second
tests/test_shell_routes.py::TestHostDockerAccess::test_socket_without_explicit_opt_in_is_disabled[None]
tests/test_shell_routes.py::TestHostDockerAccess::test_socket_without_explicit_opt_in_is_disabled[false]
tests/test_shell_routes.py::TestHostDockerAccess::test_explicit_opt_in_with_unix_socket_is_enabled
tests/test_workspace_confine.py::test_glob_confined_e2e
```

**Runtime gap:** I have no native Anthropic endpoint here, so the provider-side rejection is evidenced from the constructed payload rather than a live request. Running the replay fixture through `_sanitize_llm_messages` and `_build_anthropic_payload` on `dev` gives:

```
[0] user      'do the thing'
[1] assistant ''          <- non-final, empty
[2] user      'UNTRUSTED SOURCE DATA...'
```

and on this branch it gives a single non-empty user turn. One run against a native Anthropic endpoint would confirm the live 400.

## What to look at

Two things that need a real look before this lands.

**The untrusted boundary shifts shape.** With the empty spacer gone, the operator's request and the untrusted tool output become two adjacent user messages, and `_sanitize_llm_messages` merges them into one. The `UNTRUSTED SOURCE DATA` fence survives inline and the ordering holds, and `test_replay_merges_tool_output_after_the_request_with_its_fence_intact` pins both. Calling it out because it changes the prompt shape for every provider, not only Anthropic.

**One empty-content turn is left on purpose.** A round with reasoning and no prose still appends a carrier whose content is `""`. Dropping it would lose the reasoning DeepSeek thinking mode needs on the next request, and the approval replay never takes that path because it passes no reasoning. `test_reasoning_only_round_keeps_its_carrier_and_its_known_empty_content` characterises it so the gap is visible in the suite instead of silent. Happy to fix it here instead if you would rather have it in one go.

## Visual / UI changes

Not applicable. No rendering path is touched; the change is one branch in `src/agent_loop.py` plus a test file.
