### PR TITLE
fix(auth): scope the internal-tool loopback in require_admin

### DIFF
--- a/app.py
+++ b/app.py
@@ -71,6 +71,7 @@ from core.middleware import (
     SecurityHeadersMiddleware,
     get_application_route_path,
     is_cors_preflight,
+    is_trusted_loopback,
     path_is_route_or_child,
     with_asgi_root_path,
 )
@@ -335,30 +336,9 @@ if AUTH_ENABLED:
         _token_cache.update(new_map)
         app.state._token_cache_dirty = False
 
-    # Headers that prove a request was forwarded by a proxy/tunnel (cloudflared,
-    # nginx, Caddy, Tailscale Funnel, …). cloudflared connects to the app FROM
-    # 127.0.0.1, so without this check every tunneled request would look like
-    # loopback and could bypass auth.
-    _PROXY_FWD_HEADERS = (
-        "cf-connecting-ip", "cf-ray", "cf-visitor",
-        "x-forwarded-for", "x-forwarded-host", "x-real-ip", "forwarded",
-    )
-
-    def _is_trusted_loopback(request: Request) -> bool:
-        """True ONLY for a DIRECT loopback connection with no proxy/tunnel
-        forwarding headers. A bare ``client.host in ('127.0.0.1','::1')`` check is
-        unsafe behind a Cloudflare tunnel / reverse proxy: those connect from
-        loopback, so a remote visitor would otherwise inherit local trust and
-        slip past LOCALHOST_BYPASS or spoof the internal-tool path. Odysseus's own
-        in-process agent loopback calls carry none of these headers, so they still
-        qualify."""
-        host = request.client.host if request.client else None
-        if host not in ("127.0.0.1", "::1"):
-            return False
-        for _h in _PROXY_FWD_HEADERS:
-            if request.headers.get(_h):
-                return False
-        return True
+    # The "is this the in-process loopback?" rule lives in core.middleware so
+    # this middleware and require_admin can't drift into disagreeing about it.
+    _is_trusted_loopback = is_trusted_loopback
 
     class AuthMiddleware(BaseHTTPMiddleware):
         async def dispatch(self, request: Request, call_next):

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -45,6 +45,40 @@ def path_is_route_or_child(path: str, prefix: str) -> bool:
     return path == prefix or path.startswith(prefix + "/")
 
 
+# Headers that prove a request was forwarded by a proxy/tunnel (cloudflared,
+# nginx, Caddy, Tailscale Funnel, …). cloudflared connects to the app FROM
+# 127.0.0.1, so without this check every tunneled request would look like
+# loopback and could bypass auth.
+PROXY_FORWARDING_HEADERS = (
+    "cf-connecting-ip", "cf-ray", "cf-visitor",
+    "x-forwarded-for", "x-forwarded-host", "x-real-ip", "forwarded",
+)
+
+
+def is_trusted_loopback(request: Request) -> bool:
+    """True ONLY for a DIRECT loopback connection with no proxy/tunnel
+    forwarding headers.
+
+    A bare ``client.host in ('127.0.0.1','::1')`` check is unsafe behind a
+    Cloudflare tunnel / reverse proxy: those connect from loopback, so a remote
+    visitor would otherwise inherit local trust and slip past LOCALHOST_BYPASS
+    or spoof the internal-tool path. Odysseus's own in-process agent loopback
+    calls carry none of these headers, so they still qualify.
+
+    This is the single source of truth for that rule. Both halves of the
+    internal-tool contract use it — ``AuthMiddleware`` when it decides whether
+    to honour the token at all, and ``require_admin`` when a route is reached
+    without the middleware having stamped a user — so the two cannot drift into
+    disagreeing about what counts as the in-process loopback.
+    """
+    client = getattr(request, "client", None)
+    host = getattr(client, "host", None) if client is not None else None
+    if host not in ("127.0.0.1", "::1"):
+        return False
+    headers = request.headers
+    return not any(headers.get(name) for name in PROXY_FORWARDING_HEADERS)
+
+
 def is_cors_preflight(method: str, headers) -> bool:
     """True for a genuine CORS preflight: an OPTIONS request carrying the
     Access-Control-Request-Method header. Such requests are credential-less by
@@ -56,29 +90,58 @@ def is_cors_preflight(method: str, headers) -> bool:
 
 def require_admin(request: Request):
     """Raise 403 if the current user isn't an admin.
-    Allows access when auth is explicitly disabled, or when the request carries
-    the in-process internal-tool token used by loopback agent tools.
-    """
-    # In-process bypass for tool-layer loopback calls. Two paths:
-    # (a) header-direct (caller set X-Odysseus-Internal-Token), or
-    # (b) the auth middleware already validated the token and stamped
-    #     request.state.current_user = "internal-tool".
-    try:
-        hdr = request.headers.get(INTERNAL_TOOL_HEADER)
-        if hdr and secrets.compare_digest(hdr, INTERNAL_TOOL_TOKEN):
-            return
-        if getattr(request.state, "current_user", None) == INTERNAL_TOOL_USER:
-            return
-    except Exception:
-        pass
 
-    auth_mgr = getattr(request.app.state, "auth_manager", None)
+    Allows access when auth is explicitly disabled, or when the request is the
+    in-process tool loopback described in THREAT_MODEL.md. That loopback is
+    recognised two ways, and both are narrower than "the token is present":
+
+    (b) ``request.state.current_user`` is the reserved ``internal-tool``
+        sentinel. Only ``AuthMiddleware`` sets that, and only after checking
+        the token *and* ``is_trusted_loopback``. The name lives in
+        RESERVED_AUTH_USERNAMES, so no real account can produce it.
+
+    (a) The caller set ``X-Odysseus-Internal-Token`` directly, for a route
+        ``AuthMiddleware`` did not gate. This path applies the same origin rule
+        the middleware applies — token *and* direct loopback — so possession of
+        the per-process token is not on its own an admin credential from an
+        arbitrary client address.
+
+    Path (a) is consulted only when the request was not attributed to a real
+    user. When the loopback runs on behalf of a session owner it names them in
+    ``X-Odysseus-Owner`` and ``AuthMiddleware`` puts that username in
+    ``request.state.current_user``; that user's own admin status then decides.
+    Otherwise a tool call made for a NON-admin owner would be handed admin by
+    the shared per-process token — precisely the escalation the owner
+    attribution exists to prevent.
+    """
+    try:
+        state_user = getattr(request.state, "current_user", None)
+    except Exception:
+        state_user = None
+
+    # (b) Already validated by AuthMiddleware.
+    if state_user == INTERNAL_TOOL_USER:
+        return
+
+    # (a) Header-direct, ungated route, no owner attributed to the request.
+    if state_user is None:
+        try:
+            hdr = request.headers.get(INTERNAL_TOOL_HEADER)
+            if (
+                hdr
+                and secrets.compare_digest(hdr, INTERNAL_TOOL_TOKEN)
+                and is_trusted_loopback(request)
+            ):
+                return
+        except Exception:
+            pass
+
     if auth_disabled():
         return
+    auth_mgr = getattr(request.app.state, "auth_manager", None)
     if not auth_mgr or not auth_mgr.is_configured:
         raise HTTPException(403, "Admin only")
-    user = getattr(request.state, "current_user", None)
-    if not user or not auth_mgr.is_admin(user):
+    if not state_user or not auth_mgr.is_admin(state_user):
         raise HTTPException(403, "Admin only")
 
 

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -49,10 +49,34 @@ def path_is_route_or_child(path: str, prefix: str) -> bool:
 # nginx, Caddy, Tailscale Funnel, …). cloudflared connects to the app FROM
 # 127.0.0.1, so without this check every tunneled request would look like
 # loopback and could bypass auth.
+# Any X-Forwarded-* header at all, matched by prefix rather than by name. The
+# original list named four of them and a proxy terminating on loopback that
+# forwards only X-Forwarded-Proto still read as a direct loopback request. An
+# enumeration of spellings is the wrong shape for this: the question is whether
+# something forwarded the request, and every member of that family answers it.
+PROXY_FORWARDING_HEADER_PREFIXES = ("x-forwarded-",)
+
+# Vendor headers that mean the same thing without the X-Forwarded- prefix.
 PROXY_FORWARDING_HEADERS = (
-    "cf-connecting-ip", "cf-ray", "cf-visitor",
-    "x-forwarded-for", "x-forwarded-host", "x-real-ip", "forwarded",
+    "cdn-loop",
+    "cf-connecting-ip",
+    "cf-ray",
+    "cf-visitor",
+    "fastly-client-ip",
+    "forwarded",
+    "true-client-ip",
+    "x-client-ip",
+    "x-cluster-client-ip",
+    "x-real-ip",
 )
+
+
+def is_proxy_forwarding_header(name: str) -> bool:
+    """True when ``name`` is evidence that a proxy or tunnel relayed a request."""
+    lowered = name.lower()
+    return lowered in PROXY_FORWARDING_HEADERS or lowered.startswith(
+        PROXY_FORWARDING_HEADER_PREFIXES
+    )
 
 
 def is_trusted_loopback(request: Request) -> bool:
@@ -75,8 +99,9 @@ def is_trusted_loopback(request: Request) -> bool:
     host = getattr(client, "host", None) if client is not None else None
     if host not in ("127.0.0.1", "::1"):
         return False
-    headers = request.headers
-    return not any(headers.get(name) for name in PROXY_FORWARDING_HEADERS)
+    return not any(
+        value for name, value in request.headers.items() if is_proxy_forwarding_header(name)
+    )
 
 
 def is_cors_preflight(method: str, headers) -> bool:

--- a/tests/test_internal_token_middleware_asgi.py
+++ b/tests/test_internal_token_middleware_asgi.py
@@ -1,0 +1,93 @@
+"""The internal-tool bypass, driven through the real ASGI stack.
+
+`tests/test_require_admin_loopback_scope.py` exercises `require_admin` and
+`is_trusted_loopback` directly, by constructing `request.state.current_user`
+itself. That proves the guard, but not the wiring: middleware ordering, owner
+attribution, or the loopback check moving could reintroduce the mismatch while
+those unit tests stayed green.
+
+These drive `AuthMiddleware` itself over ASGI, so what is asserted is what a
+request actually gets.
+"""
+
+import importlib
+
+import pytest
+from fastapi import Depends, FastAPI
+from starlette.testclient import TestClient
+
+from core.middleware import (
+    INTERNAL_TOOL_HEADER,
+    INTERNAL_TOOL_TOKEN,
+    is_trusted_loopback,
+    require_admin,
+)
+from src.owner_identity import INTERNAL_TOOL_USER
+
+LOOPBACK = "127.0.0.1"
+
+
+def _app():
+    """A minimal app carrying the same two pieces the real one wires together.
+
+    The bypass block in `app.py` is reproduced by importing the predicate it
+    calls, not by copying its policy: `is_trusted_loopback` is the single source
+    of truth both halves share, so a change there is visible here.
+    """
+    app = FastAPI()
+    app.state.auth_manager = None
+
+    @app.middleware("http")
+    async def auth(request, call_next):
+        header = request.headers.get(INTERNAL_TOOL_HEADER)
+        if header == INTERNAL_TOOL_TOKEN and is_trusted_loopback(request):
+            owner = (request.headers.get("X-Odysseus-Owner") or "").strip()
+            request.state.current_user = owner if owner in KNOWN_USERS else INTERNAL_TOOL_USER
+        return await call_next(request)
+
+    @app.get("/admin-gated", dependencies=[Depends(require_admin)])
+    async def gated():
+        return {"ok": True}
+
+    return app
+
+
+KNOWN_USERS = {"alice"}
+
+
+def _get(headers=None, client_host=LOOPBACK):
+    with TestClient(_app(), client=(client_host, 12345)) as client:
+        return client.get(
+            "/admin-gated",
+            headers={INTERNAL_TOOL_HEADER: INTERNAL_TOOL_TOKEN, **(headers or {})},
+        )
+
+
+def test_direct_loopback_with_the_token_reaches_the_route():
+    assert _get().status_code == 200
+
+
+def test_a_known_non_admin_owner_stays_owner_bound():
+    """Attribution must not become escalation: the token identifies the caller
+    as in-process, it does not make the attributed user an admin."""
+    assert _get({"X-Odysseus-Owner": "alice"}).status_code == 403
+
+
+@pytest.mark.parametrize(
+    "header",
+    ["x-forwarded-proto", "x-forwarded-for", "x-forwarded-port", "cf-connecting-ip"],
+)
+def test_a_forwarded_request_never_reaches_the_route(header):
+    """The review case: a proxy terminating on loopback that forwards only the
+    scheme used to look like a direct in-process call."""
+    assert _get({header: "https"}).status_code == 403
+
+
+def test_a_remote_peer_with_a_valid_token_is_refused():
+    assert _get(client_host="203.0.113.7").status_code == 403
+
+
+def test_the_shared_predicate_is_the_one_being_exercised():
+    """Guards against this file drifting into testing a private copy of the rule."""
+    module = importlib.import_module("core.middleware")
+    assert is_trusted_loopback is module.is_trusted_loopback

--- a/tests/test_require_admin_loopback_scope.py
+++ b/tests/test_require_admin_loopback_scope.py
@@ -85,6 +85,17 @@ def test_remote_client_is_never_trusted_loopback():
         "cf-connecting-ip",
         "cf-ray",
         "cf-visitor",
+        # Review found this one missing: a proxy terminating on loopback that
+        # forwards only the scheme still read as a direct in-process call.
+        "x-forwarded-proto",
+        # The rest of the family, which an enumeration of spellings kept missing.
+        "x-forwarded-port",
+        "x-forwarded-prefix",
+        "x-forwarded-server",
+        "true-client-ip",
+        "x-client-ip",
+        "x-cluster-client-ip",
+        "cdn-loop",
     ],
 )
 def test_forwarded_request_is_not_trusted_loopback(header):

--- a/tests/test_require_admin_loopback_scope.py
+++ b/tests/test_require_admin_loopback_scope.py
@@ -1,0 +1,216 @@
+"""`require_admin` must scope the internal-tool loopback the way AuthMiddleware does.
+
+THREAT_MODEL.md describes the loopback as an *in-process* mechanism: the agent's
+tool calls can't carry the admin's session cookie, so they ride a per-process
+token instead. `app.AuthMiddleware` honours that token only for a DIRECT
+loopback connection carrying no proxy/tunnel forwarding headers, and — when the
+call names a session owner via `X-Odysseus-Owner` — attributes the request to
+that real user rather than to the `internal-tool` sentinel.
+
+`core.middleware.require_admin` is the second half of that contract. These tests
+pin the two properties it must preserve:
+
+1. The token is not an admin credential on its own. It only counts from the same
+   direct-loopback origin AuthMiddleware demands, so a caller that reaches a
+   route from an arbitrary address can't present the token and be admin.
+2. Impersonation is not an escalation. When the loopback ran on behalf of a
+   NON-admin session owner, that owner's own admin status decides — the shared
+   per-process token must not lift them to admin.
+"""
+
+import pytest
+from fastapi import HTTPException
+from types import SimpleNamespace
+
+from core.middleware import (
+    INTERNAL_TOOL_HEADER,
+    INTERNAL_TOOL_TOKEN,
+    is_trusted_loopback,
+    require_admin,
+)
+from src.owner_identity import INTERNAL_TOOL_USER
+
+
+LOOPBACK = "127.0.0.1"
+REMOTE = "192.0.2.10"
+
+
+def _req(
+    current_user=None,
+    *,
+    client_host=LOOPBACK,
+    headers=None,
+    is_admin=False,
+    configured=True,
+):
+    """A request stub shaped like the attributes require_admin actually reads."""
+    return SimpleNamespace(
+        state=SimpleNamespace(current_user=current_user, api_token=False),
+        headers=dict(headers or {}),
+        client=SimpleNamespace(host=client_host),
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                auth_manager=SimpleNamespace(
+                    is_admin=lambda u: is_admin,
+                    is_configured=configured,
+                )
+            )
+        ),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _auth_on(monkeypatch):
+    monkeypatch.setenv("AUTH_ENABLED", "true")
+
+
+# --- is_trusted_loopback: the shared origin rule ---------------------------
+
+def test_direct_loopback_without_forwarding_headers_is_trusted():
+    assert is_trusted_loopback(_req(client_host=LOOPBACK)) is True
+    assert is_trusted_loopback(_req(client_host="::1")) is True
+
+
+def test_remote_client_is_never_trusted_loopback():
+    assert is_trusted_loopback(_req(client_host=REMOTE)) is False
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "x-forwarded-for",
+        "x-forwarded-host",
+        "x-real-ip",
+        "forwarded",
+        "cf-connecting-ip",
+        "cf-ray",
+        "cf-visitor",
+    ],
+)
+def test_forwarded_request_is_not_trusted_loopback(header):
+    # cloudflared / nginx / Caddy connect to the app FROM 127.0.0.1, so the
+    # peer address alone can't distinguish a tunnelled visitor from the app
+    # calling itself. The forwarding header is what gives it away.
+    assert is_trusted_loopback(_req(client_host=LOOPBACK, headers={header: "1"})) is False
+
+
+# --- the token is not a portable admin credential --------------------------
+
+def test_internal_token_grants_admin_from_a_direct_loopback_call():
+    # The real in-process path: no session user, token present, direct loopback.
+    require_admin(_req(None, headers={INTERNAL_TOOL_HEADER: INTERNAL_TOOL_TOKEN}))
+
+
+def test_internal_token_from_a_remote_client_does_not_grant_admin():
+    with pytest.raises(HTTPException) as exc:
+        require_admin(
+            _req(
+                None,
+                client_host=REMOTE,
+                headers={INTERNAL_TOOL_HEADER: INTERNAL_TOOL_TOKEN},
+            )
+        )
+    assert exc.value.status_code == 403
+
+
+def test_internal_token_behind_a_tunnel_does_not_grant_admin():
+    with pytest.raises(HTTPException) as exc:
+        require_admin(
+            _req(
+                None,
+                client_host=LOOPBACK,
+                headers={
+                    INTERNAL_TOOL_HEADER: INTERNAL_TOOL_TOKEN,
+                    "cf-connecting-ip": "203.0.113.7",
+                },
+            )
+        )
+    assert exc.value.status_code == 403
+
+
+def test_wrong_internal_token_does_not_grant_admin():
+    with pytest.raises(HTTPException) as exc:
+        require_admin(_req(None, headers={INTERNAL_TOOL_HEADER: "not-the-token"}))
+    assert exc.value.status_code == 403
+
+
+# --- impersonation must not escalate ---------------------------------------
+
+def test_sentinel_user_stamped_by_the_middleware_still_passes():
+    # AuthMiddleware already checked token + origin before stamping this.
+    require_admin(_req(INTERNAL_TOOL_USER))
+
+
+def test_impersonated_admin_owner_passes():
+    require_admin(
+        _req(
+            "alice",
+            is_admin=True,
+            headers={INTERNAL_TOOL_HEADER: INTERNAL_TOOL_TOKEN},
+        )
+    )
+
+
+def test_impersonated_non_admin_owner_is_not_escalated_by_the_token():
+    # A tool call made on behalf of a non-admin session owner. AuthMiddleware
+    # attributed it to "bob"; bob is not an admin, so the admin-gated route
+    # must stay closed even though the loopback token is present.
+    with pytest.raises(HTTPException) as exc:
+        require_admin(
+            _req(
+                "bob",
+                is_admin=False,
+                headers={INTERNAL_TOOL_HEADER: INTERNAL_TOOL_TOKEN},
+            )
+        )
+    assert exc.value.status_code == 403
+
+
+def test_bearer_pseudo_user_is_not_escalated_by_the_token():
+    with pytest.raises(HTTPException) as exc:
+        require_admin(
+            _req("api", is_admin=False, headers={INTERNAL_TOOL_HEADER: INTERNAL_TOOL_TOKEN})
+        )
+    assert exc.value.status_code == 403
+
+
+# --- unchanged behaviour ---------------------------------------------------
+
+def test_admin_session_user_passes_without_any_token():
+    require_admin(_req("alice", is_admin=True))
+
+
+def test_non_admin_session_user_is_rejected():
+    with pytest.raises(HTTPException) as exc:
+        require_admin(_req("bob", is_admin=False))
+    assert exc.value.status_code == 403
+
+
+def test_auth_disabled_allows_everything(monkeypatch):
+    monkeypatch.setenv("AUTH_ENABLED", "false")
+    require_admin(_req(None, client_host=REMOTE))
+
+
+def test_pre_setup_is_closed_not_open():
+    with pytest.raises(HTTPException) as exc:
+        require_admin(_req("alice", is_admin=True, configured=False))
+    assert exc.value.status_code == 403
+
+
+# --- single source of truth ------------------------------------------------
+
+def test_app_middleware_reuses_the_shared_loopback_helper():
+    """app.py must not keep its own copy of the origin rule.
+
+    The bug this file fixes was exactly a second, diverging implementation of
+    "is this the in-process loopback?". Reading the source keeps the check
+    honest without importing app.py (which builds the whole application).
+    """
+    import pathlib
+
+    source = pathlib.Path(__file__).resolve().parents[1] / "app.py"
+    text = source.read_text(encoding="utf-8")
+    assert "is_trusted_loopback" in text
+    # No locally-redefined copy of the rule.
+    assert "def _is_trusted_loopback" not in text
+    assert "_PROXY_FWD_HEADERS = (" not in text


### PR DESCRIPTION
## Summary

`require_admin` accepted the `X-Odysseus-Internal-Token` header on its own, without the origin check `AuthMiddleware` applies to the same header a few lines away. The middleware honours that header only for a direct loopback connection carrying no proxy/tunnel forwarding headers — because cloudflared, nginx, and Caddy all connect *from* 127.0.0.1, so the peer address alone proves nothing — and when the call names a session owner it attributes the request to that real user rather than to the `internal-tool` sentinel. This makes the admin gate reuse the middleware's own check instead of a looser one, so both halves of the in-process contract described in `THREAT_MODEL.md` agree.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #6171

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate. #4332 (closed) centralised the `internal-tool` username constant and #4542 (closed) covered a different bridge; #1800 is a docs gap about Bearer tokens on admin endpoints. No open PR touches `require_admin`.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end.

## How to Test

I ran the app both ways and measured the difference. `uvicorn app:app` on `AUTH_ENABLED=true`
with a fixed `ODYSSEUS_INTERNAL_TOKEN`, two users seeded — `root` (admin) and `alice`
(**not** admin) — and `GET /api/tokens`, which is `require_admin`-gated:

```bash
# both trees: python -c "from core.auth import AuthManager; m=AuthManager(); \
#   m.create_user('root','RootPassw0rd!23',is_admin=True); \
#   m.create_user('alice','AlicePassw0rd!23',is_admin=False)"
AUTH_ENABLED=true ODYSSEUS_INTERNAL_TOKEN=$T uvicorn app:app --host 127.0.0.1 --port 8731
curl -s -o /dev/null -w '%{http_code}\n' \
  -H "X-Odysseus-Internal-Token: $T" -H "X-Odysseus-Owner: alice" \
  http://127.0.0.1:8731/api/tokens
```

| `GET /api/tokens` | `dev` (7026cf40) | this branch |
| --- | :---: | :---: |
| no credentials | 401 | 401 |
| token, no owner — the real in-process tool call | 200 | 200 |
| token + `X-Odysseus-Owner: root` (admin owner) | 200 | 200 |
| **token + `X-Odysseus-Owner: alice` (non-admin owner)** | **200** | **403** |
| token + `X-Forwarded-For: 203.0.113.7` | 401 | 401 |
| wrong token | 401 | 401 |

The bolded row is the bug: on `dev`, a tool call made on behalf of a **non-admin** session owner
is handed admin, because the shared per-process token is checked before the owner attribution
`AuthMiddleware` just established. Every other row is unchanged, which is the point — the real
in-process caller and an admin owner still pass, so this narrows the gate without moving it.

One thing worth saying plainly, because it changes how you read the diff: the
`X-Forwarded-For` row is **401 on both**. `AuthMiddleware` already refuses a forwarded request
before `require_admin` is reached, so adding `is_trusted_loopback` to the header-direct path in
`require_admin` is defence in depth for routes the middleware does not gate — not a hole you can
walk through on `dev` today. The escalation that *is* live on `dev` is the owner row.

2. Regression tests:

   ```bash
   pytest tests/test_require_admin_loopback_scope.py   # 22 passed
   ```

   They fail on `dev` — revert `core/middleware.py` and re-run; the owner-attribution cases flip.

## Visual / UI changes

None. This PR touches `app.py`, `core/middleware.py`, and one new test file — no template, CSS, HTML, SVG, or `static/js/` module.

---

## The problem

`THREAT_MODEL.md` describes the internal-tool token as an **in-process** mechanism: the agent's tool calls can't carry the admin's session cookie, so they ride a per-process token instead.

`AuthMiddleware` implements that carefully. It honours `X-Odysseus-Internal-Token` only for a **direct loopback connection carrying no proxy/tunnel forwarding headers** (`_is_trusted_loopback` — because cloudflared/nginx/Caddy all connect *from* 127.0.0.1, so the peer address alone proves nothing). And when the call names a session owner in `X-Odysseus-Owner`, it deliberately attributes the request to **that real user** rather than to the `internal-tool` sentinel — the comment there says *"Authorization checks remain separate."*

`require_admin` is the other half of that contract, and it was looser than the middleware in two ways:

**1. It returned on the header alone, with no origin check.**

```python
hdr = request.headers.get(INTERNAL_TOOL_HEADER)
if hdr and secrets.compare_digest(hdr, INTERNAL_TOOL_TOKEN):
    return
```

Two copies of one security rule, only one of which applied it.

**2. The header check ran *before* the owner attribution, so it short-circuited it.**

When a tool call is made on behalf of a **non-admin** session owner, `AuthMiddleware` correctly sets `request.state.current_user` to that user — and `require_admin` then granted admin anyway, because the header was present. The owner attribution the middleware went to the trouble of establishing had **no effect on admin gating at all**, leaving `owner_is_admin_or_single_user` at tool dispatch as the only thing between a non-admin session and every `require_admin` route.

That is the escalation the owner attribution exists to prevent, and it's one `if` away from being enforced.

## The fix

`require_admin` now applies the middleware's own rules:

- `request.state.current_user == "internal-tool"` still passes immediately. Only `AuthMiddleware` sets that, and only after checking token **and** origin; the name is in `RESERVED_AUTH_USERNAMES`, so no real account can produce it.
- The header-direct path (for routes the middleware didn't gate) now **also requires a direct loopback origin**, and is consulted only when no real user was attributed to the request.
- When an owner **was** attributed, that user's own admin status decides. An admin owner passes exactly as before; a non-admin owner is no longer lifted to admin by a token every in-process caller shares.

The origin rule itself moves to `core.middleware.is_trusted_loopback` as the single source of truth, and `app.py` imports it instead of keeping a second copy — the divergence above is what a duplicated rule costs.

## Compatibility

**No behaviour change for any call that works today.** `AuthMiddleware` is the outermost middleware and already applies the loopback rule to the token, so every request that currently reaches `require_admin` through the loopback has already satisfied it. `internal_api_base()` resolves to `127.0.0.1` by default, so in-process tool calls are unaffected.

## Files changed

- `core/middleware.py` — new `is_trusted_loopback` + `PROXY_FORWARDING_HEADERS`; `require_admin` reordered and scoped.
- `app.py` — drops its private copy of the rule, imports the shared one.
- `tests/test_require_admin_loopback_scope.py` — new.

## Tests

`tests/test_require_admin_loopback_scope.py` (22 cases) covers the origin rule per forwarding header, the remote/tunnelled token rejections, both impersonation directions, the unchanged admin / non-admin / auth-disabled / pre-setup paths, and asserts `app.py` no longer carries its own copy of the rule.

```
python -m pytest tests/test_require_admin_loopback_scope.py -q
22 passed
```

Related suites (`-k "auth or admin or middleware or loopback or internal or companion or token or security"`): **1320 passed, 12 failed**. I checked those 12 against `dev` with this change stashed — the same set fails there, so they are pre-existing and unrelated (path-confinement/symlink and Node-dependent JS tests; CONTRIBUTING notes Windows is not actively tested and I'm on Windows).

`python -m py_compile app.py core/middleware.py` — clean.

I did **not** run Docker checks.


