### PR TITLE
fix(main): restore Any import and pin mcp<2 so a fresh main clone boots

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,10 @@ python-dateutil
 caldav
 cryptography
 bcrypt
-mcp
+# Built-in servers use the v1 low-level Server decorator API. MCP SDK v2 is a
+# breaking rewrite, so keep fresh installs on the maintained v1 line until the
+# servers are migrated together.
+mcp<2
 pyotp
 qrcode[pil]
 croniter

--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -12,7 +12,7 @@ import json
 import re
 import time
 import logging
-from typing import AsyncGenerator, List, Dict, Optional, Set
+from typing import Any, AsyncGenerator, List, Dict, Optional, Set
 from urllib.parse import urlparse
 
 from src.llm_core import (


### PR DESCRIPTION
## Summary

A clean clone of `main` at `451900f` (v1.0.3) does not start: `src/agent_loop.py` annotates three signatures with `Any` while the `typing` import on line 15 omits it, so uvicorn dies with `NameError` before it binds a port. With that fixed, the app starts but every bundled Python MCP server fails to load, because `requirements.txt` on `main` leaves `mcp` unpinned and a fresh install now resolves to `mcp 2.1.1`, which removed the low-level `Server.list_tools()` decorator those servers are written against. This PR backports both fixes from `dev` — the `Any` import and the `mcp<2` pin with its explanatory comment — so `requirements.txt` is byte-identical to the one on `dev`.

**On the base branch, deliberately `main`:** both fixes already exist on `dev`, so a PR against `dev` would be an empty diff. CONTRIBUTING describes `main` as "fast-forwarded to a stable `dev` commit at each release", but the branches have diverged: `main` carries 2 commits absent from `dev` (`cf4e240`, `451900f`) while `dev` is 186 ahead. That divergence is how these two fixes went missing on the branch users are told to check out for stability. If you would rather fix this by fast-forwarding `main` and closing this PR, that outcome is just as good — the important part is that a fresh `main` clone boots.

## Target branch

- [ ] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

> Left unchecked on purpose — this is a backport of commits already on `dev`, and it is not on `main` by accident. See the note in Summary.

## Linked Issue

Part of #6165 (unpinned `mcp`, fixed on `dev` by #5820 and never backported).
Also fixes the `NameError` reported in #5732 and #5723.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate. Both problems are reported (#6165, #5732, #5723); no open PR carries either fix to `main` (`gh pr list --base main --state open` returns nothing).
- [ ] This PR targets `dev` — see above; targeting `dev` would produce an empty diff.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in. The diff is 2 files: one import line, one pin plus the same three comment lines `dev` carries.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end.

## How to Test

Native install on Linux, Python 3.13, no Docker.

1. **Reproduce the crash on unpatched `main`:**
   ```bash
   git clone --branch main https://github.com/odysseus-dev/odysseus.git && cd odysseus
   python3 -m venv venv && ./venv/bin/pip install -r requirements.txt
   cp .env.example .env && ./venv/bin/python setup.py
   ./venv/bin/python -m uvicorn app:app --host 127.0.0.1 --port 7000
   ```
   Exits immediately with:
   ```
   File ".../src/agent_loop.py", line 1503, in <module>
       def _resolved_tool_event_name(event: dict[str, Any]) -> str:
   NameError: name 'Any' is not defined. Did you mean: 'any'?
   ```

2. **Apply only the import fix and start again.** The app serves, but the log shows four import failures — `image_gen`, `memory`, `rag`, `email` — each `AttributeError: 'Server' object has no attribute 'list_tools'`, followed by `Failed to connect MCP server`. Installed SDK is `mcp 2.1.1`.

3. **Apply this branch in full**, reinstall requirements so the pin takes effect (`mcp 1.29.1`), and start again:
   ```
   INFO - MCP server connected: Built-in: Image Generation (image_gen) - 1 tools via stdio
   INFO - MCP server connected: Built-in: Memory (memory) - 1 tools via stdio
   INFO - MCP server connected: Built-in: RAG (rag) - 1 tools via stdio
   INFO - MCP server connected: Built-in: Email (email) - 16 tools via stdio
   INFO - MCP server connected: Built-in: Browser (builtin_browser) - 30 tools via stdio
   INFO - Application startup complete.
   ```
   `GET /` returns 302 to the login page; admin login works; all five built-in MCP servers are connected.

4. **Checks from CONTRIBUTING, on this branch:**
   ```
   python -m py_compile app.py routes/*.py src/*.py   # clean
   python -m pytest -q                                # 4765 passed, 3 skipped in 244s
   ```

5. **Cross-checked against `dev`** on the same machine, installed side by side (`dev` at `c9dd68d`, port 7001): `python -m pytest -q` there reports **5809 passed, 3 skipped** (the branch carries 1044 more tests than `main`) — it boots clean and connects the same five MCP servers, which is the behaviour this PR restores on `main`. `diff` of `requirements.txt` between this branch and `dev` is empty.

6. **Not native-only.** The Dockerfile installs this same `requirements.txt`, so a fresh `main` image inherits both problems; the `NameError` is a plain import error and does not depend on the install route.

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable: no UI, CSS, HTML, SVG or `static/js/` files are touched. The diff is one `typing` import and one dependency pin.
