### PR TITLE
fix(chroma): document and surface the ChromaDB server a native install needs

### DIFF
--- a/src/chroma_client.py
+++ b/src/chroma_client.py
@@ -52,8 +52,9 @@ def get_chroma_client():
     if not _port_open(host, port):
         raise RuntimeError(
             f"ChromaDB is not reachable at {host}:{port}. Start the ChromaDB "
-            f"service (e.g. `docker compose up chromadb`) or set CHROMADB_HOST / "
-            f"CHROMADB_PORT to point at a running instance."
+            f"service (Docker: `docker compose up chromadb`; native: "
+            f"`chroma run --host {host} --port {port} --path ./data/chroma`) or "
+            f"set CHROMADB_HOST / CHROMADB_PORT to point at a running instance."
         )
 
     client = chromadb.HttpClient(host=host, port=port)

--- a/website/setup.md
+++ b/website/setup.md
@@ -54,6 +54,22 @@ downloads and serves. The app itself is lightweight; local model serving is the
 heavy part and depends on the model, runtime, GPU, and VRAM, so small hosts can
 connect to API or remote model servers instead. Use `--host 0.0.0.0` only when you intentionally want LAN/reverse-proxy access.
 
+**A native install runs two servers.** `requirements.txt` installs
+`chromadb-client`, which is the HTTP client only — Docker Compose starts the
+ChromaDB service for you, and the native route does not. Without it the app still
+starts and the UI works, but vector RAG and vector memory come up dead
+(`VectorRAG init failed` and `MemoryVectorStore DEGRADED` in the log). Start
+ChromaDB before the app:
+
+```bash
+uv tool install chromadb        # or: pip install chromadb
+chroma run --host 127.0.0.1 --port 8100 --path ./data/chroma
+```
+
+Port 8100 is what the app expects by default. To run more than one native install
+on the same machine, give each its own ChromaDB port and `--path`, and point the
+extra instances at theirs with `CHROMADB_PORT` in `.env`.
+
 ### Apple Silicon
 Docker on macOS cannot use the Metal GPU. For GPU-accelerated Cookbook on an
 M-series Mac, run Odysseus natively:


### PR DESCRIPTION
## Summary

A native install starts one server; it needs two. `requirements.txt` installs `chromadb-client` — the HTTP client — and Docker Compose is what brings up the ChromaDB service next to the app. The native route brings up nothing, so the app starts, the UI works, and two subsystems come up dead: `VectorRAG init failed` and `MemoryVectorStore DEGRADED`. Nothing in the Native Linux / macOS section of the setup guide mentions this, and the error text itself recommends `docker compose up chromadb`, which is exactly what someone who chose the native route does not have.

This PR documents the second server in the native section — install, start command, and the `CHROMADB_PORT` / `--path` split needed when two native installs share a machine — and rewrites the unreachable-ChromaDB error so it carries both routes, with the host and port the client actually tried interpolated into a copy-pasteable native command.

Degraded-but-running is why this is worth fixing in docs rather than leaving to the log: the app answers every request, so the missing vector memory is discovered much later than a crash would be.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Part of #4425 — same root cause reported for the Windows native launcher (native install leaves RAG and memory degraded). This PR covers the Linux/macOS native docs and the shared error message, which is the part Windows readers hit too; it does not close the Windows-specific launcher work.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [x] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate. Closest existing reports are #4425 (Windows native) and #3218 (embedded mode on Windows); no open PR touches the native ChromaDB docs or this error string.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in. Two files: one section in `website/setup.md`, one error string in `src/chroma_client.py`.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end.

## How to Test

Native install on Linux, Python 3.13, no Docker, `dev` at `c9dd68d`.

1. **Reproduce.** Install natively per the setup guide and start the app without a ChromaDB service:
   ```
   ERROR - VectorRAG init failed: ChromaDB is not reachable at localhost:8100. Start the ChromaDB service (e.g. `docker compose up chromadb`) or set CHROMADB_HOST / CHROMADB_PORT to point at a running instance.
   WARNING - MemoryVectorStore DEGRADED: ChromaDB vector memory unavailable
   ```
   The app serves and the UI works, which is what makes this easy to miss.

2. **New error text.** On this branch, with nothing listening on the configured port:
   ```bash
   CHROMADB_PORT=8199 python -c "import src.chroma_client as c; c.get_chroma_client()"
   ```
   ```
   RuntimeError: ChromaDB is not reachable at localhost:8199. Start the ChromaDB
   service (Docker: `docker compose up chromadb`; native: `chroma run --host
   localhost --port 8199 --path ./data/chroma`) or set CHROMADB_HOST /
   CHROMADB_PORT to point at a running instance.
   ```
   The native command echoes the host and port that were actually tried, so it is copy-pasteable as printed.

3. **Follow the new docs.** Run the two commands now in the Native Linux / macOS section, restart the app, and the startup log changes to:
   ```
   INFO - VectorRAG ready (lanes=['fastembed'] docs=0)
   INFO - Initialized VectorRAG with ChromaDB
   INFO - MemoryVectorStore ready (lanes=['fastembed'] entries=0)
   ```

4. **Two installs on one machine.** Following the `CHROMADB_PORT` note, I ran a second native install on port 7001 against ChromaDB on 8101 with its own `--path`; both instances report their vector stores ready and neither touches the other's collections.

5. **Checks.**
   ```
   python -m py_compile src/chroma_client.py            # clean
   python -m pytest -q -k "chroma or rag or memory_vector"   # 110 passed, 5702 deselected
   python -m pytest -q                                  # 5809 passed, 3 skipped
   ```
   No test asserts the old message text.

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable: no UI, CSS, HTML, SVG or `static/js/` files are touched. The diff is one docs section and one error string.
