### PR TITLE
fix: include model_type in endpoint dedup key

### DIFF
--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -1506,8 +1506,16 @@ def setup_cookbook_routes() -> APIRouter:
 
         db = SessionLocal()
         try:
-            # Check for existing endpoint with same base_url — update it
-            existing = db.query(ModelEndpoint).filter(ModelEndpoint.base_url == base_url).first()
+            # Check for existing image endpoint with same base_url -- update it.
+            # Include model_type in the key so an LLM endpoint at the same URL
+            # is not silently retyped to "image" (mirrors the dedup fix in
+            # model_routes.py for issue #6077).
+            existing = (
+                db.query(ModelEndpoint)
+                .filter(ModelEndpoint.base_url == base_url)
+                .filter(ModelEndpoint.model_type == "image")
+                .first()
+            )
             if existing:
                 existing.is_enabled = True
                 existing.model_type = "image"

--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -2033,6 +2033,8 @@ def setup_model_routes(model_discovery):
         from src.auth_helpers import get_current_user as _gcu_dedup
         _caller = _gcu_dedup(request) or None
         _incoming_api_key = api_key.strip()
+        # Coalesce NULL model_type to "llm" so pre-existing rows still match.
+        _incoming_model_type = (model_type or "").strip() or "llm"
         _db_dedup = SessionLocal()
         try:
             _same_url_rows = (
@@ -2045,6 +2047,11 @@ def setup_model_routes(model_discovery):
             existing = None
             _empty_key_existing = None
             for _candidate in _same_url_rows:
+                # Dedup key includes model_type: one URL can serve both "llm"
+                # and "image" from separate rows (e.g. LocalAI, LM Studio).
+                _candidate_type = (getattr(_candidate, "model_type", None) or "llm")
+                if _candidate_type != _incoming_model_type:
+                    continue
                 _candidate_key = (getattr(_candidate, "api_key", None) or "").strip()
                 if _candidate_key == _incoming_api_key:
                     existing = _candidate
@@ -2077,10 +2084,6 @@ def setup_model_routes(model_discovery):
                     changed = True
                 if refresh_timeout is not None:
                     existing.model_refresh_timeout = refresh_timeout
-                    changed = True
-                incoming_model_type = (model_type or "").strip() or "llm"
-                if incoming_model_type and (getattr(existing, "model_type", None) or "llm") != incoming_model_type:
-                    existing.model_type = incoming_model_type
                     changed = True
                 if api_key.strip() and not existing.api_key:
                     existing.api_key = api_key.strip()

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -2097,3 +2097,78 @@ def test_manual_refresh_timeout_keeps_cached_models_and_warns(monkeypatch):
     assert db.commits == 0
     assert response.headers["X-Model-Refresh-Status"] == "failed"
     assert "kept cached models" in response.headers["X-Model-Refresh-Warning"]
+
+
+# ---- issue #6077: endpoint dedup key must include model_type ----
+
+def test_post_same_url_different_model_type_creates_distinct_row(monkeypatch):
+    """Adding an image endpoint for a URL that already has an LLM endpoint must
+    create a new row, not retype the existing one."""
+    llm_ep = _make_endpoint(
+        base_url="https://localai.example.com/v1",
+        model_type="llm",
+    )
+    db = _PinnedFakeDb([llm_ep])
+    _patch_create_deps(monkeypatch, db)
+    create = _get_route("/api/model-endpoints", "POST")
+
+    result = create(
+        _PinnedFakeRequest(),
+        base_url="https://localai.example.com/v1",
+        **_create_form_kwargs(model_type="image"),
+    )
+
+    # Must NOT return the existing LLM row.
+    assert result.get("existing") is not True
+    # A new row must have been written.
+    assert len(db.added) == 1
+    assert db.added[0].model_type == "image"
+    # The original LLM row must be unchanged.
+    assert llm_ep.model_type == "llm"
+
+
+def test_post_same_url_same_model_type_still_dedupes(monkeypatch):
+    """Re-adding an LLM endpoint for a URL that already has an LLM endpoint
+    must still return the existing row (normal dedup behaviour)."""
+    llm_ep = _make_endpoint(
+        base_url="https://localai.example.com/v1",
+        model_type="llm",
+    )
+    db = _PinnedFakeDb([llm_ep])
+    _patch_create_deps(monkeypatch, db)
+    create = _get_route("/api/model-endpoints", "POST")
+
+    result = create(
+        _PinnedFakeRequest(),
+        base_url="https://localai.example.com/v1",
+        **_create_form_kwargs(model_type="llm"),
+    )
+
+    assert result["existing"] is True
+    assert result["id"] == llm_ep.id
+    assert db.added == []
+
+
+def test_post_llm_registration_does_not_retype_existing_image_endpoint(monkeypatch):
+    """An LLM re-registration must not silently flip an image endpoint back to
+    llm (the step-3 flip-flop described in issue #6077)."""
+    image_ep = _make_endpoint(
+        base_url="https://localai.example.com/v1",
+        model_type="image",
+    )
+    db = _PinnedFakeDb([image_ep])
+    _patch_create_deps(monkeypatch, db)
+    create = _get_route("/api/model-endpoints", "POST")
+
+    result = create(
+        _PinnedFakeRequest(),
+        base_url="https://localai.example.com/v1",
+        **_create_form_kwargs(model_type="llm"),
+    )
+
+    # A new row is created for the LLM type, not a retype of the image row.
+    assert result.get("existing") is not True
+    assert len(db.added) == 1
+    assert db.added[0].model_type == "llm"
+    # The image row must remain intact.
+    assert image_ep.model_type == "image"


### PR DESCRIPTION
## Summary

The dedup lookup in `POST /api/model-endpoints` was keyed on `base_url` + `api_key` only. Adding the same URL twice with different `model_type` values (e.g., once as `llm` and once as `image`) retyped the existing row instead of creating a second one. Because several code paths re-register URLs as `llm` automatically (Cookbook auto-register, `markdown.js`), image endpoints registered at a shared URL were silently reverted, making them invisible to the Gallery. This PR fixes the dedup key to include `model_type` in both affected locations.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #6077

## Type of Change

- [x] Bug fix (non-breaking -- fixes a confirmed issue)
- [ ] New feature (non-breaking -- adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) -- this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above -- no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

Unit tests cover all three scenarios and can be run without a running app:

```
python -m pytest tests/test_model_routes.py -k "model_type" --import-mode=importlib -v
```

For manual verification with a running instance and an OpenAI-compatible server at `https://localai.example.com/v1`:

1. Settings -> Add Models. Add that URL with type "LLM". Confirm one endpoint row appears.
2. Add the same URL again with type "Image". Confirm a second endpoint row appears (not the same row retyped).
3. Open Gallery / image generation. Confirm the image endpoint is present and not missing.
4. Trigger any automatic LLM re-registration (e.g., add-to-model-picker on a chat message). Confirm the image endpoint row is still present and still typed "image".

## Visual / UI changes -- REQUIRED if you touched anything that renders

No UI changes. This fix is entirely in route handler and test code.

## Runtime validation (2026-08-26)

A note on the base first: this branch's fork point predates an unrelated fix on `dev` (`src/agent_loop.py` used `Any` without importing it at the fork point, so the app cannot boot from the raw branch). I therefore ran the runtime validation on this PR merged onto current `dev` (7026cf4). The merge is clean and the unit tests pass both on the branch and after the merge.

I ran `uvicorn app:app`, completed first-run setup and login, and stood up a minimal OpenAI-compatible server on `127.0.0.1:9301` answering `/v1/models`, so the endpoint probes were real (endpoints register as online with a populated model list):

1. `POST /api/model-endpoints` with that URL as type `llm` created row `db0c8c4f`.
2. The same URL again as type `image` created a second row, `63b410d2`, rather than retyping the first one.
3. The same URL again as type `llm` (simulating the Cookbook / `markdown.js` auto re-register path) returned the existing `db0c8c4f`, and the endpoint list still showed exactly two rows, with the image row intact and still typed `image`.

I verified this through the HTTP API with an authenticated session, which is the same list endpoint the Gallery UI consumes. I did not separately click through the browser UI.

Unit tests: `python -m pytest tests/test_model_routes.py -k model_type --import-mode=importlib` passes (2 tests).