### PR TITLE
fix(docker): repair app cache parent ownership

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -101,7 +101,11 @@ repair_app_tree_ownership
 # such as /app/.cache/vllm and /app/.cache/flashinfer can be created without
 # recursively walking the mounted model cache.
 chown "$PUID:$PGID" /app/.cache 2>/dev/null || true
-for dir in /app/data /app/logs /app/.ssh /app/.cache/huggingface /app/.local; do
+# The Hugging Face cache can contain hundreds of gigabytes and is a nested
+# mount with its own ownership contract. Repair its mount root so new cache
+# entries are writable, but never traverse or rewrite existing model files.
+chown "$PUID:$PGID" /app/.cache/huggingface 2>/dev/null || true
+for dir in /app/data /app/logs /app/.ssh /app/.local; do
     repair_bind_mount_ownership "$dir"
 done
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -96,6 +96,11 @@ repair_bind_mount_ownership() {
 # Repair image-owned writable paths without walking into bind-mounted host
 # trees, then repair the app-owned mount roots separately.
 repair_app_tree_ownership
+# Docker creates the parent of the HuggingFace bind mount as root before this
+# entrypoint runs. Repair only the parent directory itself so app-user caches
+# such as /app/.cache/vllm and /app/.cache/flashinfer can be created without
+# recursively walking the mounted model cache.
+chown "$PUID:$PGID" /app/.cache 2>/dev/null || true
 for dir in /app/data /app/logs /app/.ssh /app/.cache/huggingface /app/.local; do
     repair_bind_mount_ownership "$dir"
 done

--- a/tests/test_docker_devops_hardening.py
+++ b/tests/test_docker_devops_hardening.py
@@ -1,9 +1,14 @@
 """Static regressions for Docker/devops hardening contracts."""
 
 import ast
+import os
 import re
+import shutil
+import subprocess
+import uuid
 from pathlib import Path
 
+import pytest
 import yaml
 from starlette.applications import Starlette
 from starlette.middleware.cors import CORSMiddleware
@@ -129,6 +134,69 @@ def test_docker_entrypoint_repairs_cache_parent_without_recursive_walk():
     assert app_repair < cache_parent_repair < mounted_cache_root_repair
     assert 'repair_tree_ownership "/app/.cache"' not in script
     assert 'repair_bind_mount_ownership "/app/.cache/huggingface"' not in script
+
+
+@pytest.mark.skipif(shutil.which("docker") is None, reason="Docker CLI is unavailable")
+def test_docker_entrypoint_cache_parent_with_nested_volume():
+    """Run the real entrypoint against a disposable nested-volume layout."""
+    image = os.environ.get("ODYSSEUS_DOCKER_TEST_IMAGE", "odysseus-odysseus:latest")
+    if subprocess.run(
+        ["docker", "image", "inspect", image],
+        capture_output=True,
+        text=True,
+        check=False,
+    ).returncode != 0:
+        pytest.skip(f"Docker test image is unavailable: {image}")
+
+    volume = f"odysseus-cache-parent-test-{uuid.uuid4().hex}"
+    subprocess.run(
+        ["docker", "volume", "create", volume],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    try:
+        subprocess.run(
+            [
+                "docker", "run", "--rm", "--pull=never",
+                "--entrypoint", "sh",
+                "-v", f"{volume}:/fixture",
+                image,
+                "-c", "mkdir -p /fixture/nested && touch /fixture/nested/sentinel",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        result = subprocess.run(
+            [
+                "docker", "run", "--rm", "--pull=never",
+                "-e", "PUID=23456",
+                "-e", "PGID=23456",
+                "-v", f"{volume}:/app/.cache/huggingface",
+                image,
+                "sh", "-c",
+                "mkdir -p /app/.cache/vllm && "
+                "touch /app/.cache/vllm/probe && "
+                "printf 'CACHE_TEST %s %s %s %s\\n' "
+                "\"$(stat -c %u /app/.cache)\" "
+                "\"$(stat -c %u /app/.cache/vllm/probe)\" "
+                "\"$(stat -c %u /app/.cache/huggingface)\" "
+                "\"$(stat -c %u /app/.cache/huggingface/nested/sentinel)\"",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    finally:
+        subprocess.run(
+            ["docker", "volume", "rm", "-f", volume],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    assert "CACHE_TEST 23456 23456 23456 0" in result.stdout
 
 
 def test_dockerignore_excludes_secrets_editor_backups():

--- a/tests/test_docker_devops_hardening.py
+++ b/tests/test_docker_devops_hardening.py
@@ -122,12 +122,13 @@ def test_docker_entrypoint_repairs_cache_parent_without_recursive_walk():
     cache_parent_repair = script.index(
         'chown "$PUID:$PGID" /app/.cache 2>/dev/null || true'
     )
-    mounted_cache_repair = script.index(
-        "for dir in /app/data /app/logs /app/.ssh /app/.cache/huggingface /app/.local"
+    mounted_cache_root_repair = script.index(
+        'chown "$PUID:$PGID" /app/.cache/huggingface 2>/dev/null || true'
     )
 
-    assert app_repair < cache_parent_repair < mounted_cache_repair
+    assert app_repair < cache_parent_repair < mounted_cache_root_repair
     assert 'repair_tree_ownership "/app/.cache"' not in script
+    assert 'repair_bind_mount_ownership "/app/.cache/huggingface"' not in script
 
 
 def test_dockerignore_excludes_secrets_editor_backups():

--- a/tests/test_docker_devops_hardening.py
+++ b/tests/test_docker_devops_hardening.py
@@ -115,6 +115,21 @@ def test_docker_entrypoint_ownership_repair_stays_inside_expected_mounts():
     assert "Skipping recursive ownership repair" in script
 
 
+def test_docker_entrypoint_repairs_cache_parent_without_recursive_walk():
+    """Pin the hard-coded container-path contract without running entrypoint as root."""
+    script = (ROOT / "docker" / "entrypoint.sh").read_text(encoding="utf-8")
+    app_repair = script.index("repair_app_tree_ownership\n")
+    cache_parent_repair = script.index(
+        'chown "$PUID:$PGID" /app/.cache 2>/dev/null || true'
+    )
+    mounted_cache_repair = script.index(
+        "for dir in /app/data /app/logs /app/.ssh /app/.cache/huggingface /app/.local"
+    )
+
+    assert app_repair < cache_parent_repair < mounted_cache_repair
+    assert 'repair_tree_ownership "/app/.cache"' not in script
+
+
 def test_dockerignore_excludes_secrets_editor_backups():
     patterns = set((ROOT / ".dockerignore").read_text(encoding="utf-8").splitlines())
     assert {


### PR DESCRIPTION
## Summary

Repairs ownership of `/app/.cache` in the Docker entrypoint before dropping privileges so Cookbook-installed vLLM can create its model-info and FlashInfer cache directories after container recreation. The repair changes only the cache parent and nested Hugging Face mount root, preserving existing model-file ownership rather than recursively traversing a potentially very large bind mount. A disposable Docker regression now executes the real entrypoint and verifies both contracts.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #6157

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.
- [ ] I did not run the app/runtime validation and stated that gap in **How to Test**. Leave this unchecked when the app-run box above is checked.

## How to Test

1. Rebuild the image and recreate the stack with `docker compose up -d --build`.
2. Verify the application user can write the cache parent and create runtime-cache siblings:
   ```bash
   docker compose exec -T --user odysseus odysseus sh -lc \
     'test -w /app/.cache && mkdir -p /app/.cache/vllm /app/.cache/flashinfer'
   ```
3. Confirm `/app/.cache`, `/app/.cache/vllm`, and `/app/.cache/flashinfer` are owned by the application user:
   ```bash
   docker compose exec -T odysseus stat -c '%U:%G %a %n' \
     /app/.cache /app/.cache/vllm /app/.cache/flashinfer
   ```
4. Run the Docker-backed regression against the image built in step 1:
   ```bash
   ODYSSEUS_DOCKER_TEST_IMAGE=odysseus-odysseus:latest \
     ./venv/bin/python -m pytest tests/test_docker_devops_hardening.py -q
   ```
   The disposable test verifies that the app UID owns `/app/.cache`, can create `/app/.cache/vllm/probe`, owns the nested Hugging Face mount root, and does not recursively change a root-owned sentinel below that mount. All 13 tests should pass.
5. Serve a vLLM model through Cookbook and confirm startup no longer fails with `PermissionError` for `/app/.cache/vllm` or `/app/.cache/flashinfer`.

## Visual / UI changes — REQUIRED if you touched anything that renders

N/A — this PR changes only the Docker entrypoint and its regression test. It does not modify UI or rendering code.
