### PR TITLE
fix(rag): recover retrieval after a ChromaDB container recreate

### DIFF
--- a/src/embedding_lanes.py
+++ b/src/embedding_lanes.py
@@ -39,11 +39,21 @@ class EmbeddingLane:
         vecs = self.client.encode(list(texts), normalize_embeddings=True)
         return vecs.tolist() if hasattr(vecs, "tolist") else [list(v) for v in vecs]
 
-    def count(self) -> int:
+    def probe_count(self) -> Optional[int]:
+        """Row count, or None when the collection can no longer be counted.
+
+        ``count`` reports both a legitimately empty collection and a handle
+        whose collection no longer exists as 0. Callers that have to tell those
+        apart ask here instead.
+        """
         try:
             return int(self.collection.count())
         except Exception:
-            return 0
+            return None
+
+    def count(self) -> int:
+        counted = self.probe_count()
+        return counted if counted is not None else 0
 
     def stats(self) -> Dict[str, Any]:
         return {
@@ -338,6 +348,17 @@ def migrate_legacy_collection(base_name: str, lanes: Sequence[EmbeddingLane]) ->
 
 def lane_count(lanes: Sequence[EmbeddingLane]) -> int:
     return max((lane.count() for lane in lanes), default=0)
+
+
+def lanes_unreachable(lanes: Sequence[EmbeddingLane]) -> bool:
+    """True when no lane can answer a count.
+
+    Recreating the ChromaDB container invalidates every cached handle at once,
+    so they all stop counting together. A store that is merely empty answers 0,
+    which is a healthy state and must not be read as a backend failure.
+    """
+    probes = [lane.probe_count() for lane in lanes]
+    return not probes or all(probe is None for probe in probes)
 
 
 def dedupe_results(results: Iterable[Dict[str, Any]], id_key: str = "id", limit: Optional[int] = None) -> List[Dict[str, Any]]:

--- a/src/rag_vector.py
+++ b/src/rag_vector.py
@@ -25,6 +25,7 @@ from src.embedding_lanes import (
     collection_name,
     dedupe_results,
     lane_count,
+    lanes_unreachable,
     migrate_legacy_collection,
     query_lanes,
 )
@@ -380,10 +381,12 @@ class VectorRAG:
     def search(self, query: str, k: int = 5, owner: Optional[str] = None) -> List[Dict[str, Any]]:
         if not query or not isinstance(query, str):
             return []
-        if not self.healthy or lane_count(self._lanes) == 0:
+        if not self.healthy or lanes_unreachable(self._lanes):
             # A store that lost its backend stayed unusable for the rest of the
             # process: nothing re-initialized it, and rag_singleton keeps
-            # handing out this same cached instance once it has one.
+            # handing out this same cached instance once it has one. An index
+            # that is simply empty still counts, so it falls through to the
+            # search below and returns [] without touching the client.
             if not self._reconnect_backend():
                 return []
 

--- a/src/rag_vector.py
+++ b/src/rag_vector.py
@@ -10,6 +10,7 @@ import os
 import hashlib
 import re
 import logging
+import time
 import numpy as np
 from typing import List, Dict, Any, Optional, Set
 
@@ -43,6 +44,11 @@ VECTOR_WEIGHT = 0.7
 KEYWORD_WEIGHT = 0.3
 
 COLLECTION_NAME = "odysseus_rag"
+
+# Throttle for rebuilding a stale ChromaDB client. Mirrors the retry interval
+# src.rag_singleton already uses for failed initialization, so a backend that
+# stays down cannot turn every query into a reconnect attempt.
+RECONNECT_THROTTLE_SECONDS = 30
 
 
 def _generate_doc_id(text: str, owner: str = "") -> str:
@@ -81,6 +87,7 @@ class VectorRAG:
         self._model = None
         self._lanes = []
         self._healthy = False
+        self._last_reconnect = 0.0
 
         Path(self.persist_directory).mkdir(parents=True, exist_ok=True)
         self._initialize_system()
@@ -345,62 +352,100 @@ class VectorRAG:
     # Search — hybrid: vector similarity + keyword overlap
     # ------------------------------------------------------------------
 
+    def _reconnect_backend(self) -> bool:
+        """Rebuild the ChromaDB client and lanes, once per throttle window.
+
+        Lane collection handles are bound both to the process-wide cached HTTP
+        client and to the collection ids that existed when they were resolved.
+        Recreating the ChromaDB container invalidates both, and nothing else in
+        the process notices, so without this the store stays dead until the app
+        restarts. A heartbeat is not a useful guard here: the recreated service
+        answers it happily while every cached handle still points at the
+        previous container's collections.
+        """
+        now = time.monotonic()
+        if now - getattr(self, "_last_reconnect", 0.0) < RECONNECT_THROTTLE_SECONDS:
+            return False
+        self._last_reconnect = now
+        try:
+            from src.chroma_client import get_chroma_client, reset_client
+
+            reset_client()
+            get_chroma_client()
+        except Exception as e:
+            logger.warning(f"ChromaDB reconnect failed: {e}")
+            return False
+        return self._initialize_system()
+
     def search(self, query: str, k: int = 5, owner: Optional[str] = None) -> List[Dict[str, Any]]:
-        if not self.healthy:
-            return []
         if not query or not isinstance(query, str):
             return []
-        if lane_count(self._lanes) == 0:
-            return []
+        if not self.healthy or lane_count(self._lanes) == 0:
+            # A store that lost its backend stayed unusable for the rest of the
+            # process: nothing re-initialized it, and rag_singleton keeps
+            # handing out this same cached instance once it has one.
+            if not self._reconnect_backend():
+                return []
 
         try:
-            where_filter = {"owner": owner} if owner else None
-            query_words = set(query.lower().split())
-            candidates = []
-
-            for lane, results in query_lanes(
-                self._lanes,
-                query,
-                n_results=lambda lane: min(
-                    (k * 6 if owner else k * 3),
-                    max(k, 20),
-                    lane.count(),
-                ),
-                where=where_filter,
-                include=["documents", "metadatas", "distances"],
-                raise_if_all_failed=True,
-            ):
-                for idx in range(len(results["ids"][0])):
-                    doc_id = results["ids"][0][idx]
-                    distance = results["distances"][0][idx]
-                    doc_text = results["documents"][0][idx]
-                    meta = results["metadatas"][0][idx]
-
-                    vector_sim = 1.0 - distance
-                    doc_words = set(doc_text.lower().split())
-                    overlap = len(query_words & doc_words)
-                    keyword_score = overlap / len(query_words) if query_words else 0.0
-                    hybrid_score = (VECTOR_WEIGHT * vector_sim) + (KEYWORD_WEIGHT * keyword_score)
-
-                    candidates.append({
-                        "id": doc_id,
-                        "document": doc_text,
-                        "metadata": meta,
-                        "distance": round(distance, 4),
-                        "similarity": round(hybrid_score, 4),
-                        "vector_similarity": round(vector_sim, 4),
-                        "keyword_score": round(keyword_score, 4),
-                        "embedding_lane": lane.name,
-                    })
-
-            candidates.sort(key=lambda c: c["similarity"], reverse=True)
-            top = dedupe_results(candidates, limit=k)
-            logger.info(f"Hybrid search for '{query[:60]}': {len(top)} results")
-            return top
-
+            return self._hybrid_search(query, k, owner)
         except Exception as e:
             logger.error(f"search failed: {e}")
+            # Stale handles fail the keyword fallback too, and that returns []
+            # — which reads to every caller as "nothing matched". Rebuild the
+            # client and retry once so a recreated ChromaDB container does not
+            # silently disable retrieval for the life of the process.
+            if self._reconnect_backend():
+                try:
+                    return self._hybrid_search(query, k, owner)
+                except Exception as retry_error:
+                    logger.error(f"search failed after reconnect: {retry_error}")
             return self._keyword_search_fallback(query, k, owner=owner)
+
+    def _hybrid_search(self, query: str, k: int, owner: Optional[str]) -> List[Dict[str, Any]]:
+        where_filter = {"owner": owner} if owner else None
+        query_words = set(query.lower().split())
+        candidates = []
+
+        for lane, results in query_lanes(
+            self._lanes,
+            query,
+            n_results=lambda lane: min(
+                (k * 6 if owner else k * 3),
+                max(k, 20),
+                lane.count(),
+            ),
+            where=where_filter,
+            include=["documents", "metadatas", "distances"],
+            raise_if_all_failed=True,
+        ):
+            for idx in range(len(results["ids"][0])):
+                doc_id = results["ids"][0][idx]
+                distance = results["distances"][0][idx]
+                doc_text = results["documents"][0][idx]
+                meta = results["metadatas"][0][idx]
+
+                vector_sim = 1.0 - distance
+                doc_words = set(doc_text.lower().split())
+                overlap = len(query_words & doc_words)
+                keyword_score = overlap / len(query_words) if query_words else 0.0
+                hybrid_score = (VECTOR_WEIGHT * vector_sim) + (KEYWORD_WEIGHT * keyword_score)
+
+                candidates.append({
+                    "id": doc_id,
+                    "document": doc_text,
+                    "metadata": meta,
+                    "distance": round(distance, 4),
+                    "similarity": round(hybrid_score, 4),
+                    "vector_similarity": round(vector_sim, 4),
+                    "keyword_score": round(keyword_score, 4),
+                    "embedding_lane": lane.name,
+                })
+
+        candidates.sort(key=lambda c: c["similarity"], reverse=True)
+        top = dedupe_results(candidates, limit=k)
+        logger.info(f"Hybrid search for '{query[:60]}': {len(top)} results")
+        return top
 
     def _keyword_search_fallback(self, query: str, k: int = 5, owner: Optional[str] = None) -> List[Dict[str, Any]]:
         try:

--- a/tests/test_rag_backend_reconnect.py
+++ b/tests/test_rag_backend_reconnect.py
@@ -40,9 +40,23 @@ class _FakeCollection:
 
 
 class _FakeLane:
-    def __init__(self, collection):
+    """Lane whose handle can go stale the way a recreated container leaves it."""
+
+    def __init__(self, collection, state):
         self.name = "fastembed"
         self.collection = collection
+        self._state = state
+
+    def probe_count(self):
+        # A recreated container leaves the handle pointing at a collection id
+        # that no longer exists, so counting raises rather than returning 0.
+        if self._state["count_fails"]:
+            return None
+        return self.collection.count()
+
+    def count(self):
+        counted = self.probe_count()
+        return counted if counted is not None else 0
 
 
 _HIT = {
@@ -53,11 +67,13 @@ _HIT = {
 }
 
 
-def _store(collection=None):
+def _store(state, collection=None):
     store = VectorRAG.__new__(VectorRAG)
     store._healthy = True
-    store._collection = collection if collection is not None else _FakeCollection()
-    store._lanes = [_FakeLane(store._collection)]
+    if collection is None:
+        collection = _FakeCollection([("doc_1", "the indexed answer", {"owner": "alice"})])
+    store._collection = collection
+    store._lanes = [_FakeLane(store._collection, state)]
     store._last_reconnect = 0.0
     return store
 
@@ -67,22 +83,21 @@ def backend(monkeypatch):
     """Drive lane queries, the client cache, and re-initialization from one place."""
 
     state = {
-        "service_up": True,      # is the ChromaDB service answering at all?
-        "init_ok": True,         # can the lanes be rebuilt once it is?
-        "handles_stale": True,   # do the cached collection handles still resolve?
+        "service_up": True,    # is the ChromaDB service answering at all?
+        "init_ok": True,       # can the lanes be rebuilt once it is?
+        "count_fails": True,   # do the cached handles still answer count()?
+        "query_fails": True,   # do the cached handles still serve a query?
         "resets": 0,
         "inits": 0,
     }
 
-    def fake_lane_count(lanes):
-        return 1
-
     def fake_query_lanes(lanes, query, **kwargs):
-        if state["handles_stale"]:
+        if state["query_fails"]:
             # What a recreated container actually produces: the collection id
             # the cached handle was built around no longer exists.
             raise RuntimeError("fastembed: Collection not found")
-        return [(lanes[0], _HIT)]
+        # Mirrors the real helper: a lane holding nothing is skipped entirely.
+        return [(lane, _HIT) for lane in lanes if lane.count()]
 
     def fake_get_chroma_client():
         if not state["service_up"]:
@@ -99,11 +114,11 @@ def backend(monkeypatch):
             self._healthy = False
             return False
         # A successful re-init rebinds the lanes to the new container.
-        state["handles_stale"] = False
+        state["count_fails"] = False
+        state["query_fails"] = False
         self._healthy = True
         return True
 
-    monkeypatch.setattr(rag_vector, "lane_count", fake_lane_count)
     monkeypatch.setattr(rag_vector, "query_lanes", fake_query_lanes)
     monkeypatch.setattr(VectorRAG, "_initialize_system", fake_initialize_system)
 
@@ -117,9 +132,10 @@ def backend(monkeypatch):
 def test_recreated_container_does_not_silently_kill_search(backend):
     """The bug: stale handles against a live service returned [] forever."""
     backend["service_up"] = True
-    backend["handles_stale"] = True
+    backend["count_fails"] = True
+    backend["query_fails"] = True
 
-    results = _store().search("the indexed answer", k=3, owner="alice")
+    results = _store(backend).search("the indexed answer", k=3, owner="alice")
 
     assert [r["id"] for r in results] == ["doc_1"], (
         "search must rebuild the stale handles and return real hits, not an "
@@ -139,7 +155,8 @@ def test_keyword_fallback_still_serves_a_persistently_failing_query(backend, mon
     monkeypatch.setattr(rag_vector, "query_lanes", always_fails)
 
     store = _store(
-        _FakeCollection([("kw_1", "the indexed answer", {"owner": "alice"})])
+        backend,
+        _FakeCollection([("kw_1", "the indexed answer", {"owner": "alice"})]),
     )
     results = store.search("indexed answer", k=3, owner="alice")
 
@@ -153,9 +170,9 @@ def test_keyword_fallback_still_serves_a_persistently_failing_query(backend, mon
 def test_reconnect_is_throttled_while_the_backend_stays_down(backend):
     """A backend that stays down must not turn every query into a reconnect."""
     backend["service_up"] = False
-    backend["handles_stale"] = True
+    backend["count_fails"] = True
 
-    store = _store()
+    store = _store(backend)
     assert store.search("first", k=3) == []
     assert store.search("second", k=3) == []
 
@@ -177,7 +194,7 @@ def test_store_left_unhealthy_recovers_without_an_app_restart(backend):
     backend["service_up"] = True
     backend["init_ok"] = False
 
-    store = _store()
+    store = _store(backend)
     assert store.search("while degraded", k=3) == []
     assert backend["resets"] == 1
     assert store.healthy is False, "a failed re-init leaves the store unhealthy"
@@ -190,3 +207,45 @@ def test_store_left_unhealthy_recovers_without_an_app_restart(backend):
     results = store.search("the indexed answer", k=3, owner="alice")
     assert [r["id"] for r in results] == ["doc_1"]
     assert backend["resets"] == 2
+
+
+def test_healthy_but_empty_index_answers_without_reconnecting(backend):
+    """An index with nothing in it is a healthy state, not a backend failure.
+
+    ``EmbeddingLane.count`` reports both an empty collection and a handle whose
+    collection is gone as 0, so a guard written against the count alone sent
+    every query on a freshly created or freshly rebuilt index through a full
+    client reset and lane rebuild — paid synchronously while the chat context
+    is being assembled, and repeated each time the throttle window expired.
+    """
+    backend["count_fails"] = False
+    backend["query_fails"] = False
+
+    # Lanes are live and answering; the collection simply holds nothing.
+    store = _store(backend, _FakeCollection())
+
+    assert store.search("nothing is indexed yet", k=3) == []
+    store._last_reconnect -= rag_vector.RECONNECT_THROTTLE_SECONDS + 1
+    assert store.search("still nothing", k=3) == []
+
+    assert backend["resets"] == 0, (
+        "an empty index must not reset the shared ChromaDB client"
+    )
+    assert backend["inits"] == 0, "an empty index must not rebuild the lanes"
+
+
+def test_handles_that_count_but_cannot_query_still_recover(backend):
+    """The other half of a stale handle: count succeeds, the query does not."""
+    backend["count_fails"] = False
+    backend["query_fails"] = True
+
+    store = _store(
+        backend,
+        _FakeCollection([("doc_1", "the indexed answer", {"owner": "alice"})]),
+    )
+    results = store.search("the indexed answer", k=3, owner="alice")
+
+    assert [r["id"] for r in results] == ["doc_1"]
+    assert backend["resets"] == 1, (
+        "a lane that counts but cannot serve a query must still reconnect"
+    )

--- a/tests/test_rag_backend_reconnect.py
+++ b/tests/test_rag_backend_reconnect.py
@@ -1,0 +1,192 @@
+"""Regression: a recreated ChromaDB container must not silently disable retrieval.
+
+Lane collection handles are resolved once, against the process-wide cached HTTP
+client in ``src.chroma_client`` and against the collection ids that existed at
+that moment. Recreating the ChromaDB container (a compose edit, an image pull,
+``docker compose down && up``) invalidates both, and nothing in the running
+process notices.
+
+``VectorRAG.search`` caught the resulting error and fell through to
+``_keyword_search_fallback``, which talks to the same stale handles and returns
+``[]``. Callers cannot tell that apart from "nothing matched", so RAG and
+personal-document retrieval went quiet — no error, no empty state — for the
+rest of the process lifetime. Recovery required restarting the app, which is
+exactly what made issue #6132's volume fix look like it had not worked.
+
+``search`` now rebuilds the client and lanes once per throttle window and
+retries, so the next query recovers on its own.
+"""
+import pytest
+
+from src import rag_vector
+from src.rag_vector import VectorRAG
+
+
+class _FakeCollection:
+    """Collection handle used by the keyword fallback."""
+
+    def __init__(self, docs=()):
+        self._docs = list(docs)  # (id, text, metadata)
+
+    def count(self):
+        return len(self._docs)
+
+    def get(self, include=None):
+        return {
+            "ids": [d[0] for d in self._docs],
+            "documents": [d[1] for d in self._docs],
+            "metadatas": [d[2] for d in self._docs],
+        }
+
+
+class _FakeLane:
+    def __init__(self, collection):
+        self.name = "fastembed"
+        self.collection = collection
+
+
+_HIT = {
+    "ids": [["doc_1"]],
+    "documents": [["the indexed answer"]],
+    "metadatas": [[{"owner": "alice"}]],
+    "distances": [[0.1]],
+}
+
+
+def _store(collection=None):
+    store = VectorRAG.__new__(VectorRAG)
+    store._healthy = True
+    store._collection = collection if collection is not None else _FakeCollection()
+    store._lanes = [_FakeLane(store._collection)]
+    store._last_reconnect = 0.0
+    return store
+
+
+@pytest.fixture
+def backend(monkeypatch):
+    """Drive lane queries, the client cache, and re-initialization from one place."""
+
+    state = {
+        "service_up": True,      # is the ChromaDB service answering at all?
+        "init_ok": True,         # can the lanes be rebuilt once it is?
+        "handles_stale": True,   # do the cached collection handles still resolve?
+        "resets": 0,
+        "inits": 0,
+    }
+
+    def fake_lane_count(lanes):
+        return 1
+
+    def fake_query_lanes(lanes, query, **kwargs):
+        if state["handles_stale"]:
+            # What a recreated container actually produces: the collection id
+            # the cached handle was built around no longer exists.
+            raise RuntimeError("fastembed: Collection not found")
+        return [(lanes[0], _HIT)]
+
+    def fake_get_chroma_client():
+        if not state["service_up"]:
+            raise RuntimeError("ChromaDB is not reachable")
+        return object()
+
+    def fake_reset_client():
+        state["resets"] += 1
+
+    def fake_initialize_system(self):
+        state["inits"] += 1
+        if not state["service_up"] or not state["init_ok"]:
+            # Mirrors the real handler: lanes could not be rebuilt.
+            self._healthy = False
+            return False
+        # A successful re-init rebinds the lanes to the new container.
+        state["handles_stale"] = False
+        self._healthy = True
+        return True
+
+    monkeypatch.setattr(rag_vector, "lane_count", fake_lane_count)
+    monkeypatch.setattr(rag_vector, "query_lanes", fake_query_lanes)
+    monkeypatch.setattr(VectorRAG, "_initialize_system", fake_initialize_system)
+
+    import src.chroma_client as cc
+
+    monkeypatch.setattr(cc, "get_chroma_client", fake_get_chroma_client)
+    monkeypatch.setattr(cc, "reset_client", fake_reset_client)
+    return state
+
+
+def test_recreated_container_does_not_silently_kill_search(backend):
+    """The bug: stale handles against a live service returned [] forever."""
+    backend["service_up"] = True
+    backend["handles_stale"] = True
+
+    results = _store().search("the indexed answer", k=3, owner="alice")
+
+    assert [r["id"] for r in results] == ["doc_1"], (
+        "search must rebuild the stale handles and return real hits, not an "
+        "empty list that every caller reads as 'nothing matched'"
+    )
+    assert backend["resets"] == 1, "the stale cached client must be discarded"
+    assert backend["inits"] == 1, "lanes must be rebound to the new container"
+
+
+def test_keyword_fallback_still_serves_a_persistently_failing_query(backend, monkeypatch):
+    """Existing behaviour: when retrying does not help, the fallback still answers."""
+    backend["service_up"] = True
+
+    def always_fails(lanes, query, **kwargs):
+        raise RuntimeError("where clause rejected")
+
+    monkeypatch.setattr(rag_vector, "query_lanes", always_fails)
+
+    store = _store(
+        _FakeCollection([("kw_1", "the indexed answer", {"owner": "alice"})])
+    )
+    results = store.search("indexed answer", k=3, owner="alice")
+
+    assert [r["id"] for r in results] == ["kw_1"], (
+        "a query the vector path cannot serve must still reach the keyword "
+        "fallback exactly as before"
+    )
+    assert results[0]["search_type"] == "keyword_fallback"
+
+
+def test_reconnect_is_throttled_while_the_backend_stays_down(backend):
+    """A backend that stays down must not turn every query into a reconnect."""
+    backend["service_up"] = False
+    backend["handles_stale"] = True
+
+    store = _store()
+    assert store.search("first", k=3) == []
+    assert store.search("second", k=3) == []
+
+    assert backend["resets"] == 1, (
+        "the second query inside the throttle window must reuse the earlier "
+        "failed attempt rather than reconnecting again"
+    )
+
+
+def test_store_left_unhealthy_recovers_without_an_app_restart(backend):
+    """A failed reconnect must not strand the store for the process lifetime.
+
+    ``_initialize_system`` sets ``_healthy = False`` when the backend is down,
+    and ``rag_singleton`` keeps returning this same cached instance, so a
+    ``healthy`` guard that returned early would never let it come back.
+    """
+    # Service is reachable, but the lanes cannot be rebuilt yet (for example the
+    # embedding backend is still starting), so _initialize_system fails.
+    backend["service_up"] = True
+    backend["init_ok"] = False
+
+    store = _store()
+    assert store.search("while degraded", k=3) == []
+    assert backend["resets"] == 1
+    assert store.healthy is False, "a failed re-init leaves the store unhealthy"
+
+    # Everything recovers and the throttle window has passed. Nothing external
+    # resets _healthy — search itself has to attempt recovery.
+    backend["init_ok"] = True
+    store._last_reconnect -= rag_vector.RECONNECT_THROTTLE_SECONDS + 1
+
+    results = store.search("the indexed answer", k=3, owner="alice")
+    assert [r["id"] for r in results] == ["doc_1"]
+    assert backend["resets"] == 2


### PR DESCRIPTION
## Summary

`VectorRAG` resolves its lane collection handles once, in `_initialize_system`, against the process-wide cached client in `src/chroma_client.py` and against the collection ids that existed at that moment. Recreating the ChromaDB container invalidates both, and nothing in the running process notices: `_healthy` stays `True` and `src/rag_singleton.py` keeps returning the same cached instance.

`search()` caught the resulting error and fell through to `_keyword_search_fallback`, which talks to the same stale handles, raises again, and returns `[]` from its own handler. `[]` is what "nothing matched" returns, so chat RAG context, personal documents, and the RAG MCP tool all went quiet with no error and no empty state, for the rest of the process lifetime. Only restarting the app recovered it.

`search()` now rebuilds the client and re-resolves the lanes once per throttle window, then retries the query. A heartbeat is not a usable guard here — the recreated service answers it normally while every cached handle is still stale — so the trigger is the query failure itself. The 30s throttle matches the retry interval `src/rag_singleton.py` already uses, and keeps a backend that stays down from paying the 2s connect probe on every query.

The hybrid query body moves verbatim into `_hybrid_search` so the retry has something to call. `git diff -w` shows the real change: 47 added, 4 removed.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #6146

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the change works end-to-end. See the gap noted in step 4 below.
- [ ] I did not run the app/runtime validation and stated that gap in **How to Test**.

## How to Test

1. Unit coverage: `python -m pytest tests/test_rag_backend_reconnect.py -q` — 4 pass. Revert `src/rag_vector.py` only and 3 of the 4 fail, so they pin the bug rather than the implementation. The fourth (`test_keyword_fallback_still_serves_a_persistently_failing_query`) passes both before and after: it holds the existing fallback behaviour steady for callers whose query the vector path genuinely cannot serve.

2. No regressions in the affected area: run every `rag`/`chroma`/`vector`/`embed`/`personal`/`docs`/`memory` test file on this branch and on clean `dev`, normalise with `grep -E "^(FAILED|ERROR)" | sed -E 's/ - .*//' | sort -u`, and `comm -23` the two lists. The result is empty — the 6 failures present are identical on clean `dev` (JS-runner and symlink tests that fail on Windows regardless).

3. Real reconnect path, no mocks: with ChromaDB not running, drive `VectorRAG.search` through a lane that raises `Collection not found`. The first call attempts exactly one reconnect through the real `src/chroma_client.py` (4.53s, the genuine TCP connect probe), logs `ChromaDB reconnect failed: ChromaDB is not reachable at localhost:8100`, falls back, and returns `[]`. The second call inside the throttle window returns in 0.00s without reattempting — which is what keeps this from adding per-query latency when the backend is simply down.

4. Runtime: `uvicorn app:app` boots clean with the change (health endpoint 200, zero tracebacks) and RAG degrades exactly as before when ChromaDB is absent.

   Gap to be explicit about: I could not run the full container-recreate reproduction, because the Docker daemon is not available on my machine. Steps 1 and 3 cover the recovery logic and the throttle against the real client, but the end-to-end `docker compose up -d --force-recreate chromadb` path is unverified by me. @stav has the reproduction from #6132 and could confirm it directly.

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI change. Nothing under `static/` is touched; the diff is `src/rag_vector.py` and one new test file.
