### PR TITLE
fix(llm): suppress thinking on the native Ollama endpoint, where it works

### DIFF
--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -764,6 +764,17 @@ def _build_ollama_payload(
         payload["options"] = options
     if tools:
         payload["tools"] = _alias_harmony_tools(tools, model)
+    # Mirror of the /v1 injection below, for the native endpoint — and the only
+    # one that currently has an effect.
+    #
+    # Measured on Ollama 0.32.4 with qwen3:14b, same short question: think=false
+    # here produced 4 generated tokens with an empty `thinking` field, against
+    # 395 on /v1/chat/completions, where the flag is accepted and ignored.
+    # Without it the model reasons on every turn, and when the budget runs out
+    # before the conclusion the round returns empty content — no text, no tool
+    # call — which reads as the agent silently doing nothing.
+    if _supports_thinking(model):
+        payload["think"] = False
     return payload
 
 

--- a/tests/test_ollama_native_think.py
+++ b/tests/test_ollama_native_think.py
@@ -1,0 +1,50 @@
+"""Thinking must be suppressed on the NATIVE Ollama endpoint too.
+
+`think: false` is already injected on Ollama's /v1 surface, but that surface
+ignores it: measured on Ollama 0.32.4 with qwen3:14b, the same short question
+generated 395 tokens there against 4 on /api/chat with the flag set. The native
+payload builder never emitted the field at all, so no code path actually
+suppressed reasoning.
+
+The consequence is not just slowness. Odysseus strips thinking from the round
+response and accumulates only native tool calls, so a round whose budget is
+consumed by reasoning ends with 0 chars, 0 native calls and 0 tool blocks — the
+agent appears to silently do nothing.
+"""
+
+import pytest
+
+from src.llm_core import _build_ollama_payload
+
+
+MSGS = [{"role": "user", "content": "hello"}]
+
+
+def _payload(model, **kw):
+    return _build_ollama_payload(
+        model, MSGS, temperature=0.7, max_tokens=256, **kw
+    )
+
+
+@pytest.mark.parametrize("model", ["qwen3:14b", "qwq:32b", "deepseek-r1:7b"])
+def test_thinking_models_get_think_false(model):
+    assert _payload(model)["think"] is False
+
+
+@pytest.mark.parametrize("model", ["llama3.2:latest", "mistral:7b"])
+def test_non_thinking_models_are_left_alone(model):
+    """Do not send a field a model has no use for."""
+    assert "think" not in _payload(model)
+
+
+def test_suppression_does_not_disturb_the_rest_of_the_payload():
+    """The flag is additive — options, tools and messages are untouched."""
+    tools = [{"type": "function", "function": {"name": "web_fetch", "parameters": {}}}]
+    p = _payload("qwen3:14b", tools=tools)
+
+    assert p["think"] is False
+    assert p["model"] == "qwen3:14b"
+    assert p["messages"]
+    assert p["options"]["temperature"] == 0.7
+    assert p["options"]["num_predict"] == 256
+    assert p["tools"]


### PR DESCRIPTION
﻿## Summary

`think: false` is injected for thinking models on Ollama's OpenAI-compatible
`/v1` surface, but that surface ignores it. Measured on Ollama 0.32.4 with
`qwen3:14b`, same short question:

| Endpoint | Flag | Generated tokens | Thinking |
|---|---|---|---|
| `/v1/chat/completions` | `think=false` | 395 | â€” |
| `/v1/chat/completions` | none | 533 | â€” |
| `/api/chat` | `think=false` | **4** | empty |
| `/api/chat` | none | 362 | 988 chars |

The 395 vs 533 gap is sampling noise between two reasoning runs; neither
suppresses anything. Only the native endpoint honours the flag, and
`_build_ollama_payload` never emitted it â€” so as things stand, no code path
actually suppresses reasoning on Ollama.

The consequence is not just latency. Odysseus strips thinking from the round
response and accumulates only native tool calls, so a round whose budget is
spent reasoning ends with `0 chars, 0 native calls, 0 tool blocks`: the agent
appears to silently do nothing. That is what #3228 was added to prevent, and it
is worth noting the fix reads as working while being a no-op â€” nothing logs that
the flag was dropped. #3228 states it was verified on Ollama 0.24.

This mirrors the existing injection into the native payload builder, gated on
the same `_supports_thinking` helper, so non-reasoning models are unaffected.
The `/v1` injection is left in place: harmless, and correct again if Ollama
restores the behaviour.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #6213

## Type of Change

- [x] Bug fix (non-breaking â€” fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs â€” this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above â€” no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up`) and verified the change works end-to-end.

## How to Test

1. Reproduce the table above directly against a local Ollama, comparing
   `usage.completion_tokens` on `/v1` with `eval_count` on `/api/chat`. Token
   counts are the only reliable signal here â€” a generous `max_tokens` lets the
   model reason *and* answer, so the presence of a reply proves nothing.
2. With an endpoint routed natively (`base_url` ending in `/api`), send an
   agent-mode request needing a tool.
3. **Before** â€” rounds end with `0 chars, 0 native calls, 0 tool blocks`, and
   the stream carries hundreds of `thinking` deltas.
4. **After** â€” zero thinking deltas, the tool is called, and a real answer
   returns. Measured end to end on a local install: 20 minutes and empty content
   became 8.3s with one `web_fetch` call and an answer.

`tests/test_ollama_native_think.py` covers the payload directly: thinking models
get `think: false`, non-thinking models get no such field, and the flag is
additive â€” messages, options and tools are untouched. Verified the tests fail
without the change: removing the two added lines turns the four assertions on
`think` red while the two guarding non-thinking models stay green.

## Visual / UI changes

None. `src/llm_core.py` only â€” one payload field, server-side.
