### PR TITLE
docs(specs): add repo-local maintenance skill

### DIFF
--- a/.agents/skills/odysseus-specs-maintenance/SKILL.md
+++ b/.agents/skills/odysseus-specs-maintenance/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: odysseus-specs-maintenance
+description: Reconcile Odysseus implementation-truth specs with the latest origin/dev when explicitly asked to check, refresh, or update specs. Do not use for ordinary code changes or PR reviews that only read specs as context.
+---
+
+# Odysseus Specs Maintenance
+
+Keep `specs/` aligned with the final implementation on the latest upstream `dev` without turning plans, commit summaries, or assumptions into implementation truth.
+
+## Mutation Boundary
+
+- Edit specs only when the user explicitly requests spec maintenance or the current task intentionally includes spec changes.
+- Treat specs as read-only during ordinary implementation work and code review. Report drift in the task's normal output instead of changing specs.
+- Do not require a pull request author to update specs unless the user explicitly asks for that spec work.
+- Do not modify product code as part of a specs-only reconciliation. Report a discovered implementation bug separately unless the user expands the task.
+- Do not commit, push, open a pull request, or change remote state unless the user explicitly requests that action.
+
+## Establish the Basis
+
+1. Read `specs/_readme.md` completely, including its quality contract, subsystem map, and cross-cutting update triggers.
+2. Read `specs/last_specs_check.txt` and identify the most recent completed `dev` checkpoint.
+3. Fetch `origin/dev` and record its exact full SHA before inspection. Treat that fetched tree as the implementation source of truth, not the current feature or review branch.
+4. Work in a clean focused branch or worktree based on that `origin/dev` SHA. Preserve unrelated user changes; if the current worktree is dirty or serves another task, use a separate worktree.
+5. Verify whether the checkpoint is an ancestor of the fetched SHA. If history was rewritten, do not report a misleading linear commit count; compare the final source trees, record the discontinuity, and inspect the affected implementation directly.
+
+## Reconcile
+
+1. Compare the last completed checkpoint with the fetched `origin/dev` tree. Use changed paths and commit history only to route inspection; commit titles, pull request descriptions, and existing specs are not proof of runtime behavior.
+2. Map changed implementation paths through the subsystem map and update triggers in `specs/_readme.md`. Read each affected spec plus adjacent cross-cutting specs whose ownership, security, persistence, context, runtime, frontend, integration, or testing contracts may have changed.
+3. Inspect the final source, call sites, tests, configuration, migrations, and runtime wiring needed to verify each claim. Distinguish current behavior from superseded intermediate commits.
+4. Update only claims that are stale. Preserve accurate content and the established domain-specific structure; do not rewrite unaffected specs for style.
+5. Set each changed spec's `Last updated` header to the fetched `dev` short SHA and reconciliation date. Update `specs/_readme.md` only when its own control text, subsystem map, or update triggers changed.
+6. Keep planning, research, branch notes, audit logs, and speculative proposals out of `specs/`.
+
+## Validate
+
+1. Re-read the resulting diff against the final `origin/dev` source and confirm that every changed factual claim is source-grounded.
+2. Run focused existing tests or checks when they materially validate the documented behavior. Record commands, outcomes, and any residual validation gap; do not claim that passing tests prove untested behavior.
+3. Verify Markdown structure and links, confirm every non-index top-level `specs/*.md` file appears exactly once in the subsystem map, confirm provider specs remain routed through `specs/model-providers/_readme.md`, and run `git diff --check`.
+4. Confirm the task diff contains no unintended product-code changes and no private paths, credentials, raw logs, or environment-specific workspace details.
+5. Append the completed check to `specs/last_specs_check.txt` only after reconciliation and validation finish. Include the date, full checked `dev` SHA, whether specs changed, relevant validation, and the local spec-update branch or commit when available.
+
+## Closeout
+
+Report the checked `dev` SHA, inspected range or history discontinuity, specs changed or confirmed current, validation performed, and residual uncertainty. A no-change reconciliation is a valid result and should still advance the checkpoint after the comparison is complete.

--- a/.agents/skills/odysseus-specs-maintenance/SKILL.md
+++ b/.agents/skills/odysseus-specs-maintenance/SKILL.md
@@ -35,7 +35,7 @@ Keep `specs/` aligned with the final implementation on the latest upstream `dev`
 ## Validate
 
 1. Re-read the resulting diff against the final `origin/dev` source and confirm that every changed factual claim is source-grounded.
-2. Run focused existing tests or checks when they materially validate the documented behavior. Record commands, outcomes, and any residual validation gap; do not claim that passing tests prove untested behavior.
+2. Run focused existing tests or checks when they materially validate the documented behavior. Static Git and Markdown inspection that does not execute repository-controlled code may run in the controller. Run every repository-controlled test, build, install, or reproduction command only through the project's secretless `review-run <source-or-worktree> -- <command...>` boundary; if that boundary is unavailable or bypassed, do not run the command and record it as not run with the residual validation gap. Record commands and outcomes, and do not claim that passing tests prove untested behavior.
 3. Verify Markdown structure and links, confirm every non-index top-level `specs/*.md` file appears exactly once in the subsystem map, confirm provider specs remain routed through `specs/model-providers/_readme.md`, and run `git diff --check`.
 4. Confirm the task diff contains no unintended product-code changes and no private paths, credentials, raw logs, or environment-specific workspace details.
 5. Append the completed check to `specs/last_specs_check.txt` only after reconciliation and validation finish. Include the date, full checked `dev` SHA, whether specs changed, relevant validation, and the local spec-update branch or commit when available.

--- a/specs/_readme.md
+++ b/specs/_readme.md
@@ -32,6 +32,7 @@ project documentation.
 ## Working Rules
 
 - Start here before substantial work.
+- For an explicit latest-`dev` specs reconciliation, follow the [Odysseus specs maintenance skill](../.agents/skills/odysseus-specs-maintenance/SKILL.md) and start from [the last completed checkpoint](last_specs_check.txt).
 - Read the related subsystem spec before changing code in that area. For cross-cutting work, include the owning domain spec plus route/runtime, auth/security, persistence, frontend, tool/context, integration, and testing/devops specs as applicable.
 - Treat specs as read-only context during ordinary project work, PR review, and code review. Do not edit specs unless the user explicitly asks for spec work or the current PR intentionally includes spec changes.
 - During explicit spec-maintenance work, update the related spec when source inspection shows behavior, ownership, security boundaries, data shape, import paths, or implementation contracts have changed.

--- a/specs/last_specs_check.txt
+++ b/specs/last_specs_check.txt
@@ -1,0 +1,5 @@
+# Specs Maintenance Checkpoints
+
+Append one entry only after a latest-`origin/dev` reconciliation and its validation are complete. Each entry records the durable comparison basis for the next run; detailed scratch notes and environment-specific paths do not belong here.
+
+- 2026-08-25: reconciled against `origin/dev` commit `e71f8ceb653aeca7ce39d98bd7c2b98a152c3291` (commit date 2026-08-25 10:26:18 +0100, `chore(release): align dev version with 1.0.3 (#6168)`). Twenty-seven affected specs were updated from final source inspection. Validation: 565 focused tests passed with 1 skipped; all 61 spec Markdown files passed structure, link, and subsystem-map checks. Spec update commit: `b5be3f1feb63487842d00ed8e20568b61952523f`.


### PR DESCRIPTION
## Summary

Adds a repository-contained maintenance skill for the implementation-truth specs now that the specs foundation has landed. The skill preserves the existing latest-`dev` reconciliation contract, moves the durable last-completed checkpoint under `specs/`, and links both from the compact DocumentMap without changing application behavior or rewriting any subsystem spec.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release.

## Linked Issue

Fixes #6177

Parent contributor-onboarding tracker: #4071

Completed specs foundation: #2537 and #5794

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [x] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes are mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.
- [x] I did not run the app/runtime validation and stated that gap in **How to Test**.

## How to Test

1. Run `git diff --check origin/dev...HEAD`. Expected result: no output.
2. Run `git diff --name-only origin/dev...HEAD`. Expected result: only `.agents/skills/odysseus-specs-maintenance/SKILL.md`, `specs/_readme.md`, and `specs/last_specs_check.txt`.
3. Open `specs/_readme.md` and follow both new links. Confirm the skill and checkpoint resolve inside the repository.
4. Compare the skill with the existing spec quality contract and update triggers. Confirm it fetches the latest `origin/dev`, starts from the recorded checkpoint, uses changed paths only to route final-source inspection, updates only stale claims, validates the spec structure, and advances the checkpoint only after completion.
5. Confirm the checkpoint preserves the exact `e71f8ceb653aeca7ce39d98bd7c2b98a152c3291` implementation basis from the last completed reconciliation rather than advancing it merely because this workflow-only PR exists.

Validation completed on commit `5ee82500350e165553d67e368714d79a73933478`:

- The skill-structure validator reports `Skill is valid!`.
- A repository-relative scan validated links and `Last updated` headers across all 61 spec Markdown files, plus exact-once entries in the root subsystem map and provider map.
- The skill and checkpoint contain no private workspace paths or environment-specific dependencies.
- The branch diff is confined to the three documentation paths listed above, and `git diff --check` passes.

The application was not started because this PR changes no product code, runtime configuration, dependency, test, template, or rendered UI file.

## Scope choices

- `.agents/skills/` owns the repo-local contributor skill; the existing installable Odysseus product-integration skills remain unchanged.
- `specs/_readme.md` remains the quality-contract and routing authority. The operational sequence lives in the skill so the DocumentMap stays compact.
- `specs/last_specs_check.txt` contains the durable comparison basis needed by the next reconciliation, without carrying detailed scratch history into the repository.
- No helper script, template, reference bundle, UI metadata, CI workflow, scheduled automation, or write-token path is added in this slice.

## Visual / UI changes — REQUIRED if you touched anything that renders

N/A — no rendering, UI, CSS, HTML, SVG, or browser-side JavaScript changed.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: no UI styling changed.
- [x] **No new component patterns.**
- [x] **I am not an LLM agent submitting a bulk PR.** This is a focused, one-off, user-directed documentation change prepared after opening #6177.

### Screenshots / clips

N/A — no rendered UI files changed.
