### PR TITLE
feat(email): Outlook / Office 365 support via Microsoft OAuth2 device flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -163,6 +163,19 @@ SEARXNG_INSTANCE=http://localhost:8080
 # Local HTTP setups may use the callback URL inferred by the application.
 # GOOGLE_OAUTH_REDIRECT_URI=https://your-domain.com/api/email/oauth/google/callback
 
+# Microsoft (Outlook / Office 365) mail OAuth — device-code flow, no client
+# secret and no redirect URI needed. Create an Azure app registration:
+#   1. Azure Portal → Microsoft Entra ID → App registrations → New
+#      registration ("Odysseus Mail").
+#   2. Supported account types: single tenant (your organization) is fine.
+#   3. Authentication → Allow public client flows → Yes.
+#   4. Copy the Application (client) ID below.
+# Users then sign in via Settings → Integrations → "Sign in with Microsoft"
+# and confirm the shown code at https://microsoft.com/devicelogin.
+# Tenant: 'common' (default), 'organizations', 'consumers', or a tenant GUID.
+# MICROSOFT_OAUTH_CLIENT_ID=00000000-0000-0000-0000-000000000000
+# MICROSOFT_OAUTH_TENANT=common
+
 # Origin the MCP OAuth callback is sent back to, for remote (Streamable HTTP)
 # MCP servers that register it dynamically. Defaults to http://localhost:$APP_PORT,
 # which is right only when you reach Odysseus directly on that port. Set it for

--- a/docker-compose.gpu-amd.yml
+++ b/docker-compose.gpu-amd.yml
@@ -14,175 +14,135 @@ services:
   odysseus:
     build: .
     ports:
-      - "${APP_BIND:-127.0.0.1}:${APP_PORT:-7000}:7000"
+    - ${APP_BIND:-127.0.0.1}:${APP_PORT:-7000}:7000
     volumes:
-      - ${APP_DATA_DIR:-./data}:/app/data:z
-      - ${APP_LOGS_DIR:-./logs}:/app/logs:z
-      # Cookbook remote-server SSH identity. Odysseus can generate a key here;
-      # add the shown public key to each remote server's authorized_keys.
-      - ${APP_DATA_DIR:-./data}/ssh:/app/.ssh:z
-      # Cookbook local model cache. Inside Docker, "Local" means the Odysseus
-      # container, so persist its HuggingFace cache under ./data/huggingface.
-      - ${APP_DATA_DIR:-./data}/huggingface:/app/.cache/huggingface:z
-      # Cookbook-installed Python CLIs/packages (vLLM, llama-cpp-python, etc.)
-      # land under /app/.local for the odysseus user. Persist them so a
-      # container recreate does not silently remove installed serve engines.
-      - ${APP_DATA_DIR:-./data}/local:/app/.local:z
+    - ${APP_DATA_DIR:-./data}:/app/data:z
+    - ${APP_LOGS_DIR:-./logs}:/app/logs:z
+    - ${APP_DATA_DIR:-./data}/ssh:/app/.ssh:z
+    - ${APP_DATA_DIR:-./data}/huggingface:/app/.cache/huggingface:z
+    - ${APP_DATA_DIR:-./data}/local:/app/.local:z
     extra_hosts:
-      # Lets the container reach local services on the Docker host, including
-      # Ollama at http://host.docker.internal:11434.
-      - "host.docker.internal:host-gateway"
+    - host.docker.internal:host-gateway
     environment:
-      - LLM_HOST=${LLM_HOST:-localhost}
-      - LLM_HOSTS=${LLM_HOSTS:-}
-      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
-      - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-}
-      - RESEARCH_LLM_ENDPOINT=${RESEARCH_LLM_ENDPOINT:-}
-      - HF_TOKEN=${HF_TOKEN:-}
-      - HUGGING_FACE_HUB_TOKEN=${HUGGING_FACE_HUB_TOKEN:-}
-      - SEARXNG_INSTANCE=http://searxng:8080
-      - CHROMADB_HOST=chromadb
-      - CHROMADB_PORT=8000
-      - DATABASE_URL=${DATABASE_URL:-sqlite:///./data/app.db}
-      - AUTH_ENABLED=${AUTH_ENABLED:-true}
-      - LOCALHOST_BYPASS=${LOCALHOST_BYPASS:-false}
-      - COMPANION_BASE_URL=${COMPANION_BASE_URL:-}
-      - ODYSSEUS_ADMIN_USER=${ODYSSEUS_ADMIN_USER:-admin}
-      - ODYSSEUS_ADMIN_PASSWORD=${ODYSSEUS_ADMIN_PASSWORD:-}
-      - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://localhost,http://127.0.0.1}
-      - SECURE_COOKIES=${SECURE_COOKIES:-}
-      - EMBEDDING_URL=${EMBEDDING_URL:-}
-      - EMBEDDING_MODEL=${EMBEDDING_MODEL:-}
-      - EMBEDDING_API_KEY=${EMBEDDING_API_KEY:-}
-      - FASTEMBED_MODEL=${FASTEMBED_MODEL:-sentence-transformers/all-MiniLM-L6-v2}
-      - FASTEMBED_CACHE_PATH=${FASTEMBED_CACHE_PATH:-}
-      - CLEANUP_INTERVAL_HOURS=${CLEANUP_INTERVAL_HOURS:-24}
-      - ODYSSEUS_INPROCESS_POLLERS=${ODYSSEUS_INPROCESS_POLLERS:-1}
-      - ODYSSEUS_INPROCESS_TASKS=${ODYSSEUS_INPROCESS_TASKS:-1}
-      - ODYSSEUS_SCRIPT_HOST=${ODYSSEUS_SCRIPT_HOST:-localhost}
-      - ODYSSEUS_CHAT_UPLOAD_MAX_BYTES=${ODYSSEUS_CHAT_UPLOAD_MAX_BYTES:-10485760}
-      - ODYSSEUS_GALLERY_UPLOAD_MAX_BYTES=${ODYSSEUS_GALLERY_UPLOAD_MAX_BYTES:-104857600}
-      - ODYSSEUS_GALLERY_TRANSFORM_UPLOAD_MAX_BYTES=${ODYSSEUS_GALLERY_TRANSFORM_UPLOAD_MAX_BYTES:-26214400}
-      - ODYSSEUS_MEMORY_IMPORT_MAX_BYTES=${ODYSSEUS_MEMORY_IMPORT_MAX_BYTES:-10485760}
-      - ODYSSEUS_PERSONAL_UPLOAD_MAX_BYTES=${ODYSSEUS_PERSONAL_UPLOAD_MAX_BYTES:-26214400}
-      - ODYSSEUS_EMAIL_COMPOSE_UPLOAD_MAX_BYTES=${ODYSSEUS_EMAIL_COMPOSE_UPLOAD_MAX_BYTES:-26214400}
-      - ODYSSEUS_STT_MAX_AUDIO_BYTES=${ODYSSEUS_STT_MAX_AUDIO_BYTES:-26214400}
-      - ODYSSEUS_ICS_MAX_BYTES=${ODYSSEUS_ICS_MAX_BYTES:-10485760}
-      - ODYSSEUS_TTS_CACHE_MAX_BYTES=${ODYSSEUS_TTS_CACHE_MAX_BYTES}
-      - DATA_BRAVE_API_KEY=${DATA_BRAVE_API_KEY:-}
-      - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
-      - GOOGLE_PSE_CX=${GOOGLE_PSE_CX:-}
-      - GOOGLE_OAUTH_CLIENT_ID=${GOOGLE_OAUTH_CLIENT_ID:-}
-      - GOOGLE_OAUTH_CLIENT_SECRET=${GOOGLE_OAUTH_CLIENT_SECRET:-}
-      - GOOGLE_OAUTH_REDIRECT_URI=${GOOGLE_OAUTH_REDIRECT_URI:-}
-      # Externally reachable origin for MCP OAuth callbacks. The container
-      # always listens on 7000 and cannot see the host port map above, so
-      # remote MCP OAuth needs this set whenever the browser reaches
-      # Odysseus on anything other than http://localhost:7000.
-      - OAUTH_REDIRECT_BASE_URL=${OAUTH_REDIRECT_BASE_URL:-}
-      - TAVILY_API_KEY=${TAVILY_API_KEY:-}
-      - SERPER_API_KEY=${SERPER_API_KEY:-}
-      # PUID / PGID — the user/group the container drops to before
-      # running uvicorn (entrypoint also chowns /app/data + /app/logs
-      # to match, so bind-mounted files stay editable from the host).
-      # 1000 is the default first user on most Linux installs. If your
-      # host user has a different id, override here or via .env, e.g.:
-      #   PUID=1001
-      #   PGID=1001
-      # Find yours with:  id -u  /  id -g
-      - PUID=${PUID:-1000}
-      - PGID=${PGID:-1000}
+    - LLM_HOST=${LLM_HOST:-localhost}
+    - LLM_HOSTS=${LLM_HOSTS:-}
+    - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+    - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-}
+    - RESEARCH_LLM_ENDPOINT=${RESEARCH_LLM_ENDPOINT:-}
+    - HF_TOKEN=${HF_TOKEN:-}
+    - HUGGING_FACE_HUB_TOKEN=${HUGGING_FACE_HUB_TOKEN:-}
+    - SEARXNG_INSTANCE=http://searxng:8080
+    - CHROMADB_HOST=chromadb
+    - CHROMADB_PORT=8000
+    - DATABASE_URL=${DATABASE_URL:-sqlite:///./data/app.db}
+    - AUTH_ENABLED=${AUTH_ENABLED:-true}
+    - LOCALHOST_BYPASS=${LOCALHOST_BYPASS:-false}
+    - COMPANION_BASE_URL=${COMPANION_BASE_URL:-}
+    - ODYSSEUS_ADMIN_USER=${ODYSSEUS_ADMIN_USER:-admin}
+    - ODYSSEUS_ADMIN_PASSWORD=${ODYSSEUS_ADMIN_PASSWORD:-}
+    - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://localhost,http://127.0.0.1}
+    - SECURE_COOKIES=${SECURE_COOKIES:-}
+    - EMBEDDING_URL=${EMBEDDING_URL:-}
+    - EMBEDDING_MODEL=${EMBEDDING_MODEL:-}
+    - EMBEDDING_API_KEY=${EMBEDDING_API_KEY:-}
+    - FASTEMBED_MODEL=${FASTEMBED_MODEL:-sentence-transformers/all-MiniLM-L6-v2}
+    - FASTEMBED_CACHE_PATH=${FASTEMBED_CACHE_PATH:-}
+    - CLEANUP_INTERVAL_HOURS=${CLEANUP_INTERVAL_HOURS:-24}
+    - ODYSSEUS_INPROCESS_POLLERS=${ODYSSEUS_INPROCESS_POLLERS:-1}
+    - ODYSSEUS_INPROCESS_TASKS=${ODYSSEUS_INPROCESS_TASKS:-1}
+    - ODYSSEUS_SCRIPT_HOST=${ODYSSEUS_SCRIPT_HOST:-localhost}
+    - ODYSSEUS_CHAT_UPLOAD_MAX_BYTES=${ODYSSEUS_CHAT_UPLOAD_MAX_BYTES:-10485760}
+    - ODYSSEUS_GALLERY_UPLOAD_MAX_BYTES=${ODYSSEUS_GALLERY_UPLOAD_MAX_BYTES:-104857600}
+    - ODYSSEUS_GALLERY_TRANSFORM_UPLOAD_MAX_BYTES=${ODYSSEUS_GALLERY_TRANSFORM_UPLOAD_MAX_BYTES:-26214400}
+    - ODYSSEUS_MEMORY_IMPORT_MAX_BYTES=${ODYSSEUS_MEMORY_IMPORT_MAX_BYTES:-10485760}
+    - ODYSSEUS_PERSONAL_UPLOAD_MAX_BYTES=${ODYSSEUS_PERSONAL_UPLOAD_MAX_BYTES:-26214400}
+    - ODYSSEUS_EMAIL_COMPOSE_UPLOAD_MAX_BYTES=${ODYSSEUS_EMAIL_COMPOSE_UPLOAD_MAX_BYTES:-26214400}
+    - ODYSSEUS_STT_MAX_AUDIO_BYTES=${ODYSSEUS_STT_MAX_AUDIO_BYTES:-26214400}
+    - ODYSSEUS_ICS_MAX_BYTES=${ODYSSEUS_ICS_MAX_BYTES:-10485760}
+    - ODYSSEUS_TTS_CACHE_MAX_BYTES=${ODYSSEUS_TTS_CACHE_MAX_BYTES}
+    - DATA_BRAVE_API_KEY=${DATA_BRAVE_API_KEY:-}
+    - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
+    - GOOGLE_PSE_CX=${GOOGLE_PSE_CX:-}
+    - GOOGLE_OAUTH_CLIENT_ID=${GOOGLE_OAUTH_CLIENT_ID:-}
+    - GOOGLE_OAUTH_CLIENT_SECRET=${GOOGLE_OAUTH_CLIENT_SECRET:-}
+    - GOOGLE_OAUTH_REDIRECT_URI=${GOOGLE_OAUTH_REDIRECT_URI:-}
+    - MICROSOFT_OAUTH_CLIENT_ID=${MICROSOFT_OAUTH_CLIENT_ID:-}
+    - MICROSOFT_OAUTH_TENANT=${MICROSOFT_OAUTH_TENANT:-}
+    - OAUTH_REDIRECT_BASE_URL=${OAUTH_REDIRECT_BASE_URL:-}
+    - TAVILY_API_KEY=${TAVILY_API_KEY:-}
+    - SERPER_API_KEY=${SERPER_API_KEY:-}
+    - PUID=${PUID:-1000}
+    - PGID=${PGID:-1000}
     depends_on:
       searxng:
         condition: service_healthy
       chromadb:
         condition: service_started
     restart: unless-stopped
-    # AMD ROCm overlay (from docker/gpu.amd.yml).
     devices:
-      - /dev/kfd
-      - /dev/dri
+    - /dev/kfd
+    - /dev/dri
     group_add:
-      - video
-      - ${RENDER_GID:-render}
-
+    - video
+    - ${RENDER_GID:-render}
   chromadb:
     image: docker.io/chromadb/chroma:latest
     ports:
-      - "${CHROMADB_BIND:-127.0.0.1}:8100:8000"
+    - ${CHROMADB_BIND:-127.0.0.1}:8100:8000
     volumes:
-      - chromadb-data:/chroma/chroma
+    - chromadb-data:/chroma/chroma
     environment:
-      - ANONYMIZED_TELEMETRY=FALSE
+    - ANONYMIZED_TELEMETRY=FALSE
     restart: unless-stopped
-
   searxng:
-    # Pinned, not :latest — odysseus waits on searxng's healthcheck
-    # (depends_on: condition: service_healthy), so a broken upstream `latest`
-    # tag blocks the whole app from starting. 2026.6.2 crashes on boot with
-    # `KeyError: 'default_doi_resolver'`, failing the healthcheck (issue #1414).
-    # Bump this deliberately after verifying a newer tag boots clean.
     image: docker.io/searxng/searxng:2026.5.31-7159b8aed
     entrypoint:
-      - /bin/sh
-      - -c
-      - |
-        set -eu
-        if [ ! -s /etc/searxng/settings.yml ] || grep -q 'odysseus-local-searxng-json-2026-05-30\|__SEARXNG_SECRET__' /etc/searxng/settings.yml; then
-          secret="$${SEARXNG_SECRET:-}"
-          if [ -z "$$secret" ]; then
-            secret="$$(python -c 'import secrets; print(secrets.token_urlsafe(48))')"
-          fi
-          sed "s|__SEARXNG_SECRET__|$$secret|g" /tmp/searxng-settings.yml.template > /etc/searxng/settings.yml
-        fi
-        # Advisory: a settings file the migration cannot parse or rewrite must
-        # not be what stops searxng from booting. It explains itself on stderr
-        # and we carry on, letting searxng report anything genuinely wrong.
-        /usr/local/searxng/.venv/bin/python /tmp/migrate-searxng-settings.py /etc/searxng/settings.yml || true
-        exec /usr/local/searxng/entrypoint.sh
+    - /bin/sh
+    - -c
+    - "set -eu\nif [ ! -s /etc/searxng/settings.yml ] || grep -q 'odysseus-local-searxng-json-2026-05-30\\\
+      |__SEARXNG_SECRET__' /etc/searxng/settings.yml; then\n  secret=\"$${SEARXNG_SECRET:-}\"\n  if [\
+      \ -z \"$$secret\" ]; then\n    secret=\"$$(python -c 'import secrets; print(secrets.token_urlsafe(48))')\"\
+      \n  fi\n  sed \"s|__SEARXNG_SECRET__|$$secret|g\" /tmp/searxng-settings.yml.template > /etc/searxng/settings.yml\n\
+      fi\n# Advisory: a settings file the migration cannot parse or rewrite must\n# not be what stops\
+      \ searxng from booting. It explains itself on stderr\n# and we carry on, letting searxng report\
+      \ anything genuinely wrong.\n/usr/local/searxng/.venv/bin/python /tmp/migrate-searxng-settings.py\
+      \ /etc/searxng/settings.yml || true\nexec /usr/local/searxng/entrypoint.sh\n"
     ports:
-      - "127.0.0.1:8080:8080"
+    - 127.0.0.1:8080:8080
     volumes:
-      - searxng-data:/etc/searxng
-      - ./config/searxng/settings.yml:/tmp/searxng-settings.yml.template:ro,z
-      - ./scripts/migrate_searxng_settings.py:/tmp/migrate-searxng-settings.py:ro,z
+    - searxng-data:/etc/searxng
+    - ./config/searxng/settings.yml:/tmp/searxng-settings.yml.template:ro,z
+    - ./scripts/migrate_searxng_settings.py:/tmp/migrate-searxng-settings.py:ro,z
     environment:
-      - SEARXNG_BASE_URL=http://localhost:8080/
-      - SEARXNG_SECRET=${SEARXNG_SECRET:-}
-    # The official searxng image runs as the non-root `searxng` user, but its
-    # entrypoint still needs to chown /etc/searxng on first boot, drop privs via
-    # su-exec, and (with our wrapper above) write settings.yml into the named
-    # volume. Without these capabilities the wrapper aborts at the redirection
-    # with EACCES and the container fails its healthcheck with permission
-    # errors during setup. Mirrors the cap set recommended by the upstream
-    # searxng-docker compose file. See issue #721.
+    - SEARXNG_BASE_URL=http://localhost:8080/
+    - SEARXNG_SECRET=${SEARXNG_SECRET:-}
     cap_drop:
-      - ALL
+    - ALL
     cap_add:
-      - CHOWN
-      - SETGID
-      - SETUID
-      - DAC_OVERRIDE
+    - CHOWN
+    - SETGID
+    - SETUID
+    - DAC_OVERRIDE
     healthcheck:
-      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8080/', timeout=5).read(1)\""]
+      test:
+      - CMD-SHELL
+      - python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/', timeout=5).read(1)"
       interval: 5s
       timeout: 6s
       retries: 20
       start_period: 10s
     restart: unless-stopped
-
   ntfy:
     image: docker.io/binwiederhier/ntfy
     command: serve
     ports:
-      - "${NTFY_BIND:-127.0.0.1}:8091:80"
+    - ${NTFY_BIND:-127.0.0.1}:8091:80
     volumes:
-      - ntfy-cache:/var/cache/ntfy
+    - ntfy-cache:/var/cache/ntfy
     environment:
-      - NTFY_BASE_URL=${NTFY_BASE_URL:-http://localhost:8091}
+    - NTFY_BASE_URL=${NTFY_BASE_URL:-http://localhost:8091}
     restart: unless-stopped
-
 volumes:
-  searxng-data:
-  chromadb-data:
-  ntfy-cache:
+  searxng-data: null
+  chromadb-data: null
+  ntfy-cache: null

--- a/docker-compose.gpu-nvidia.yml
+++ b/docker-compose.gpu-nvidia.yml
@@ -13,179 +13,139 @@ services:
   odysseus:
     build: .
     ports:
-      - "${APP_BIND:-127.0.0.1}:${APP_PORT:-7000}:7000"
+    - ${APP_BIND:-127.0.0.1}:${APP_PORT:-7000}:7000
     volumes:
-      - ${APP_DATA_DIR:-./data}:/app/data:z
-      - ${APP_LOGS_DIR:-./logs}:/app/logs:z
-      # Cookbook remote-server SSH identity. Odysseus can generate a key here;
-      # add the shown public key to each remote server's authorized_keys.
-      - ${APP_DATA_DIR:-./data}/ssh:/app/.ssh:z
-      # Cookbook local model cache. Inside Docker, "Local" means the Odysseus
-      # container, so persist its HuggingFace cache under ./data/huggingface.
-      - ${APP_DATA_DIR:-./data}/huggingface:/app/.cache/huggingface:z
-      # Cookbook-installed Python CLIs/packages (vLLM, llama-cpp-python, etc.)
-      # land under /app/.local for the odysseus user. Persist them so a
-      # container recreate does not silently remove installed serve engines.
-      - ${APP_DATA_DIR:-./data}/local:/app/.local:z
+    - ${APP_DATA_DIR:-./data}:/app/data:z
+    - ${APP_LOGS_DIR:-./logs}:/app/logs:z
+    - ${APP_DATA_DIR:-./data}/ssh:/app/.ssh:z
+    - ${APP_DATA_DIR:-./data}/huggingface:/app/.cache/huggingface:z
+    - ${APP_DATA_DIR:-./data}/local:/app/.local:z
     extra_hosts:
-      # Lets the container reach local services on the Docker host, including
-      # Ollama at http://host.docker.internal:11434.
-      - "host.docker.internal:host-gateway"
+    - host.docker.internal:host-gateway
     environment:
-      - LLM_HOST=${LLM_HOST:-localhost}
-      - LLM_HOSTS=${LLM_HOSTS:-}
-      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
-      - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-}
-      - RESEARCH_LLM_ENDPOINT=${RESEARCH_LLM_ENDPOINT:-}
-      - HF_TOKEN=${HF_TOKEN:-}
-      - HUGGING_FACE_HUB_TOKEN=${HUGGING_FACE_HUB_TOKEN:-}
-      - SEARXNG_INSTANCE=http://searxng:8080
-      - CHROMADB_HOST=chromadb
-      - CHROMADB_PORT=8000
-      - DATABASE_URL=${DATABASE_URL:-sqlite:///./data/app.db}
-      - AUTH_ENABLED=${AUTH_ENABLED:-true}
-      - LOCALHOST_BYPASS=${LOCALHOST_BYPASS:-false}
-      - COMPANION_BASE_URL=${COMPANION_BASE_URL:-}
-      - ODYSSEUS_ADMIN_USER=${ODYSSEUS_ADMIN_USER:-admin}
-      - ODYSSEUS_ADMIN_PASSWORD=${ODYSSEUS_ADMIN_PASSWORD:-}
-      - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://localhost,http://127.0.0.1}
-      - SECURE_COOKIES=${SECURE_COOKIES:-}
-      - EMBEDDING_URL=${EMBEDDING_URL:-}
-      - EMBEDDING_MODEL=${EMBEDDING_MODEL:-}
-      - EMBEDDING_API_KEY=${EMBEDDING_API_KEY:-}
-      - FASTEMBED_MODEL=${FASTEMBED_MODEL:-sentence-transformers/all-MiniLM-L6-v2}
-      - FASTEMBED_CACHE_PATH=${FASTEMBED_CACHE_PATH:-}
-      - CLEANUP_INTERVAL_HOURS=${CLEANUP_INTERVAL_HOURS:-24}
-      - ODYSSEUS_INPROCESS_POLLERS=${ODYSSEUS_INPROCESS_POLLERS:-1}
-      - ODYSSEUS_INPROCESS_TASKS=${ODYSSEUS_INPROCESS_TASKS:-1}
-      - ODYSSEUS_SCRIPT_HOST=${ODYSSEUS_SCRIPT_HOST:-localhost}
-      - ODYSSEUS_CHAT_UPLOAD_MAX_BYTES=${ODYSSEUS_CHAT_UPLOAD_MAX_BYTES:-10485760}
-      - ODYSSEUS_GALLERY_UPLOAD_MAX_BYTES=${ODYSSEUS_GALLERY_UPLOAD_MAX_BYTES:-104857600}
-      - ODYSSEUS_GALLERY_TRANSFORM_UPLOAD_MAX_BYTES=${ODYSSEUS_GALLERY_TRANSFORM_UPLOAD_MAX_BYTES:-26214400}
-      - ODYSSEUS_MEMORY_IMPORT_MAX_BYTES=${ODYSSEUS_MEMORY_IMPORT_MAX_BYTES:-10485760}
-      - ODYSSEUS_PERSONAL_UPLOAD_MAX_BYTES=${ODYSSEUS_PERSONAL_UPLOAD_MAX_BYTES:-26214400}
-      - ODYSSEUS_EMAIL_COMPOSE_UPLOAD_MAX_BYTES=${ODYSSEUS_EMAIL_COMPOSE_UPLOAD_MAX_BYTES:-26214400}
-      - ODYSSEUS_STT_MAX_AUDIO_BYTES=${ODYSSEUS_STT_MAX_AUDIO_BYTES:-26214400}
-      - ODYSSEUS_ICS_MAX_BYTES=${ODYSSEUS_ICS_MAX_BYTES:-10485760}
-      - ODYSSEUS_TTS_CACHE_MAX_BYTES=${ODYSSEUS_TTS_CACHE_MAX_BYTES}
-      - DATA_BRAVE_API_KEY=${DATA_BRAVE_API_KEY:-}
-      - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
-      - GOOGLE_PSE_CX=${GOOGLE_PSE_CX:-}
-      - GOOGLE_OAUTH_CLIENT_ID=${GOOGLE_OAUTH_CLIENT_ID:-}
-      - GOOGLE_OAUTH_CLIENT_SECRET=${GOOGLE_OAUTH_CLIENT_SECRET:-}
-      - GOOGLE_OAUTH_REDIRECT_URI=${GOOGLE_OAUTH_REDIRECT_URI:-}
-      # Externally reachable origin for MCP OAuth callbacks. The container
-      # always listens on 7000 and cannot see the host port map above, so
-      # remote MCP OAuth needs this set whenever the browser reaches
-      # Odysseus on anything other than http://localhost:7000.
-      - OAUTH_REDIRECT_BASE_URL=${OAUTH_REDIRECT_BASE_URL:-}
-      - TAVILY_API_KEY=${TAVILY_API_KEY:-}
-      - SERPER_API_KEY=${SERPER_API_KEY:-}
-      # PUID / PGID — the user/group the container drops to before
-      # running uvicorn (entrypoint also chowns /app/data + /app/logs
-      # to match, so bind-mounted files stay editable from the host).
-      # 1000 is the default first user on most Linux installs. If your
-      # host user has a different id, override here or via .env, e.g.:
-      #   PUID=1001
-      #   PGID=1001
-      # Find yours with:  id -u  /  id -g
-      - PUID=${PUID:-1000}
-      - PGID=${PGID:-1000}
-      # NVIDIA overlay (from docker/gpu.nvidia.yml).
-      - NVIDIA_VISIBLE_DEVICES=all
-      - NVIDIA_DRIVER_CAPABILITIES=compute,utility
+    - LLM_HOST=${LLM_HOST:-localhost}
+    - LLM_HOSTS=${LLM_HOSTS:-}
+    - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+    - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-}
+    - RESEARCH_LLM_ENDPOINT=${RESEARCH_LLM_ENDPOINT:-}
+    - HF_TOKEN=${HF_TOKEN:-}
+    - HUGGING_FACE_HUB_TOKEN=${HUGGING_FACE_HUB_TOKEN:-}
+    - SEARXNG_INSTANCE=http://searxng:8080
+    - CHROMADB_HOST=chromadb
+    - CHROMADB_PORT=8000
+    - DATABASE_URL=${DATABASE_URL:-sqlite:///./data/app.db}
+    - AUTH_ENABLED=${AUTH_ENABLED:-true}
+    - LOCALHOST_BYPASS=${LOCALHOST_BYPASS:-false}
+    - COMPANION_BASE_URL=${COMPANION_BASE_URL:-}
+    - ODYSSEUS_ADMIN_USER=${ODYSSEUS_ADMIN_USER:-admin}
+    - ODYSSEUS_ADMIN_PASSWORD=${ODYSSEUS_ADMIN_PASSWORD:-}
+    - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://localhost,http://127.0.0.1}
+    - SECURE_COOKIES=${SECURE_COOKIES:-}
+    - EMBEDDING_URL=${EMBEDDING_URL:-}
+    - EMBEDDING_MODEL=${EMBEDDING_MODEL:-}
+    - EMBEDDING_API_KEY=${EMBEDDING_API_KEY:-}
+    - FASTEMBED_MODEL=${FASTEMBED_MODEL:-sentence-transformers/all-MiniLM-L6-v2}
+    - FASTEMBED_CACHE_PATH=${FASTEMBED_CACHE_PATH:-}
+    - CLEANUP_INTERVAL_HOURS=${CLEANUP_INTERVAL_HOURS:-24}
+    - ODYSSEUS_INPROCESS_POLLERS=${ODYSSEUS_INPROCESS_POLLERS:-1}
+    - ODYSSEUS_INPROCESS_TASKS=${ODYSSEUS_INPROCESS_TASKS:-1}
+    - ODYSSEUS_SCRIPT_HOST=${ODYSSEUS_SCRIPT_HOST:-localhost}
+    - ODYSSEUS_CHAT_UPLOAD_MAX_BYTES=${ODYSSEUS_CHAT_UPLOAD_MAX_BYTES:-10485760}
+    - ODYSSEUS_GALLERY_UPLOAD_MAX_BYTES=${ODYSSEUS_GALLERY_UPLOAD_MAX_BYTES:-104857600}
+    - ODYSSEUS_GALLERY_TRANSFORM_UPLOAD_MAX_BYTES=${ODYSSEUS_GALLERY_TRANSFORM_UPLOAD_MAX_BYTES:-26214400}
+    - ODYSSEUS_MEMORY_IMPORT_MAX_BYTES=${ODYSSEUS_MEMORY_IMPORT_MAX_BYTES:-10485760}
+    - ODYSSEUS_PERSONAL_UPLOAD_MAX_BYTES=${ODYSSEUS_PERSONAL_UPLOAD_MAX_BYTES:-26214400}
+    - ODYSSEUS_EMAIL_COMPOSE_UPLOAD_MAX_BYTES=${ODYSSEUS_EMAIL_COMPOSE_UPLOAD_MAX_BYTES:-26214400}
+    - ODYSSEUS_STT_MAX_AUDIO_BYTES=${ODYSSEUS_STT_MAX_AUDIO_BYTES:-26214400}
+    - ODYSSEUS_ICS_MAX_BYTES=${ODYSSEUS_ICS_MAX_BYTES:-10485760}
+    - ODYSSEUS_TTS_CACHE_MAX_BYTES=${ODYSSEUS_TTS_CACHE_MAX_BYTES}
+    - DATA_BRAVE_API_KEY=${DATA_BRAVE_API_KEY:-}
+    - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
+    - GOOGLE_PSE_CX=${GOOGLE_PSE_CX:-}
+    - GOOGLE_OAUTH_CLIENT_ID=${GOOGLE_OAUTH_CLIENT_ID:-}
+    - GOOGLE_OAUTH_CLIENT_SECRET=${GOOGLE_OAUTH_CLIENT_SECRET:-}
+    - GOOGLE_OAUTH_REDIRECT_URI=${GOOGLE_OAUTH_REDIRECT_URI:-}
+    - MICROSOFT_OAUTH_CLIENT_ID=${MICROSOFT_OAUTH_CLIENT_ID:-}
+    - MICROSOFT_OAUTH_TENANT=${MICROSOFT_OAUTH_TENANT:-}
+    - OAUTH_REDIRECT_BASE_URL=${OAUTH_REDIRECT_BASE_URL:-}
+    - TAVILY_API_KEY=${TAVILY_API_KEY:-}
+    - SERPER_API_KEY=${SERPER_API_KEY:-}
+    - PUID=${PUID:-1000}
+    - PGID=${PGID:-1000}
+    - NVIDIA_VISIBLE_DEVICES=all
+    - NVIDIA_DRIVER_CAPABILITIES=compute,utility
     depends_on:
       searxng:
         condition: service_healthy
       chromadb:
         condition: service_started
     restart: unless-stopped
-    # NVIDIA overlay (from docker/gpu.nvidia.yml).
     deploy:
       resources:
         reservations:
           devices:
-            - driver: nvidia
-              count: all
-              capabilities: [gpu]
-
+          - driver: nvidia
+            count: all
+            capabilities:
+            - gpu
   chromadb:
     image: docker.io/chromadb/chroma:latest
     ports:
-      - "${CHROMADB_BIND:-127.0.0.1}:8100:8000"
+    - ${CHROMADB_BIND:-127.0.0.1}:8100:8000
     volumes:
-      - chromadb-data:/chroma/chroma
+    - chromadb-data:/chroma/chroma
     environment:
-      - ANONYMIZED_TELEMETRY=FALSE
+    - ANONYMIZED_TELEMETRY=FALSE
     restart: unless-stopped
-
   searxng:
-    # Pinned, not :latest — odysseus waits on searxng's healthcheck
-    # (depends_on: condition: service_healthy), so a broken upstream `latest`
-    # tag blocks the whole app from starting. 2026.6.2 crashes on boot with
-    # `KeyError: 'default_doi_resolver'`, failing the healthcheck (issue #1414).
-    # Bump this deliberately after verifying a newer tag boots clean.
     image: docker.io/searxng/searxng:2026.5.31-7159b8aed
     entrypoint:
-      - /bin/sh
-      - -c
-      - |
-        set -eu
-        if [ ! -s /etc/searxng/settings.yml ] || grep -q 'odysseus-local-searxng-json-2026-05-30\|__SEARXNG_SECRET__' /etc/searxng/settings.yml; then
-          secret="$${SEARXNG_SECRET:-}"
-          if [ -z "$$secret" ]; then
-            secret="$$(python -c 'import secrets; print(secrets.token_urlsafe(48))')"
-          fi
-          sed "s|__SEARXNG_SECRET__|$$secret|g" /tmp/searxng-settings.yml.template > /etc/searxng/settings.yml
-        fi
-        # Advisory: a settings file the migration cannot parse or rewrite must
-        # not be what stops searxng from booting. It explains itself on stderr
-        # and we carry on, letting searxng report anything genuinely wrong.
-        /usr/local/searxng/.venv/bin/python /tmp/migrate-searxng-settings.py /etc/searxng/settings.yml || true
-        exec /usr/local/searxng/entrypoint.sh
+    - /bin/sh
+    - -c
+    - "set -eu\nif [ ! -s /etc/searxng/settings.yml ] || grep -q 'odysseus-local-searxng-json-2026-05-30\\\
+      |__SEARXNG_SECRET__' /etc/searxng/settings.yml; then\n  secret=\"$${SEARXNG_SECRET:-}\"\n  if [\
+      \ -z \"$$secret\" ]; then\n    secret=\"$$(python -c 'import secrets; print(secrets.token_urlsafe(48))')\"\
+      \n  fi\n  sed \"s|__SEARXNG_SECRET__|$$secret|g\" /tmp/searxng-settings.yml.template > /etc/searxng/settings.yml\n\
+      fi\n# Advisory: a settings file the migration cannot parse or rewrite must\n# not be what stops\
+      \ searxng from booting. It explains itself on stderr\n# and we carry on, letting searxng report\
+      \ anything genuinely wrong.\n/usr/local/searxng/.venv/bin/python /tmp/migrate-searxng-settings.py\
+      \ /etc/searxng/settings.yml || true\nexec /usr/local/searxng/entrypoint.sh\n"
     ports:
-      - "127.0.0.1:8080:8080"
+    - 127.0.0.1:8080:8080
     volumes:
-      - searxng-data:/etc/searxng
-      - ./config/searxng/settings.yml:/tmp/searxng-settings.yml.template:ro,z
-      - ./scripts/migrate_searxng_settings.py:/tmp/migrate-searxng-settings.py:ro,z
+    - searxng-data:/etc/searxng
+    - ./config/searxng/settings.yml:/tmp/searxng-settings.yml.template:ro,z
+    - ./scripts/migrate_searxng_settings.py:/tmp/migrate-searxng-settings.py:ro,z
     environment:
-      - SEARXNG_BASE_URL=http://localhost:8080/
-      - SEARXNG_SECRET=${SEARXNG_SECRET:-}
-    # The official searxng image runs as the non-root `searxng` user, but its
-    # entrypoint still needs to chown /etc/searxng on first boot, drop privs via
-    # su-exec, and (with our wrapper above) write settings.yml into the named
-    # volume. Without these capabilities the wrapper aborts at the redirection
-    # with EACCES and the container fails its healthcheck with permission
-    # errors during setup. Mirrors the cap set recommended by the upstream
-    # searxng-docker compose file. See issue #721.
+    - SEARXNG_BASE_URL=http://localhost:8080/
+    - SEARXNG_SECRET=${SEARXNG_SECRET:-}
     cap_drop:
-      - ALL
+    - ALL
     cap_add:
-      - CHOWN
-      - SETGID
-      - SETUID
-      - DAC_OVERRIDE
+    - CHOWN
+    - SETGID
+    - SETUID
+    - DAC_OVERRIDE
     healthcheck:
-      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8080/', timeout=5).read(1)\""]
+      test:
+      - CMD-SHELL
+      - python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/', timeout=5).read(1)"
       interval: 5s
       timeout: 6s
       retries: 20
       start_period: 10s
     restart: unless-stopped
-
   ntfy:
     image: docker.io/binwiederhier/ntfy
     command: serve
     ports:
-      - "${NTFY_BIND:-127.0.0.1}:8091:80"
+    - ${NTFY_BIND:-127.0.0.1}:8091:80
     volumes:
-      - ntfy-cache:/var/cache/ntfy
+    - ntfy-cache:/var/cache/ntfy
     environment:
-      - NTFY_BASE_URL=${NTFY_BASE_URL:-http://localhost:8091}
+    - NTFY_BASE_URL=${NTFY_BASE_URL:-http://localhost:8091}
     restart: unless-stopped
-
 volumes:
-  searxng-data:
-  chromadb-data:
-  ntfy-cache:
+  searxng-data: null
+  chromadb-data: null
+  ntfy-cache: null

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,8 @@ services:
       - GOOGLE_OAUTH_CLIENT_ID=${GOOGLE_OAUTH_CLIENT_ID:-}
       - GOOGLE_OAUTH_CLIENT_SECRET=${GOOGLE_OAUTH_CLIENT_SECRET:-}
       - GOOGLE_OAUTH_REDIRECT_URI=${GOOGLE_OAUTH_REDIRECT_URI:-}
+      - MICROSOFT_OAUTH_CLIENT_ID=${MICROSOFT_OAUTH_CLIENT_ID:-}
+      - MICROSOFT_OAUTH_TENANT=${MICROSOFT_OAUTH_TENANT:-}
       # Externally reachable origin for MCP OAuth callbacks. The container
       # always listens on 7000 and cannot see the host port map above, so
       # remote MCP OAuth needs this set whenever the browser reaches

--- a/routes/email_helpers.py
+++ b/routes/email_helpers.py
@@ -150,6 +150,104 @@ def _get_valid_google_token(account_id: str, cfg: dict) -> str | None:
     return _refresh_google_token(account_id)
 
 
+# --- Microsoft / Office 365 OAuth (device flow + XOAUTH2) ------------------
+#
+# Microsoft removed basic auth for IMAP/SMTP on Exchange Online, so Outlook /
+# Office 365 mailboxes authenticate with OAuth2 XOAUTH2 exactly like Google.
+# The connect flow uses the device-code grant (no redirect URI / public
+# callback URL needed) — see routes/email_routes.py.
+
+_MS_IMAP_SCOPE = "https://outlook.office365.com/IMAP.AccessAsUser.All"
+_MS_SMTP_SCOPE = "https://outlook.office365.com/SMTP.Send"
+# openid/email/profile ride along so the ID token carries the signing user's
+# UPN (preferred_username), which the connect flow checks against the
+# configured IMAP username — same wrong-mailbox guard the Google flow uses.
+MICROSOFT_OAUTH_SCOPES = (
+    f"{_MS_IMAP_SCOPE} {_MS_SMTP_SCOPE} openid email profile offline_access"
+)
+
+
+def microsoft_oauth_tenant() -> str:
+    """Azure AD tenant for the OAuth endpoints.
+
+    'common' (work/school + personal), 'organizations' (work/school only),
+    'consumers' (personal only), or a specific tenant GUID.
+    """
+    return os.environ.get("MICROSOFT_OAUTH_TENANT", "").strip() or "common"
+
+
+def microsoft_oauth_configured() -> bool:
+    return bool(os.environ.get("MICROSOFT_OAUTH_CLIENT_ID", "").strip())
+
+
+def _microsoft_token_endpoint() -> str:
+    return (
+        "https://login.microsoftonline.com/"
+        f"{microsoft_oauth_tenant()}/oauth2/v2.0/token"
+    )
+
+
+def _refresh_microsoft_token(account_id: str) -> str | None:
+    """Exchange the stored refresh token for a new access token and persist it.
+
+    The v2 endpoint rotates refresh tokens; when the response carries a new
+    one it replaces the stored token so the grant chain never expires out
+    from under a long-lived account row.
+    """
+    import httpx
+    from core.database import SessionLocal as _SL, EmailAccount as _EA
+    from src.secret_storage import encrypt as _enc, decrypt as _dec
+    client_id = os.environ.get("MICROSOFT_OAUTH_CLIENT_ID", "").strip()
+    if not client_id:
+        return None
+    db = _SL()
+    try:
+        row = db.get(_EA, account_id)
+        if not row or row.oauth_provider != "microsoft" or not row.oauth_refresh_token:
+            return None
+        refresh_token = _dec(row.oauth_refresh_token or "")
+        if not refresh_token:
+            return None
+        resp = httpx.post(
+            _microsoft_token_endpoint(),
+            data={
+                "client_id": client_id,
+                "refresh_token": refresh_token,
+                "grant_type": "refresh_token",
+                "scope": MICROSOFT_OAUTH_SCOPES,
+            },
+            timeout=10,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        access_token = data["access_token"]
+        row.oauth_access_token = _enc(access_token)
+        if data.get("refresh_token"):
+            row.oauth_refresh_token = _enc(data["refresh_token"])
+        row.oauth_token_expiry = str(int(time.time()) + data.get("expires_in", 3600))
+        db.commit()
+        return access_token
+    except Exception:
+        logger.warning(f"Microsoft token refresh failed for account {account_id}")
+        return None
+    finally:
+        db.close()
+
+
+def _get_valid_microsoft_token(account_id: str, cfg: dict) -> str | None:
+    """Return a valid Microsoft access token, refreshing if expired or missing."""
+    from src.secret_storage import decrypt as _dec
+    access_token = _dec(cfg.get("oauth_access_token") or "")
+    expiry_str = cfg.get("oauth_token_expiry") or ""
+    if access_token and expiry_str:
+        try:
+            if int(expiry_str) - 60 > time.time():
+                return access_token
+        except (ValueError, TypeError):
+            pass
+    return _refresh_microsoft_token(account_id)
+
+
 def _smtp_security_mode(cfg: dict) -> str:
     raw = str(cfg.get("smtp_security") or "").strip().lower()
     if raw in {"ssl", "starttls", "none"}:
@@ -168,10 +266,17 @@ def _send_smtp_message(cfg: dict, from_addr: str, recipients: list[str], message
     password = cfg.get("smtp_password") or ""
 
     def _auth_smtp(smtp):
-        if cfg.get("oauth_provider") == "google":
+        oauth_provider = cfg.get("oauth_provider")
+        if oauth_provider == "google":
             token = _get_valid_google_token(cfg.get("account_id"), cfg)
             if not token:
                 raise RuntimeError("Google OAuth token unavailable — reconnect the account")
+            smtp.ehlo()
+            smtp.auth("XOAUTH2", lambda challenge=None: _xoauth2_raw(user, token), initial_response_ok=True)
+        elif oauth_provider == "microsoft":
+            token = _get_valid_microsoft_token(cfg.get("account_id"), cfg)
+            if not token:
+                raise RuntimeError("Microsoft OAuth token unavailable — reconnect the account")
             smtp.ehlo()
             smtp.auth("XOAUTH2", lambda challenge=None: _xoauth2_raw(user, token), initial_response_ok=True)
         elif user and password:
@@ -1232,6 +1337,11 @@ def _imap_connect(account_id: str | None = None, owner: str = "",
             token = _get_valid_google_token(cfg.get("account_id"), cfg)
             if not token:
                 raise RuntimeError("Google OAuth token unavailable — reconnect the account in Settings → Integrations")
+            conn.authenticate("XOAUTH2", lambda x: _xoauth2_bytes(cfg["imap_user"], token))
+        elif cfg.get("oauth_provider") == "microsoft":
+            token = _get_valid_microsoft_token(cfg.get("account_id"), cfg)
+            if not token:
+                raise RuntimeError("Microsoft OAuth token unavailable — reconnect the account in Settings → Integrations")
             conn.authenticate("XOAUTH2", lambda x: _xoauth2_bytes(cfg["imap_user"], token))
         else:
             conn.login(cfg["imap_user"], cfg["imap_password"])

--- a/routes/email_routes.py
+++ b/routes/email_routes.py
@@ -43,6 +43,13 @@ from src.constants import DATA_DIR
 from src.llm_core import llm_call_async
 from src.upload_limits import read_upload_limited, EMAIL_COMPOSE_UPLOAD_MAX_BYTES
 
+from routes.device_flow import (
+    DeviceFlowPoll,
+    DeviceFlowStart,
+    PendingDeviceFlowStore,
+    create_device_flow_router,
+)
+from src.auth_helpers import get_current_user
 from routes.email_helpers import (
     _strip_think, _extract_reply, _apply_email_style_mechanics, require_owner, require_user, _assert_owns_account,
     _account_visible_to_owner,
@@ -50,8 +57,10 @@ from routes.email_helpers import (
     _load_settings, _save_settings, _get_email_config,
     _send_smtp_message, _smtp_security_mode,
     _IMAP_TIMEOUT_SECONDS, _open_imap_connection,
-    _get_valid_google_token, _xoauth2_bytes, _xoauth2_raw,
+    _get_valid_google_token, _get_valid_microsoft_token, _xoauth2_bytes, _xoauth2_raw,
     make_oauth_state, verify_oauth_state,
+    microsoft_oauth_configured, microsoft_oauth_tenant, _microsoft_token_endpoint,
+    MICROSOFT_OAUTH_SCOPES,
     EmailNotConfiguredError,
     _imap_connect, _imap, _decode_header, _detect_sent_folder, _detect_drafts_folder,
     _extract_attachment_text, _list_attachments_from_msg, _has_visible_attachments, _is_likely_signature_image_attachment,
@@ -72,6 +81,8 @@ ODYSSEUS_MAIL_ORIGIN = "odysseus-ui"
 EMAIL_READ_ATTACHMENT_VERSION = 2
 _GOOGLE_OAUTH_IMAP_HOST = "imap.gmail.com"
 _GOOGLE_OAUTH_SMTP_HOST = "smtp.gmail.com"
+_MICROSOFT_OAUTH_IMAP_HOSTS = {"outlook.office365.com"}
+_MICROSOFT_OAUTH_SMTP_HOSTS = {"smtp.office365.com"}
 _SERVER_OWNED_OAUTH_FIELDS = {
     "oauth_provider",
     "oauth_access_token",
@@ -91,6 +102,16 @@ def _google_oauth_imap_transport_allowed(port: int, starttls: bool) -> bool:
 
 def _google_oauth_smtp_transport_allowed(port: int, security: str) -> bool:
     return (port == 465 and security == "ssl") or (port == 587 and security == "starttls")
+
+
+def _microsoft_oauth_imap_transport_allowed(port: int, starttls: bool) -> bool:
+    # Exchange Online IMAP: implicit TLS on 993 (standard) or STARTTLS on 143.
+    return (port == 993 and not starttls) or (port == 143 and starttls)
+
+
+def _microsoft_oauth_smtp_transport_allowed(port: int, security: str) -> bool:
+    # Exchange Online SMTP client submission: STARTTLS on 587 only.
+    return port == 587 and security == "starttls"
 
 def _email_style_key(account_id: str | None) -> str:
     return str(account_id or "").strip()
@@ -5867,14 +5888,30 @@ def setup_email_routes():
                 raise RuntimeError("Google OAuth token unavailable — reconnect the account")
             return google_token
 
+        microsoft_token = None
+        microsoft_token_loaded = False
+
+        def _ms_token():
+            nonlocal microsoft_token, microsoft_token_loaded
+            if not microsoft_token_loaded:
+                microsoft_token = _get_valid_microsoft_token(body.get("account_id"), body)
+                microsoft_token_loaded = True
+            if not microsoft_token:
+                raise RuntimeError("Microsoft OAuth token unavailable — reconnect the account")
+            return microsoft_token
+
         if imap_port_err:
             imap_result = {"ok": False, "error": imap_port_err}
-        elif not (imap_host and imap_user and (imap_pass or oauth_provider == "google")):
+        elif not (imap_host and imap_user and (imap_pass or oauth_provider in ("google", "microsoft"))):
             imap_result = {"ok": False, "error": "Need IMAP host, username, and password"}
         elif oauth_provider == "google" and _normalized_mail_host(imap_host) != _GOOGLE_OAUTH_IMAP_HOST:
             imap_result = {"ok": False, "error": "Google OAuth IMAP requires imap.gmail.com"}
         elif oauth_provider == "google" and not _google_oauth_imap_transport_allowed(imap_port, imap_starttls):
             imap_result = {"ok": False, "error": "Google OAuth IMAP requires TLS on port 993 or STARTTLS on port 143"}
+        elif oauth_provider == "microsoft" and _normalized_mail_host(imap_host) not in _MICROSOFT_OAUTH_IMAP_HOSTS:
+            imap_result = {"ok": False, "error": "Microsoft OAuth IMAP requires outlook.office365.com"}
+        elif oauth_provider == "microsoft" and not _microsoft_oauth_imap_transport_allowed(imap_port, imap_starttls):
+            imap_result = {"ok": False, "error": "Microsoft OAuth IMAP requires TLS on port 993 or STARTTLS on port 143"}
         else:
             # Connection mode resolution:
             #   STARTTLS on  → plain IMAP4 + .starttls() (upgrade)
@@ -5899,6 +5936,9 @@ def setup_email_routes():
                     if oauth_provider == "google":
                         token = _google_token()
                         conn.authenticate("XOAUTH2", lambda x: _xoauth2_bytes(imap_user, token))
+                    elif oauth_provider == "microsoft":
+                        token = _ms_token()
+                        conn.authenticate("XOAUTH2", lambda x: _xoauth2_bytes(imap_user, token))
                     else:
                         conn.login(imap_user, imap_pass)
                     imap_result = {"ok": True}
@@ -5914,6 +5954,17 @@ def setup_email_routes():
             smtp_result = {"ok": False, "error": smtp_port_err}
         elif oauth_provider == "google" and smtp_host and _normalized_mail_host(smtp_host) != _GOOGLE_OAUTH_SMTP_HOST:
             smtp_result = {"ok": False, "error": "Google OAuth SMTP requires smtp.gmail.com"}
+        elif oauth_provider == "microsoft" and smtp_host and _normalized_mail_host(smtp_host) not in _MICROSOFT_OAUTH_SMTP_HOSTS:
+            smtp_result = {"ok": False, "error": "Microsoft OAuth SMTP requires smtp.office365.com"}
+        elif (
+            oauth_provider == "microsoft"
+            and smtp_host
+            and not _microsoft_oauth_smtp_transport_allowed(
+                smtp_port,
+                _smtp_security_mode({"smtp_security": body.get("smtp_security"), "smtp_port": smtp_port}),
+            )
+        ):
+            smtp_result = {"ok": False, "error": "Microsoft OAuth SMTP requires STARTTLS on port 587"}
         elif (
             oauth_provider == "google"
             and smtp_host
@@ -5960,6 +6011,10 @@ def setup_email_routes():
                             raise
                 if oauth_provider == "google":
                     token = _google_token()
+                    smtp.ehlo()
+                    smtp.auth("XOAUTH2", lambda challenge=None: _xoauth2_raw(smtp_user, token), initial_response_ok=True)
+                elif oauth_provider == "microsoft":
+                    token = _ms_token()
                     smtp.ehlo()
                     smtp.auth("XOAUTH2", lambda challenge=None: _xoauth2_raw(smtp_user, token), initial_response_ok=True)
                 else:
@@ -6148,5 +6203,196 @@ def setup_email_routes():
         finally:
             db.close()
         return _RR("/?section=integrations&email_oauth_success=1")
+
+    # ── Microsoft OAuth2 (device-code flow) ──────────────────────────────
+    # Microsoft removed basic auth for IMAP/SMTP on Exchange Online, so
+    # Outlook / Office 365 accounts connect with OAuth2 XOAUTH2. The
+    # device-code grant keeps Odysseus free of redirect URIs and public
+    # callback URLs: the user proves identity at microsoft.com/devicelogin
+    # with a short code, we poll for tokens, then persist them (encrypted)
+    # on the account row — mirroring the Google flow's ownership guards.
+
+    def _ms_id_token_identity(id_token: str) -> str:
+        """Best-effort mailbox identity from an ID token.
+
+        The token arrives directly from the token endpoint over TLS (not via
+        the browser), so decoding the claims without signature verification
+        carries the same trust level as the access token beside it.
+
+        UPN (preferred_username) is preferred over the `email` claim: with a
+        multi-tenant app, `email` is an unverified claim a foreign tenant can
+        set to a victim address (the "nOAuth" attack) — prefer the UPN, which
+        always identifies the signing user inside the issuing tenant.
+        """
+        import base64
+        import json as _json
+        try:
+            payload = id_token.split(".")[1]
+            payload += "=" * (-len(payload) % 4)
+            claims = _json.loads(base64.urlsafe_b64decode(payload))
+            return str(
+                claims.get("preferred_username")
+                or claims.get("upn")
+                or claims.get("email")
+                or ""
+            ).strip()
+        except Exception:
+            return ""
+
+    def _ms_require_account(account_id: str, owner: str):
+        from core.database import SessionLocal, EmailAccount
+        if not account_id:
+            raise HTTPException(404, "Email account not found — save it first")
+        db = SessionLocal()
+        try:
+            row = db.query(EmailAccount).filter(EmailAccount.id == account_id).first()
+            if not row:
+                raise HTTPException(404, "Email account not found — save it first")
+            # SECURITY: same ownership model as the Google callback — the
+            # device flow may only attach credentials to the initiator's row.
+            if owner and row.owner and row.owner != owner:
+                raise HTTPException(403, "This email account belongs to another user")
+            return row
+        finally:
+            db.close()
+
+    async def _start_ms_device_flow(request, form) -> "DeviceFlowStart":
+        import httpx
+        if not microsoft_oauth_configured():
+            raise HTTPException(
+                400,
+                "MICROSOFT_OAUTH_CLIENT_ID is not configured — register an Azure "
+                "app registration (public client with device-code allowed) and "
+                "set the env var, then retry",
+            )
+        account_id = str(form.get("account_id") or "").strip()
+        owner = get_current_user(request) or None
+        _ms_require_account(account_id, owner or "")
+        client_id = os.environ.get("MICROSOFT_OAUTH_CLIENT_ID", "").strip()
+        try:
+            resp = httpx.post(
+                f"https://login.microsoftonline.com/{microsoft_oauth_tenant()}/oauth2/v2.0/devicecode",
+                data={"client_id": client_id, "scope": MICROSOFT_OAUTH_SCOPES},
+                timeout=10,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except httpx.HTTPStatusError as e:
+            status = e.response.status_code if e.response is not None else "unknown"
+            raise HTTPException(502, f"Microsoft device-code request failed (HTTP {status})")
+        except Exception as e:
+            raise HTTPException(502, f"Microsoft device-code request failed: {e}")
+        if not data.get("device_code"):
+            raise HTTPException(502, "Microsoft did not return a device code")
+        return DeviceFlowStart(
+            pending={
+                "device_code": data["device_code"],
+                "account_id": account_id,
+                "owner": owner,
+            },
+            response={
+                "user_code": data.get("user_code"),
+                "verification_uri": data.get("verification_uri"),
+                "verification_uri_complete": data.get("verification_uri_complete"),
+                "message": data.get("message"),
+            },
+            interval=int(data.get("interval") or 5),
+            expires_in=int(data.get("expires_in") or 900),
+        )
+
+    async def _poll_ms_device_flow(_request, pending) -> "DeviceFlowPoll":
+        import httpx
+        from core.database import SessionLocal, EmailAccount
+        from src.secret_storage import encrypt as _enc
+        account_id = pending.get("account_id") or ""
+        owner = pending.get("owner") or ""
+        client_id = os.environ.get("MICROSOFT_OAUTH_CLIENT_ID", "").strip()
+        try:
+            resp = httpx.post(
+                _microsoft_token_endpoint(),
+                data={
+                    "client_id": client_id,
+                    "device_code": pending.get("device_code") or "",
+                    "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                    "scope": MICROSOFT_OAUTH_SCOPES,
+                },
+                timeout=10,
+            )
+        except Exception as e:
+            return DeviceFlowPoll.pending(f"poll error: {e}")
+        try:
+            data = resp.json()
+        except Exception:
+            data = {}
+
+        access_token = data.get("access_token")
+        if resp.is_success and access_token:
+            refresh_token = data.get("refresh_token") or ""
+            if not refresh_token:
+                return DeviceFlowPoll.failed(
+                    "Microsoft omitted the offline refresh token — retry the sign-in"
+                )
+            identity = _ms_id_token_identity(data.get("id_token") or "")
+            db = SessionLocal()
+            try:
+                row = db.query(EmailAccount).filter(EmailAccount.id == account_id).first()
+                if not row:
+                    return DeviceFlowPoll.failed("Email account disappeared — save it and retry")
+                if owner and row.owner and row.owner != owner:
+                    return DeviceFlowPoll.failed("This email account belongs to another user")
+                # SECURITY: a reconnect must prove the token belongs to the
+                # mailbox configured on this row (mirrors the Google flow) —
+                # otherwise authorizing a different Microsoft account pairs
+                # another identity's credentials with our usernames.
+                verified = identity.strip().casefold()
+                if not verified:
+                    return DeviceFlowPoll.failed(
+                        "Could not determine the authorized mailbox — retry the sign-in"
+                    )
+                # First-time connect with no username typed: adopt the identity.
+                if not (row.imap_user or "").strip():
+                    row.imap_user = identity
+                if not (row.smtp_user or "").strip():
+                    row.smtp_user = identity
+                configured_logins = {
+                    value.strip().casefold()
+                    for value in (row.imap_user or "", row.smtp_user or "")
+                    if value.strip()
+                }
+                if verified not in configured_logins:
+                    return DeviceFlowPoll.failed(
+                        f"Authorized as {identity} but this mailbox is configured "
+                        f"for {row.imap_user or 'a different user'} — update the "
+                        "Username field to match and retry"
+                    )
+                row.oauth_provider = "microsoft"
+                row.oauth_access_token = _enc(access_token)
+                row.oauth_refresh_token = _enc(refresh_token)
+                row.oauth_token_expiry = str(int(time.time()) + data.get("expires_in", 3600))
+                db.commit()
+            finally:
+                db.close()
+            return DeviceFlowPoll.authorized(
+                {"account_id": account_id, "email": identity}
+            )
+
+        err = data.get("error")
+        if err == "authorization_pending":
+            return DeviceFlowPoll.pending()
+        if err == "slow_down":
+            return DeviceFlowPoll.slow_down(int(data.get("interval") or 0) or None)
+        if err in ("expired_token", "access_denied", "authorization_declined"):
+            return DeviceFlowPoll.failed(err)
+        return DeviceFlowPoll.pending(err or f"HTTP {resp.status_code}")
+
+    router.include_router(
+        create_device_flow_router(
+            prefix="/oauth/microsoft",
+            tags=["email"],
+            store=PendingDeviceFlowStore(),
+            start_flow=_start_ms_device_flow,
+            poll_flow=_poll_ms_device_flow,
+        )
+    )
 
     return router

--- a/static/index.html
+++ b/static/index.html
@@ -2581,7 +2581,7 @@
 <script type="module" src="/static/js/search-chat.js"></script>
 <script type="module" src="/static/js/theme.js"></script>
 <script type="module" src="/static/js/censor.js"></script>
-<script type="module" src="/static/js/settings.js?v=20260815approvalsave1"></script>
+<script type="module" src="/static/js/settings.js?v=20260820msmail2"></script>
 <script type="module" src="/static/js/assistant.js"></script>
 <script type="module" src="/static/app.js?v=20260815toolapproval4"></script>  <!-- app.js must be LAST -->
   <script type="module" src="/static/js/init.js?v=20260715freshroot3"></script>

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -2263,7 +2263,7 @@ async function initReminderSettings() {
   const smtpAccountReady = (account) => !!(
     account.smtp_host
     && account.smtp_user
-    && (account.has_smtp_password || account.oauth_provider === 'google')
+    && (account.has_smtp_password || account.oauth_provider === 'google' || account.oauth_provider === 'microsoft')
   );
   try {
     const res = await fetch('/api/email/accounts', { credentials: 'same-origin' });
@@ -2771,7 +2771,7 @@ async function initEmailAccountsSettings() {
       google_workspace:  { label: 'Google Workspace / .edu',   imap: { host: 'imap.gmail.com',        port: 993, starttls: false }, smtp: { host: 'smtp.gmail.com',        port: 587 }, oauth: 'google' },
       migadu:            { label: 'Migadu',                     imap: { host: 'imap.migadu.com',       port: 993, starttls: false }, smtp: { host: 'smtp.migadu.com',       port: 465 } },
       icloud:            { label: 'iCloud',                     imap: { host: 'imap.mail.me.com',      port: 993, starttls: false }, smtp: { host: 'smtp.mail.me.com',      port: 587 } },
-      outlook:           { label: 'Outlook / Office 365',       imap: { host: 'outlook.office365.com', port: 993, starttls: false }, smtp: { host: 'smtp.office365.com',    port: 587 } },
+      outlook:           { label: 'Outlook / Office 365',       imap: { host: 'outlook.office365.com', port: 993, starttls: false }, smtp: { host: 'smtp.office365.com',    port: 587 }, oauth: 'microsoft' },
       fastmail:          { label: 'Fastmail',                   imap: { host: 'imap.fastmail.com',     port: 993, starttls: false }, smtp: { host: 'smtp.fastmail.com',     port: 465 } },
       yahoo:             { label: 'Yahoo',                      imap: { host: 'imap.mail.yahoo.com',   port: 993, starttls: false }, smtp: { host: 'smtp.mail.yahoo.com',   port: 465 } },
       dovecot:           { label: 'Dovecot IMAP (no SMTP)',     imap: { host: '',                      port: 31143, starttls: false }, smtp: { host: '',                     port: 465 } },
@@ -2789,9 +2789,10 @@ async function initEmailAccountsSettings() {
         <div class="settings-row"><label class="settings-label">Email${_hint('Your email address. Used as the From: header on outgoing mail and as the display label when Name is blank.')}</label><input id="eaf-from" class="settings-input" placeholder="you@example.com" value="${esc(a.from_address || '')}"></div>
         <div class="settings-row"><label class="settings-label">Display Name${_hint('Your name as it appears in the From: field of emails you send, e.g. Jane Smith. Auto-filled from Google during OAuth.')}</label><input id="eaf-display-name" class="settings-input" placeholder="Your Name" value="${esc(a.display_name || '')}"></div>
         <div id="eaf-oauth-section" style="display:none;margin:8px 0;padding:10px;border:1px solid var(--border);border-radius:6px;background:color-mix(in srgb,var(--accent,#50fa7b) 6%,transparent)">
-          <div style="font-size:11px;font-weight:600;margin-bottom:6px">Google OAuth2 — required for Workspace / .edu accounts</div>
-          <div id="eaf-oauth-status" style="font-size:11px;opacity:0.7;margin-bottom:6px">${a.oauth_provider === 'google' ? '✓ Connected via Google OAuth' : 'Not connected — click below to authorize'}</div>
-          <button type="button" id="eaf-oauth-btn" class="admin-btn-add" style="font-size:11px">${a.oauth_provider === 'google' ? 'Reconnect with Google' : 'Connect with Google'}</button>
+          <div id="eaf-oauth-title" style="font-size:11px;font-weight:600;margin-bottom:6px">OAuth2</div>
+          <div id="eaf-oauth-status" style="font-size:11px;opacity:0.7;margin-bottom:6px">Not connected — click below to sign in</div>
+          <button type="button" id="eaf-oauth-btn" class="admin-btn-add" style="font-size:11px">Connect</button>
+          <div id="eaf-oauth-device" style="display:none;font-size:11px;line-height:1.6;margin-top:8px;padding-top:8px;border-top:1px dashed var(--border)"></div>
         </div>
         <div style="font-size:11px;font-weight:600;opacity:0.6;margin:6px 0 2px">IMAP (Receiving)</div>
         <div class="settings-row"><label class="settings-label">Host${_hint('Your IMAP server, e.g. imap.gmail.com, imap.migadu.com, a LAN host, or a Tailscale IP for Dovecot.')}</label><input id="eaf-imap-host" class="settings-input" value="${esc(a.imap_host || '')}"></div>
@@ -2821,9 +2822,20 @@ async function initEmailAccountsSettings() {
     `;
 
     // Show/hide OAuth section and password fields based on provider selection.
+    const _OAUTH_PROVIDERS = {
+      google:    { title: 'Google OAuth2 — required for Workspace / .edu accounts', connect: 'Connect with Google',    reconnect: 'Reconnect with Google',    connected: '✓ Connected via Google OAuth' },
+      microsoft: { title: 'Microsoft OAuth2 — required for Outlook / Office 365',   connect: 'Sign in with Microsoft', reconnect: 'Reconnect with Microsoft', connected: '✓ Connected via Microsoft OAuth' },
+    };
     function _syncOauthUI(providerKey) {
       const p = PROVIDERS[providerKey];
       const isOauth = !!(p && p.oauth);
+      if (isOauth) {
+        const meta = _OAUTH_PROVIDERS[p.oauth];
+        el('eaf-oauth-title').textContent = meta.title;
+        const connected = a.oauth_provider === p.oauth;
+        el('eaf-oauth-status').textContent = connected ? meta.connected : 'Not connected — click below to sign in';
+        el('eaf-oauth-btn').textContent = connected ? meta.reconnect : meta.connect;
+      }
       el('eaf-oauth-section').style.display = isOauth ? '' : 'none';
       formEl.querySelectorAll('.eaf-password-section').forEach(r => {
         r.style.display = isOauth ? 'none' : '';
@@ -2832,8 +2844,8 @@ async function initEmailAccountsSettings() {
 
     const eafProviderNotes = {
       outlook: {
-        title: 'Outlook / Office 365 needs OAuth',
-        body: 'Microsoft disables normal password login for IMAP/SMTP in most Outlook and Microsoft 365 accounts. Odysseus does not support Microsoft OAuth/Graph mail yet, so this preset is only a placeholder for future support.',
+        title: 'Outlook / Office 365 uses Microsoft sign-in',
+        body: 'Microsoft disables normal password login for IMAP/SMTP. Use "Sign in with Microsoft" below — a short code is confirmed at microsoft.com/devicelogin. Requires MICROSOFT_OAUTH_CLIENT_ID to be configured by the admin.',
       },
     };
     const eafNoteEl = el('eaf-provider-note');
@@ -2866,9 +2878,83 @@ async function initEmailAccountsSettings() {
 
     // Init OAuth UI for accounts already connected via OAuth.
     if (a.oauth_provider === 'google') _syncOauthUI('google_workspace');
+    else if (a.oauth_provider === 'microsoft') _syncOauthUI('outlook');
 
-    // "Connect with Google" button — save the account first, then redirect to OAuth.
+    // "Connect with Google" / "Sign in with Microsoft" — save the account
+    // first, then redirect to Google OAuth or run the Microsoft device-code
+    // flow inline (no redirect URI needed).
+    async function _runMsDeviceFlow(accId) {
+      const box = el('eaf-oauth-device');
+      const status = el('eaf-oauth-status');
+      const btn = el('eaf-oauth-btn');
+      btn.disabled = true;
+      box.style.display = '';
+      box.innerHTML = 'Starting Microsoft sign-in…';
+      try {
+        const r = await fetch('/api/email/oauth/microsoft/device/start', {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: `account_id=${encodeURIComponent(accId)}`,
+        });
+        const d = await r.json().catch(() => ({}));
+        if (!r.ok || !d.poll_id) {
+          box.innerHTML = `<span style="color:var(--red)">${esc(d.detail || d.error || 'Failed to start Microsoft sign-in')}</span>`;
+          btn.disabled = false;
+          return;
+        }
+        const link = d.verification_uri_complete || d.verification_uri || 'https://microsoft.com/devicelogin';
+        const code = d.user_code || '';
+        box.innerHTML =
+          `<div style="margin-bottom:4px">1. Open <a href="${esc(link)}" target="_blank" rel="noopener">${esc(link)}</a> and sign in with ${esc(el('eaf-imap-user').value.trim() || 'your Microsoft account')}</div>` +
+          (d.verification_uri_complete ? '' : `<div style="margin-bottom:4px">2. Enter this code: <b style="letter-spacing:1px">${esc(code)}</b></div>`) +
+          `<div id="eaf-oauth-poll" style="opacity:0.7">Waiting for authorization…</div>`;
+        const intervalMs = Math.max(parseInt(d.interval || 5, 10), 2) * 1000;
+        const deadline = Date.now() + (parseInt(d.expires_in || 900, 10) * 1000);
+        const poll = async () => {
+          if (Date.now() > deadline) {
+            status.textContent = 'Microsoft sign-in timed out — try again';
+            box.innerHTML = '';
+            btn.disabled = false;
+            return;
+          }
+          let pd = null;
+          try {
+            const res = await fetch('/api/email/oauth/microsoft/device/poll', {
+              method: 'POST',
+              credentials: 'same-origin',
+              headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+              body: `poll_id=${encodeURIComponent(d.poll_id)}`,
+            });
+            pd = await res.json().catch(() => ({}));
+          } catch (err) { /* transient network error — keep polling */ }
+          if (pd && pd.status === 'authorized') {
+            status.textContent = '✓ Connected via Microsoft OAuth' + (pd.endpoint && pd.endpoint.email ? ` (${pd.endpoint.email})` : '');
+            box.innerHTML = '<span style="color:var(--accent,#50fa7b)">Connected — you can close this panel.</span>';
+            btn.disabled = false;
+            btn.textContent = 'Reconnect with Microsoft';
+            return;
+          }
+          if (pd && pd.status === 'failed') {
+            status.textContent = '';
+            box.innerHTML = `<span style="color:var(--red)">Microsoft sign-in failed: ${esc(pd.error || 'denied')}</span>`;
+            btn.disabled = false;
+            return;
+          }
+          const pollEl = box.querySelector('#eaf-oauth-poll');
+          if (pollEl) pollEl.textContent = (pd && pd.detail) ? pd.detail : 'Waiting for authorization…';
+          setTimeout(poll, intervalMs);
+        };
+        setTimeout(poll, intervalMs);
+      } catch (e) {
+        box.innerHTML = `<span style="color:var(--red)">${esc(String(e))}</span>`;
+        btn.disabled = false;
+      }
+    }
+
     el('eaf-oauth-btn').addEventListener('click', async () => {
+      const p = PROVIDERS[el('eaf-provider').value];
+      if (!p || !p.oauth) return;
       // Must save the account first to get an account_id to pass to the OAuth flow.
       const body = {
         name: el('eaf-name').value.trim() || el('eaf-from').value.trim(),
@@ -2890,7 +2976,11 @@ async function initEmailAccountsSettings() {
       const d = await r.json();
       if (!d.ok) { el('eaf-msg').textContent = d.error || 'Save failed'; el('eaf-msg').style.color = 'var(--red)'; return; }
       const accId = isEdit ? a.id : d.id;
-      window.location.href = `/api/email/oauth/google/authorize?account_id=${encodeURIComponent(accId)}`;
+      if (p.oauth === 'google') {
+        window.location.href = `/api/email/oauth/google/authorize?account_id=${encodeURIComponent(accId)}`;
+      } else if (p.oauth === 'microsoft') {
+        await _runMsDeviceFlow(accId);
+      }
     });
     el('eaf-smtp-security').value = _smtpSecurity(a);
 
@@ -4251,7 +4341,7 @@ async function initUnifiedIntegrations() {
       google_workspace: { label: 'Google Workspace / .edu', emailEx: 'you@yourschool.edu', imap: { host: 'imap.gmail.com', port: 993, starttls: false }, smtp: { host: 'smtp.gmail.com', port: 587 }, oauth: 'google' },
       migadu:   { label: 'Migadu',                  emailEx: 'you@yourdomain.com', imap: { host: 'imap.migadu.com',          port: 993, starttls: false }, smtp: { host: 'smtp.migadu.com',    port: 465 } },
       icloud:   { label: 'iCloud',                  emailEx: 'you@icloud.com',    imap: { host: 'imap.mail.me.com',         port: 993, starttls: false }, smtp: { host: 'smtp.mail.me.com',   port: 587 } },
-      outlook:  { label: 'Outlook / Office 365',    emailEx: 'you@outlook.com',   imap: { host: 'outlook.office365.com',    port: 993, starttls: false }, smtp: { host: 'smtp.office365.com', port: 587 } },
+      outlook:  { label: 'Outlook / Office 365',    emailEx: 'you@outlook.com',   imap: { host: 'outlook.office365.com',    port: 993, starttls: false }, smtp: { host: 'smtp.office365.com', port: 587 }, oauth: 'microsoft' },
       fastmail: { label: 'Fastmail',                emailEx: 'you@fastmail.com',  imap: { host: 'imap.fastmail.com',        port: 993, starttls: false }, smtp: { host: 'smtp.fastmail.com',  port: 465 } },
       yahoo:    { label: 'Yahoo',                   emailEx: 'you@yahoo.com',     imap: { host: 'imap.mail.yahoo.com',      port: 993, starttls: false }, smtp: { host: 'smtp.mail.yahoo.com', port: 465 } },
       dovecot:  { label: 'Dovecot IMAP (no SMTP)',  emailEx: 'you@example.com',   imap: { host: '',                         port: 31143, starttls: false }, smtp: { host: '',                   port: 465 } },
@@ -4297,9 +4387,10 @@ async function initUnifiedIntegrations() {
           <div class="settings-row"><label class="settings-label">Email${_hint('Your email address. Used as the From: header on outgoing mail and as the display label when Name is blank.')}</label><input id="uf-email-from" class="settings-input" placeholder="you@example.com"></div>
           <div class="settings-row"><label class="settings-label">Display Name${_hint('Your name as it appears in the From: field of emails you send, e.g. Jane Smith. Auto-filled from Google during OAuth.')}</label><input id="uf-display-name" class="settings-input" placeholder="Your Name"></div>
           <div id="uf-oauth-section" style="display:none;margin:8px 0;padding:10px;border:1px solid var(--border);border-radius:6px;background:color-mix(in srgb,var(--accent,#50fa7b) 6%,transparent)">
-            <div style="font-size:11px;font-weight:600;margin-bottom:6px">Google OAuth2 — required for Workspace / .edu accounts</div>
-            <div id="uf-oauth-status" style="font-size:11px;opacity:0.7;margin-bottom:6px">${existing && existing.oauth_provider === 'google' ? '✓ Connected via Google OAuth' : 'Not connected — click below to authorize'}</div>
-            <button type="button" id="uf-oauth-btn" class="admin-btn-add" style="font-size:11px">${existing && existing.oauth_provider === 'google' ? 'Reconnect with Google' : 'Connect with Google'}</button>
+            <div id="uf-oauth-title" style="font-size:11px;font-weight:600;margin-bottom:6px">OAuth2</div>
+            <div id="uf-oauth-status" style="font-size:11px;opacity:0.7;margin-bottom:6px">Not connected — click below to sign in</div>
+            <button type="button" id="uf-oauth-btn" class="admin-btn-add" style="font-size:11px">Connect</button>
+            <div id="uf-oauth-device" style="display:none;font-size:11px;line-height:1.6;margin-top:8px;padding-top:8px;border-top:1px dashed var(--border)"></div>
           </div>
           <div style="font-size:11px;font-weight:600;opacity:0.6;margin:4px 0 2px;display:flex;align-items:center;gap:5px;"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--accent, var(--red));flex-shrink:0;" aria-hidden="true"><polyline points="22 12 16 12 14 15 10 15 8 12 2 12"/><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/></svg>IMAP (Receiving)</div>
           <div class="settings-row"><label class="settings-label">Host${_hint('Your IMAP server, e.g. imap.gmail.com, imap.migadu.com, a LAN host, or a Tailscale IP for Dovecot.')}</label><input id="uf-imap-host" class="settings-input" placeholder="imap.example.com"></div>
@@ -4359,8 +4450,8 @@ async function initUnifiedIntegrations() {
         url: 'https://login.yahoo.com/account/security/app-passwords',
       },
       outlook: {
-        title: 'Outlook / Office 365 needs OAuth',
-        body: 'Microsoft disables normal password login for IMAP/SMTP in most Outlook and Microsoft 365 accounts. Odysseus does not support Microsoft OAuth/Graph mail yet, so this preset is only a placeholder for future support.',
+        title: 'Outlook / Office 365 uses Microsoft sign-in',
+        body: 'Microsoft disables normal password login for IMAP/SMTP. Use "Sign in with Microsoft" below — a short code is confirmed at microsoft.com/devicelogin. Requires MICROSOFT_OAUTH_CLIENT_ID to be configured by the admin.',
         url: 'https://learn.microsoft.com/exchange/clients-and-mobile-in-exchange-online/disable-basic-authentication-in-exchange-online',
         linkLabel: 'Read Microsoft note',
       },
@@ -4431,9 +4522,20 @@ async function initUnifiedIntegrations() {
     };
 
     // Show/hide the OAuth section and password fields based on provider selection.
+    const _OAUTH_PROVIDERS = {
+      google:    { title: 'Google OAuth2 — required for Workspace / .edu accounts', connect: 'Connect with Google',    reconnect: 'Reconnect with Google',    connected: '✓ Connected via Google OAuth' },
+      microsoft: { title: 'Microsoft OAuth2 — required for Outlook / Office 365',   connect: 'Sign in with Microsoft', reconnect: 'Reconnect with Microsoft', connected: '✓ Connected via Microsoft OAuth' },
+    };
     function _syncOauthUI(providerKey) {
       const p = PROVIDERS[providerKey];
       const isOauth = !!(p && p.oauth);
+      if (isOauth) {
+        const meta = _OAUTH_PROVIDERS[p.oauth];
+        el('uf-oauth-title').textContent = meta.title;
+        const connected = !!(existing && existing.oauth_provider === p.oauth);
+        el('uf-oauth-status').textContent = connected ? meta.connected : 'Not connected — click below to sign in';
+        el('uf-oauth-btn').textContent = connected ? meta.reconnect : meta.connect;
+      }
       el('uf-oauth-section').style.display = isOauth ? '' : 'none';
       formEl.querySelectorAll('.uf-password-section').forEach(r => {
         r.style.display = isOauth ? 'none' : '';
@@ -4516,9 +4618,83 @@ async function initUnifiedIntegrations() {
 
     // Init OAuth UI for accounts already connected via OAuth.
     if (existing && existing.oauth_provider === 'google') _syncOauthUI('google_workspace');
+    else if (existing && existing.oauth_provider === 'microsoft') _syncOauthUI('outlook');
 
-    // "Connect with Google" — save the account first, then redirect to OAuth.
+    // Microsoft device-code flow — run inline, no redirect URI needed.
+    async function _runMsDeviceFlow(accId) {
+      const box = el('uf-oauth-device');
+      const status = el('uf-oauth-status');
+      const btn = el('uf-oauth-btn');
+      btn.disabled = true;
+      box.style.display = '';
+      box.innerHTML = 'Starting Microsoft sign-in…';
+      try {
+        const r = await fetch('/api/email/oauth/microsoft/device/start', {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: `account_id=${encodeURIComponent(accId)}`,
+        });
+        const d = await r.json().catch(() => ({}));
+        if (!r.ok || !d.poll_id) {
+          box.innerHTML = `<span style="color:var(--red)">${esc(d.detail || d.error || 'Failed to start Microsoft sign-in')}</span>`;
+          btn.disabled = false;
+          return;
+        }
+        const link = d.verification_uri_complete || d.verification_uri || 'https://microsoft.com/devicelogin';
+        const code = d.user_code || '';
+        box.innerHTML =
+          `<div style="margin-bottom:4px">1. Open <a href="${esc(link)}" target="_blank" rel="noopener">${esc(link)}</a> and sign in with ${esc(el('uf-imap-user').value.trim() || 'your Microsoft account')}</div>` +
+          (d.verification_uri_complete ? '' : `<div style="margin-bottom:4px">2. Enter this code: <b style="letter-spacing:1px">${esc(code)}</b></div>`) +
+          `<div id="uf-oauth-poll" style="opacity:0.7">Waiting for authorization…</div>`;
+        const intervalMs = Math.max(parseInt(d.interval || 5, 10), 2) * 1000;
+        const deadline = Date.now() + (parseInt(d.expires_in || 900, 10) * 1000);
+        const poll = async () => {
+          if (Date.now() > deadline) {
+            status.textContent = 'Microsoft sign-in timed out — try again';
+            box.innerHTML = '';
+            btn.disabled = false;
+            return;
+          }
+          let pd = null;
+          try {
+            const res = await fetch('/api/email/oauth/microsoft/device/poll', {
+              method: 'POST',
+              credentials: 'same-origin',
+              headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+              body: `poll_id=${encodeURIComponent(d.poll_id)}`,
+            });
+            pd = await res.json().catch(() => ({}));
+          } catch (err) { /* transient network error — keep polling */ }
+          if (pd && pd.status === 'authorized') {
+            status.textContent = '✓ Connected via Microsoft OAuth' + (pd.endpoint && pd.endpoint.email ? ` (${pd.endpoint.email})` : '');
+            box.innerHTML = '<span style="color:var(--accent,#50fa7b)">Connected — you can close this panel.</span>';
+            btn.disabled = false;
+            btn.textContent = 'Reconnect with Microsoft';
+            return;
+          }
+          if (pd && pd.status === 'failed') {
+            status.textContent = '';
+            box.innerHTML = `<span style="color:var(--red)">Microsoft sign-in failed: ${esc(pd.error || 'denied')}</span>`;
+            btn.disabled = false;
+            return;
+          }
+          const pollEl = box.querySelector('#uf-oauth-poll');
+          if (pollEl) pollEl.textContent = (pd && pd.detail) ? pd.detail : 'Waiting for authorization…';
+          setTimeout(poll, intervalMs);
+        };
+        setTimeout(poll, intervalMs);
+      } catch (e) {
+        box.innerHTML = `<span style="color:var(--red)">${esc(String(e))}</span>`;
+        btn.disabled = false;
+      }
+    }
+
+    // "Connect with Google" / "Sign in with Microsoft" — save the account
+    // first, then redirect to Google OAuth or run the device flow inline.
     el('uf-oauth-btn').addEventListener('click', async () => {
+      const p = PROVIDERS[el('uf-email-provider').value];
+      if (!p || !p.oauth) return;
       const body = _collectBody();
       if (!body.name) body.name = body.from_address;
       if (!body.name) { el('uf-email-msg').textContent = 'Enter a Name or Email first'; el('uf-email-msg').style.color = 'var(--red)'; return; }
@@ -4528,7 +4704,11 @@ async function initUnifiedIntegrations() {
       const d = await r.json();
       if (!(d.ok || d.id)) { el('uf-email-msg').textContent = d.error || 'Save failed'; el('uf-email-msg').style.color = 'var(--red)'; return; }
       const accId = isEdit ? editId : d.id;
-      window.location.href = `/api/email/oauth/google/authorize?account_id=${encodeURIComponent(accId)}`;
+      if (p.oauth === 'google') {
+        window.location.href = `/api/email/oauth/google/authorize?account_id=${encodeURIComponent(accId)}`;
+      } else if (p.oauth === 'microsoft') {
+        await _runMsDeviceFlow(accId);
+      }
     });
 
     // "Same as IMAP" toggle — hide the SMTP creds rows when on.

--- a/tests/test_microsoft_oauth_mail.py
+++ b/tests/test_microsoft_oauth_mail.py
@@ -1,0 +1,264 @@
+"""Microsoft (Outlook / Office 365) mail OAuth coverage.
+
+Scopes, ID-token identity parsing, OAuth transport allowlists, refresh-token
+rotation, and the XOAUTH2 wiring on the SMTP send path.
+"""
+
+import base64
+import json
+
+import pytest
+from types import SimpleNamespace
+
+
+def _jwt(claims):
+    def seg(obj):
+        raw = json.dumps(obj).encode()
+        return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+    return f"{seg({'alg': 'none', 'typ': 'JWT'})}.{seg(claims)}.sig"
+
+
+@pytest.fixture
+def account_db(tmp_path, monkeypatch):
+    from core import database as core_db
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from sqlalchemy.pool import NullPool
+
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'accounts.db'}",
+        connect_args={"check_same_thread": False, "timeout": 5},
+        poolclass=NullPool,
+    )
+    core_db.Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    monkeypatch.setattr(core_db, "SessionLocal", factory)
+    yield factory
+    engine.dispose()
+
+
+def _make_account(factory, *, imap_user="info@craftale.it", provider="microsoft"):
+    import uuid
+
+    from core.database import EmailAccount
+    from src.secret_storage import encrypt
+
+    db = factory()
+    try:
+        row = EmailAccount(
+            id=f"acc-{uuid.uuid4().hex[:12]}",
+            owner="admin",
+            name="Craftale",
+            from_address=imap_user,
+            imap_host="outlook.office365.com",
+            imap_port=993,
+            imap_starttls=False,
+            imap_user=imap_user,
+            oauth_provider=provider,
+            oauth_refresh_token=encrypt("old-refresh"),
+        )
+        db.add(row)
+        db.commit()
+        return row.id
+    finally:
+        db.close()
+
+
+# --- Scopes -----------------------------------------------------------------
+
+
+def test_scopes_contain_required_grants():
+    from routes.email_helpers import MICROSOFT_OAUTH_SCOPES
+
+    assert "https://outlook.office365.com/IMAP.AccessAsUser.All" in MICROSOFT_OAUTH_SCOPES
+    assert "https://outlook.office365.com/SMTP.Send" in MICROSOFT_OAUTH_SCOPES
+    assert "offline_access" in MICROSOFT_OAUTH_SCOPES
+    # Identity claims ride along so the connect flow can verify the mailbox.
+    assert "openid" in MICROSOFT_OAUTH_SCOPES and "email" in MICROSOFT_OAUTH_SCOPES
+
+
+def test_tenant_defaults_to_common(monkeypatch):
+    from routes.email_helpers import microsoft_oauth_tenant
+
+    monkeypatch.delenv("MICROSOFT_OAUTH_TENANT", raising=False)
+    assert microsoft_oauth_tenant() == "common"
+    monkeypatch.setenv("MICROSOFT_OAUTH_TENANT", "organizations")
+    assert microsoft_oauth_tenant() == "organizations"
+
+
+def test_configured_requires_client_id(monkeypatch):
+    from routes.email_helpers import microsoft_oauth_configured
+
+    monkeypatch.delenv("MICROSOFT_OAUTH_CLIENT_ID", raising=False)
+    assert microsoft_oauth_configured() is False
+    monkeypatch.setenv("MICROSOFT_OAUTH_CLIENT_ID", "abc")
+    assert microsoft_oauth_configured() is True
+
+
+# --- Transport allowlists (routes module) -----------------------------------
+
+
+def test_microsoft_transport_allowlists():
+    from routes.email_routes import (
+        _microsoft_oauth_imap_transport_allowed,
+        _microsoft_oauth_smtp_transport_allowed,
+    )
+
+    assert _microsoft_oauth_imap_transport_allowed(993, False) is True
+    assert _microsoft_oauth_imap_transport_allowed(143, True) is True
+    assert _microsoft_oauth_imap_transport_allowed(993, True) is False
+    assert _microsoft_oauth_imap_transport_allowed(587, False) is False
+    # Exchange Online client submission is STARTTLS-only on 587.
+    assert _microsoft_oauth_smtp_transport_allowed(587, "starttls") is True
+    assert _microsoft_oauth_smtp_transport_allowed(465, "ssl") is False
+    assert _microsoft_oauth_smtp_transport_allowed(587, "ssl") is False
+
+
+def test_microsoft_oauth_hosts_are_pinned():
+    from routes.email_routes import (
+        _MICROSOFT_OAUTH_IMAP_HOSTS,
+        _MICROSOFT_OAUTH_SMTP_HOSTS,
+    )
+
+    assert _MICROSOFT_OAUTH_IMAP_HOSTS == {"outlook.office365.com"}
+    assert _MICROSOFT_OAUTH_SMTP_HOSTS == {"smtp.office365.com"}
+
+
+# --- Refresh flow -----------------------------------------------------------
+
+
+def test_refresh_rotates_tokens_and_persists(account_db, monkeypatch):
+    import httpx
+    from routes.email_helpers import _refresh_microsoft_token
+    from core.database import EmailAccount
+    from src.secret_storage import decrypt
+
+    monkeypatch.setenv("MICROSOFT_OAUTH_CLIENT_ID", "client-123")
+    account_id = _make_account(account_db)
+
+    captured = {}
+
+    def fake_post(url, data=None, timeout=None):
+        captured["url"] = url
+        captured["data"] = data
+        return SimpleNamespace(
+            raise_for_status=lambda: None,
+            json=lambda: {
+                "access_token": "new-access",
+                "refresh_token": "new-refresh",
+                "expires_in": 3600,
+            },
+        )
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+    token = _refresh_microsoft_token(account_id)
+
+    assert token == "new-access"
+    assert "login.microsoftonline.com/common/oauth2/v2.0/token" in captured["url"]
+    assert captured["data"]["grant_type"] == "refresh_token"
+    assert captured["data"]["refresh_token"] == "old-refresh"
+    assert captured["data"]["scope"].startswith("https://outlook.office365.com/")
+
+    db = account_db()
+    try:
+        row = db.get(EmailAccount, account_id)
+        assert row.oauth_provider == "microsoft"
+        assert decrypt(row.oauth_access_token) == "new-access"
+        # v2 rotates refresh tokens — the new one must replace the old.
+        assert decrypt(row.oauth_refresh_token) == "new-refresh"
+    finally:
+        db.close()
+
+
+def test_refresh_ignores_non_microsoft_rows(account_db, monkeypatch):
+    import httpx
+    from routes.email_helpers import _refresh_microsoft_token
+
+    monkeypatch.setenv("MICROSOFT_OAUTH_CLIENT_ID", "client-123")
+    account_id = _make_account(account_db, provider="google")
+
+    def explode(*a, **kw):
+        raise AssertionError("httpx must not be called for non-microsoft rows")
+
+    monkeypatch.setattr(httpx, "post", explode)
+    assert _refresh_microsoft_token(account_id) is None
+
+
+def test_valid_token_uses_cache_without_refresh(account_db, monkeypatch):
+    import httpx
+    from routes.email_helpers import _get_valid_microsoft_token
+    from src.secret_storage import encrypt
+
+    monkeypatch.setattr(
+        httpx,
+        "post",
+        lambda *a, **kw: (_ for _ in ()).throw(AssertionError("no refresh expected")),
+    )
+    cfg = {
+        "oauth_access_token": encrypt("cached-token"),
+        "oauth_token_expiry": str(int(__import__("time").time()) + 600),
+    }
+    assert _get_valid_microsoft_token("any-account", cfg) == "cached-token"
+
+
+# --- XOAUTH2 wiring on the send path ----------------------------------------
+
+
+def test_smtp_send_authenticates_xoauth2_for_microsoft(monkeypatch):
+    import smtplib
+    from routes import email_helpers
+    from routes.email_helpers import _send_smtp_message, _xoauth2_raw
+
+    monkeypatch.setattr(
+        email_helpers,
+        "_get_valid_microsoft_token",
+        lambda account_id, cfg: "ms-access-token",
+    )
+
+    calls = {"auth": None, "login": False, "starttls": False}
+
+    class FakeSMTP:
+        def __init__(self, host, port, timeout=None):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def ehlo(self):
+            pass
+
+        def starttls(self):
+            calls["starttls"] = True
+
+        def auth(self, mechanism, auth_cb, initial_response_ok=False):
+            calls["auth"] = (mechanism, auth_cb)
+
+        def login(self, user, password):
+            calls["login"] = True
+
+        def sendmail(self, from_addr, recipients, message):
+            pass
+
+        def quit(self):
+            pass
+
+    monkeypatch.setattr(smtplib, "SMTP", FakeSMTP)
+    cfg = {
+        "account_id": "acc-1",
+        "oauth_provider": "microsoft",
+        "smtp_host": "smtp.office365.com",
+        "smtp_port": 587,
+        "smtp_user": "info@craftale.it",
+        "smtp_security": "starttls",
+    }
+    _send_smtp_message(cfg, "info@craftale.it", ["dest@example.com"], "body")
+
+    assert calls["starttls"] is True
+    assert calls["login"] is False
+    mechanism, auth_cb = calls["auth"]
+    assert mechanism == "XOAUTH2"
+    assert auth_cb() == _xoauth2_raw("info@craftale.it", "ms-access-token")


### PR DESCRIPTION
## Summary

Adds Microsoft (Outlook / Office 365) mail support using OAuth2 XOAUTH2 on IMAP+SMTP, mirroring the existing Google flow's guards and lifecycle. Connect uses the **device-code grant** — no redirect URI or public callback URL — so it works unchanged behind reverse proxies, tunnels, and LAN-only deployments; the user confirms a short code at `microsoft.com/devicelogin`. Tokens are polled server-side via the provider-generic `routes/device_flow.py` scaffolding (proven by the Copilot login), stored encrypted on the account row, and refreshed with v2 refresh-token rotation persisted.

Mailbox identity is taken from the ID token **UPN**, not the spoofable `email` claim (nOAuth), and must match the configured username — the same wrong-mailbox guard as the Google callback. `/accounts/test` pins Microsoft transports like Google's host pinning (IMAP `outlook.office365.com` 993-TLS/143-STARTTLS, SMTP `smtp.office365.com` 587-STARTTLS only). Both `settings.js` account forms (legacy `eaf-*` and live `uf-*`) get the OAuth section and provider-neutral copy; the standalone GPU compose files are regenerated to keep the drift test green.

Setup: Azure app registration (public client, device code allowed) + `MICROSOFT_OAUTH_CLIENT_ID` env; `MICROSOFT_OAUTH_TENANT` optional (default `common`). Walkthrough in `.env.example`.

## Target branch

- [x] This PR targets **`dev`, not `main`**.

## Linked Issue

Fixes #159
Relates to #6022 — @Tatertottimmy posted the same-goal redirect-flow implementation there first, including MCP-server OAuth visibility and `odysseus-mail send` fixes this PR does not have. Full credit for the nOAuth/UPN hardening reasoning, which this PR adopts. Happy to reconcile, rebase onto theirs, or withdraw in favour of their branch — maintainer's call; I'll leave a comment there linking this PR.

## Type of Change

- [x] New feature (non-breaking — adds new behaviour)

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — no PR for this exists yet; the related issue is credited above.
- [x] This PR targets `dev` (rebased on today's tip)
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end: connected a live Microsoft 365 mailbox (single-tenant Entra app, device-code sign-in); IMAP read and SMTP send both pass the account Test in the running app. Also: new `tests/test_microsoft_oauth_mail.py` (9 cases) plus gpu-compose drift and shell-routes suites green, `node --check` and `py_compile` clean.