### PR TITLE
chore(release): align dev version with 1.0.3

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ import os
 
 from src.runtime_paths import get_app_root, get_default_data_dir
 
-APP_VERSION = "1.0.2"
+APP_VERSION = "1.0.3"
 
 # Base paths
 BASE_DIR = os.path.join(get_app_root(), "")


### PR DESCRIPTION
## Summary

Aligns the rolling `dev` branch's canonical application version with the current `v1.0.3` hotfix release. This deliberately changes only `APP_VERSION`; the broader `dev` → `main` release remains planned for `v1.1.0`.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Part of #4693

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes are mixed in.
- [ ] I ran the complete application end-to-end. This is a one-line version-metadata change with no runtime behavior change.

## How to Test

1. Run `python -c 'from src.constants import APP_VERSION; assert APP_VERSION == "1.0.3"; print(APP_VERSION)'`. Expected result: `1.0.3`.
2. Run `git diff --check origin/dev...HEAD`. Expected result: no output.
3. Run `git diff --stat origin/dev...HEAD`. Expected scope: one changed line in `src/constants.py`.

## Visual / UI changes

Not applicable. No rendering, UI, CSS, HTML, SVG, or browser-side JavaScript is changed.
