### PR TITLE
chore(specs): assign shared CODEOWNERS reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,6 @@
 # Code owners.
 #
-# Intentionally empty for now. The catch-all rule that mapped every path to a
-# single owner froze all merges the moment "Require review from Code Owners"
-# was enabled, because no other maintainer's approval could satisfy the gate.
-# A per-area ownership map (security/auth, CI, frontend, agent internals, with
-# multiple named owners per line) is being worked out in issue #593; once
-# agreed it replaces this file. Until then, required reviews and the security
-# CI gate (docs/security-ci.md) remain in force via branch protection.
+# Keep ownership path-specific and shared. Issue #593 tracks the broader per-area ownership map; this first rule covers only implementation-truth specs.
+#
+# Implementation-truth specs
+/specs/ @RaresKeY @pewdiepie-archdaemon @alteixeira20 @StressTestor @o3LL @nopoz


### PR DESCRIPTION

## Summary

Adds one narrow CODEOWNERS rule for the repository's implementation-truth specs, with six verified collaborators sharing review ownership. This gives future `specs/` changes an automatic reviewer pool without restoring a repository-wide catch-all, making one maintainer the sole owner, changing branch protection, or affecting application/runtime behavior.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release.

## Linked Issue

Fixes #6181

Parent CODEOWNERS tracker: #593

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — #593 owns the broader CODEOWNERS map, but no open item owns this focused `specs/` rule.
- [x] This PR targets `dev`.
- [x] My changes are limited to the scope described above — only `.github/CODEOWNERS` changes.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.
- [x] I did not run the app/runtime validation and stated that gap in **How to Test**.

## How to Test

1. Run `git diff --check origin/dev...HEAD`. Expected result: no output.
2. Run `git diff --name-only origin/dev...HEAD`. Expected result: only `.github/CODEOWNERS`.
3. Inspect the `/specs/` rule. Confirm it is rooted at the repository's `specs/` directory and lists `@RaresKeY`, `@pewdiepie-archdaemon`, `@alteixeira20`, `@StressTestor`, `@o3LL`, and `@nopoz` on one line.
4. Verify each listed login is a current collaborator with write or admin access using the authenticated GitHub API's collaborator-permission endpoint.
5. Confirm there is no catch-all pattern, no owner rule for `.github/CODEOWNERS`, and no branch-protection or ruleset change in the diff.

Validation completed on commit `64e9e15b8`:

- All six GitHub logins resolve to current collaborators: `@RaresKeY`, `@alteixeira20`, `@StressTestor`, `@o3LL`, and `@nopoz` have write access; `@pewdiepie-archdaemon` has admin access.
- GitHub's documented CODEOWNERS syntax supports a root directory pattern and requires alternative owners for one pattern to be listed on the same line.
- `git diff --check` passes and the diff contains only `.github/CODEOWNERS`.

The application was not started because this PR changes only repository review-routing configuration and does not change product code, runtime configuration, dependencies, tests, templates, or rendered UI files.

## Scope choices

- `/specs/` is the only owned path in this slice and matches that repository-root directory recursively.
- Six named collaborators share the rule; no single account becomes a merge bottleneck.
- #593 remains the owner of the broader per-area CODEOWNERS map.
- Branch protection and required-review policy remain unchanged. If required code-owner review is enabled separately, GitHub accepts an approval from any one eligible owner listed for the matching path; this PR does not require all six approvals.

## Visual / UI changes — REQUIRED if you touched anything that renders

N/A — no rendering, UI, CSS, HTML, SVG, or browser-side JavaScript changed.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: no UI styling changed.
- [x] **No new component patterns.**
- [x] **I am not an LLM agent submitting a bulk PR.** This is a focused, one-off, user-directed repository-configuration change with a prepared issue.

### Screenshots / clips

N/A — no rendered UI files changed.
