### PR TITLE
fix(app): classify the three app middlewares by application route path

### DIFF
--- a/app.py
+++ b/app.py
@@ -193,7 +193,10 @@ _TIMEOUT_EXEMPT_PREFIXES = (
 
 class _RequestTimeoutMiddleware(_BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
-        path = request.url.path or ""
+        # Application route path, not request.url.path: the latter still carries a
+        # configured ASGI root_path, so under `--root-path /odysseus` every prefix
+        # below stops matching and the exemptions silently switch off.
+        path = get_application_route_path(request.scope)
         if any(path.startswith(p) for p in _TIMEOUT_EXEMPT_PREFIXES):
             return await call_next(request)
         try:
@@ -209,7 +212,10 @@ class _InteractiveActivityMiddleware(_BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
         from src.interactive_gate import should_track_interactive_request, track_interactive_request
 
-        path = request.url.path or ""
+        # Same rule: the gate matches exact paths and prefixes, so a mounted
+        # deployment would read every passive poll as interactive traffic and
+        # stop background tasks on each one.
+        path = get_application_route_path(request.scope)
         if not should_track_interactive_request(path, request.method):
             return await call_next(request)
         async def _stop_background():
@@ -240,7 +246,7 @@ class _SlowRequestLogMiddleware(_BaseHTTPMiddleware):
                 logging.getLogger("app.slow_request").warning(
                     "slow_request method=%s path=%s status=%s elapsed=%.3fs",
                     request.method,
-                    request.url.path,
+                    get_application_route_path(request.scope),
                     status,
                     elapsed,
                 )

--- a/tests/test_app_middleware_root_path.py
+++ b/tests/test_app_middleware_root_path.py
@@ -1,0 +1,120 @@
+"""The app-level middlewares must classify the same path Starlette routes.
+
+`core/middleware.get_application_route_path` exists because uvicorn prefixes
+`scope["path"]` with a configured ASGI `root_path` while Starlette strips it
+before matching routes. `AuthMiddleware` and `SecurityHeadersMiddleware` follow
+that rule; the three middlewares defined in `app.py` read `request.url.path`,
+which still carries the prefix, so behind the reverse-proxy mount SECURITY.md
+recommends (`--root-path /odysseus`) their prefix lists stopped matching.
+"""
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+from core.middleware import get_application_route_path
+from src.interactive_gate import should_track_interactive_request
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_SOURCE = (ROOT / "app.py").read_text(encoding="utf-8")
+
+MIDDLEWARES = (
+    "_RequestTimeoutMiddleware",
+    "_InteractiveActivityMiddleware",
+    "_SlowRequestLogMiddleware",
+)
+
+
+def _middleware_node(name):
+    for node in ast.walk(ast.parse(APP_SOURCE)):
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            return node
+    raise AssertionError(f"{name} not found in app.py")
+
+
+def _reads_raw_request_path(node):
+    """True if the class actually evaluates `request.url.path` anywhere.
+
+    Checked on the AST rather than the text so a comment naming the attribute —
+    which is exactly how the fix documents itself — is not mistaken for a use.
+    """
+    for child in ast.walk(node):
+        if (
+            isinstance(child, ast.Attribute)
+            and child.attr == "path"
+            and isinstance(child.value, ast.Attribute)
+            and child.value.attr == "url"
+        ):
+            return True
+    return False
+
+
+def _calls(node, function_name):
+    return any(
+        isinstance(child, ast.Call)
+        and isinstance(child.func, ast.Name)
+        and child.func.id == function_name
+        for child in ast.walk(node)
+    )
+
+
+@pytest.mark.parametrize("name", MIDDLEWARES)
+def test_middleware_uses_the_application_route_path(name):
+    node = _middleware_node(name)
+    assert _calls(node, "get_application_route_path"), (
+        f"{name} must resolve the path with get_application_route_path()"
+    )
+    assert not _reads_raw_request_path(node), (
+        f"{name} must not read request.url.path — it carries the root_path prefix"
+    )
+
+
+# ── What the raw path actually breaks ──
+
+
+def _timeout_exempt_prefixes():
+    namespace = {}
+    match = re.search(r"^_TIMEOUT_EXEMPT_PREFIXES = \(.*?^\)", APP_SOURCE, re.S | re.M)
+    assert match, "_TIMEOUT_EXEMPT_PREFIXES not found"
+    exec(compile(match.group(0), "<app>", "exec"), namespace)  # noqa: S102
+    return namespace["_TIMEOUT_EXEMPT_PREFIXES"]
+
+
+@pytest.mark.parametrize("prefix", _timeout_exempt_prefixes())
+def test_timeout_exemptions_survive_a_root_path_mount(prefix):
+    """A mounted deployment must keep its long-running routes exempt.
+
+    `/api/upload` and friends are exempt because they legitimately outrun the
+    hard timeout. Behind a mount the raw path is `/odysseus/api/upload`, which
+    matches no prefix, so every one of them became subject to a 504.
+    """
+    route = f"{prefix}/x"
+    scope = {"path": f"/odysseus{route}", "root_path": "/odysseus"}
+
+    assert get_application_route_path(scope) == route
+    assert any(get_application_route_path(scope).startswith(p) for p in _timeout_exempt_prefixes())
+    # The raw path is what used to be matched, and it matches nothing.
+    assert not any(scope["path"].startswith(p) for p in _timeout_exempt_prefixes())
+
+
+@pytest.mark.parametrize("passive", ["/api/health", "/api/version", "/static/app.js"])
+def test_passive_polls_stay_passive_behind_a_mount(passive):
+    """Otherwise a health poll reads as foreground traffic.
+
+    `_InteractiveActivityMiddleware` stops background tasks for every request
+    the gate calls interactive, so misclassifying a poll does not merely lose
+    tracking — it kills background work on each one.
+    """
+    scope = {"path": f"/odysseus{passive}", "root_path": "/odysseus"}
+    resolved = get_application_route_path(scope)
+
+    assert resolved == passive
+    if not should_track_interactive_request(passive, "GET"):
+        assert not should_track_interactive_request(resolved, "GET")
+
+
+def test_unmounted_deployments_are_unchanged():
+    scope = {"path": "/api/upload", "root_path": ""}
+    assert get_application_route_path(scope) == "/api/upload"


### PR DESCRIPTION
## Summary

`core/middleware.get_application_route_path` exists because uvicorn prefixes `scope["path"]` with a configured ASGI `root_path` while Starlette strips it before matching routes, and its own docstring says middleware policy must use the same form. `AuthMiddleware` follows it; the three middlewares defined in `app.py` read `request.url.path`, which still carries the prefix. Behind the reverse-proxy mount SECURITY.md recommends, that switches off the request-timeout exemption list, makes every passive poll look like interactive traffic, and logs paths that match no route. This routes all three through the helper.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #6178

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate. #6172 / #6162 cover `SecurityHeadersMiddleware`, and `tests/test_auth_root_path.py` pins `AuthMiddleware`; nothing covers the three in `app.py`.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — three path lookups and one new test file.
- [x] I actually ran the app (`uvicorn app:app --root-path /odysseus`) and verified the change works end-to-end, before and after. Output below.
- [ ] I did not run the app/runtime validation and stated that gap in **How to Test**.

## Runtime validation

Ran the real app under `uvicorn app:app --root-path /odysseus` and issued the same requests against `origin/dev`'s `app.py` and against this branch's. `ODYSSEUS_SLOW_REQUEST_LOG_SECONDS=0` makes `_SlowRequestLogMiddleware` log the path it resolved for every request, so the difference is directly observable:

```
# app.py from origin/dev
slow_request method=GET path=/odysseus/api/health  status=200 elapsed=0.437s
slow_request method=GET path=/odysseus/api/version status=200 elapsed=0.006s

# app.py from this branch
slow_request method=GET path=/api/health  status=200 elapsed=0.433s
slow_request method=GET path=/api/version status=200 elapsed=0.003s
```

Both runs answered `200` — the routing was never the problem, only what the middlewares believed the path was.

To confirm the premise rather than take the docstring's word for it, I served a bare ASGI app under the same `--root-path` and printed the scope:

```
GET /api/upload   ->  scope["path"]  = "/odysseus/api/upload"
                      root_path      = "/odysseus"
                      get_application_route_path(scope) = "/api/upload"
```

That is the whole bug in one line: with the proxy stripping the prefix and the app told `--root-path`, `request.url.path` returns `/odysseus/api/upload`, which matches no entry in `_TIMEOUT_EXEMPT_PREFIXES`, while the helper returns `/api/upload`, which matches.

Environment note: uvicorn 0.52.4, Python 3.12 on Windows. ChromaDB was unreachable so `MemoryVectorStore` started degraded; that subsystem is unrelated to request path handling and both runs were identical in that respect.

## How to Test

1. Run the new tests and the existing one that pins the same rule for `AuthMiddleware`:

   ```bash
   pytest tests/test_app_middleware_root_path.py tests/test_auth_root_path.py
   # 32 passed
   ```

2. Confirm they fail without the fix — revert any one of the three lookups in `app.py` to `request.url.path` and re-run. The AST check for that middleware flips.

3. To reproduce the runtime output above:

   ```bash
   ODYSSEUS_SLOW_REQUEST_LOG_SECONDS=0 uvicorn app:app --root-path /odysseus
   curl -s -o /dev/null http://127.0.0.1:8000/api/health
   ```

   and read the `app.slow_request` line.

## Why it matters, per middleware

| middleware | behind a mount, before this PR |
| :-- | :-- |
| `_RequestTimeoutMiddleware` | `/odysseus/api/upload` matches no entry in `_TIMEOUT_EXEMPT_PREFIXES`, so every route exempted for legitimately outrunning the hard timeout gets a **504** |
| `_InteractiveActivityMiddleware` | `should_track_interactive_request` matches exact paths and prefixes, so `/odysseus/api/health` reads as interactive — and this middleware **stops background tasks** for interactive traffic, so background work is cancelled on every health poll |
| `_SlowRequestLogMiddleware` | logs a path that matches no route in the codebase — the two `origin/dev` lines above are exactly that |

Unmounted deployments are unaffected: `root_path` is empty and the helper returns the same string. A test pins that too.

## A note on the test

The first case asserts on the **AST**, not the text, of each middleware class. A regex over the source flagged my own explanatory comment — which names `request.url.path` precisely so the next reader knows why it is wrong — as a use of it. Walking for a real `.url.path` attribute access keeps the check honest and lets the comment stay.

The rest of the file is behavioural: it loads `_TIMEOUT_EXEMPT_PREFIXES` from `app.py` and asserts, for each entry, that the mounted path resolves back to something the list matches **and** that the raw path matches nothing — so the test would still be meaningful if the list changes.
