### PR TITLE
fix(chat): distinguish Calendar data reads from panel navigation (#6184)

### DIFF
--- a/src/action_intents.py
+++ b/src/action_intents.py
@@ -68,6 +68,13 @@ _ROUTING_PATTERNS: tuple[tuple[str, str, Pattern[str]], ...] = tuple(
         ("calendar", "calendar agenda question", r"\bwhat(?:'s| is)\s+on\s+(?:my\s+)?calendar\b"),
         ("calendar", "next calendar item question", r"\bwhen\s+(?:is|are)\s+(?:my\s+)?next\s+(?:event|meeting|appointment|class)\b"),
 
+        # Broader calendar data reads without time qualifiers.
+        # Distinguish "show my calendar events" (data) from "show my calendar" (panel).
+        ("calendar", "calendar events list request", rf"\b(?:list|show|read|get|view)\b.{{0,80}}\b(?:my\s+|the\s+)?calendar\s+(?:events?|meetings?|appointments?|classes?|schedule)\b"),
+        ("calendar", "calendar schedule list request", rf"\b(?:list|show|read|get|view)\b.{{0,80}}\b(?:my\s+|the\s+)(?:events?|meetings?|appointments?|classes?|schedule)\b"),
+        ("calendar", "calendar events question", rf"\b(?:what|which)\b.{{0,80}}\b(?:events?|meetings?|appointments?|classes?|schedule)\b.{{0,80}}\b(?:my\s+|the\s+)?calendar\b"),
+        ("calendar", "calendar content question", rf"\b(?:what|which)\b.{{0,80}}\b(?:is\s+)?(?:in|on)\b.{{0,80}}\b(?:my\s+|the\s+)?calendar\b"),
+        
         # Notes, todos, checklists, and reminders.
         ("notes", "reminder request", r"\bremind\s+me\b"),
         ("notes", "assistant note/todo action request", rf"{_ACTION_QUESTION}(?:add|create|make|take|jot|write\s+down|set)\b.{{0,120}}\b(?:note|todo|task|checklist|reminder)\b"),

--- a/tests/test_action_intents_calendar.py
+++ b/tests/test_action_intents_calendar.py
@@ -1,0 +1,54 @@
+"""Regression tests for issue #6184 — Calendar data reads vs panel navigation."""
+
+import pytest
+from src.action_intents import classify_tool_intent
+
+
+CALENDAR_DATA_READS = [
+    ("List my calendar events", "calendar events list request"),
+    ("Show all my calendar events", "calendar events list request"),
+    ("Read my calendar schedule", "calendar events list request"),
+    ("What events are in my calendar?", "calendar events question"),
+    ("What meetings are on the calendar?", "calendar events question"),
+    ("What is in my calendar?", "calendar content question"),
+    ("What is on my calendar?", "calendar agenda question"),
+    ("Show my schedule", "calendar schedule list request"),
+    ("List my appointments", "calendar schedule list request"),
+    ("View the calendar agenda", "calendar events list request"),
+]
+
+
+CALENDAR_PANEL_NAV = [
+    "Show my calendar",
+    "Open my calendar",
+    "Bring up the calendar",
+    "Show calendar",
+]
+
+
+NON_CALENDAR = [
+    "List world events",
+    "What events happened in 2020",
+]
+
+
+@pytest.mark.parametrize("text,expected_reason", CALENDAR_DATA_READS)
+def test_calendar_data_read_routing(text, expected_reason):
+    intent = classify_tool_intent(text)
+    assert intent.needs_tools is True
+    assert intent.category == "calendar"
+    assert intent.reason == expected_reason
+
+
+@pytest.mark.parametrize("text", CALENDAR_PANEL_NAV)
+def test_calendar_panel_navigation(text):
+    intent = classify_tool_intent(text)
+    assert intent.needs_tools is True
+    assert intent.category == "ui"
+    assert intent.reason == "open/show panel request"
+
+
+@pytest.mark.parametrize("text", NON_CALENDAR)
+def test_calendar_false_negatives(text):
+    intent = classify_tool_intent(text)
+    assert intent.needs_tools is False


### PR DESCRIPTION
## Summary

The Chat intent classifier (`classify_tool_intent()`) required time qualifiers like "today" or "this week" to promote a Calendar read to agent mode. Phrases like "List my calendar events" or "What events are in my calendar?" fell through to plain chat, so the model never received `manage_calendar` and could not answer the user's question. Additionally, "Show my calendar" was caught by the UI panel-opener pattern instead of being treated as a data read.

This PR adds four broader regex patterns that match list/show/question phrasing when `events`/`meetings`/`appointments`/`schedule` are mentioned alongside `calendar`, while preserving bare "Show my calendar" as UI navigation. It also adds a focused regression test file covering the reported examples plus false-negative guardrails.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #6184

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.
- [x] I did not run the app/runtime validation and stated that gap in **How to Test**. Leave this unchecked when the app-run box above is checked.

## How to Test

1. Check out this branch.
2. Run the new regression tests:
   ```bash
   ./venv/bin/python -m pytest tests/test_action_intents_calendar.py -v