### PR TITLE
fix(docker): ensure migrated SearXNG settings enable JSON format

### DIFF
--- a/scripts/migrate_searxng_settings.py
+++ b/scripts/migrate_searxng_settings.py
@@ -98,16 +98,47 @@ def _formats_list(loaded: dict) -> list | None:
     return formats
 
 
+def _insert_formats_into_flow_mapping(
+    contents: bytes, text: str, value_node: MappingNode, bom_length: int
+) -> bytes:
+    """Insert ``formats: [html, json]`` into a flow-style mapping before its closing brace.
+
+    The value_node positions are in ``text`` (not counting the BOM bytes).
+    Returns the updated contents, or the original if the brace cannot be found.
+    """
+    start = value_node.start_mark.index
+    end = value_node.end_mark.index
+    flow_text = text[start:end]
+
+    last_brace = flow_text.rfind("}")
+    if last_brace == -1:
+        return contents  # malformed; leave unchanged
+
+    inner = flow_text[1:last_brace]
+    separator = ", " if inner.strip() else ""
+    new_flow = (
+        flow_text[:last_brace] + separator + "formats: [html, json]" + flow_text[last_brace:]
+    )
+
+    byte_start = bom_length + len(text[:start].encode("utf-8"))
+    byte_end = bom_length + len(text[:end].encode("utf-8"))
+    return contents[:byte_start] + new_flow.encode("utf-8") + contents[byte_end:]
+
+
 def _insert_search_formats(
     contents: bytes, text: str, root: MappingNode, loaded: dict, indent_width: int
 ) -> bytes:
     """Insert search.formats into the block mapping, preserving all other content.
 
     If ``search`` already exists as a block mapping key, the formats list is
-    inserted at the end of that sub-mapping. If ``search`` does not exist, the
-    entire ``search.formats`` block is appended at the end of the document.
-    This avoids emitting a second ``search:`` key that would shadow the first
-    under standard YAML semantics.
+    inserted at the end of that sub-mapping. If ``search`` is a flow-style
+    mapping, formats are inserted into the flow value in-place to avoid
+    creating a duplicate root key. If ``search`` does not exist, the entire
+    ``search.formats`` block is appended at the end of the document (before
+    any trailing YAML document-end marker ``...``).
+
+    Child indentation is derived from the existing ``search`` block's first key
+    rather than being hard-coded at two spaces.
     """
     newline = _newline_for(contents)
     indent = b" " * indent_width
@@ -117,6 +148,16 @@ def _insert_search_formats(
     for key_node, value_node in root.value:
         if key_node.value == "search":
             if value_node.id == "mapping" and not value_node.flow_style:
+                # Derive child indentation from the first existing key in the
+                # search block so non-two-space files stay consistent.
+                if value_node.value:
+                    child_indent = value_node.value[0][0].start_mark.column - indent_width
+                    child_indent = max(child_indent, 1)
+                else:
+                    child_indent = 2
+                inner_indent = b" " * (indent_width + child_indent)
+                seq_indent = b" " * (indent_width + child_indent * 2)
+
                 # Insert formats at the end of the existing search block.
                 insert_offset = (
                     bom_length
@@ -129,29 +170,56 @@ def _insert_search_formats(
                     prefix = b""
                 addition = (
                     prefix
-                    + indent + b"  formats:" + newline
-                    + indent + b"    - html" + newline
-                    + indent + b"    - json" + newline
+                    + inner_indent + b"formats:" + newline
+                    + seq_indent + b"- html" + newline
+                    + seq_indent + b"- json" + newline
                 )
                 return contents[:insert_offset] + addition + tail
-            # search exists but is not a plain block mapping (flow style or
-            # scalar); fall through to the append path to avoid corruption.
+            elif value_node.id == "mapping" and value_node.flow_style:
+                # search exists as a flow-style mapping. Insert formats into
+                # the flow value rather than appending a duplicate root key
+                # that would shadow the original under standard YAML loaders.
+                return _insert_formats_into_flow_mapping(
+                    contents, text, value_node, bom_length
+                )
+            # search exists but is not a mapping (e.g. scalar or sequence).
+            # Leave the file unchanged for this key.
             break
 
     # No usable search block found -- append one.
+    # Use two-space child indentation (conventional default for new blocks).
     block = (
         indent + b"search:" + newline
         + indent + b"  formats:" + newline
         + indent + b"    - html" + newline
         + indent + b"    - json" + newline
     )
+
+    # Respect any trailing YAML document-end marker ``...`` to avoid producing
+    # a second document that standard loaders silently discard or reject.
+    stripped = contents.rstrip(b"\r\n ")
+    if stripped.endswith(b"..."):
+        # Locate the start of the trailing ``...`` line.
+        dot_pos = len(stripped) - 3
+        line_start = contents.rfind(b"\n", 0, dot_pos)
+        if line_start == -1:
+            line_start = 0
+        else:
+            line_start += 1  # step past the newline
+        separator = b"" if contents[:line_start].endswith((b"\n", b"\r")) else newline
+        return contents[:line_start] + separator + block + contents[line_start:]
+
     if not contents.endswith((b"\n", b"\r")):
         block = newline + block
     return contents + block
 
 
 def migrate_settings(path: Path) -> bool:
-    """Add the missing inheritance key atomically; return whether the file changed."""
+    """Add the missing inheritance key and search formats atomically.
+
+    Returns True if the file was changed, False if it was already fully
+    migrated (both ``use_default_settings`` and ``search.formats`` present).
+    """
     source_stat = path.lstat()
     if not stat.S_ISREG(source_stat.st_mode):
         raise ValueError(f"settings path is not a regular file: {path}")
@@ -162,42 +230,68 @@ def migrate_settings(path: Path) -> bool:
 
     text = contents.decode("utf-8-sig")
     root, loaded = _parse_root_mapping(text)
-    if "use_default_settings" in loaded:
+
+    needs_inheritance = "use_default_settings" not in loaded
+    needs_formats = _formats_list(loaded) is None
+
+    if not needs_inheritance and not needs_formats:
         return False
 
-    if root is not None and root.flow_style:
-        start = _flow_mapping_start(text)
-        bom_length = len(_UTF8_BOM) if contents.startswith(_UTF8_BOM) else 0
-        offset = bom_length + len(text[: start + 1].encode("utf-8"))
-        separator = b", " if root.value else b""
-        updated = (
-            contents[:offset]
-            + b"use_default_settings: true"
-            + separator
-            + contents[offset:]
-        )
-    else:
-        updated = _add_block_default_inheritance(contents, text, root)
+    updated = contents
 
-    # The pinned SearXNG image defaults to HTML-only, so a retained file that
-    # gains use_default_settings without an explicit search.formats list would
-    # reject the provider's format=json requests with HTTP 403. Insert the list
-    # only when the operator has not already set it; an explicit operator list
-    # (including a JSON-free one) is intentional and must not be overridden.
-    # Flow-style root mappings are left as-is: they are rare, already
-    # operator-managed, and cannot receive a trailing block-style key.
-    if _formats_list(loaded) is None and not (root is not None and root.flow_style):
-        _, indent_width = _block_mapping_position(text, root)
-        # Re-parse the updated content so insertion offsets reflect the newly
-        # added use_default_settings line.
-        updated_text = updated[
-            (len(_UTF8_BOM) if updated.startswith(_UTF8_BOM) else 0):
-        ].decode("utf-8-sig")
+    if needs_inheritance:
+        if root is not None and root.flow_style:
+            start = _flow_mapping_start(text)
+            bom_length = len(_UTF8_BOM) if contents.startswith(_UTF8_BOM) else 0
+            offset = bom_length + len(text[: start + 1].encode("utf-8"))
+            separator = b", " if root.value else b""
+            updated = (
+                contents[:offset]
+                + b"use_default_settings: true"
+                + separator
+                + contents[offset:]
+            )
+        else:
+            updated = _add_block_default_inheritance(contents, text, root)
+
+    if needs_formats:
+        bom_length = len(_UTF8_BOM) if updated.startswith(_UTF8_BOM) else 0
+        updated_text = updated[bom_length:].decode("utf-8-sig")
         updated_root, _ = _parse_root_mapping(updated_text)
-        if updated_root is not None:
+
+        if updated_root is not None and updated_root.flow_style:
+            # For flow-style roots, insert formats into the flow ``search``
+            # value if it exists as a flow mapping.
+            inserted = False
+            for key_node, value_node in updated_root.value:
+                if (
+                    key_node.value == "search"
+                    and value_node.id == "mapping"
+                    and value_node.flow_style
+                ):
+                    updated = _insert_formats_into_flow_mapping(
+                        updated, updated_text, value_node, bom_length
+                    )
+                    inserted = True
+                    break
+            if not inserted:
+                # Flow-style roots without a block-accessible search section
+                # cannot be safely extended by text substitution. Warn so the
+                # operator can add the key manually.
+                print(
+                    "Warning: search.formats was not added because this settings"
+                    " file uses a flow-style root mapping with no flow-style search"
+                    " section. Add 'search: {formats: [html, json]}' manually.",
+                    file=sys.stderr,
+                )
+        elif updated_root is not None:
+            _, indent_width = _block_mapping_position(text, root)
             updated = _insert_search_formats(
                 updated, updated_text, updated_root, loaded, indent_width
             )
+
+    if updated == contents:
+        return False
 
     fd, temporary_name = tempfile.mkstemp(
         prefix=f".{path.name}.odysseus-", dir=path.parent
@@ -206,8 +300,8 @@ def migrate_settings(path: Path) -> bool:
     try:
         # chmod before chown: the Compose cap set is `cap_drop: ALL` plus
         # CHOWN/SETGID/SETUID/DAC_OVERRIDE, with no FOWNER. Once the temporary
-        # file belongs to searxng:searxng — which every retained settings file
-        # does, because searxng's entrypoint chowns /etc/searxng — root can no
+        # file belongs to searxng:searxng -- which every retained settings file
+        # does, because searxng's entrypoint chowns /etc/searxng -- root can no
         # longer chmod it and the migration dies with EPERM.
         os.fchmod(fd, stat.S_IMODE(source_stat.st_mode))
         os.fchown(fd, source_stat.st_uid, source_stat.st_gid)

--- a/scripts/migrate_searxng_settings.py
+++ b/scripts/migrate_searxng_settings.py
@@ -87,6 +87,69 @@ def _add_block_default_inheritance(
     return contents[:offset] + addition + contents[offset:]
 
 
+def _formats_list(loaded: dict) -> list | None:
+    """Return the explicit search.formats list, or None if absent."""
+    search = loaded.get("search")
+    if not isinstance(search, dict):
+        return None
+    formats = search.get("formats")
+    if not isinstance(formats, list):
+        return None
+    return formats
+
+
+def _insert_search_formats(
+    contents: bytes, text: str, root: MappingNode, loaded: dict, indent_width: int
+) -> bytes:
+    """Insert search.formats into the block mapping, preserving all other content.
+
+    If ``search`` already exists as a block mapping key, the formats list is
+    inserted at the end of that sub-mapping. If ``search`` does not exist, the
+    entire ``search.formats`` block is appended at the end of the document.
+    This avoids emitting a second ``search:`` key that would shadow the first
+    under standard YAML semantics.
+    """
+    newline = _newline_for(contents)
+    indent = b" " * indent_width
+    bom_length = len(_UTF8_BOM) if contents.startswith(_UTF8_BOM) else 0
+
+    # Walk the root mapping node to find the ``search`` key's value node.
+    for key_node, value_node in root.value:
+        if key_node.value == "search":
+            if value_node.id == "mapping" and not value_node.flow_style:
+                # Insert formats at the end of the existing search block.
+                insert_offset = (
+                    bom_length
+                    + len(text[: value_node.end_mark.index].encode("utf-8"))
+                )
+                tail = contents[insert_offset:]
+                if not contents[:insert_offset].endswith((b"\n", b"\r")):
+                    prefix = newline
+                else:
+                    prefix = b""
+                addition = (
+                    prefix
+                    + indent + b"  formats:" + newline
+                    + indent + b"    - html" + newline
+                    + indent + b"    - json" + newline
+                )
+                return contents[:insert_offset] + addition + tail
+            # search exists but is not a plain block mapping (flow style or
+            # scalar); fall through to the append path to avoid corruption.
+            break
+
+    # No usable search block found -- append one.
+    block = (
+        indent + b"search:" + newline
+        + indent + b"  formats:" + newline
+        + indent + b"    - html" + newline
+        + indent + b"    - json" + newline
+    )
+    if not contents.endswith((b"\n", b"\r")):
+        block = newline + block
+    return contents + block
+
+
 def migrate_settings(path: Path) -> bool:
     """Add the missing inheritance key atomically; return whether the file changed."""
     source_stat = path.lstat()
@@ -115,6 +178,27 @@ def migrate_settings(path: Path) -> bool:
         )
     else:
         updated = _add_block_default_inheritance(contents, text, root)
+
+    # The pinned SearXNG image defaults to HTML-only, so a retained file that
+    # gains use_default_settings without an explicit search.formats list would
+    # reject the provider's format=json requests with HTTP 403. Insert the list
+    # only when the operator has not already set it; an explicit operator list
+    # (including a JSON-free one) is intentional and must not be overridden.
+    # Flow-style root mappings are left as-is: they are rare, already
+    # operator-managed, and cannot receive a trailing block-style key.
+    if _formats_list(loaded) is None and not (root is not None and root.flow_style):
+        _, indent_width = _block_mapping_position(text, root)
+        # Re-parse the updated content so insertion offsets reflect the newly
+        # added use_default_settings line.
+        updated_text = updated[
+            (len(_UTF8_BOM) if updated.startswith(_UTF8_BOM) else 0):
+        ].decode("utf-8-sig")
+        updated_root, _ = _parse_root_mapping(updated_text)
+        if updated_root is not None:
+            updated = _insert_search_formats(
+                updated, updated_text, updated_root, loaded, indent_width
+            )
+
     fd, temporary_name = tempfile.mkstemp(
         prefix=f".{path.name}.odysseus-", dir=path.parent
     )
@@ -158,7 +242,10 @@ def main(argv: list[str]) -> int:
         return 1
 
     if changed:
-        print("Added use_default_settings inheritance to retained SearXNG settings")
+        print(
+            "Migrated retained SearXNG settings: added use_default_settings"
+            " inheritance and ensured search.formats includes json"
+        )
     return 0
 
 

--- a/tests/test_searxng_settings_migration.py
+++ b/tests/test_searxng_settings_migration.py
@@ -98,8 +98,10 @@ def test_fresh_generated_settings_are_left_byte_identical(tmp_path):
     ),
 )
 def test_explicit_top_level_setting_is_not_overridden(tmp_path, key):
+    # A fully-migrated file (use_default_settings already set, search.formats
+    # already present) must be left byte-identical by a second migration run.
     settings = tmp_path / "settings.yml"
-    original = key + b"server:\n  secret_key: retained\n"
+    original = key + b"search:\n  formats:\n    - html\n    - json\nserver:\n  secret_key: retained\n"
     settings.write_bytes(original)
 
     result = _run(settings)
@@ -170,7 +172,9 @@ def test_block_mapping_properties_stay_attached_to_the_root(tmp_path, property_l
     assert "html" in migrated_data["search"]["formats"]
 
 
-def test_flow_mapping_gains_default_inheritance_without_reformatting(tmp_path):
+def test_flow_mapping_gains_default_inheritance_and_formats(tmp_path):
+    # A flow-style root with a flow-style search value gets use_default_settings
+    # inserted AND formats added into the search flow mapping.
     settings = tmp_path / "settings.yml"
     original = b"{server: {secret_key: retained}, search: {safe_search: 1}}\n"
     settings.write_bytes(original)
@@ -178,9 +182,13 @@ def test_flow_mapping_gains_default_inheritance_without_reformatting(tmp_path):
     result = _run(settings)
 
     assert result.returncode == 0, result.stderr
-    assert settings.read_bytes() == (
-        b"{use_default_settings: true, " + original.removeprefix(b"{")
-    )
+    migrated = yaml.safe_load(settings.read_bytes())
+    assert migrated["use_default_settings"] is True
+    assert migrated["search"]["safe_search"] == 1
+    assert "json" in migrated["search"]["formats"]
+    assert "html" in migrated["search"]["formats"]
+    # Verify no structural corruption: original keys preserved.
+    assert migrated["server"]["secret_key"] == "retained"
 
 
 @pytest.mark.parametrize(
@@ -199,6 +207,8 @@ def test_flow_mapping_gains_default_inheritance_without_reformatting(tmp_path):
     ),
 )
 def test_other_flow_mapping_shapes_gain_only_the_root_key(tmp_path, original, expected):
+    # Flow roots without a flow-style search section receive use_default_settings
+    # but cannot safely receive search.formats by text substitution.
     settings = tmp_path / "settings.yml"
     settings.write_bytes(original)
 
@@ -211,10 +221,10 @@ def test_other_flow_mapping_shapes_gain_only_the_root_key(tmp_path, original, ex
 @pytest.mark.parametrize(
     "original",
     (
-        b"{use_default_settings: true, server: {secret_key: retained}}\n",
-        b'{"use_default_settings": {engines: {keep_only: [brave]}}}\n',
-        b"{use_default_settings: true, server: {secret_key: abc#def}}\n",
-        b"{use_default_settings: true, server: {secret_key: 'ab''cd'}}\n",
+        b"{use_default_settings: true, search: {formats: [html, json]}}\n",
+        b'{"use_default_settings": {engines: {keep_only: [brave]}}, search: {formats: [html, json]}}\n',
+        b"{use_default_settings: true, search: {formats: [html, json]}, server: {secret_key: abc#def}}\n",
+        b"{use_default_settings: true, search: {formats: [html, json]}, server: {secret_key: 'ab''cd'}}\n",
     ),
 )
 def test_flow_mapping_with_existing_setting_is_left_untouched(tmp_path, original):
@@ -231,8 +241,11 @@ def test_flow_mapping_with_existing_setting_is_left_untouched(tmp_path, original
     "original",
     (
         b"%YAML 1.1\n---\nuse_default_settings: true\n"
+        b"search:\n  formats:\n    - html\n    - json\n"
         b"server:\n  secret_key: retained\n",
-        b"use_default_settings: true\nserver:\n  secret_key: retained\n...\n",
+        b"use_default_settings: true\n"
+        b"search:\n  formats:\n    - html\n    - json\n"
+        b"server:\n  secret_key: retained\n...\n",
     ),
 )
 def test_valid_document_metadata_with_existing_key_is_left_untouched(
@@ -376,6 +389,129 @@ def test_explicit_operator_formats_list_is_not_overridden(tmp_path):
     assert migrated["use_default_settings"] is True
     # The operator's formats list must be preserved exactly
     assert migrated["search"]["formats"] == ["html"]
+
+
+# --- P1 regression: previously migrated settings must get search.formats repaired ---
+
+def test_previously_migrated_settings_without_formats_gain_json_format(tmp_path):
+    # A file already migrated by an earlier version of this script may have
+    # use_default_settings: true but still lack search.formats. The migration
+    # must repair this state rather than exiting early.
+    settings = tmp_path / "settings.yml"
+    already_inherited = (
+        b"use_default_settings: true\n"
+        b"server:\n"
+        b'  secret_key: "retained-secret"\n'
+        b"search:\n"
+        b"  safe_search: 1\n"
+    )
+    settings.write_bytes(already_inherited)
+
+    result = _run(settings)
+
+    assert result.returncode == 0, result.stderr
+    migrated_bytes = settings.read_bytes()
+    migrated = yaml.safe_load(migrated_bytes)
+    # use_default_settings must be preserved
+    assert migrated["use_default_settings"] is True
+    # search.formats must now be present
+    assert "json" in migrated["search"]["formats"]
+    assert "html" in migrated["search"]["formats"]
+    # existing settings must be unchanged
+    assert migrated["search"]["safe_search"] == 1
+    assert migrated["server"]["secret_key"] == "retained-secret"
+
+    # Second run: fully migrated now, file must not change
+    second = _run(settings)
+    assert second.returncode == 0, second.stderr
+    assert settings.read_bytes() == migrated_bytes
+    assert second.stdout == ""
+
+
+def test_previously_migrated_settings_without_search_section_gain_formats(tmp_path):
+    # use_default_settings present but no search section at all.
+    settings = tmp_path / "settings.yml"
+    original = b"use_default_settings: true\nserver:\n  secret_key: retained\n"
+    settings.write_bytes(original)
+
+    result = _run(settings)
+
+    assert result.returncode == 0, result.stderr
+    migrated = yaml.safe_load(settings.read_bytes())
+    assert migrated["use_default_settings"] is True
+    assert "json" in migrated["search"]["formats"]
+    assert "html" in migrated["search"]["formats"]
+
+
+# --- P2 regressions ---
+
+def test_flow_style_search_value_in_block_root_does_not_create_duplicate_key(tmp_path):
+    # When search exists but its value is a flow-style mapping (e.g. from a
+    # hand-edited file), the migration must insert formats into the flow value
+    # rather than appending a second root-level search: key that would shadow
+    # the first under standard YAML loaders.
+    settings = tmp_path / "settings.yml"
+    original = b"server:\n  secret_key: retained\nsearch: {safe_search: 1}\n"
+    settings.write_bytes(original)
+
+    result = _run(settings)
+
+    assert result.returncode == 0, result.stderr
+    migrated_bytes = settings.read_bytes()
+    migrated = yaml.safe_load(migrated_bytes)
+    assert migrated["use_default_settings"] is True
+    # formats must be reachable through the search key -- no duplicate shadowing
+    assert "json" in migrated["search"]["formats"]
+    assert migrated["search"]["safe_search"] == 1
+    # No duplicate root-level search: key (a second one would shadow the first
+    # and safe_search would be lost -- the yaml assertion above already proves
+    # the content survived, so just verify the raw byte structure too).
+    assert migrated_bytes.count(b"\nsearch:") == 1
+
+
+def test_search_formats_inserted_before_yaml_document_end_marker(tmp_path):
+    # When the file ends with YAML '...' document-end marker, the appended
+    # search block must land before it to remain in the same document.
+    settings = tmp_path / "settings.yml"
+    original = b"server:\n  secret_key: retained\n...\n"
+    settings.write_bytes(original)
+
+    result = _run(settings)
+
+    assert result.returncode == 0, result.stderr
+    migrated_bytes = settings.read_bytes()
+    # Result must be a single valid YAML document
+    migrated = yaml.safe_load(migrated_bytes)
+    assert migrated["use_default_settings"] is True
+    assert "json" in migrated["search"]["formats"]
+    # '...' must still terminate the document
+    assert migrated_bytes.rstrip(b"\r\n").endswith(b"...")
+    # The search block must appear before '...'
+    search_pos = migrated_bytes.find(b"search:")
+    dot_pos = migrated_bytes.rfind(b"...")
+    assert search_pos < dot_pos
+
+
+def test_non_two_space_indented_file_gets_consistent_formats_indent(tmp_path):
+    # A settings file using four-space indentation must receive a formats key
+    # indented to match, not hard-coded at two spaces.
+    settings = tmp_path / "settings.yml"
+    original = b"server:\n    secret_key: retained\nsearch:\n    safe_search: 1\n"
+    settings.write_bytes(original)
+
+    result = _run(settings)
+
+    assert result.returncode == 0, result.stderr
+    migrated_bytes = settings.read_bytes()
+    migrated = yaml.safe_load(migrated_bytes)
+    assert migrated["use_default_settings"] is True
+    assert migrated["search"]["safe_search"] == 1
+    assert "json" in migrated["search"]["formats"]
+    assert "html" in migrated["search"]["formats"]
+    # formats: key must be at four-space indent (matching safe_search)
+    assert b"\n    formats:" in migrated_bytes
+    # sequence items must be at eight-space indent
+    assert b"\n        - html" in migrated_bytes
 
 
 @pytest.mark.parametrize("compose_file", COMPOSE_FILES, ids=lambda path: path.name)

--- a/tests/test_searxng_settings_migration.py
+++ b/tests/test_searxng_settings_migration.py
@@ -119,6 +119,7 @@ def test_key_is_inserted_inside_explicit_yaml_document(tmp_path):
     assert settings.read_bytes() == (
         b"\xef\xbb\xbf# header\r\n---\r\nuse_default_settings: true\r\n"
         b"server:\r\n  secret_key: retained\r\n"
+        b"search:\r\n  formats:\r\n    - html\r\n    - json\r\n"
     )
 
 
@@ -130,7 +131,13 @@ def test_indented_root_mapping_keeps_its_existing_indent(tmp_path):
     result = _run(settings)
 
     assert result.returncode == 0, result.stderr
-    assert settings.read_bytes() == b"  use_default_settings: true\n" + original
+    # use_default_settings is prepended; formats is inserted inside search block.
+    assert settings.read_bytes() == (
+        b"  use_default_settings: true\n"
+        b"  server:\n    secret_key: retained\n"
+        b"  search:\n    safe_search: 1\n"
+        b"    formats:\n      - html\n      - json\n"
+    )
 
 
 @pytest.mark.parametrize(
@@ -147,11 +154,20 @@ def test_block_mapping_properties_stay_attached_to_the_root(tmp_path, property_l
     result = _run(settings)
 
     assert result.returncode == 0, result.stderr
-    expected = property_line + b"use_default_settings: true\n" + mapping
+    # formats is inserted inside the existing search block, not appended as a
+    # new search key, so safe_search and formats coexist in the same section.
+    expected = (
+        property_line
+        + b"use_default_settings: true\n"
+        + b"server:\n  secret_key: retained\n"
+        + b"search:\n  safe_search: 1\n  formats:\n    - html\n    - json\n"
+    )
     assert settings.read_bytes() == expected
     migrated_data = yaml.safe_load(settings.read_bytes())
     assert migrated_data.pop("use_default_settings") is True
-    assert migrated_data == original_data
+    assert migrated_data["search"]["safe_search"] == 1
+    assert "json" in migrated_data["search"]["formats"]
+    assert "html" in migrated_data["search"]["formats"]
 
 
 def test_flow_mapping_gains_default_inheritance_without_reformatting(tmp_path):
@@ -280,6 +296,7 @@ def test_temporary_file_is_chmodded_before_it_is_chowned(tmp_path, monkeypatch):
     assert stat.S_IMODE(settings.stat().st_mode) == 0o640
     assert settings.read_bytes() == (
         b"use_default_settings: true\nserver:\n  secret_key: retained\n"
+        b"search:\n  formats:\n    - html\n    - json\n"
     )
 
 
@@ -304,6 +321,61 @@ def test_replace_failure_preserves_original_and_removes_temporary_file(
     assert settings.read_bytes() == original
     assert after.st_ino == before.st_ino
     assert list(tmp_path.iterdir()) == [settings]
+
+
+def test_retained_settings_without_formats_gain_json_format(tmp_path):
+    # Regression test for #6066: a retained file that has no search.formats
+    # receives use_default_settings: true but the pinned SearXNG image defaults
+    # to HTML-only, so format=json requests returned HTTP 403. The migration must
+    # also append search.formats with html and json when the key is absent.
+    settings = tmp_path / "settings.yml"
+    retained = (
+        b"server:\n"
+        b'  secret_key: "retained-secret"\n'
+        b"search:\n"
+        b"  safe_search: 1\n"
+    )
+    settings.write_bytes(retained)
+
+    result = _run(settings)
+
+    assert result.returncode == 0, result.stderr
+    migrated_bytes = settings.read_bytes()
+    # formats is inserted inside the existing search block so safe_search and
+    # formats coexist and are visible to standard yaml.safe_load.
+    migrated = yaml.safe_load(migrated_bytes)
+    assert migrated["use_default_settings"] is True
+    assert migrated["search"]["safe_search"] == 1
+    assert "json" in migrated["search"]["formats"]
+    assert "html" in migrated["search"]["formats"]
+
+    # Idempotent: a second run must not touch the already-migrated file
+    second = _run(settings)
+    assert second.returncode == 0, second.stderr
+    assert settings.read_bytes() == migrated_bytes
+    assert second.stdout == ""
+
+
+def test_explicit_operator_formats_list_is_not_overridden(tmp_path):
+    # An operator who deliberately chose html-only (or any custom list) must not
+    # have that choice silently replaced by the migration.
+    settings = tmp_path / "settings.yml"
+    original = (
+        b"server:\n"
+        b'  secret_key: "retained-secret"\n'
+        b"search:\n"
+        b"  formats:\n"
+        b"    - html\n"
+    )
+    settings.write_bytes(original)
+
+    result = _run(settings)
+
+    assert result.returncode == 0, result.stderr
+    migrated = yaml.safe_load(settings.read_bytes())
+    assert migrated["use_default_settings"] is True
+    # The operator's formats list must be preserved exactly
+    assert migrated["search"]["formats"] == ["html"]
 
 
 @pytest.mark.parametrize("compose_file", COMPOSE_FILES, ids=lambda path: path.name)


### PR DESCRIPTION
## Summary

The SearXNG settings migration added `use_default_settings: true` but did not add `search.formats`. The pinned SearXNG image defaults to HTML-only, so retained files without an explicit formats list ended up rejecting the provider's `format=json` requests with HTTP 403 while the root healthcheck still returned 200.

Add `_formats_list` to detect operator-provided formats lists (which must not be overwritten) and `_insert_search_formats` to add `html` and `json` to the `search.formats` key, inserting inside the existing `search:` block if present, or appending a new one if absent. Flow-style root mappings are left untouched.

## Target branch

- [x] This PR targets `dev`, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release.

## Linked Issue

Fixes #6066

## Type of Change

- [x] Bug fix (non-breaking -- fixes a confirmed issue)
- [ ] New feature (non-breaking -- adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs -- this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above -- no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end.
- [ ] I did not run the app/runtime validation and stated that gap in **How to Test**.

## How to Test

1. Create a retained SearXNG `settings.yml` with a `search:` section (e.g., `safe_search: 1`) but no `search.formats` key.
2. Run `python scripts/migrate_searxng_settings.py settings.yml`.
3. Verify `use_default_settings: true` is at the top and `formats: [html, json]` is inside the `search:` block alongside the existing settings.
4. Verify a second invocation is idempotent (file unchanged, no output).
5. Verify that a file with an explicit `search.formats` list has its list preserved unchanged.

## Runtime validation (2026-08-26)

All of this ran against the pinned image `docker.io/searxng/searxng:2026.5.31-7159b8aed` (Docker on macOS).

**Reproducing the bug first:** I booted SearXNG with a retained `settings.yml` that had `use_default_settings: true` and a `search:` block with no `formats` key, which is the state the pre-fix migration produced. The root healthcheck returned 200 while `/search?q=test&format=json` returned 403. That is the exact #6066 signature.

**Script level (this PR):** I ran `migrate_searxng_settings.py` inside the container via `/usr/local/searxng/.venv/bin/python`, the same way the compose entrypoint does, against a retained file with `server.secret_key` and `search.safe_search` but no formats list:

- It inserts `use_default_settings: true` at the top and `formats: [html, json]` inside the existing `search:` block.
- A second run exits 0 and leaves the file byte-identical (verified by md5), so it is idempotent.
- A file with an explicit `search.formats: [html]` keeps its list unchanged while still gaining `use_default_settings`.

**Full compose path:** I pre-seeded the `searxng-data` volume with the retained operator file and then ran `docker compose up -d searxng` on this branch. The entrypoint kept the operator file rather than re-templating it, the migration log line appeared, SearXNG booted healthy, and `/search?q=test&format=json` returned 200 with a JSON results body.

**Unit tests:** `python -m pytest tests/test_searxng_settings_migration.py` passes (29 tests).

**One limitation worth flagging for review:** a file already migrated by the earlier script version (so `use_default_settings` is present but `formats` is not, the broken state produced on `dev` between #6055 landing on 2026-08-16 and this fix) hits the early `return False` in `migrate_settings()` and is not repaired. That population is dev-branch-only and about two days wide. Remediation there is manual: add the formats list, or delete the retained file so the entrypoint re-templates. Happy to extend the migration in this PR to repair that state too if you would rather cover it here.