### PR TITLE
refactor(tools): extract manage_tasks, manage_skills, api_call to registry (#2917)

### DIFF
--- a/src/agent_tools/__init__.py
+++ b/src/agent_tools/__init__.py
@@ -33,6 +33,7 @@ from .admin_tools import (
     do_manage_endpoints, do_manage_mcp, do_manage_webhooks,
     do_manage_tokens, do_manage_settings,
 )
+from .system_tools import ManageTasksTool, ManageSkillsTool, ApiCallTool
 
 TOOL_HANDLERS = {
     "bash": BashTool().execute,
@@ -63,6 +64,9 @@ TOOL_HANDLERS = {
     "list_sessions": ListSessionsTool().execute,
     "send_to_session": SendToSessionTool().execute,
     "manage_session": ManageSessionTool().execute,
+    "manage_tasks": ManageTasksTool().execute,
+    "manage_skills": ManageSkillsTool().execute,
+    "api_call": ApiCallTool().execute,
 }
 # Config/integration admin tools (manage_endpoints/mcp/webhooks/tokens/settings).
 TOOL_HANDLERS.update(ADMIN_TOOL_HANDLERS)

--- a/src/agent_tools/system_tools.py
+++ b/src/agent_tools/system_tools.py
@@ -1,0 +1,24 @@
+"""system_tools.py — Handler classes for system/utility tools.
+
+Migrates manage_tasks, manage_skills, and api_call out of the
+execute_tool_block if/elif chain into the TOOL_HANDLERS registry.
+Part of the incremental refactor tracked in issue #2917.
+"""
+from typing import Dict
+
+from src.tools.system import do_manage_tasks, do_manage_skills, do_api_call
+
+
+class ManageTasksTool:
+    async def execute(self, content: str, ctx: dict) -> Dict:
+        return await do_manage_tasks(content, owner=ctx.get("owner"))
+
+
+class ManageSkillsTool:
+    async def execute(self, content: str, ctx: dict) -> Dict:
+        return await do_manage_skills(content, owner=ctx.get("owner"))
+
+
+class ApiCallTool:
+    async def execute(self, content: str, ctx: dict) -> Dict:
+        return await do_api_call(content)

--- a/src/tool_execution.py
+++ b/src/tool_execution.py
@@ -763,8 +763,7 @@ async def _execute_tool_block_impl(
     events while the command is in flight. Ignored by other tools.
     """
     from src.tool_implementations import (
-        do_search_chats, do_manage_tasks,
-        do_manage_skills, do_api_call, do_manage_notes,
+        do_search_chats, do_manage_notes,
         do_manage_calendar,
         do_download_model, do_serve_model, do_list_served_models, do_stop_served_model,
         do_tail_serve_output,
@@ -952,16 +951,6 @@ async def _execute_tool_block_impl(
     elif tool in ("pipeline", "manage_memory", "ui_control"):
         from src.ai_interaction import dispatch_ai_tool
         desc, result = await dispatch_ai_tool(tool, content, session_id, owner=owner)
-    elif tool == "manage_tasks":
-        desc = "manage_tasks"
-        result = await do_manage_tasks(content, owner=owner)
-    elif tool == "manage_skills":
-        desc = "manage_skills"
-        result = await do_manage_skills(content, owner=owner)
-    elif tool == "api_call":
-        first_line = content.split("\n")[0].strip()[:60]
-        desc = f"api_call: {first_line}"
-        result = await do_api_call(content)
     elif tool in ("manage_endpoints", "manage_mcp", "manage_webhooks", "manage_tokens", "manage_settings"):
         # Registry-dispatched (agent_tools.admin_tools); owner threaded for ownership/admin checks.
         desc = tool


### PR DESCRIPTION
## Summary
Moves three system-utility tools (`manage_tasks`, `manage_skills`, `api_call`) out of the legacy `execute_tool_block` if/elif chain and routes them through the `TOOL_HANDLERS` registry in `src/agent_tools/`. This isolates their payload parsing into their own module while keeping shared coordinator concerns in `tool_execution.py`.

## Target branch
- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue
Part of #2917

## Type of Change
- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [x] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist
- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.
- [ ] I did not run the app/runtime validation and stated that gap in **How to Test**. Leave this unchecked when the app-run box above is checked.

## How to Test
1. Run the test suite covering the tool implementation facade shim and tool policy: `pytest tests/test_tool_implementations_shim.py tests/test_manage_tasks_owner_scope.py tests/test_manage_skills_action_required.py tests/test_chat_route_tool_policy.py -v`.
2. Confirm the tests pass.
3. Start the application locally with `python -m src.main` or via `docker compose up`.
4. Trigger the agent to list or manipulate tasks/skills to ensure the tool executes successfully via the new registry routing.
