### PR TITLE
feat(podman): add rootless Compose overlays [codex]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -259,6 +259,13 @@ SEARXNG_INSTANCE=http://localhost:8080
 # These overlays only expose the GPU devices. The slim Odysseus image
 # still needs CUDA/ROCm userspace via Cookbook -> Dependencies (vLLM,
 # llama-cpp-python, etc.) before models can actually serve on GPU.
+#
+# Rootless Podman uses its own user-namespace overlay. Run through
+# `podman compose`, not `sudo podman`, and pick at most one GPU overlay:
+# COMPOSE_FILE=docker-compose.yml:docker/podman.yml
+# COMPOSE_FILE=docker-compose.yml:docker/podman.yml:docker/podman.gpu-nvidia.yml
+# COMPOSE_FILE=docker-compose.yml:docker/podman.yml:docker/podman.gpu-amd.yml
+# See docs/podman.md for prerequisites and security boundaries.
 
 # ============================================================
 # Storage Paths (Docker Compose)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ Open `http://localhost:7000` when the containers are healthy. The first admin pa
 
 Native installs, GPU notes, Windows/macOS instructions, HTTPS, and configuration live in the [setup guide](docs/setup.md).
 
+Rootless Podman users can run the same stack with the focused overlays in the
+[Podman guide](docs/podman.md).
+
 ## Features
 
 - **Chat + Agents** — local/API models, tools, MCP, files, shell, skills, and memory.

--- a/docker/podman.gpu-amd.yml
+++ b/docker/podman.gpu-amd.yml
@@ -1,0 +1,12 @@
+# AMD ROCm overlay for rootless Podman.
+#
+# Combine this with docker/podman.yml; do not also load docker/gpu.amd.yml.
+# The host user must already have access to /dev/kfd and /dev/dri. Podman's
+# keep-groups extension preserves those supplementary device groups.
+services:
+  odysseus:
+    devices:
+      - /dev/kfd
+      - /dev/dri
+    group_add:
+      - keep-groups

--- a/docker/podman.gpu-nvidia.yml
+++ b/docker/podman.gpu-nvidia.yml
@@ -1,0 +1,12 @@
+# NVIDIA CDI overlay for rootless Podman.
+#
+# Combine this with docker/podman.yml; do not also load docker/gpu.nvidia.yml.
+# NVIDIA's CDI documentation recommends label=disable for Podman workloads.
+# This file intentionally does not set NVIDIA_VISIBLE_DEVICES because that can
+# activate the legacy OCI hook and conflict with native CDI injection.
+services:
+  odysseus:
+    devices:
+      - nvidia.com/gpu=all
+    security_opt:
+      - label=disable

--- a/docker/podman.yml
+++ b/docker/podman.yml
@@ -1,0 +1,17 @@
+# Rootless Podman overlay.
+#
+# Usage:
+#   podman compose -f docker-compose.yml -f docker/podman.yml up -d --build
+#
+# Odysseus normally starts as container root, repairs ownership, then drops to
+# PUID/PGID. Rootless Podman maps the invoking host user to container UID/GID 0
+# here so that flow keeps bind-mounted files owned by the host user. The
+# keep-id mode is intentionally unavailable to rootful Podman.
+services:
+  odysseus:
+    userns_mode: "keep-id:uid=0,gid=0"
+    environment:
+      - PUID=0
+      - PGID=0
+    security_opt:
+      - no-new-privileges:true

--- a/docs/podman.md
+++ b/docs/podman.md
@@ -1,0 +1,141 @@
+# Rootless Podman
+
+This is the rootless Podman path for the existing Odysseus Compose stack. It
+keeps `docker-compose.yml` as the source of truth and adds small overlays for
+Podman-specific user mapping and optional GPU access.
+
+## Requirements
+
+- Podman with rootless user namespaces configured.
+- A Compose provider available through [`podman compose`](https://docs.podman.io/en/latest/markdown/podman-compose.1.html).
+- `crun` when using the AMD overlay's `keep-groups` device access.
+
+Confirm the runtime before starting:
+
+```bash
+podman info --format '{{.Host.Security.Rootless}}'
+podman compose version
+```
+
+The first command must print `true`. The Podman overlay deliberately uses a
+rootless-only user mapping and is not supported with `sudo podman`.
+
+## CPU setup
+
+```bash
+git clone https://github.com/odysseus-dev/odysseus.git
+cd odysseus
+cp .env.example .env
+podman compose -f docker-compose.yml -f docker/podman.yml up -d --build
+```
+
+Open `http://localhost:7000` when the containers are healthy. The generated
+first-login password is available without placing a fixed password in `.env`:
+
+```bash
+podman compose -f docker-compose.yml -f docker/podman.yml logs odysseus
+```
+
+Common lifecycle commands use the same file list:
+
+```bash
+podman compose -f docker-compose.yml -f docker/podman.yml ps
+podman compose -f docker-compose.yml -f docker/podman.yml logs --tail=120 odysseus
+podman compose -f docker-compose.yml -f docker/podman.yml down
+```
+
+The overlay uses Podman's
+[`keep-id`](https://docs.podman.io/en/latest/markdown/podman-run.1.html#userns-mode)
+mapping to place the rootless host user at UID/GID 0 inside the Odysseus
+container and sets `PUID=0`/`PGID=0`. Container root still maps to the
+unprivileged user on the host; this lets the existing entrypoint repair and use
+bind mounts without leaving subordinate-UID files in `data/` or `logs/`.
+
+The base Compose file keeps every published service on host loopback by
+default. It also provides `host.docker.internal` for host-side Ollama and other
+model endpoints.
+
+## NVIDIA GPU through CDI
+
+Install the host NVIDIA driver and NVIDIA Container Toolkit, then follow the
+toolkit's [CDI setup](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/cdi-support.html)
+and confirm that it publishes devices:
+
+```bash
+nvidia-ctk cdi list
+podman run --rm --security-opt=label=disable \
+  --device=nvidia.com/gpu=all docker.io/library/ubuntu:24.04 nvidia-smi -L
+```
+
+Start Odysseus with the Podman CDI overlay:
+
+```bash
+podman compose \
+  -f docker-compose.yml \
+  -f docker/podman.yml \
+  -f docker/podman.gpu-nvidia.yml \
+  up -d --build
+```
+
+Do not combine `docker/podman.gpu-nvidia.yml` with
+`docker/gpu.nvidia.yml`. The Docker overlay uses the Docker GPU reservation
+and legacy NVIDIA environment variables; the Podman overlay requests the CDI
+device directly.
+
+If the host still has the legacy NVIDIA OCI hook, remove or disable that hook
+before using CDI. Native CDI injection can conflict with the hook when
+`NVIDIA_VISIBLE_DEVICES` is set.
+
+## AMD ROCm GPU
+
+The host must provide `/dev/kfd` and `/dev/dri`, and the rootless user must
+already belong to the groups that can access them. Verify that before starting:
+
+```bash
+test -r /dev/kfd && test -w /dev/kfd
+ls -l /dev/kfd /dev/dri/renderD*
+```
+
+Then use the Podman AMD overlay:
+
+```bash
+podman compose \
+  -f docker-compose.yml \
+  -f docker/podman.yml \
+  -f docker/podman.gpu-amd.yml \
+  up -d --build
+```
+
+The overlay preserves the rootless user's supplementary groups through
+Podman's `keep-groups` extension. Do not combine it with
+`docker/gpu.amd.yml`.
+
+GPU overlays expose host devices only. Install the matching vLLM,
+llama-cpp-python, or other serving engine separately through Cookbook after
+the container can see the GPU.
+
+## Security boundary
+
+The Podman overlays do not mount a Docker socket, Podman socket, broad home
+directory, or host network. Do not substitute a Podman socket into
+`docker/host-docker.yml`: either control socket grants broad authority over the
+host user's containers. Host Ollama and OpenAI-compatible endpoints work over
+the existing network path without a control socket.
+
+Keep `APP_BIND=127.0.0.1`, `AUTH_ENABLED=true`, and `LOCALHOST_BYPASS=false`
+unless the deployment is intentionally protected by a trusted private network
+or reverse proxy.
+
+## Troubleshooting
+
+Render the merged configuration without starting containers:
+
+```bash
+podman compose -f docker-compose.yml -f docker/podman.yml config
+```
+
+If bind-mounted files have unexpected numeric owners, confirm the command is
+rootless and that `docker/podman.yml` is present in every lifecycle command.
+If a GPU is absent, validate the host device/CDI path independently before
+debugging Odysseus. GPU enumeration alone does not install CUDA or ROCm
+userspace in the image.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -32,6 +32,9 @@ binds the web UI to `127.0.0.1` by default. If the port is taken, set
 `APP_PORT=7001` in `.env` and recreate the container. Set `APP_BIND=0.0.0.0`
 only when you intentionally want LAN/reverse-proxy access.
 
+For a rootless Podman deployment, use the Podman-specific user/GPU overlays
+and commands in the [Rootless Podman guide](podman.md).
+
 > **On Apple Silicon (M-series) Macs:** Docker can't reach the Metal GPU, so
 > Cookbook serves local models on CPU only. For GPU-accelerated model serving,
 > run natively instead — see [Apple Silicon](#apple-silicon) below.

--- a/tests/test_podman_compose.py
+++ b/tests/test_podman_compose.py
@@ -1,0 +1,74 @@
+"""Static contracts for the rootless Podman Compose overlays."""
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+PODMAN = ROOT / "docker" / "podman.yml"
+NVIDIA = ROOT / "docker" / "podman.gpu-nvidia.yml"
+AMD = ROOT / "docker" / "podman.gpu-amd.yml"
+DOCS = ROOT / "docs" / "podman.md"
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _service(path: Path) -> dict:
+    compose = _load(path)
+    assert set(compose["services"]) == {"odysseus"}
+    return compose["services"]["odysseus"]
+
+
+def _environment(entries: list[str]) -> dict[str, str]:
+    return dict(entry.split("=", 1) for entry in entries)
+
+
+def test_rootless_overlay_preserves_host_owned_bind_mounts():
+    service = _service(PODMAN)
+
+    assert service["userns_mode"] == "keep-id:uid=0,gid=0"
+    assert _environment(service["environment"]) == {"PUID": "0", "PGID": "0"}
+    assert service["security_opt"] == ["no-new-privileges:true"]
+
+
+def test_rootless_overlay_does_not_expose_a_control_socket_or_host_network():
+    text = PODMAN.read_text(encoding="utf-8")
+
+    assert "/var/run/docker.sock" not in text
+    assert "/run/user/" not in text
+    assert "podman.sock" not in text
+    assert "network_mode: host" not in text
+
+
+def test_nvidia_overlay_uses_cdi_without_legacy_hook_selector():
+    service = _service(NVIDIA)
+
+    assert service["devices"] == ["nvidia.com/gpu=all"]
+    assert service["security_opt"] == ["label=disable"]
+    assert "environment" not in service
+
+
+def test_amd_overlay_preserves_rootless_device_groups():
+    service = _service(AMD)
+
+    assert service["devices"] == ["/dev/kfd", "/dev/dri"]
+    assert service["group_add"] == ["keep-groups"]
+
+
+def test_docs_use_supported_wrapper_without_mutating_host_setup():
+    text = DOCS.read_text(encoding="utf-8")
+
+    assert "podman compose -f docker-compose.yml -f docker/podman.yml" in text
+    assert "sudo podman" in text
+    assert "podman-compose -f" not in text
+    assert "enable --now podman.socket" not in text
+    assert "ODYSSEUS_ADMIN_PASSWORD=" not in text
+    assert "network_mode: host" not in text
+
+
+def test_readme_links_the_podman_guide():
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+
+    assert "[Podman guide](docs/podman.md)" in readme


### PR DESCRIPTION
## Summary

Add a focused rootless Podman path on top of the current Compose stack without duplicating `docker-compose.yml` or introducing a host-mutating setup script. The base overlay preserves host ownership through an explicit rootless user mapping, separate NVIDIA CDI and AMD device overlays keep GPU modes mutually exclusive, and the guide documents the socket-free security boundary and lifecycle commands.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Part of #3194

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [x] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.
- [x] I did not run the app/runtime validation and stated that gap in **How to Test**. Leave this unchecked when the app-run box above is checked.

## How to Test

Static validation completed:

- `git diff --check`
- YAML safe parsing for the base and all three new overlays
- `podman compose ... config` for CPU, NVIDIA CDI, and AMD combinations on rootless Podman 6.1.0 with podman-compose 1.6.0
- the same three merged configurations on Debian with rootless Podman 5.4.2 and Docker Compose 2.26.1 as the provider

No container or application workload was started. Before marking this ready, a reviewer should:

1. Start the CPU stack with `podman compose -f docker-compose.yml -f docker/podman.yml up -d --build` and verify all four services become healthy.
2. Confirm files created under `data/` and `logs/` remain owned by the rootless host user after recreation.
3. Verify the UI remains loopback-only and the generated first-login password appears in `logs odysseus`.
4. On matching hardware, validate NVIDIA CDI and AMD ROCm separately with the commands in `docs/podman.md`.

The proposed static regression file was not executed locally because this checkout's repository policy prohibits executing repository-controlled tests and workloads. CI execution and live rootless startup remain required.

## Scope choices

- Uses `podman compose`, allowing Podman to select an installed Compose provider.
- Does not enable a persistent Podman socket or mount a Docker/Podman control socket.
- Does not generate or source `.env`, and does not persist a known administrator password.
- Does not combine CDI device injection with `NVIDIA_VISIBLE_DEVICES`.
- Deliberately omits an automated setup helper until the Compose path has live CPU/GPU proof.

The local implementation was prepared with Codex against the already-open tracker, so no duplicate issue was created.

## Visual / UI changes — REQUIRED if you touched anything that renders

N/A — no UI, CSS, HTML, SVG, or rendering behavior changed.

### Screenshots / clips

N/A.
