### PR TITLE
refactor(static): load the gallery on first use

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -27,7 +27,7 @@ import sessionModule from './js/sessions.js';
 import memoryModule from './js/memory.js?v=20260722memoryloading1';
 import voiceRecorderModule from './js/voiceRecorder.js';
 import censorModule from './js/censor.js';
-import galleryModule from './js/gallery.js';
+import { loadPanel } from './js/panels.js';
 import { UI_VIS_DEFAULT_OFF, resolveVisibility } from './js/ui_visibility.js';
 import tasksModule from './js/tasks.js?v=20260723tasksbulkfeedback1';
 import calendarModule from './js/calendar.js';
@@ -1041,16 +1041,28 @@ function initializeEventListeners() {
     });
   }
 
-  // Gallery tool button
+  // Gallery tool button. gallery.js is 145 KB and most sessions never open the
+  // panel, so it loads on first use via the panel registry. Modals.toggle runs
+  // first, unchanged: a minimized gallery can only exist if the module already
+  // loaded, so restoring one must not wait on an import.
   const toolGalleryBtn = el('tool-gallery-btn');
   if (toolGalleryBtn) {
     toolGalleryBtn.addEventListener('click', async () => {
-      if (!galleryModule) return;
       const Modals = await import('./js/modalManager.js');
-      if (!Modals.toggle('gallery-modal')) {
-        if (galleryModule.isGalleryOpen()) galleryModule.closeGallery();
-        else galleryModule.openGallery();
+      if (Modals.toggle('gallery-modal')) return;
+      let galleryModule;
+      try {
+        galleryModule = (await loadPanel('gallery')).default;
+      } catch (e) {
+        // Previously unreachable — a static import either loaded or the whole
+        // page failed. Now it can fail on its own (offline before the module
+        // was ever cached), so say so instead of doing nothing.
+        console.error('[app] gallery failed to load', e);
+        uiModule?.showError?.('Failed to load the gallery');
+        return;
       }
+      if (galleryModule.isGalleryOpen()) galleryModule.closeGallery();
+      else galleryModule.openGallery();
     });
   }
 

--- a/static/index.html
+++ b/static/index.html
@@ -2571,7 +2571,6 @@
 <script type="module" src="/static/js/spinner.js"></script>
 <script type="module" src="/static/js/tts-ai.js"></script>
 <script type="module" src="/static/js/document.js?v=20260815approvalsave1"></script>
-<script type="module" src="/static/js/gallery.js?v=20260708match1"></script>
 <script type="module" src="/static/js/chatRenderer.js?v=20260819approvalcontrol1"></script>
 <script type="module" src="/static/js/codeRunner.js"></script>
 <script type="module" src="/static/js/chatStream.js?v=20260819approvalcontrol1"></script>

--- a/static/js/panels.js
+++ b/static/js/panels.js
@@ -16,6 +16,7 @@
 
 const LOADERS = {
   editor: () => import('./galleryEditor.js'),
+  gallery: () => import('./gallery.js'),
 };
 
 /**

--- a/static/sw.js
+++ b/static/sw.js
@@ -7,7 +7,7 @@
 //   - Other static assets (images/fonts/libs): cache-first with bg refresh.
 //   - API / non-GET: never cached.
 // Bump CACHE_NAME whenever the precache list or SW logic changes.
-const CACHE_NAME = 'odysseus-v380-shared-config-image-editor-lazy-katex-mermaid';
+const CACHE_NAME = 'odysseus-v381-gallery-lazy';
 
 // KaTeX resolves these from its own stylesheet, so caching the CSS without them
 // gives offline math fallback glyphs instead of proper typesetting.
@@ -59,7 +59,6 @@ const PRECACHE = [
   '/static/js/spinner.js',
   '/static/js/tts-ai.js',
   '/static/js/document.js',
-  '/static/js/gallery.js',
   '/static/js/chatRenderer.js',
   '/static/js/codeRunner.js',
   '/static/js/chatStream.js',
@@ -101,6 +100,8 @@ const PRECACHE = [
 // Lazily-imported panel modules (js/panels.js). Not in index.html by design;
 // precached so the panel still opens with no network.
 const PANEL_PRECACHE = [
+  // Gallery panel.
+  '/static/js/gallery.js',
   // Image editor — galleryEditor.js and its js/editor/ graph.
   '/static/js/galleryEditor.js',
   '/static/js/editor/ai-inpaint.js?v=20260708match1',

--- a/tests/test_panel_loader_js.py
+++ b/tests/test_panel_loader_js.py
@@ -139,6 +139,54 @@ def test_the_image_editor_is_registered():
     assert "editor" in json.loads(_run(js))
 
 
+def test_the_gallery_is_registered():
+    js = textwrap.dedent(
+        f"""
+        const {{ panelNames }} = await import('{_PANELS}');
+        console.log(JSON.stringify(panelNames()));
+        """
+    )
+    assert "gallery" in json.loads(_run(js))
+
+
+# ── The gallery stays off the critical path ───────────────────────────────
+# gallery.js had *two* eager entry points — a <script type="module"> tag in
+# index.html and a static `import` in app.js — and re-adding either one puts
+# 145 KB back on every page load without breaking anything visible. Nothing
+# else would catch that, so pin both.
+
+_INDEX_HTML = _REPO / "static" / "index.html"
+_APP_JS = _REPO / "static" / "app.js"
+
+
+def test_gallery_is_not_eagerly_loaded_by_index_html():
+    tags = re.findall(
+        r"""<script[^>]*type=["']module["'][^>]*src=["']([^"']+)["']""",
+        _INDEX_HTML.read_text(encoding="utf-8"),
+    )
+    eager = [t for t in tags if t.split("?")[0].endswith("/js/gallery.js")]
+    assert not eager, (
+        "gallery.js is loaded eagerly by index.html again — it is meant to load "
+        f"on first open through panels.js: {eager}"
+    )
+
+
+def test_gallery_is_not_statically_imported_by_app_js():
+    static_specs = _STATIC_IMPORT.findall(_APP_JS.read_text(encoding="utf-8"))
+    eager = [s for s in static_specs if s.split("?")[0].endswith("/gallery.js")]
+    assert not eager, (
+        "app.js statically imports gallery.js again, which drags it back onto "
+        f"the critical path: {eager}"
+    )
+
+
+def test_gallery_is_precached_for_offline_use():
+    assert "/static/js/gallery.js" in _panel_precache_entries(), (
+        "gallery.js loads lazily, so without a PANEL_PRECACHE entry the panel "
+        "opens online and dies offline"
+    )
+
+
 # ── Offline coverage ──────────────────────────────────────────────────────
 # A lazily-loaded panel is never fetched during a normal page load, so it only
 # lands in the service-worker cache if sw.js precaches it explicitly. Miss one


### PR DESCRIPTION
## Summary

`gallery.js` is 145 KB decoded and most sessions never open the panel, but `index.html` loaded it eagerly on every page. Worse, it loaded it as `/static/js/gallery.js?v=20260708match1` while `app.js:30` imported `./js/gallery.js` — different URLs, so the browser evaluated the file twice as two unrelated modules, each with its own `_items`/`_open`/`_sort` and `gallery-refresh` listener. This is the same defect the comment at `app.js:44` already records for `cookbook.js`. Registering the panel in the `panels.js` registry from #6074 and importing it on first click fixes both: one instance, and it only loads when the panel is actually opened.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #6196

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [x] Refactor / cleanup (behaviour unchanged)

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate. No open PR touches `static/js/panels.js`; #6019 changes `gallery.js` contents but not how it is loaded, and does not conflict with this diff.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.
- [ ] I did not run the app/runtime validation and stated that gap in **How to Test**.

## How to Test

1. Start the app: `python -m uvicorn app:app --host 127.0.0.1 --port 7099`.
2. Load `http://127.0.0.1:7099/` in a fresh profile and **do not** open the Gallery. In DevTools:

```js
performance.getEntriesByType('resource').filter(e => e.name.includes('/js/gallery.js')).length
```

   On `dev` this is `2`. On this branch it is `0`.

3. Click the Gallery button. The panel opens; re-run the snippet and it is `1`.
4. Close and reopen the panel a few times — it stays `1`, so the import is memoised.
5. Upload an image and confirm the grid updates; open the **Edit** tab and pick a template to confirm the image editor still loads through the now-lazy gallery.
6. `python -m pytest tests/test_panel_loader_js.py -q` — 10 passed.

Resource Timing on a cold load, `dev` vs this branch: 121 → 119 JS files, 1,993,438 → 1,920,059 bytes transferred, 7,457,248 → 7,168,136 decoded. First panel open is ~44 ms on both.

## Visual / UI changes

The panel's markup, CSS and rendering are untouched — `gallery.js` itself is not in the diff, so the panel looks identical, it just loads later. Screenshots are the panel open on this branch, desktop and mobile.

- [x] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match** — no CSS touched, no new colour values, font sizes or spacing units, no new classes.
- [x] **No new component patterns.**
- [x] **I am not an LLM agent submitting a bulk PR.**

### Screenshots / clips

Desktop:

![Gallery panel open on the lazy-load branch](https://raw.githubusercontent.com/o3LL/odysseus/assets/lazy-load-gallery/gallery-lazy-desktop.png)

Mobile:

![Gallery panel open on the lazy-load branch, mobile](https://raw.githubusercontent.com/o3LL/odysseus/assets/lazy-load-gallery/gallery-lazy-mobile.png)

### Not verified

- Offline: the panel is precached under `PANEL_PRECACHE` and `CACHE_NAME` is bumped, but I could not confirm an offline open end-to-end — `index.html` registers `/static/sw.js` with no `Service-Worker-Allowed` header, so the worker's scope is `/static/` and it never controls the page. That is true on unmodified `dev` too, so it is pre-existing and not something this PR changes.
- Only tested on macOS, manual venv install, Chromium. Not tested on Docker or Windows.
- I did not audit the rest of the `index.html` tag list for the same query-string mismatch; `cookbook.js` is the other known case and I left it alone.
