### PR TITLE
fix(ui): make the RAG toggle reachable — it has no Customize row

### DIFF
--- a/static/js/ui_visibility.js
+++ b/static/js/ui_visibility.js
@@ -46,7 +46,7 @@ export const UI_VIS_MAP = {
 };
 
 // Keys hidden by default on first run (no localStorage yet).
-export const UI_VIS_DEFAULT_OFF = new Set(['rag-toggle-btn', 'text-emojis', 'chat-fullwidth']);
+export const UI_VIS_DEFAULT_OFF = new Set(['text-emojis', 'chat-fullwidth']);
 
 /**
  * Resolve every UI_VIS_MAP selector to visible (true) or hidden (false) for the

--- a/tests/test_ui_visibility_js.py
+++ b/tests/test_ui_visibility_js.py
@@ -87,7 +87,7 @@ def test_defaults_everything_visible_except_default_off():
     assert m[TOOLS] is True
     assert m[CAL] is True
     assert m[NEWCHAT] is True
-    assert m[RAG] is False  # rag-toggle-btn is default-off
+    assert m[RAG] is True  # rag-toggle-btn is visible by default
 
 
 def test_email_off_hides_email_and_its_rail_only():


### PR DESCRIPTION
## Summary

`rag-toggle-btn` is listed in `UI_VIS_DEFAULT_OFF`, so `#overflow-rag-btn` is hidden on first run — and it is the **only** tool key in `UI_VIS_MAP` with no matching `data-ui-key` row in the Customize panel, so nothing in the UI can turn it back on. The two together make RAG unreachable: the More tools menu shows *Attach files / Documents / Prompt* and no setting anywhere reveals the RAG control. There is no error and no hint a feature is missing, so it reads as "this build has no RAG" rather than "RAG is hidden." Retrieval itself works fine underneath once the control is reachable. This removes the key from `UI_VIS_DEFAULT_OFF`, matching every other tool toggle; the toggle itself still defaults to off, so retrieval stays opt-in.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #6130

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate. (Closest matches, both unrelated: #5203 `/rag` slash-command dead code, #302 file import.)
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — two files, one line of behaviour plus the one test that asserted the old default.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end.
- [ ] I did not run the app/runtime validation and stated that gap in **How to Test**. Leave this unchecked when the app-run box above is checked.

## How to Test

Reproduce the bug first, on a profile where `localStorage` has never been written (a fresh browser profile is enough):

1. `docker compose up -d --build`, open the app.
2. Click **More tools** (the chevron, `#overflow-plus-btn`) at the left of the chat input. The menu shows *Attach files*, *Documents*, *Prompt* — no **RAG**.
3. Open **Settings → Customize** and confirm there is no switch anywhere that reveals it. This is the bug: not "off", but unreachable.

Then with this branch:

4. `git checkout fix/rag-toggle-visible-by-default && docker compose build odysseus && docker compose up -d odysseus`
5. Clear the override if you set one while reproducing: `localStorage.removeItem('odysseus-ui-visibility'); location.reload()`
6. Click **More tools** again — **RAG** is now listed. Click it: an active dot appears on the row and a `RAG` chip appears in the input bar.
7. Confirm retrieval is still **opt-in** — before clicking RAG, the toggle is unchecked and `chat.js` sends `use_rag=false`. This PR only makes the control visible; it does not turn retrieval on.

Unit tests:

```console
$ pytest tests/test_ui_visibility_js.py -q
10 passed
```

`tests/test_ui_visibility_js.py:90` asserted `m[RAG] is False  # rag-toggle-btn is default-off`; updated to `is True` to match the new default.

## Visual / UI changes

- [x] **Screenshot or short clip** of the change in the running app, attached below.
- [x] **Style match** — no styling is added or changed. The diff removes one string from a `Set`; no new CSS variables, classes, colors, font sizes, spacing units, or emoji. The RAG row and its icon already exist in `static/index.html` and are simply no longer hidden.
- [x] **No new component patterns.** No new components; an existing menu row becomes visible.
- [x] **I am not an LLM agent submitting a bulk PR.**

### Screenshots / clips

_Before: More tools menu with RAG absent. After: RAG present and active._

Before 
<img width="1243" height="306" alt="image" src="https://github.com/user-attachments/assets/f7fa5365-ecc9-4f79-939d-a13bd475bbe7" />

After 
<img width="1260" height="358" alt="image" src="https://github.com/user-attachments/assets/79810f12-3627-4d46-ad30-bc6caa798dd0" />



