### PR TITLE
fix(docker): mount the ChromaDB volume where the image actually persists

### DIFF
--- a/docker-compose.gpu-amd.yml
+++ b/docker-compose.gpu-amd.yml
@@ -111,7 +111,11 @@ services:
     ports:
       - "${CHROMADB_BIND:-127.0.0.1}:8100:8000"
     volumes:
-      - chromadb-data:/chroma/chroma
+      # The image runs `chroma run /config.yaml`, whose persist_path is "/data".
+      # It declares no VOLUME, so anything written outside a mount lives in the
+      # container's writable layer and dies with it. /chroma/chroma is where
+      # pre-1.0 images kept the store; mounting there now catches nothing.
+      - chromadb-data:/data
     environment:
       - ANONYMIZED_TELEMETRY=FALSE
     restart: unless-stopped

--- a/docker-compose.gpu-nvidia.yml
+++ b/docker-compose.gpu-nvidia.yml
@@ -114,7 +114,11 @@ services:
     ports:
       - "${CHROMADB_BIND:-127.0.0.1}:8100:8000"
     volumes:
-      - chromadb-data:/chroma/chroma
+      # The image runs `chroma run /config.yaml`, whose persist_path is "/data".
+      # It declares no VOLUME, so anything written outside a mount lives in the
+      # container's writable layer and dies with it. /chroma/chroma is where
+      # pre-1.0 images kept the store; mounting there now catches nothing.
+      - chromadb-data:/data
     environment:
       - ANONYMIZED_TELEMETRY=FALSE
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,11 @@ services:
     ports:
       - "${CHROMADB_BIND:-127.0.0.1}:8100:8000"
     volumes:
-      - chromadb-data:/chroma/chroma
+      # The image runs `chroma run /config.yaml`, whose persist_path is "/data".
+      # It declares no VOLUME, so anything written outside a mount lives in the
+      # container's writable layer and dies with it. /chroma/chroma is where
+      # pre-1.0 images kept the store; mounting there now catches nothing.
+      - chromadb-data:/data
     environment:
       - ANONYMIZED_TELEMETRY=FALSE
     restart: unless-stopped

--- a/tests/test_chromadb_volume_path.py
+++ b/tests/test_chromadb_volume_path.py
@@ -1,0 +1,69 @@
+"""Regression guard for issue #6132 — the ChromaDB named volume was mounted at a
+path the image never writes to, so the whole vector store lived in the
+container's writable layer and was destroyed on every recreate. Silently: the
+collection survived with a count of 0, and retrieval just stopped returning
+anything.
+
+``chromadb/chroma`` runs ``chroma run /config.yaml``, and that config is a single
+line — ``persist_path: "/data"``. The image declares no ``VOLUME``, so nothing
+outside a mount survives. ``/chroma/chroma`` is where pre-1.0 images kept the
+store.
+
+The documented backup procedure (docs/backup-restore.md) archives the
+``chromadb-data`` volume, so a wrong mount point also makes that tarball empty.
+
+Pure YAML — no Docker required.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+COMPOSE_FILES = [
+    ROOT / "docker-compose.yml",
+    ROOT / "docker-compose.gpu-nvidia.yml",
+    ROOT / "docker-compose.gpu-amd.yml",
+]
+
+# `persist_path` from the image's own /config.yaml.
+CHROMA_PERSIST_PATH = "/data"
+LEGACY_PERSIST_PATH = "/chroma/chroma"
+VOLUME_NAME = "chromadb-data"
+
+
+def _chromadb_volumes(path: Path) -> list[str]:
+    compose = yaml.safe_load(path.read_text(encoding="utf-8"))
+    service = compose["services"]["chromadb"]
+    return list(service.get("volumes") or [])
+
+
+@pytest.mark.parametrize("path", COMPOSE_FILES, ids=lambda p: p.name)
+def test_chromadb_volume_is_mounted_at_the_persist_path(path: Path):
+    mounts = _chromadb_volumes(path)
+    targets = {m.split(":")[1] for m in mounts if m.startswith(f"{VOLUME_NAME}:")}
+    assert targets, f"{path.name}: no {VOLUME_NAME} mount on the chromadb service"
+    assert targets == {CHROMA_PERSIST_PATH}, (
+        f"{path.name}: {VOLUME_NAME} is mounted at {sorted(targets)}, but the image "
+        f"persists to {CHROMA_PERSIST_PATH!r}. Anything written outside a mount is "
+        "lost when the container is recreated (issue #6132)."
+    )
+
+
+@pytest.mark.parametrize("path", COMPOSE_FILES, ids=lambda p: p.name)
+def test_chromadb_does_not_use_the_pre_1_0_path(path: Path):
+    mounts = _chromadb_volumes(path)
+    assert not any(m.endswith(f":{LEGACY_PERSIST_PATH}") for m in mounts), (
+        f"{path.name}: {LEGACY_PERSIST_PATH} is the pre-1.0 store location; current "
+        "images never write there"
+    )
+
+
+@pytest.mark.parametrize("path", COMPOSE_FILES, ids=lambda p: p.name)
+def test_chromadb_data_volume_is_declared(path: Path):
+    compose = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert VOLUME_NAME in (compose.get("volumes") or {}), (
+        f"{path.name}: the {VOLUME_NAME} volume is mounted but not declared"
+    )


### PR DESCRIPTION
## Summary

The `chromadb` service mounts its named volume at `/chroma/chroma`, but the current `chromadb/chroma` image runs `chroma run /config.yaml` with `persist_path: "/data"` and declares no `VOLUME` of its own. The entire vector store therefore lives in the container's writable layer and is destroyed on every `docker compose up --force-recreate`, `pull`, or `down` — silently, because the collection is recreated with a count of `0` and retrieval simply stops returning anything. This moves the mount to `/data` in all three compose files and adds a YAML-only regression guard.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Closes #6132

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate. #6132 is the report; @stav offered the compose change and I credit that below. #6146 / #6147 cover the *stale client after a recreate*, which is a different defect.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — the three compose files carry the identical one-line mount change, plus one new test file.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end.

## How to Test

I ran the actual `chromadb/chroma:latest` image both ways and checked whether a collection
survives a container replacement. That is the whole claim, so it is the thing to measure.

**1. The image's own facts** — no guessing about where it persists:

```console
$ docker inspect chromadb/chroma:latest \
    --format 'Cmd={{.Config.Cmd}} Entrypoint={{.Config.Entrypoint}} Volumes={{.Config.Volumes}}'
Cmd=[run /config.yaml] Entrypoint=[dumb-init -- chroma] Volumes=map[]

$ docker run --rm --entrypoint cat chromadb/chroma:latest /config.yaml
persist_path: "/data"
```

`Volumes=map[]` is the part that makes this data loss rather than a stale-path annoyance:
the image declares no anonymous volume, so with nothing mounted at `/data` the store is
written to the container's writable layer and dies with the container.

**2. Does the data survive?** Same image, same steps, only the mount differs — create a
collection, `docker rm -f` the container, start a new one on the same named volume, list
collections.

| | `dev`: `chromadb-data:/chroma/chroma` | this PR: `chromadb-data:/data` |
| --- | --- | --- |
| contents of the mounted path | *(empty)* | `chroma.sqlite3` |
| contents of `/data` | `chroma.sqlite3` | `chroma.sqlite3` |
| collections before restart | `[persistence_probe]` | `[persistence_probe]` |
| **collections after restart** | **`[]`** | **`[persistence_probe]`, same id** |

On `dev` the mounted volume is empty for the container's whole life — every byte Chroma writes
goes to `/data` on the writable layer — and the collection is gone after the container is
replaced. On this branch the volume holds `chroma.sqlite3` and the collection comes back with
the identical `id` (`b0384dcb-8a60-4a7d-9ed9-f43442870558`).

**3. All three compose files resolve to the new target:**

```console
$ for f in docker-compose.yml docker-compose.gpu-nvidia.yml docker-compose.gpu-amd.yml; do
    docker compose -f $f config | sed -n '/^  chromadb:/,/^  [a-z]/p' | grep -E 'source|target'
  done
source: chromadb-data / target: /data      # x3
```

**4. Unit tests:**

```bash
pytest tests/test_chromadb_volume_path.py   # 9 passed
```

Docker version used: 29.4.3; image digest
`sha256:1e0b73a187a28757c572acba508c46f48c9e8b0acaf5c20e6d95cdedce1acdf6`.

I did **not** bring the full `docker compose up` stack up — this change only concerns the
`chromadb` service's mount, and the isolated container test above exercises exactly that with
less that can confound it.

## Visual / UI changes

None. This PR touches `docker-compose*.yml` and one new test file — no template, CSS, HTML, SVG, or `static/js/` module.

---

Reported and diagnosed by @stav, who offered to send the compose change. It has been open a few days, so I am putting up the fix with a regression guard and independent verification — happy to close this in favour of theirs.

## The bug

```yaml
chromadb:
  image: docker.io/chromadb/chroma:latest
  volumes:
    - chromadb-data:/chroma/chroma
```

`/chroma/chroma` is not a path the current image writes to.

I verified this from the image itself rather than from a running container, by pulling the manifest and config for `chromadb/chroma:latest` off the registry:

```
Entrypoint: ["dumb-init","--","chroma"]
Cmd:        ["run","/config.yaml"]
Volumes:    undefined
```

and extracting the 131-byte layer that `COPY /chroma/rust/frontend/sample_configs/docker_single_node.yaml /config.yaml` produced:

```yaml
persist_path: "/data"
```

So: the store is written to `/data`, the image declares **no** `VOLUME`, and the named volume sits on `/chroma/chroma` catching nothing. Everything Chroma writes lives in the container's writable layer and goes away with the container. `/chroma/chroma` is where pre-1.0 images kept the store, which is why this used to work.

@stav's report has the runtime half of the same evidence:

```console
$ docker exec odysseus-chromadb-1 du -sh /data /chroma/chroma
396K    /data                  # the real database — container-local, ephemeral
0       /chroma/chroma         # the mounted volume — empty, never written to
```

**Nothing reports the loss.** The collection is recreated on next use with a count of `0`, so retrieval just stops returning anything — indistinguishable from a query that did not match.

It also makes the documented backup empty. `docs/backup-restore.md` tells users to archive the `chromadb-data` volume:

```bash
docker run --rm -v <project>_chromadb-data:/data -v "$PWD":/backup \
  alpine tar czf /backup/chromadb.tar.gz -C /data .
```

Today that tarball contains nothing, and you find out at restore time.

## Fix

`chromadb-data:/data` in all three compose files — `docker-compose.yml`, `docker-compose.gpu-nvidia.yml` and `docker-compose.gpu-amd.yml` all carried the same mount. The comment above it records where `/data` comes from, so the next reader does not have to re-derive it.

**No migration.** The volume was never written to, so there is nothing in it to move. (The one exception: an install still running a pre-1.0 image *would* have real data at `/chroma/chroma` — but it would also be unreadable by any current image, so it is not data this change strands.)

## Verification

`tests/test_chromadb_volume_path.py`, pure YAML, no Docker — following `test_gpu_compose_standalone.py` and `test_searxng_image_pinned.py`:

- the `chromadb-data` mount target equals the image's persist path, in each of the three files
- the pre-1.0 `/chroma/chroma` path is not used
- the volume is declared as well as mounted

Reverting the three mounts to `/chroma/chroma`:

```
6 failed, 3 passed
```

With the fix, and re-running the neighbouring compose suites so the standalone GPU files are still in sync with the base plus overlay:

```
tests/test_chromadb_volume_path.py tests/test_gpu_compose_standalone.py
tests/test_docker_devops_hardening.py tests/test_searxng_image_pinned.py
tests/test_fastembed_cache_path.py
36 passed
```

## Two things I deliberately left out

**Pinning the image.** `:latest` is what let the path drift silently in the first place, and `docker-compose.yml` already sets the precedent for pinning with the SearXNG comment. I did not do it here because picking the tag is a call about which Chroma version Odysseus supports, not a bug fix — and every non-`.dev` tag is far enough back that the choice deserves its own PR.

**The stale client after a recreate.** @stav notes that recreating the `chromadb` container leaves the long-running app holding a dead client that returns empty results instead of raising. That is #6146, and #6147 is already open against it. Worth flagging together because applying *this* fix is exactly what makes people recreate the container.

