### PR TITLE
fix(desktop): fix frozen build browser tab and MCP server connection failures

### DIFF
--- a/Odysseus.spec
+++ b/Odysseus.spec
@@ -1,12 +1,20 @@
 # -*- mode: python ; coding: utf-8 -*-
+import os
+from PyInstaller.utils.hooks import collect_all
+
+datas = [('static', 'static'), ('scripts', 'scripts'), ('mcp_servers', 'mcp_servers'), ('services/hwfit/data', 'services/hwfit/data'), ('config', 'config'), ('.env.example', '.env.example')]
+binaries = []
+hiddenimports = []
+tmp_ret = collect_all('webview')
+datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
 
 
 a = Analysis(
     ['launcher.py'],
     pathex=[],
-    binaries=[],
-    datas=[('static', 'static'), ('scripts', 'scripts'), ('mcp_servers', 'mcp_servers'), ('services/hwfit/data', 'services/hwfit/data'), ('config', 'config'), ('.env.example', '.env.example')],
-    hiddenimports=[],
+    binaries=binaries,
+    datas=datas,
+    hiddenimports=hiddenimports,
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],
@@ -32,7 +40,7 @@ exe = EXE(
     target_arch=None,
     codesign_identity=None,
     entitlements_file=None,
-    icon=['static\\icon.ico'],
+    icon=['static/icon.ico'],
 )
 coll = COLLECT(
     exe,
@@ -43,3 +51,14 @@ coll = COLLECT(
     upx_exclude=[],
     name='Odysseus',
 )
+
+# Ship the real runtime .env alongside the exe (not via the `datas` list above:
+# PyInstaller's onedir layout treats a (src, dest) datas tuple's dest as a
+# directory, so ('.env', '.env') would land at _internal/.env/.env instead of
+# next to Odysseus.exe — which is where load_dotenv() actually looks, since it
+# reads from the app's working directory). SPECPATH/DISTPATH are globals
+# PyInstaller injects into this spec's execution namespace.
+import shutil
+_env_src = os.path.join(SPECPATH, '.env')
+if os.path.isfile(_env_src):
+    shutil.copy2(_env_src, os.path.join(DISTPATH, 'Odysseus', '.env'))

--- a/launcher.py
+++ b/launcher.py
@@ -1,21 +1,51 @@
 # launcher.py
 """Dedicated entrypoint for the standalone Windows portable launcher.
 
-Handles:
-- Immediate GUI splash screen creation using tkinter.
-- Suppressing console stream crashes in windowed GUI mode via NullWriter.
-- Spawning system tray icon via pystray and Pillow (lazy-loaded).
-- Auto-opening default browser pointing to the running backend.
-- Launching the FastAPI server (importing and running app.py).
+Runs the FastAPI server in a background thread and shows it in a genuine
+native application window via pywebview (WebView2 on Windows) — not a
+browser tab, and not an external browser process at all.
 """
+import ctypes
+import logging
 import os
 import sys
 import threading
 import time
-import webbrowser
+import urllib.error
+import urllib.request
+
+_log_path = os.path.join(os.path.expandvars(r"%LOCALAPPDATA%\Odysseus"), "desktop_launcher.log")
+try:
+    os.makedirs(os.path.dirname(_log_path), exist_ok=True)
+except Exception:
+    pass
+# Use a uniquely-named, isolated logger (not "launcher" — that name is already
+# used elsewhere in the app for DB-migration logging) with its own handler,
+# so app.py's own logging setup can't swallow or redirect these messages.
+log = logging.getLogger("odysseus_desktop_launcher")
+log.setLevel(logging.INFO)
+log.propagate = False
+_handler = logging.FileHandler(_log_path, mode="a", encoding="utf-8")
+_handler.setFormatter(logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s"))
+log.addHandler(_handler)
+
 
 # Define a dummy NullWriter to suppress standard stream crashes (isatty etc.) in GUI mode
 class NullWriter:
+    """Dummy stream used for sys.stdout/sys.stderr when running frozen with no
+    console (both are None in that case).
+
+    fileno() matters here: built-in MCP servers are spawned via subprocess with
+    stderr defaulting to sys.stderr (see mcp.client.stdio.stdio_client), and
+    Python's subprocess machinery calls .fileno() on whatever it's given to
+    duplicate a real OS handle for the child. Without a working fileno(), that
+    raises "'NullWriter' object has no attribute 'fileno'" and the subprocess
+    is never spawned, so every built-in MCP server fails to connect. Lazily
+    open os.devnull to hand back a real, if discarded, file descriptor.
+    """
+    def __init__(self):
+        self._devnull_fd = None
+
     def write(self, text):
         pass
     def flush(self):
@@ -23,120 +53,87 @@ class NullWriter:
     def isatty(self):
         return False
 
+    def fileno(self):
+        if self._devnull_fd is None:
+            self._devnull_fd = os.open(os.devnull, os.O_WRONLY)
+        return self._devnull_fd
+
 if sys.stdout is None:
     sys.stdout = NullWriter()
 if sys.stderr is None:
     sys.stderr = NullWriter()
 
 
-splash_root = None
-
-# If running from a frozen PyInstaller bundle, launch the splash screen IMMEDIATELY
-if getattr(sys, 'frozen', False):
-    import tkinter as tk
-
-    def show_splash_instantly():
-        global splash_root
+def wait_until_ready(url, timeout=60.0, interval=0.5):
+    """Poll url until it responds (any HTTP status) or timeout elapses."""
+    deadline = time.time() + timeout
+    attempts = 0
+    while time.time() < deadline:
+        attempts += 1
         try:
-            splash_root = tk.Tk()
-            splash_root.title("Odysseus")
-            splash_root.overrideredirect(True)
-            splash_root.configure(bg="#1a1c23")
-
-            # Accented borders
-            splash_root.config(highlightbackground="#e06c75", highlightcolor="#e06c75", highlightthickness=1)
-
-            w, h = 360, 160
-            ws = splash_root.winfo_screenwidth()
-            hs = splash_root.winfo_screenheight()
-            x = (ws - w) // 2
-            y = (hs - h) // 2
-            splash_root.geometry(f"{w}x{h}+{x}+{y}")
-
-            tk.Label(splash_root, text="⛵ Odysseus", font=("Segoe UI", 22, "bold"), bg="#1a1c23", fg="#e06c75").pack(pady=(22, 2))
-            tk.Label(splash_root, text="Launching background services...", font=("Segoe UI", 10), bg="#1a1c23", fg="#d1d4e0").pack(pady=2)
-            tk.Label(splash_root, text="Please wait, this will take a few seconds.", font=("Segoe UI", 8, "italic"), bg="#1a1c23", fg="#5c6370").pack(pady=(12, 0))
-
-            splash_root.attributes("-topmost", True)
-            splash_root.mainloop()
+            urllib.request.urlopen(url, timeout=2)
+            log.info("wait_until_ready: server ready after %d attempts", attempts)
+            return True
+        except urllib.error.HTTPError:
+            # Any HTTP response (even 3xx/4xx) means the server is up.
+            log.info("wait_until_ready: server ready (HTTPError response) after %d attempts", attempts)
+            return True
         except Exception:
-            pass
-
-    # Launch the GUI splash screen immediately on a background thread
-    threading.Thread(target=show_splash_instantly, daemon=True).start()
-
-
-def create_tray_image():
-    # Generate a beautiful 64x64 icon matching Odysseus brand red accent (#e06c75)
-    from PIL import Image, ImageDraw
-    image = Image.new('RGBA', (64, 64), (0, 0, 0, 0))
-    dc = ImageDraw.Draw(image)
-    accent_red = (224, 108, 117, 255)
-    light_red = (224, 108, 117, 150)
-
-    # Draw premium sailing boat
-    dc.polygon([(32, 10), (32, 45), (12, 45)], fill=accent_red)
-    dc.polygon([(32, 18), (32, 45), (48, 45)], fill=light_red)
-    dc.polygon([(8, 48), (56, 48), (44, 56), (20, 56)], fill=accent_red)
-    return image
+            time.sleep(interval)
+    log.warning("wait_until_ready: timed out after %.1fs waiting for %s", timeout, url)
+    return False
 
 
-def on_open_browser(icon, item, url):
-    webbrowser.open(url)
-
-
-def on_exit(icon, item):
-    icon.stop()
-    os._exit(0)
-
-
-def setup_system_tray(url):
-    try:
-        import pystray
-        icon_img = create_tray_image()
-        menu = (
-            pystray.MenuItem('Open Odysseus', lambda icon, item: on_open_browser(icon, item, url), default=True),
-            pystray.MenuItem('Exit', on_exit)
-        )
-        tray_icon = pystray.Icon(
-            "Odysseus",
-            icon_img,
-            "Odysseus",
-            menu
-        )
-        tray_icon.run()
-    except Exception:
-        pass
-
-
-def open_browser(url):
-    # Allow uvicorn and app lifecycles to complete warmups
-    time.sleep(3.5)
-
-    # Safely close the splash screen
-    try:
-        global splash_root
-        if splash_root:
-            splash_root.after(0, splash_root.destroy)
-    except Exception:
-        pass
-
-    webbrowser.open(url)
+def run_server(fastapi_app, bind_host, bind_port):
+    import uvicorn
+    uvicorn.run(fastapi_app, host=bind_host, port=bind_port, log_level="info")
 
 
 if __name__ == "__main__":
-    import uvicorn
-    # Import the FastAPI app from app.py
-    from app import app
+    # Re-entry mode: when frozen, built-in Python MCP servers (mcp_servers/*.py)
+    # have no bundled python.exe to run as, so src/builtin_mcp.py spawns them by
+    # re-invoking this same exe with a sentinel argv instead. Handle that here,
+    # before the single-instance mutex and app/GUI imports below, so the child
+    # actually runs the MCP server's stdio loop on this process's real stdio
+    # rather than tripping the mutex check and exiting immediately (which the
+    # parent sees as the subprocess closing its connection before any handshake).
+    if len(sys.argv) >= 3 and sys.argv[1] == "--run-mcp-server":
+        import asyncio
+        import importlib
+        module = importlib.import_module(sys.argv[2])
+        asyncio.run(module.run())
+        sys.exit(0)
+
+    from app import app as fastapi_app
 
     bind_host = os.getenv("APP_BIND", "127.0.0.1")
     bind_port = int(os.getenv("APP_PORT", "7000"))
     url = f"http://{bind_host}:{bind_port}"
+    frozen = getattr(sys, 'frozen', False)
+    log.info("launcher starting, frozen=%s, url=%s, log_path=%s", frozen, url, _log_path)
 
-    if getattr(sys, 'frozen', False):
-        # Start browser manager thread
-        threading.Thread(target=open_browser, args=(url,), daemon=True).start()
-        # Start system tray manager thread
-        threading.Thread(target=setup_system_tray, args=(url,), daemon=True).start()
+    if frozen:
+        # Single-instance guard: if Odysseus is already running, exit
+        # immediately rather than starting a second server + window.
+        ERROR_ALREADY_EXISTS = 183
+        _mutex = ctypes.windll.kernel32.CreateMutexW(None, False, "Global\\OdysseusDesktopSingleInstance")
+        already_running = ctypes.windll.kernel32.GetLastError() == ERROR_ALREADY_EXISTS
+        log.info("single-instance check: already_running=%s", already_running)
+        if already_running:
+            log.info("another instance is already running; exiting without opening a new window")
+            sys.exit(0)
 
-    uvicorn.run(app, host=bind_host, port=bind_port, log_level="info")
+        # Run the server in the background so the main thread is free for
+        # the native window's GUI event loop (required by webview on Windows).
+        threading.Thread(target=run_server, args=(fastapi_app, bind_host, bind_port), daemon=True).start()
+        wait_until_ready(url, timeout=60.0)
+
+        import webview
+        webview.create_window("Odysseus", url, width=1400, height=900, min_size=(900, 600))
+        log.info("opening native app window")
+        webview.start()
+        log.info("app window closed, exiting")
+        os._exit(0)
+    else:
+        import uvicorn
+        uvicorn.run(fastapi_app, host=bind_host, port=bind_port, log_level="info")

--- a/src/builtin_mcp.py
+++ b/src/builtin_mcp.py
@@ -168,15 +168,29 @@ async def register_builtin_servers(mcp_manager):
 
     base_dir = get_app_root()
     python = sys.executable
+    frozen = getattr(sys, "frozen", False)
 
-    async def _connect_python_server(server_id: str, script_path: str, name: str):
+    async def _connect_python_server(server_id: str, script: str, script_path: str, name: str):
         try:
+            if frozen:
+                # sys.executable is this app's own bundled exe when frozen — there's
+                # no python.exe shipped alongside it to run script_path directly.
+                # Re-invoke this same exe with a sentinel argv that launcher.py
+                # recognizes: it imports the module and runs its MCP stdio loop
+                # in-process instead of the normal single-instance-mutex + GUI
+                # startup, so the subprocess actually speaks MCP instead of just
+                # detecting "already running" and exiting (which the parent sees
+                # as an immediate "Connection closed").
+                module_name = os.path.splitext(script)[0].replace("/", ".").replace("\\", ".")
+                args = ["--run-mcp-server", module_name]
+            else:
+                args = [script_path]
             ok = await mcp_manager.connect_server(
                 server_id=server_id,
                 name=name,
                 transport="stdio",
                 command=python,
-                args=[script_path],
+                args=args,
                 env=builtin_python_env(base_dir),
             )
             if ok:
@@ -194,7 +208,7 @@ async def register_builtin_servers(mcp_manager):
         if not os.path.exists(script_path):
             logger.warning(f"Built-in MCP server script not found: {script_path}")
             continue
-        _spawn_bg(_connect_python_server(server_id, script_path, name))
+        _spawn_bg(_connect_python_server(server_id, script, script_path, name))
 
     # Register NPX-based servers in the background (they take longer to start)
     npx_path = _find_npx()


### PR DESCRIPTION
## Summary

Migrates the Windows portable launcher from a tray-icon + splash-screen setup (which opened the default system browser via `webbrowser.open`, causing a stray browser tab on autostart) to a genuine native app window via pywebview/WebView2, and fixes two bugs that migration surfaced in the frozen (`--noconsole`) build where every built-in MCP server (Memory, RAG, Email, Image Generation, Browser) was failing to connect. Also fixes a packaging gap where a clean rebuild silently dropped the portable build's `.env`.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #6153

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.
- [ ] I did not run the app/runtime validation and stated that gap in **How to Test**.

## How to Test

1. Build the portable exe: `pyinstaller --noconfirm --clean Odysseus.spec` (needs `pyinstaller`, `pywebview`, and the project's other deps installed, e.g. via `.venv`).
2. Launch it **detached**, not from a console (the console-attached case doesn't reproduce the bug — `sys.stdout`/`sys.stderr` are only `None` when truly unattached, e.g. a Startup-folder shortcut or `Start-Process "dist\Odysseus\Odysseus.exe"`).
3. Tail `~/.odysseus/data/logs/app.log` (Windows: `%USERPROFILE%\.odysseus\data\logs\app.log`) and confirm all 5 built-in MCP servers connect, with no `fileno` or `Connection closed` errors:
   ```
   MCP server connected: Built-in: Image Generation (image_gen) - 1 tools via stdio
   MCP server connected: Built-in: RAG (rag) - 1 tools via stdio
   MCP server connected: Built-in: Memory (memory) - 1 tools via stdio
   MCP server connected: Built-in: Email (email) - 16 tools via stdio
   MCP server connected: Built-in: Browser (builtin_browser) - 30 tools via stdio
   ```
4. Confirm `dist/Odysseus/.env` exists after the clean rebuild without any manual copy step, and that the app logs `Auth config loaded` (not "first-run setup required") using that config.
5. Confirm no Opera/Chrome/Edge/any browser tab opens on launch — only the native app window.

I ran all of the above against a real clean rebuild + detached launch before opening this PR.

## Visual / UI changes — REQUIRED if you touched anything that renders

N/A — this PR only touches the desktop launcher entrypoint, the built-in MCP server spawn logic, and the PyInstaller build spec. No UI/rendering files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)