### PR TITLE
fix(mcp): auto-reconnect user-added MCP servers on dead session

### DIFF
--- a/src/mcp_manager.py
+++ b/src/mcp_manager.py
@@ -146,6 +146,9 @@ class McpManager:
         self._stacks: Dict[str, Any] = {}
         # server_id -> background connect task (HTTP transport / OAuth)
         self._connect_tasks: Dict[str, Any] = {}
+        # server_id -> original connect_server kwargs, kept so a user-added
+        # server whose session died can be reconnected (issue #1789)
+        self._connect_params: Dict[str, Dict[str, Any]] = {}
         # Tracking updates to tools/connections for RAG indexing / prompt cache
         self._generation = 0
 
@@ -160,6 +163,14 @@ class McpManager:
         url: Optional[str] = None,
     ) -> bool:
         """Connect to an MCP server via stdio, SSE, or Streamable HTTP transport."""
+        self._connect_params[server_id] = {
+            "name": name,
+            "transport": transport,
+            "command": command,
+            "args": list(args or []),
+            "env": dict(env or {}),
+            "url": url,
+        }
         try:
             if transport == "stdio":
                 res = await self._connect_stdio(server_id, name, command, args or [], env or {})
@@ -483,26 +494,24 @@ class McpManager:
         try:
             result = await self._do_call(session, tool_name, arguments)
         except Exception as e:
-            # Auto-reconnect for builtin servers whose subprocess may have died
-            if self.is_builtin(server_id):
-                logger.warning(f"MCP call failed for {qualified_name}, attempting reconnect: {e}")
-                reconnected = await self._reconnect_builtin(server_id)
-                if reconnected:
-                    session = self._sessions.get(server_id)
-                    if session:
-                        try:
-                            result = await self._do_call(session, tool_name, arguments)
-                        except Exception as e2:
-                            logger.error(f"MCP tool call failed after reconnect: {qualified_name}: {e2}")
-                            return {"error": str(e2), "exit_code": 1}
-                    else:
-                        return {"error": f"Reconnected but no session for {server_id}", "exit_code": 1}
+            # Auto-reconnect: the session may have died — a builtin subprocess
+            # crash, or a stdio session whose creating asyncio task has exited
+            # (issue #1789) — so try one reconnect for user-added servers too.
+            logger.warning(f"MCP call failed for {qualified_name}, attempting reconnect: {e}")
+            reconnected = await self._reconnect_any(server_id)
+            if reconnected:
+                session = self._sessions.get(server_id)
+                if session:
+                    try:
+                        result = await self._do_call(session, tool_name, arguments)
+                    except Exception as e2:
+                        logger.error(f"MCP tool call failed after reconnect: {qualified_name}: {e2}")
+                        return {"error": str(e2), "exit_code": 1}
                 else:
-                    logger.error(f"MCP reconnect failed for {server_id}")
-                    return {"error": f"MCP server crashed and reconnect failed: {server_id}", "exit_code": 1}
+                    return {"error": f"Reconnected but no session for {server_id}", "exit_code": 1}
             else:
-                logger.error(f"MCP tool call failed: {qualified_name}: {e}")
-                return {"error": str(e), "exit_code": 1}
+                logger.error(f"MCP reconnect failed for {server_id}")
+                return {"error": f"MCP server crashed and reconnect failed: {server_id}", "exit_code": 1}
 
         return result
 
@@ -535,6 +544,24 @@ class McpManager:
         if images:
             result_dict["images"] = images
         return result_dict
+
+    async def _reconnect_any(self, server_id: str) -> bool:
+        """Tear down and reconnect any MCP server, builtin or user-added."""
+        if self.is_builtin(server_id):
+            return await self._reconnect_builtin(server_id)
+        params = self._connect_params.get(server_id)
+        if not params:
+            logger.error(f"No stored connect params to reconnect MCP server {server_id}")
+            return False
+        await self.disconnect_server(server_id)
+        try:
+            ok = await self.connect_server(server_id=server_id, **params)
+            if ok:
+                logger.info(f"Reconnected user MCP server: {params.get('name', server_id)}")
+            return ok
+        except Exception as e:
+            logger.error(f"Failed to reconnect MCP server {server_id}: {e}")
+            return False
 
     async def _reconnect_builtin(self, server_id: str) -> bool:
         """Tear down and reconnect a crashed builtin MCP server."""

--- a/src/mcp_manager.py
+++ b/src/mcp_manager.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import re
+import time
 import asyncio 
 from typing import Any, Dict, List, Optional, Set, Tuple
 from src.database import McpServer, SessionLocal
@@ -104,6 +105,15 @@ _MCP_READONLY_VERBS = (
 )
 
 
+# A reconnect must not hang a caller forever on a stalled transport, and must
+# not be attempted concurrently for the same server (see _reconnect_any).
+# The bound covers one attempt; a transport may add its own teardown grace.
+_MCP_RECONNECT_TIMEOUT = 30.0
+# After a failed recovery, don't re-attempt on every single tool call: a
+# permanently dead server would make each call pay the full timeout.
+_MCP_RECONNECT_COOLDOWN = 15.0
+
+
 def mcp_tool_is_readonly(tool: Dict) -> bool:
     """Classify an MCP tool as safe (non-mutating) for plan mode.
 
@@ -149,6 +159,20 @@ class McpManager:
         # server_id -> original connect_server kwargs, kept so a user-added
         # server whose session died can be reconnected (issue #1789)
         self._connect_params: Dict[str, Dict[str, Any]] = {}
+        # server_id -> session identity, bumped on every connect AND disconnect.
+        # A caller records the epoch it used so a stale in-flight failure can
+        # never act on (or resurrect) a session that has since been replaced,
+        # explicitly disabled, or deleted.
+        self._session_epoch: Dict[str, int] = {}
+        # server_id -> lock, so concurrent failures coalesce onto ONE reconnect
+        # instead of racing to spawn duplicate processes.
+        self._reconnect_locks: Dict[str, asyncio.Lock] = {}
+        # Servers taken down explicitly (disable/delete/shutdown). Auto-recovery
+        # must never resurrect these — including builtins, which carry no
+        # user-supplied connect params to revoke.
+        self._revoked: Set[str] = set()
+        # server_id -> monotonic timestamp of the last failed recovery.
+        self._reconnect_failed_at: Dict[str, float] = {}
         # Tracking updates to tools/connections for RAG indexing / prompt cache
         self._generation = 0
 
@@ -171,6 +195,11 @@ class McpManager:
             "env": dict(env or {}),
             "url": url,
         }
+        # An explicit connect request is the un-revoke signal: clear it here,
+        # not on success, so a failed first attempt cannot leave the server
+        # permanently ineligible for automatic recovery.
+        self._revoked.discard(server_id)
+        self._reconnect_failed_at.pop(server_id, None)
         try:
             if transport == "stdio":
                 res = await self._connect_stdio(server_id, name, command, args or [], env or {})
@@ -182,6 +211,7 @@ class McpManager:
                 logger.error(f"Unknown MCP transport: {transport}")
                 res = False
             if res:
+                self._session_epoch[server_id] = self._session_epoch.get(server_id, 0) + 1
                 self._generation += 1
             return res
         except Exception as e:
@@ -377,6 +407,7 @@ class McpManager:
                     "name": tool.name,
                     "description": tool.description or "",
                     "input_schema": tool.inputSchema if hasattr(tool, "inputSchema") else {},
+                    "annotations": getattr(tool, "annotations", None),
                 })
 
             self._sessions[server_id] = session
@@ -386,6 +417,12 @@ class McpManager:
                 "status": "connected", "name": name, "transport": "http",
                 "tool_count": len(tools),
             }
+            # This can complete long after connect_server returned (background
+            # OAuth), so do the session accounting here too — otherwise the
+            # epoch guard would not see this session at all.
+            self._session_epoch[server_id] = self._session_epoch.get(server_id, 0) + 1
+            self._revoked.discard(server_id)
+            self._reconnect_failed_at.pop(server_id, None)
             clear_auth_url(server_id)
             # Tools changed (this can complete after connect_server already
             # returned, via the background OAuth flow), so bump the generation
@@ -402,8 +439,14 @@ class McpManager:
             self._connections[server_id] = {"status": "error", "error": str(e), "name": name}
             return False
 
-    async def disconnect_server(self, server_id: str):
-        """Disconnect from an MCP server."""
+    async def disconnect_server(self, server_id: str, *, revoke_params: bool = True):
+        """Disconnect from an MCP server.
+
+        `revoke_params=True` (the default, i.e. an explicit disable/delete)
+        also drops the cached connect parameters so a late in-flight call
+        cannot silently respawn the server from that snapshot. Internal
+        recycling (reconnect) passes False to keep the config for the retry.
+        """
         # Cancel any in-flight HTTP/OAuth background connect so it stops
         # publishing status for a server that may be getting deleted.
         task = self._connect_tasks.pop(server_id, None)
@@ -425,6 +468,12 @@ class McpManager:
         self._sessions.pop(server_id, None)
         self._tools.pop(server_id, None)
         self._connections.pop(server_id, None)
+        if revoke_params:
+            self._connect_params.pop(server_id, None)
+            self._revoked.add(server_id)
+        # Invalidate the session identity either way: a caller holding the old
+        # epoch must not treat the next session as the one it was using.
+        self._session_epoch[server_id] = self._session_epoch.get(server_id, 0) + 1
         self._generation += 1
         logger.info(f"MCP server disconnected: {server_id}")
 
@@ -487,33 +536,115 @@ class McpManager:
         server_id = parts[1]
         tool_name = parts[2]
 
+        # Record which session generation this call uses, so a failure can
+        # never act on a session that was replaced or revoked meanwhile.
+        epoch = self._session_epoch.get(server_id, 0)
+        # Snapshot the schema now: a reconnect clears the live tool table, and
+        # replay safety must not fall back to "unknown tool" because of that.
+        tool_schema = self._find_tool_schema(server_id, tool_name)
         session = self._sessions.get(server_id)
         if not session:
-            return {"error": f"MCP server not connected: {server_id}", "exit_code": 1}
+            # An earlier reconnect may have failed after tearing the session
+            # down. Retry once from the cached config so one transient failure
+            # doesn't strand the server until a manual reconnect (#1789).
+            # expected_epoch matters here too: without it this path skips the
+            # single-flight check, and concurrent callers each run a full
+            # reconnect that tears down the session a peer just restored.
+            # Only for servers we actually know: the tool name is model-supplied,
+            # so an invented id must not allocate recovery state.
+            known = self.is_builtin(server_id) or server_id in self._connect_params
+            if known and await self._reconnect_any(server_id, expected_epoch=epoch):
+                epoch = self._session_epoch.get(server_id, 0)
+                session = self._sessions.get(server_id)
+                # The tool table was empty before the reconnect, so re-resolve
+                # the schema — otherwise an annotated read-only tool would be
+                # reported as having an unknown outcome.
+                if tool_schema is None:
+                    tool_schema = self._find_tool_schema(server_id, tool_name)
+            if not session:
+                return {"error": f"MCP server not connected: {server_id}", "exit_code": 1}
 
         try:
             result = await self._do_call(session, tool_name, arguments)
         except Exception as e:
-            # Auto-reconnect: the session may have died — a builtin subprocess
-            # crash, or a stdio session whose creating asyncio task has exited
-            # (issue #1789) — so try one reconnect for user-added servers too.
+            # The session may have died — a builtin subprocess crash, or a
+            # stdio session whose creating asyncio task has exited (#1789).
+            # Reconnect so later calls succeed, but only REPLAY this call when
+            # that cannot duplicate a side effect: a transport error can arrive
+            # after the server already committed the operation.
             logger.warning(f"MCP call failed for {qualified_name}, attempting reconnect: {e}")
-            reconnected = await self._reconnect_any(server_id)
-            if reconnected:
-                session = self._sessions.get(server_id)
-                if session:
-                    try:
-                        result = await self._do_call(session, tool_name, arguments)
-                    except Exception as e2:
-                        logger.error(f"MCP tool call failed after reconnect: {qualified_name}: {e2}")
-                        return {"error": str(e2), "exit_code": 1}
-                else:
-                    return {"error": f"Reconnected but no session for {server_id}", "exit_code": 1}
-            else:
+            replay_safe = self._replay_is_safe(tool_schema)
+            if not await self._reconnect_any(server_id, expected_epoch=epoch):
                 logger.error(f"MCP reconnect failed for {server_id}")
                 return {"error": f"MCP server crashed and reconnect failed: {server_id}", "exit_code": 1}
+            session = self._sessions.get(server_id)
+            if not session:
+                return {"error": f"Reconnected but no session for {server_id}", "exit_code": 1}
+            if not replay_safe:
+                logger.warning(
+                    f"Not replaying {qualified_name} after reconnect: the tool is not "
+                    f"declared read-only/idempotent, so its outcome is indeterminate"
+                )
+                return {
+                    "error": (
+                        f"MCP call '{tool_name}' failed in flight and its outcome is UNKNOWN — "
+                        "the server may have applied it before the connection dropped. The "
+                        "session was reconnected, but the call was not replayed automatically "
+                        "because the tool is not declared read-only or idempotent. Check the "
+                        "server's state before retrying."
+                    ),
+                    "exit_code": 1,
+                    "indeterminate": True,
+                }
+            try:
+                result = await self._do_call(session, tool_name, arguments)
+            except Exception as e2:
+                logger.error(f"MCP tool call failed after reconnect: {qualified_name}: {e2}")
+                return {"error": str(e2), "exit_code": 1}
 
         return result
+
+    def _find_tool_schema(self, server_id: str, tool_name: str) -> Optional[Dict]:
+        """Return the advertised schema for a tool, or None if unknown."""
+        for tool in self._tools.get(server_id) or []:
+            if (tool.get("name") or "") == tool_name:
+                return tool
+        return None
+
+    @staticmethod
+    def _replay_is_safe(tool: Optional[Dict]) -> bool:
+        """May a failed call be transparently replayed after a reconnect?
+
+        Only when the SERVER ITSELF declares a read-only or idempotent
+        contract (MCP `readOnlyHint` / `idempotentHint`). A transport error can
+        arrive AFTER the server committed the write, so replaying anything else
+        can execute a user-visible action (send, create, delete, ...) twice
+        while the caller sees only one result.
+
+        The name-verb heuristic used for plan mode is deliberately NOT accepted
+        here: names like `get_or_create_issue` read as "get" but mutate, and a
+        guess is not a contract. Fails closed — unknown or unannotated tools
+        are never replayed.
+        """
+        if not tool:
+            return False
+        ann = tool.get("annotations")
+        if ann is None:
+            return False
+        if isinstance(ann, dict):
+            read_hint = ann.get("readOnlyHint")
+            idempotent = ann.get("idempotentHint")
+            destructive = ann.get("destructiveHint")
+        else:
+            read_hint = getattr(ann, "readOnlyHint", None)
+            idempotent = getattr(ann, "idempotentHint", None)
+            destructive = getattr(ann, "destructiveHint", None)
+        # Contradictory annotations (read-only AND destructive) are malformed —
+        # fail closed unless the server also promises idempotency, which by
+        # definition makes a repeat harmless.
+        if destructive is True and idempotent is not True:
+            return False
+        return read_hint is True or idempotent is True
 
     async def _do_call(self, session, tool_name: str, arguments: Dict) -> Dict:
         """Execute a single MCP tool call and return result dict."""
@@ -545,15 +676,70 @@ class McpManager:
             result_dict["images"] = images
         return result_dict
 
-    async def _reconnect_any(self, server_id: str) -> bool:
-        """Tear down and reconnect any MCP server, builtin or user-added."""
+    async def _reconnect_any(self, server_id: str, *, expected_epoch: Optional[int] = None) -> bool:
+        """Tear down and reconnect any MCP server, builtin or user-added.
+
+        Serialized per server: concurrent failures coalesce onto ONE recovery
+        instead of racing to spawn duplicate processes and overwrite the shared
+        session/cleanup slots. `expected_epoch` pins the recovery to the
+        session the caller actually used — if it changed while we waited for
+        the lock (another caller recovered, or an admin disabled/deleted the
+        server), we adopt that outcome instead of reconnecting on top of it.
+
+        One attempt is bounded by _MCP_RECONNECT_TIMEOUT (plus the transport's
+        own teardown grace), and a failure starts a short cooldown so a dead
+        server doesn't make every later tool call pay that timeout.
+        """
+        lock = self._reconnect_locks.setdefault(server_id, asyncio.Lock())
+        async with lock:
+            if expected_epoch is not None and self._session_epoch.get(server_id, 0) != expected_epoch:
+                # Someone else already resolved this server's fate while we
+                # waited for the lock — adopt their outcome instead of
+                # reconnecting on top of it.
+                return self._sessions.get(server_id) is not None
+            last_failure = self._reconnect_failed_at.get(server_id)
+            if last_failure is not None and (time.monotonic() - last_failure) < _MCP_RECONNECT_COOLDOWN:
+                # A permanently dead server would otherwise make every tool
+                # call pay the full reconnect timeout.
+                logger.debug(f"Skipping MCP reconnect for {server_id}: in cooldown")
+                return False
+            try:
+                # asyncio.timeout (not wait_for): wait_for runs the coroutine in
+                # a NEW task, which would close the transport's anyio cancel
+                # scope from a different task than the one that entered it —
+                # the very failure mode this reconnect exists to recover from.
+                async with asyncio.timeout(_MCP_RECONNECT_TIMEOUT):
+                    ok = await self._do_reconnect(server_id)
+            except asyncio.TimeoutError:
+                logger.error(
+                    f"MCP reconnect for {server_id} timed out after "
+                    f"{_MCP_RECONNECT_TIMEOUT:.0f}s; closing partial connection"
+                )
+                # Close whatever the cancelled connect left behind, but keep
+                # the config so a later call can retry.
+                await self.disconnect_server(server_id, revoke_params=False)
+                ok = False
+            if not ok:
+                self._reconnect_failed_at[server_id] = time.monotonic()
+            return ok
+
+    async def _do_reconnect(self, server_id: str) -> bool:
+        """One reconnect attempt. Callers hold the per-server lock."""
+        if server_id in self._revoked:
+            # Explicitly disabled, deleted, or shut down: an in-flight call
+            # that failed afterwards must not respawn it. Applies to builtins
+            # too, which have no user-supplied params to revoke.
+            logger.info(f"Not reconnecting MCP server {server_id}: explicitly disconnected")
+            return False
         if self.is_builtin(server_id):
             return await self._reconnect_builtin(server_id)
         params = self._connect_params.get(server_id)
         if not params:
+            # Never connected, or explicitly disabled/deleted (params revoked)
+            # — do not resurrect a server from a stale snapshot.
             logger.error(f"No stored connect params to reconnect MCP server {server_id}")
             return False
-        await self.disconnect_server(server_id)
+        await self.disconnect_server(server_id, revoke_params=False)
         try:
             ok = await self.connect_server(server_id=server_id, **params)
             if ok:
@@ -575,8 +761,8 @@ class McpManager:
         base_dir = get_app_root()
         script_path = os.path.join(base_dir, script_rel)
 
-        # Clean up old connection
-        await self.disconnect_server(server_id)
+        # Clean up old connection (internal recycle — keep the config)
+        await self.disconnect_server(server_id, revoke_params=False)
 
         try:
             ok = await self.connect_server(

--- a/tests/test_mcp_user_server_reconnect.py
+++ b/tests/test_mcp_user_server_reconnect.py
@@ -7,8 +7,10 @@ kept failing every call until an app restart even though the integration page
 showed them as connected.
 """
 import asyncio
+import time
 from types import SimpleNamespace
 
+import src.mcp_manager as mcp_manager_module
 from src.mcp_manager import McpManager
 
 
@@ -32,6 +34,16 @@ def _register_user_server(mgr, server_id="usersrv"):
     """Populate internals as connect_server would after a successful connect."""
     mgr._sessions[server_id] = _DeadSession()
     mgr._connections[server_id] = {"status": "connected", "name": server_id}
+    # Tool schemas drive replay safety: only read-only/idempotent tools may be
+    # replayed after a reconnect (a transport error can arrive after the write
+    # committed, so replaying a mutating call can duplicate the action).
+    mgr._tools[server_id] = [
+        {"name": "list_items", "annotations": {"readOnlyHint": True}},
+        {"name": "set_label", "annotations": {"idempotentHint": True}},
+        {"name": "ping", "annotations": {"readOnlyHint": True}},
+        {"name": "create_issue"},        # unannotated mutation
+        {"name": "get_or_create_issue"}, # reads like a getter, but mutates
+    ]
     mgr._connect_params[server_id] = {
         "name": server_id,
         "transport": "stdio",
@@ -93,6 +105,9 @@ def test_missing_params_fails_gracefully():
 def test_builtin_path_unchanged():
     mgr = McpManager()
     mgr._sessions["builtin_x"] = _DeadSession()
+    # Replay safety applies to builtins too — declare the tool read-only so
+    # this test exercises the reconnect path, not the replay refusal.
+    mgr._tools["builtin_x"] = [{"name": "ping", "annotations": {"readOnlyHint": True}}]
     called = {}
 
     async def fake_reconnect_builtin(server_id):
@@ -104,4 +119,485 @@ def test_builtin_path_unchanged():
 
     result = asyncio.run(mgr.call_tool("mcp__builtin_x__ping", {}))
     assert called["id"] == "builtin_x"
+    assert result.get("exit_code") == 0
+
+
+# --- Review follow-ups: replay safety, lifecycle, concurrency, retryability ---
+
+
+def _fake_connect(mgr, session=None, ok=True, record=None):
+    """Stand-in for connect_server that installs a live session."""
+    live = session or _LiveSession()
+
+    async def fake_connect(server_id, **params):
+        if record is not None:
+            record.append(server_id)
+        if not ok:
+            return False
+        mgr._sessions[server_id] = live
+        mgr._connections[server_id] = {"status": "connected", "name": params.get("name")}
+        mgr._session_epoch[server_id] = mgr._session_epoch.get(server_id, 0) + 1
+        return True
+
+    mgr.connect_server = fake_connect  # type: ignore[method-assign]
+    return live
+
+
+def test_mutating_call_is_not_replayed_after_reconnect():
+    """A write whose transport died has an UNKNOWN outcome — the server may
+    have committed it. Reconnect, but never silently execute it twice."""
+    mgr = McpManager()
+    _register_user_server(mgr)
+    live = _fake_connect(mgr)
+
+    result = asyncio.run(mgr.call_tool("mcp__usersrv__create_issue", {"title": "x"}))
+
+    assert result.get("exit_code") == 1
+    assert result.get("indeterminate") is True
+    assert "UNKNOWN" in result.get("error", "")
+    assert live.calls == []                      # the write was NOT repeated
+    assert mgr._sessions["usersrv"] is live      # but the session was restored
+
+
+def test_readonly_tool_is_replayed():
+    mgr = McpManager()
+    _register_user_server(mgr)
+    live = _fake_connect(mgr)
+
+    result = asyncio.run(mgr.call_tool("mcp__usersrv__list_items", {"q": 1}))
+
+    assert result.get("exit_code") == 0
+    assert live.calls == [("list_items", {"q": 1})]
+
+
+def test_idempotent_hint_allows_replay():
+    mgr = McpManager()
+    _register_user_server(mgr)
+    live = _fake_connect(mgr)
+
+    result = asyncio.run(mgr.call_tool("mcp__usersrv__set_label", {"label": "bug"}))
+
+    assert result.get("exit_code") == 0
+    assert live.calls == [("set_label", {"label": "bug"})]
+
+
+def test_unknown_tool_fails_closed():
+    """No schema for the tool -> we cannot prove it is safe -> do not replay."""
+    mgr = McpManager()
+    _register_user_server(mgr)
+    live = _fake_connect(mgr)
+
+    result = asyncio.run(mgr.call_tool("mcp__usersrv__mystery_op", {}))
+
+    assert result.get("indeterminate") is True
+    assert live.calls == []
+
+
+def test_explicit_disconnect_prevents_resurrection():
+    """An admin disable/delete revokes the cached config: a late in-flight
+    failure must not respawn the server from that snapshot."""
+    mgr = McpManager()
+    _register_user_server(mgr)
+    record = []
+    _fake_connect(mgr, record=record)
+    dead = mgr._sessions["usersrv"]
+
+    async def scenario():
+        await mgr.disconnect_server("usersrv")      # explicit disable/delete
+        mgr._sessions["usersrv"] = dead             # a stale caller still holds it
+        return await mgr.call_tool("mcp__usersrv__list_items", {})
+
+    result = asyncio.run(scenario())
+
+    assert result.get("exit_code") == 1
+    assert record == []                              # never reconnected
+    assert "usersrv" not in mgr._connect_params      # config revoked
+
+
+def test_stale_epoch_does_not_reconnect_over_a_newer_session():
+    mgr = McpManager()
+    _register_user_server(mgr)
+    record = []
+    live = _fake_connect(mgr, record=record)
+
+    async def scenario():
+        # Another caller already recovered the server; ours holds the old one.
+        await mgr._reconnect_any("usersrv")
+        stale_epoch = 0
+        return await mgr._reconnect_any("usersrv", expected_epoch=stale_epoch)
+
+    assert asyncio.run(scenario()) is True
+    assert len(record) == 1                          # no second reconnect
+    assert mgr._sessions["usersrv"] is live
+
+
+def test_concurrent_failures_coalesce_into_one_reconnect():
+    mgr = McpManager()
+    _register_user_server(mgr)
+    record = []
+
+    live = _LiveSession()
+
+    async def slow_connect(server_id, **params):
+        record.append(server_id)
+        await asyncio.sleep(0.05)                    # widen the race window
+        mgr._sessions[server_id] = live
+        mgr._session_epoch[server_id] = mgr._session_epoch.get(server_id, 0) + 1
+        return True
+
+    mgr.connect_server = slow_connect  # type: ignore[method-assign]
+
+    async def scenario():
+        return await asyncio.gather(*(
+            mgr.call_tool("mcp__usersrv__list_items", {"i": i}) for i in range(5)
+        ))
+
+    results = asyncio.run(scenario())
+
+    assert len(record) == 1                          # ONE reconnect, not five
+    assert all(r.get("exit_code") == 0 for r in results)
+
+
+def test_failed_reconnect_can_still_recover_later(monkeypatch):
+    """A transient reconnect failure must not strand the server until a
+    manual reconnect: the next call retries from the cached config."""
+    mgr = McpManager()
+    _register_user_server(mgr)
+    monkeypatch.setattr(mcp_manager_module, "_MCP_RECONNECT_COOLDOWN", 0.0)
+    attempts = []
+    live = _LiveSession()
+
+    async def flaky_connect(server_id, **params):
+        attempts.append(server_id)
+        if len(attempts) == 1:
+            return False                             # first recovery fails
+        mgr._sessions[server_id] = live
+        mgr._session_epoch[server_id] = mgr._session_epoch.get(server_id, 0) + 1
+        return True
+
+    mgr.connect_server = flaky_connect  # type: ignore[method-assign]
+
+    async def scenario():
+        first = await mgr.call_tool("mcp__usersrv__list_items", {})
+        second = await mgr.call_tool("mcp__usersrv__list_items", {})
+        return first, second
+
+    first, second = asyncio.run(scenario())
+
+    assert first.get("exit_code") == 1               # reconnect failed
+    assert "usersrv" in mgr._connect_params          # config preserved
+    assert second.get("exit_code") == 0              # later call recovers
+    assert len(attempts) == 2
+
+
+def test_reconnect_timeout_is_bounded_and_cleans_up(monkeypatch):
+    """A stalled transport must not block callers forever, and whatever the
+    cancelled connect left behind must be closed."""
+    mgr = McpManager()
+    _register_user_server(mgr)
+    monkeypatch.setattr(mcp_manager_module, "_MCP_RECONNECT_TIMEOUT", 0.05)
+    closed = []
+
+    async def hanging_connect(server_id, **params):
+        await asyncio.sleep(10)
+        return True
+
+    real_disconnect = mgr.disconnect_server
+
+    async def spy_disconnect(server_id, *, revoke_params=True):
+        closed.append((server_id, revoke_params))
+        return await real_disconnect(server_id, revoke_params=revoke_params)
+
+    mgr.connect_server = hanging_connect  # type: ignore[method-assign]
+    mgr.disconnect_server = spy_disconnect  # type: ignore[method-assign]
+
+    started = time.monotonic()
+    result = asyncio.run(mgr.call_tool("mcp__usersrv__list_items", {}))
+    elapsed = time.monotonic() - started
+
+    assert result.get("exit_code") == 1
+    # bounded: nowhere near the 10s the connect would have taken
+    assert elapsed < 1.0, f"reconnect was not bounded (took {elapsed:.2f}s)"
+    # cleanup ran and kept the config so a later call can retry
+    assert closed and all(rev is False for _, rev in closed)
+    assert "usersrv" in mgr._connect_params
+
+
+def test_name_heuristic_does_not_authorize_replay():
+    """`get_or_create_*` reads like a getter but mutates. A guess is not a
+    contract: only the server's own annotations may authorize a replay."""
+    mgr = McpManager()
+    _register_user_server(mgr)
+    live = _fake_connect(mgr)
+
+    result = asyncio.run(mgr.call_tool("mcp__usersrv__get_or_create_issue", {"t": "x"}))
+
+    assert result.get("indeterminate") is True
+    assert live.calls == []
+
+
+def test_annotations_object_is_honoured():
+    """Servers may send annotations as a model, not a dict."""
+    assert McpManager._replay_is_safe(
+        {"name": "x", "annotations": SimpleNamespace(readOnlyHint=True)}
+    ) is True
+    assert McpManager._replay_is_safe(
+        {"name": "x", "annotations": SimpleNamespace(readOnlyHint=False, idempotentHint=None)}
+    ) is False
+    assert McpManager._replay_is_safe({"name": "x"}) is False
+    assert McpManager._replay_is_safe(None) is False
+
+
+def test_no_session_calls_coalesce_into_one_reconnect():
+    """Recovery from a *missing* session must be single-flight too: without
+    that, each concurrent caller tears down the session a peer just restored
+    and reports a false 'unknown outcome'."""
+    mgr = McpManager()
+    _register_user_server(mgr)
+    del mgr._sessions["usersrv"]                 # nothing connected at all
+    record = []
+    live = _LiveSession()
+
+    async def slow_connect(server_id, **params):
+        record.append(server_id)
+        await asyncio.sleep(0.05)
+        mgr._sessions[server_id] = live
+        mgr._session_epoch[server_id] = mgr._session_epoch.get(server_id, 0) + 1
+        return True
+
+    mgr.connect_server = slow_connect  # type: ignore[method-assign]
+
+    async def scenario():
+        return await asyncio.gather(*(
+            mgr.call_tool("mcp__usersrv__list_items", {"i": i}) for i in range(5)
+        ))
+
+    results = asyncio.run(scenario())
+
+    assert len(record) == 1, f"spawned {len(record)} reconnects for 5 concurrent calls"
+    assert all(r.get("exit_code") == 0 for r in results)
+    assert not any(r.get("indeterminate") for r in results)
+
+
+def test_explicit_disconnect_prevents_builtin_resurrection():
+    """Builtins carry no user params to revoke, so lifecycle state must gate
+    them too — otherwise shutdown's disconnect_all() races an in-flight call
+    into respawning an orphaned subprocess."""
+    mgr = McpManager()
+    mgr._sessions["builtin_x"] = _DeadSession()
+    mgr._tools["builtin_x"] = [{"name": "ping", "annotations": {"readOnlyHint": True}}]
+    respawned = []
+
+    async def fake_reconnect_builtin(server_id):
+        respawned.append(server_id)
+        mgr._sessions[server_id] = _LiveSession()
+        return True
+
+    mgr._reconnect_builtin = fake_reconnect_builtin  # type: ignore[method-assign]
+    mgr.is_builtin = lambda sid: sid.startswith("builtin_")  # type: ignore[method-assign]
+
+    async def scenario():
+        dead = mgr._sessions["builtin_x"]
+        await mgr.disconnect_server("builtin_x")     # explicit shutdown/disable
+        mgr._sessions["builtin_x"] = dead            # stale in-flight caller
+        return await mgr.call_tool("mcp__builtin_x__ping", {})
+
+    result = asyncio.run(scenario())
+
+    assert respawned == [], f"respawned {respawned} after an explicit disconnect"
+    assert result.get("exit_code") == 1
+
+
+def test_failed_reconnect_enters_cooldown():
+    """A permanently dead server must not make every tool call pay the full
+    reconnect timeout."""
+    mgr = McpManager()
+    _register_user_server(mgr)
+    attempts = []
+
+    async def failing_connect(server_id, **params):
+        attempts.append(server_id)
+        return False
+
+    mgr.connect_server = failing_connect  # type: ignore[method-assign]
+
+    async def scenario():
+        for _ in range(4):
+            await mgr.call_tool("mcp__usersrv__list_items", {})
+
+    asyncio.run(scenario())
+
+    assert len(attempts) == 1, f"hammered the dead server {len(attempts)} times"
+
+
+def test_reenabling_after_a_failed_connect_stays_recoverable():
+    """Re-enabling a server is an intent, not an outcome: if its first connect
+    attempt fails, automatic recovery must not stay locked out forever."""
+    mgr = McpManager()
+    _register_user_server(mgr)
+    live = _LiveSession()
+    attempt = {"n": 0}
+
+    async def flaky_connect_stdio(server_id, name, command, args, env):
+        attempt["n"] += 1
+        if attempt["n"] == 1:
+            return False                       # cold start fails
+        mgr._sessions[server_id] = live
+        return True
+
+    mgr._connect_stdio = flaky_connect_stdio  # type: ignore[method-assign]
+
+    async def scenario():
+        await mgr.disconnect_server("usersrv")          # explicit disable
+        assert "usersrv" in mgr._revoked
+        # user re-enables it; the first attempt fails
+        first = await mgr.connect_server(
+            server_id="usersrv", name="usersrv", transport="stdio",
+            command="some-cmd", args=[], env={},
+        )
+        # recovery must now be allowed again
+        return first, await mgr._reconnect_any("usersrv")
+
+    first, recovered = asyncio.run(scenario())
+
+    assert first is False
+    assert recovered is True, "server stayed permanently revoked after a failed re-enable"
+    assert "usersrv" not in mgr._revoked
+
+
+def test_contradictory_annotations_fail_closed():
+    """readOnlyHint + destructiveHint is malformed — do not replay unless the
+    server also promises idempotency."""
+    assert McpManager._replay_is_safe(
+        {"name": "x", "annotations": {"readOnlyHint": True, "destructiveHint": True}}
+    ) is False
+    assert McpManager._replay_is_safe(
+        {"name": "x", "annotations": {"destructiveHint": True, "idempotentHint": True}}
+    ) is True
+    assert McpManager._replay_is_safe(
+        {"name": "x", "annotations": {"readOnlyHint": True}}
+    ) is True
+
+
+# --- Transport coverage: the tool table feeds the replay decision, so every
+# --- transport must preserve the server's annotations (stdio/SSE/HTTP).
+
+
+class _FakeTool:
+    def __init__(self, name, annotations):
+        self.name = name
+        self.description = "d"
+        self.inputSchema = {"type": "object"}
+        self.annotations = annotations
+
+
+def _stub_mcp_transport(monkeypatch, tools):
+    """Make every transport's session.list_tools() return `tools`."""
+    class _Session:
+        def __init__(self, *a, **k):
+            pass
+
+        async def initialize(self):
+            return None
+
+        async def list_tools(self):
+            return SimpleNamespace(tools=tools)
+
+    class _Transport:
+        """SSE yields (read, write); Streamable HTTP yields a third element."""
+        def __init__(self, arity):
+            self.arity = arity
+
+    class _Stack:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def aclose(self):
+            return None
+
+        async def enter_async_context(self, cm):
+            if isinstance(cm, _Transport):
+                return tuple([None] * cm.arity)
+            return cm
+
+    import contextlib
+    import mcp
+    import mcp.client.sse as sse_mod
+    import mcp.client.streamable_http as http_mod
+    monkeypatch.setattr(mcp, "ClientSession", _Session, raising=False)
+    monkeypatch.setattr(contextlib, "AsyncExitStack", _Stack, raising=False)
+    monkeypatch.setattr(sse_mod, "sse_client", lambda *a, **k: _Transport(2), raising=False)
+    monkeypatch.setattr(http_mod, "streamablehttp_client", lambda *a, **k: _Transport(3), raising=False)
+
+
+def test_sse_transport_preserves_tool_annotations(monkeypatch):
+    mgr = McpManager()
+    _stub_mcp_transport(monkeypatch, [_FakeTool("list_things", {"readOnlyHint": True})])
+
+    ok = asyncio.run(mgr._connect_sse("sse1", "sse1", "https://example.invalid/sse"))
+
+    assert ok is True
+    tool = mgr._find_tool_schema("sse1", "list_things")
+    assert tool is not None and tool.get("annotations") == {"readOnlyHint": True}
+    assert McpManager._replay_is_safe(tool) is True
+
+
+def test_http_transport_preserves_tool_annotations(monkeypatch):
+    """Regression: the Streamable-HTTP path used to drop `annotations`, which
+    silently downgraded every HTTP tool to 'unknown' for replay safety."""
+    mgr = McpManager()
+    _stub_mcp_transport(monkeypatch, [_FakeTool("list_things", {"readOnlyHint": True})])
+
+    ok = asyncio.run(mgr._connect_http("http1", "http1", "https://example.invalid/mcp"))
+
+    assert ok is True
+    tool = mgr._find_tool_schema("http1", "list_things")
+    assert tool is not None and tool.get("annotations") == {"readOnlyHint": True}
+    assert McpManager._replay_is_safe(tool) is True
+
+
+def test_unknown_server_id_allocates_no_recovery_state():
+    """Tool names are model-supplied: an invented server id must not create
+    per-server locks or cooldown entries."""
+    mgr = McpManager()
+
+    result = asyncio.run(mgr.call_tool("mcp__made_up_id__do_thing", {}))
+
+    assert result.get("exit_code") == 1
+    assert mgr._reconnect_locks == {}
+    assert mgr._reconnect_failed_at == {}
+
+
+def test_readonly_tool_after_reconnect_is_not_reported_unknown():
+    """The tool table is empty while the session is gone; once the reconnect
+    repopulates it, an annotated read-only tool must not be mislabelled."""
+    mgr = McpManager()
+    _register_user_server(mgr)
+    del mgr._sessions["usersrv"]
+    mgr._tools.pop("usersrv")                     # nothing known yet
+    calls = []
+
+    class _FailsOnce:
+        async def call_tool(self, tool_name, arguments):
+            calls.append(tool_name)
+            if len(calls) == 1:
+                raise RuntimeError("session closed")
+            return SimpleNamespace(content=[SimpleNamespace(text="pong")], isError=False)
+
+    session = _FailsOnce()
+
+    async def fake_connect(server_id, **params):
+        mgr._sessions[server_id] = session
+        mgr._tools[server_id] = [{"name": "ping", "annotations": {"readOnlyHint": True}}]
+        mgr._session_epoch[server_id] = mgr._session_epoch.get(server_id, 0) + 1
+        return True
+
+    mgr.connect_server = fake_connect  # type: ignore[method-assign]
+
+    result = asyncio.run(mgr.call_tool("mcp__usersrv__ping", {}))
+
+    assert result.get("indeterminate") is not True, "annotated read-only tool reported as unknown"
     assert result.get("exit_code") == 0

--- a/tests/test_mcp_user_server_reconnect.py
+++ b/tests/test_mcp_user_server_reconnect.py
@@ -1,0 +1,107 @@
+"""Regression tests for issue #1789: a user-added MCP server whose session has
+died (e.g. the asyncio task that created its stdio session has exited) must be
+auto-reconnected on the next tool call, the way builtin servers already are.
+
+call_tool used to gate the reconnect on is_builtin(), so user-added servers
+kept failing every call until an app restart even though the integration page
+showed them as connected.
+"""
+import asyncio
+from types import SimpleNamespace
+
+from src.mcp_manager import McpManager
+
+
+class _DeadSession:
+    """Session whose transport has died — every call raises."""
+
+    async def call_tool(self, tool_name, arguments):
+        raise RuntimeError("session closed (stdio task exited)")
+
+
+class _LiveSession:
+    def __init__(self):
+        self.calls = []
+
+    async def call_tool(self, tool_name, arguments):
+        self.calls.append((tool_name, arguments))
+        return SimpleNamespace(content=[SimpleNamespace(text="pong")], isError=False)
+
+
+def _register_user_server(mgr, server_id="usersrv"):
+    """Populate internals as connect_server would after a successful connect."""
+    mgr._sessions[server_id] = _DeadSession()
+    mgr._connections[server_id] = {"status": "connected", "name": server_id}
+    mgr._connect_params[server_id] = {
+        "name": server_id,
+        "transport": "stdio",
+        "command": "some-cmd",
+        "args": [],
+        "env": {},
+        "url": None,
+    }
+
+
+def test_user_server_reconnects_and_retries():
+    mgr = McpManager()
+    _register_user_server(mgr)
+    live = _LiveSession()
+
+    async def fake_connect(server_id, **params):
+        mgr._sessions[server_id] = live
+        mgr._connections[server_id] = {"status": "connected", "name": params.get("name")}
+        return True
+
+    mgr.connect_server = fake_connect  # type: ignore[method-assign]
+
+    result = asyncio.run(mgr.call_tool("mcp__usersrv__ping", {"x": 1}))
+    assert result.get("exit_code") == 0
+    assert result.get("stdout") == "pong"
+    assert live.calls == [("ping", {"x": 1})]
+
+
+def test_reconnect_uses_stored_connect_params():
+    mgr = McpManager()
+    _register_user_server(mgr)
+    seen = {}
+
+    async def fake_connect(server_id, **params):
+        seen.update(params, server_id=server_id)
+        mgr._sessions[server_id] = _LiveSession()
+        return True
+
+    mgr.connect_server = fake_connect  # type: ignore[method-assign]
+
+    asyncio.run(mgr.call_tool("mcp__usersrv__ping", {}))
+    assert seen["server_id"] == "usersrv"
+    assert seen["transport"] == "stdio"
+    assert seen["command"] == "some-cmd"
+
+
+def test_missing_params_fails_gracefully():
+    mgr = McpManager()
+    # Session present but no stored connect params (never went through
+    # connect_server) — must return an error dict, not crash.
+    mgr._sessions["usersrv"] = _DeadSession()
+    mgr._connections["usersrv"] = {"status": "connected", "name": "usersrv"}
+
+    result = asyncio.run(mgr.call_tool("mcp__usersrv__ping", {}))
+    assert result.get("exit_code") == 1
+    assert "reconnect failed" in result.get("error", "")
+
+
+def test_builtin_path_unchanged():
+    mgr = McpManager()
+    mgr._sessions["builtin_x"] = _DeadSession()
+    called = {}
+
+    async def fake_reconnect_builtin(server_id):
+        called["id"] = server_id
+        mgr._sessions[server_id] = _LiveSession()
+        return True
+
+    mgr._reconnect_builtin = fake_reconnect_builtin  # type: ignore[method-assign]
+
+    result = asyncio.run(mgr.call_tool("mcp__builtin_x__ping", {}))
+    assert called["id"] == "builtin_x"
+    assert result.get("exit_code") == 0


### PR DESCRIPTION
## Summary

A user-added MCP server whose client session has died — typically a stdio session whose creating asyncio task has exited — failed every subsequent tool call with a transport error / "MCP server not connected" until the app was restarted, even though the Integrations page still showed the server as connected with its tools listed. `call_tool` already recovered from exactly this for builtin servers, but the retry path was gated on `is_builtin()`, so user-added servers stayed dead. This PR stores each server's `connect_server` kwargs at connect time and routes the retry through a new `_reconnect_any()`, which reuses the existing `_reconnect_builtin()` for builtins and performs a full disconnect + reconnect from the stored params for user-added servers. A failing call now transparently reconnects and retries once. The error dict shape (`error` + `exit_code: 1`) is unchanged; when reconnection fails the message now says so explicitly instead of surfacing the raw transport error.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Part of #1789 — this addresses the dead-session sub-cause; the MCP schema keyword-filtering sub-cause discussed in that thread is a separate problem. Likely also relevant to #3055 and #1795.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate (no open PR touches the `call_tool` reconnect path).
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end: this fix (same logic, previously rebased onto `main`) has been running on my daily native macOS install since 2026-08-10 — user-added stdio servers (`filesystem`, `sequential-thinking`) that previously went dead after a background task's session closed now reconnect on the next call. The included regression tests pass: `python -m pytest tests/test_mcp_user_server_reconnect.py tests/test_mcp_cache_invalidation.py`.

## How to Test

1. Start Odysseus and add a user MCP server over stdio on the Integrations page (e.g. `npx -y @modelcontextprotocol/server-filesystem <dir>`); verify its tools load.
2. Kill that server's underlying session (deterministic repro: let a scheduled/background agent task use the server and close its session; or `kill` the spawned npx process).
3. On `dev` without this patch: the next chat/agent call to any of that server's tools fails until an app restart.
4. With this patch: the first call logs `MCP call failed ... attempting reconnect`, then `Reconnected user MCP server: ...`, and the tool call succeeds.
5. `python -m pytest tests/test_mcp_user_server_reconnect.py` — 4 regression tests cover reconnect+retry, stored-params reuse, graceful failure when no params are stored, and the unchanged builtin path.
