### PR TITLE
fix(diagnostics): report a failed config source instead of "disabled" (#6154)

### DIFF
--- a/src/service_health.py
+++ b/src/service_health.py
@@ -76,7 +76,21 @@ _ERROR_DETAIL = {
     "auth_or_protocol_error": "authentication or protocol error",
     "no_models": "endpoint returned no models",
     "no_host": "no host configured",
+    "config_source_error": "configuration source could not be read",
     "error": "probe failed",
+}
+
+# Config/inventory source behind each network subsystem. `_gather_inputs()`
+# fails soft, so a source that could not be read hands its probe an empty
+# inventory — indistinguishable from "nothing configured", which every probe
+# answers with `disabled`. The collector therefore reports the source failure
+# instead of running a probe whose verdict would be a lie.
+CONFIG_SOURCE_ERROR = "config_source_error"
+_SUBSYSTEM_SOURCE = {
+    "searxng": "settings",
+    "ntfy": "integrations",
+    "email": "accounts",
+    "providers": "endpoints",
 }
 
 
@@ -411,26 +425,33 @@ def _gather_inputs() -> Dict[str, Any]:
     """Pull live config/account/endpoint lists from the app's data sources.
 
     Each lookup fails soft: a broken source yields an empty/neutral value so a
-    single failure can't take down the whole health report.
+    single failure can't take down the whole health report. The failure is also
+    *recorded* under `failed` (source -> controlled category), because the empty
+    value alone cannot be told apart from a source that loaded and is genuinely
+    empty — and the probes read empty as `disabled`.
     """
     settings: Dict[str, Any] = {}
     integrations: List[Dict[str, Any]] = []
     accounts: List[Dict[str, Any]] = []
     endpoints: List[Dict[str, Any]] = []
+    failed: Dict[str, str] = {}
     try:
         from src.settings import load_settings
         settings = load_settings() or {}
     except Exception as e:
+        failed["settings"] = _classify_error(e)
         logger.debug(f"service_health: settings load failed: {e}")
     try:
         from src.integrations import load_integrations
         integrations = load_integrations() or []
     except Exception as e:
+        failed["integrations"] = _classify_error(e)
         logger.debug(f"service_health: integrations load failed: {e}")
     try:
         from routes.email_helpers import _list_email_accounts
         accounts = _list_email_accounts() or []
     except Exception as e:
+        failed["accounts"] = _classify_error(e)
         logger.debug(f"service_health: email accounts load failed: {e}")
     try:
         from core.database import SessionLocal, ModelEndpoint
@@ -443,9 +464,10 @@ def _gather_inputs() -> Dict[str, Any]:
         finally:
             db.close()
     except Exception as e:
+        failed["endpoints"] = _classify_error(e)
         logger.debug(f"service_health: endpoint load failed: {e}")
     return {"settings": settings, "integrations": integrations,
-            "accounts": accounts, "endpoints": endpoints}
+            "accounts": accounts, "endpoints": endpoints, "failed": failed}
 
 
 async def _run_subsystem(name: str, fn: Callable, *args: Any) -> Dict[str, Any]:
@@ -464,6 +486,24 @@ async def _run_subsystem(name: str, fn: Callable, *args: Any) -> Dict[str, Any]:
         return _svc(name, DOWN, _detail_for(category), error=category)
 
 
+async def _source_unavailable(name: str, source: str,
+                              category: str) -> Dict[str, Any]:
+    """Controlled entry for a subsystem whose config source could not be read.
+
+    Deliberately not `disabled`: the configured state is *unknown*, not known to
+    be off. `degraded` rather than `down` because the failure is in reading the
+    inventory, not a probe that reached the subsystem and failed — but it still
+    carries non-zero severity, so a report containing one can never roll up to
+    `ok`. `meta` names the source and the controlled category of the underlying
+    exception; never its text.
+    """
+    return _svc(name, DEGRADED,
+                f"Could not read configuration "
+                f"({_detail_for(CONFIG_SOURCE_ERROR)}).",
+                error=CONFIG_SOURCE_ERROR, source=source,
+                source_error=category)
+
+
 async def collect_service_health(rag_manager: Any = None,
                                  memory_vector: Any = None) -> Dict[str, Any]:
     """Run every probe and return {overall, services, timestamp}.
@@ -472,6 +512,10 @@ async def collect_service_health(rag_manager: Any = None,
     four network subsystems run concurrently, each under `_SUBSYSTEM_DEADLINE`,
     with an overall `_AGGREGATE_DEADLINE` backstop. Per-item probes inside
     providers/email are themselves bounded by `_FANOUT_BUDGET`.
+
+    A subsystem whose config/inventory source failed to load is reported via
+    `_source_unavailable()` instead of being probed with an empty inventory,
+    which every probe would otherwise report as `disabled`.
     """
     from datetime import datetime, timezone
 
@@ -482,12 +526,23 @@ async def collect_service_health(rag_manager: Any = None,
     chroma = chromadb_health(rag_manager, memory_vector)
 
     names = ["searxng", "ntfy", "email", "providers"]
-    coros = [
-        _run_subsystem("searxng", searxng_health, settings),
-        _run_subsystem("ntfy", ntfy_health, inputs["integrations"], settings),
-        _run_subsystem("email", email_health, inputs["accounts"]),
-        _run_subsystem("providers", providers_health, inputs["endpoints"]),
-    ]
+    probes = {
+        "searxng": (searxng_health, (settings,)),
+        "ntfy": (ntfy_health, (inputs["integrations"], settings)),
+        "email": (email_health, (inputs["accounts"],)),
+        "providers": (providers_health, (inputs["endpoints"],)),
+    }
+    # A subsystem whose inventory could not be read is reported as such. The
+    # others are still probed normally — one broken source degrades one entry.
+    failed = inputs.get("failed") or {}
+    coros = []
+    for name in names:
+        source = _SUBSYSTEM_SOURCE[name]
+        if source in failed:
+            coros.append(_source_unavailable(name, source, failed[source]))
+        else:
+            fn, args = probes[name]
+            coros.append(_run_subsystem(name, fn, *args))
     try:
         results = await asyncio.wait_for(asyncio.gather(*coros),
                                          timeout=_AGGREGATE_DEADLINE)

--- a/tests/test_service_health_collect.py
+++ b/tests/test_service_health_collect.py
@@ -137,3 +137,170 @@ def test_collect_aggregate_deadline_yields_controlled_result(monkeypatch):
     net = [s for s in out["services"] if s["name"] != "chromadb"]
     assert all(s["status"] == sh.DOWN and s["meta"].get("error") == "timeout"
                for s in net)
+
+
+# ── Discovery failure is not "disabled" (#6154) ──
+#
+# `_gather_inputs()` fails soft to an empty inventory, and every probe reads an
+# empty inventory as `disabled`. Without a record of *why* it is empty, a broken
+# integrations file / email store / endpoint DB is reported as an intentionally
+# unconfigured subsystem — and, with the rest disabled, `overall: "ok"`.
+
+def _boom(*_a, **_k):
+    raise RuntimeError("secret-bearing detail: postgres://u:p@db/x")
+
+
+def test_gather_inputs_records_each_failed_source(monkeypatch):
+    import core.database
+    import routes.email_helpers
+    import src.integrations
+    import src.settings
+
+    monkeypatch.setattr(src.settings, "load_settings", lambda: {"a": 1})
+    monkeypatch.setattr(src.integrations, "load_integrations", _boom)
+    monkeypatch.setattr(routes.email_helpers, "_list_email_accounts", _boom)
+    monkeypatch.setattr(core.database, "SessionLocal", _boom)
+
+    out = sh._gather_inputs()
+    assert out["settings"] == {"a": 1}
+    assert set(out["failed"]) == {"integrations", "accounts", "endpoints"}
+    # Controlled categories only — never the exception text.
+    assert set(out["failed"].values()) <= set(sh._ERROR_DETAIL)
+    assert "postgres" not in repr(out)
+
+
+def test_gather_inputs_reports_no_failures_when_sources_load(monkeypatch):
+    import core.database
+    import routes.email_helpers
+    import src.integrations
+    import src.settings
+
+    class _DB:
+        def query(self, *_a):
+            return self
+
+        def filter(self, *_a):
+            return self
+
+        def all(self):
+            return []
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(src.settings, "load_settings", lambda: {})
+    monkeypatch.setattr(src.integrations, "load_integrations", lambda: [])
+    monkeypatch.setattr(routes.email_helpers, "_list_email_accounts", lambda: [])
+    monkeypatch.setattr(core.database, "SessionLocal", lambda: _DB())
+
+    assert sh._gather_inputs()["failed"] == {}
+
+
+@pytest.mark.parametrize("source,service", [
+    ("settings", "searxng"),
+    ("integrations", "ntfy"),
+    ("accounts", "email"),
+    ("endpoints", "providers"),
+])
+def test_failed_source_is_not_reported_as_disabled(monkeypatch, source, service):
+    import asyncio
+    monkeypatch.setattr(sh, "_gather_inputs", lambda: {
+        "settings": {"search_provider": "disabled"},
+        "integrations": [], "accounts": [], "endpoints": [],
+        "failed": {source: "network_error"},
+    })
+    out = asyncio.run(sh.collect_service_health(None, None))
+    entry = next(s for s in out["services"] if s["name"] == service)
+    assert entry["status"] != sh.DISABLED
+    assert entry["meta"]["error"] == sh.CONFIG_SOURCE_ERROR
+    assert entry["meta"]["source"] == source
+    assert entry["meta"]["source_error"] == "network_error"
+    # A failed source must reach the aggregate verdict.
+    assert out["overall"] != sh.OK
+    assert set(out) == {"overall", "services", "timestamp"}
+
+
+def test_all_sources_failing_cannot_report_overall_ok(monkeypatch):
+    # The exact shape from the report: settings loads and says search is off,
+    # the other three sources raise. Before the fix this was overall "ok" with
+    # five "disabled" entries.
+    import asyncio
+    monkeypatch.setattr(sh, "_gather_inputs", lambda: {
+        "settings": {"search_provider": "disabled"},
+        "integrations": [], "accounts": [], "endpoints": [],
+        "failed": {"integrations": "error", "accounts": "error",
+                   "endpoints": "error"},
+    })
+    out = asyncio.run(sh.collect_service_health(None, None))
+    by_name = {s["name"]: s for s in out["services"]}
+    assert out["overall"] == sh.DEGRADED
+    # Loaded-and-genuinely-empty still reads as disabled.
+    assert by_name["searxng"]["status"] == sh.DISABLED
+    for name in ("ntfy", "email", "providers"):
+        assert by_name[name]["status"] == sh.DEGRADED
+
+
+def test_empty_inventory_without_failure_stays_disabled(monkeypatch):
+    import asyncio
+    monkeypatch.setattr(sh, "_gather_inputs", lambda: {
+        "settings": {"search_provider": "disabled"},
+        "integrations": [], "accounts": [], "endpoints": [], "failed": {},
+    })
+    out = asyncio.run(sh.collect_service_health(_Store(True), _Store(True)))
+    assert out["overall"] == sh.OK
+    assert all(s["status"] == sh.DISABLED
+               for s in out["services"] if s["name"] != "chromadb")
+
+
+def test_one_failed_source_still_probes_the_others(monkeypatch):
+    # A broken endpoint DB must not stop ntfy/email from being probed.
+    import asyncio
+    probed = []
+
+    def _probe(name):
+        def _fn(*_a, **_k):
+            probed.append(name)
+            return sh._svc(name, sh.OK, "probed")
+        return _fn
+
+    monkeypatch.setattr(sh, "_gather_inputs", lambda: {
+        "settings": {}, "integrations": [], "accounts": [], "endpoints": [],
+        "failed": {"endpoints": "timeout"},
+    })
+    monkeypatch.setattr(sh, "searxng_health", _probe("searxng"))
+    monkeypatch.setattr(sh, "ntfy_health", _probe("ntfy"))
+    monkeypatch.setattr(sh, "email_health", _probe("email"))
+    monkeypatch.setattr(sh, "providers_health", _probe("providers"))
+
+    out = asyncio.run(sh.collect_service_health(None, None))
+    assert sorted(probed) == ["email", "ntfy", "searxng"]
+    assert "providers" not in probed
+    by_name = {s["name"]: s for s in out["services"]}
+    assert by_name["providers"]["status"] == sh.DEGRADED
+    assert by_name["ntfy"]["status"] == sh.OK
+
+
+def test_source_failure_entry_carries_no_raw_detail(monkeypatch):
+    import asyncio
+    monkeypatch.setattr(sh, "_gather_inputs", lambda: {
+        "settings": {}, "integrations": [], "accounts": [], "endpoints": [],
+        "failed": {"accounts": "auth_or_protocol_error"},
+    })
+    out = asyncio.run(sh.collect_service_health(None, None))
+    entry = next(s for s in out["services"] if s["name"] == "email")
+    assert entry["detail"] == (
+        "Could not read configuration (configuration source could not be read).")
+    assert set(entry["meta"]) == {"error", "source", "source_error"}
+
+
+def test_collect_tolerates_inputs_without_a_failed_key(monkeypatch):
+    # `_gather_inputs()` is monkeypatched in a number of existing tests (and by
+    # anything calling the collector with a stub); a payload predating `failed`
+    # must still probe normally rather than raise.
+    import asyncio
+    monkeypatch.setattr(sh, "_gather_inputs", lambda: {
+        "settings": {"search_provider": "disabled"},
+        "integrations": [], "accounts": [], "endpoints": [],
+    })
+    out = asyncio.run(sh.collect_service_health(_Store(True), _Store(True)))
+    assert out["overall"] == sh.OK


### PR DESCRIPTION
## Summary

`GET /api/diagnostics/services` cannot tell a subsystem that is switched off from one whose configuration source failed to load. `_gather_inputs()` fails soft to an empty inventory, and every probe reads an empty inventory as "not configured" and answers `disabled` — so a broken integrations file, email store, or endpoint database is reported exactly like a subsystem the operator turned off, and with the rest disabled the endpoint reports `overall: "ok"` while three of its inputs failed. This records why an inventory is empty and reports the affected subsystem as `degraded` with a controlled, secret-free reason instead of probing it with an inventory that is empty for the wrong reason.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #6154

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate. (#3082 / #964 introduced the endpoint; #4815 / #4816 fixed the analogous false-`disabled` for ChromaDB init but not for these three sources; #4835 / #2463 are frontend display. No open PR touches `service_health`.)
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end.

## How to Test

I ran `uvicorn app:app` on this branch and on `dev`, broke one config source for real, and
compared `GET /api/diagnostics/services`.

The source I broke is the DB-backed endpoint inventory, because it is the one that genuinely
raises. Worth being precise about this, since it bounds what the PR fixes: `load_settings()`,
`load_integrations()` and `_list_email_accounts()` all swallow their own read errors and return
a default, so `_gather_inputs()` never sees an exception from them. The `endpoints` lookup is
different — it runs a SQLAlchemy query, and a DB-level fault propagates.

```bash
uvicorn app:app --host 127.0.0.1 --port 8761      # AUTH_ENABLED=false
# fault injection: make the inventory read fail the way a real DB fault would
sqlite3 data/app.db 'ALTER TABLE model_endpoints RENAME TO model_endpoints_hidden;'
curl -s http://127.0.0.1:8761/api/diagnostics/services | jq '.services[] | select(.name=="providers")'
```

**Before the fault** — `dev` and this branch are identical on all five services, `providers`
reporting `disabled / "No model endpoints configured."`

**After the fault**, same request, same everything else:

| | `dev` (7026cf40) | this branch |
| --- | --- | --- |
| status | `disabled` | `degraded` |
| detail | `No model endpoints configured.` | `Could not read configuration (configuration source could not be read).` |
| meta | *(none)* | `error=config_source_error source=endpoints source_error=error` |

`dev`'s answer is not merely unhelpful, it is **false**: endpoints *were* configured, the read
of them failed, and the operator is told the opposite. That is the whole bug — an unreadable
source and an empty source are indistinguishable downstream, and the probe resolves the
ambiguity the wrong way.

The other four services are unchanged in both runs, before and after, so the new branch is
reached only by the subsystem whose source actually failed.

One thing I did **not** demonstrate at runtime: the docstring's claim that a report containing
a `degraded` entry can never roll up to `ok`. In this environment ChromaDB and SearXNG are
already `down`, so `overall` was `down` in every run above and the rollup was never the
deciding factor. That path is covered by the unit tests rather than by this run.

Regression tests:

```bash
pytest tests/test_service_health_collect.py   # 24 passed
```

## Visual / UI changes

None. This PR touches `src/service_health.py` and `tests/test_service_health_collect.py` only — no template, CSS, HTML, SVG, or `static/js/` module. The JSON response keeps its `{overall, services, timestamp}` shape and its existing status vocabulary (`degraded` was already one of the four statuses and already rendered).

---

## The defect

`_gather_inputs()` fails soft — a source that raises leaves its inventory as `[]`. Every probe reads an empty inventory as "not configured" and answers `disabled`. So a broken integrations file, email store, or endpoint database is reported identically to a subsystem the operator deliberately turned off, and the exceptions survive only in DEBUG logs.

Reproduced on `dev` with the reporter's offline harness — settings loads with `search_provider: "disabled"`, the other three sources raise:

```
overall: ok
  chromadb   disabled  Vector RAG and vector memory are not initialized.
  searxng    disabled  Search provider is 'disabled', not SearXNG.
  ntfy       disabled  No ntfy integration configured.
  email      disabled  No email accounts configured.
  providers  disabled  No model endpoints configured.
```

Three inputs failed to load and the endpoint says `ok`.

## The fix

Record each failure next to the empty value (`failed`: source → controlled category) and report the affected subsystem through a new `_source_unavailable()` instead of probing it with an inventory that is empty for the wrong reason.

Same harness, after:

```
overall: degraded
  chromadb   disabled  Vector RAG and vector memory are not initialized.
  searxng    disabled  Search provider is 'disabled', not SearXNG.
  ntfy       degraded  Could not read configuration (configuration source could not be read).
  email      degraded  Could not read configuration (configuration source could not be read).
  providers  degraded  Could not read configuration (configuration source could not be read).
```

`searxng` loaded successfully and is genuinely off, so it stays `disabled`.

## Status choice

The issue deliberately left `down` vs `degraded` open. This uses **`degraded`**: the configured state is *unknown*, not known-off, and nothing reached the subsystem and failed — the inventory could not be read. `_run_subsystem()` keeps `down` for a probe that did reach a configured subsystem and errored, which preserves a useful distinction in the report. Either way severity is non-zero, so `_rollup()` can no longer return `ok` for a report with a failed source. Happy to switch to `down` if you prefer the louder reading; it is one constant.

`settings` → `searxng` is covered too. It is the same defect from the same `_gather_inputs()` line, and leaving it out would have made the mapping inconsistent.

## Safety

- `meta` carries the source name and the controlled `_classify_error()` category only — never exception text, credentials, or database detail. A test asserts a `RuntimeError` carrying a `postgres://u:p@db/x` string never reaches the payload.
- `collect_service_health()` still returns `{overall, services, timestamp}` and stays fail-soft.
- `inputs.get("failed")` rather than `inputs["failed"]`, so an inputs payload predating the key (several existing tests monkeypatch `_gather_inputs`) still probes normally instead of raising.
- One broken source degrades one entry; the other three are still probed.

## Acceptance criteria

| criterion | test |
| :-- | :-- |
| successful-but-empty stays `disabled` | `test_empty_inventory_without_failure_stays_disabled` |
| integrations failure → `ntfy` non-disabled | `test_failed_source_is_not_reported_as_disabled[integrations-ntfy]` |
| email failure → `email` non-disabled | `…[accounts-email]` |
| endpoint DB failure → `providers` non-disabled | `…[endpoints-providers]` |
| failures reach the aggregate | `test_all_sources_failing_cannot_report_overall_ok` |
| others still probed | `test_one_failed_source_still_probes_the_others` |
| response shape preserved | asserted in `test_failed_source_is_not_reported_as_disabled` |
| no raw exception text / secrets | `test_gather_inputs_records_each_failed_source`, `test_source_failure_entry_carries_no_raw_detail` |
| exceptions at the `_gather_inputs()` boundary | `test_gather_inputs_records_each_failed_source`, `test_gather_inputs_reports_no_failures_when_sources_load` |

## Verification

`61 passed` across `test_service_health_{collect,ntfy,email,providers,search,chromadb}.py` and `test_diagnostics_service_route.py` — 45 before, 16 added.

Mutation-tested, each in isolation:

- suppress the `_source_unavailable()` dispatch → **7 failures**
- stop recording `failed[...]` in `_gather_inputs()` → **1 failure** (`test_gather_inputs_records_each_failed_source`)


