### PR TITLE
fix(mcp): reject malformed Args on Add MCP Server instead of silently defaulting to []

### DIFF
--- a/routes/mcp/mcp_routes.py
+++ b/routes/mcp/mcp_routes.py
@@ -189,6 +189,8 @@ def setup_mcp_routes(mcp_manager: McpManager):
                 parsed_args = json.loads(args)
             except json.JSONDecodeError:
                 raise HTTPException(400, "args must be valid JSON, e.g. [\"-y\", \"pkg\"]")
+            if not isinstance(parsed_args, list):
+                raise HTTPException(400, "args must be a JSON array, e.g. [\"-y\", \"pkg\"]")
         else:
             parsed_args = []
         try:

--- a/routes/mcp/mcp_routes.py
+++ b/routes/mcp/mcp_routes.py
@@ -181,10 +181,15 @@ def setup_mcp_routes(mcp_manager: McpManager):
         if transport == "http" and not url:
             raise HTTPException(400, "url is required for HTTP transport")
 
-        # Parse JSON fields
-        try:
-            parsed_args = json.loads(args) if args else []
-        except json.JSONDecodeError:
+        # Parse JSON fields. args is not defaulted on a parse failure: an
+        # unparseable value is silently discarded downstream (stdio spawns
+        # with an empty argv), so the caller must be told instead.
+        if args:
+            try:
+                parsed_args = json.loads(args)
+            except json.JSONDecodeError:
+                raise HTTPException(400, "args must be valid JSON, e.g. [\"-y\", \"pkg\"]")
+        else:
             parsed_args = []
         try:
             parsed_env = json.loads(env) if env else {}

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -2366,6 +2366,7 @@ function initMcpForm() {
     if (transport === 'stdio' && !command) { msg.textContent = 'Command is required for stdio'; msg.className = 'admin-error'; return; }
     if (transport === 'sse' && !url) { msg.textContent = 'URL is required for SSE'; msg.className = 'admin-error'; return; }
     try { JSON.parse(env); } catch { msg.textContent = 'Env must be valid JSON'; msg.className = 'admin-error'; return; }
+    try { JSON.parse(args); } catch { msg.textContent = 'Args must be valid JSON, e.g. ["-y", "pkg"]'; msg.className = 'admin-error'; return; }
     const fd = new FormData();
     fd.append('name', name); fd.append('transport', transport); fd.append('command', command); fd.append('args', args); fd.append('env', env); fd.append('url', url);
     // If preset has oauthFile config, send credentials for file generation

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -5036,7 +5036,11 @@ async function initUnifiedIntegrations() {
         fd.append('transport', transport);
         if (transport === 'stdio') {
           fd.append('command', el('uf-mcp-cmd').value);
-          let args = '[]'; try { args = JSON.stringify(JSON.parse(el('uf-mcp-args').value || '[]')); } catch (_) {}
+          // Unlike env below, an unparseable args value is not silently
+          // defaulted: it would spawn the subprocess with an empty argv.
+          let args;
+          try { args = JSON.stringify(JSON.parse(el('uf-mcp-args').value || '[]')); }
+          catch (_) { el('uf-mcp-msg').textContent = 'Args must be valid JSON, e.g. ["-y", "pkg"]'; return; }
           let env  = '{}'; try { env  = JSON.stringify(JSON.parse(el('uf-mcp-env').value  || '{}')); } catch (_) {}
           fd.append('args', args);
           fd.append('env', env);

--- a/tests/test_mcp_add_server_args_validation.py
+++ b/tests/test_mcp_add_server_args_validation.py
@@ -100,6 +100,31 @@ def test_add_server_still_accepts_valid_json_args(monkeypatch):
     assert fake_session.added[0].args == json.dumps(["/app/data/jarvis-files"])
 
 
+def test_add_server_rejects_valid_json_args_that_is_not_a_list(monkeypatch):
+    """Valid JSON that is not a list (e.g. args=5) must not reach
+    StdioServerParameters(args=5), which raises an unhandled TypeError when
+    the error formatter later does " ".join([command, *args])."""
+    add_server, manager = _add_server(monkeypatch)
+    monkeypatch.setattr(mcp_routes, "SessionLocal", lambda: (_ for _ in ()).throw(
+        AssertionError("must not reach the DB when args has the wrong shape")))
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(add_server(
+            request=None,
+            name="filesystem",
+            transport="stdio",
+            command="mcp-server-filesystem",
+            args="5",
+            env="{}",
+            url=None,
+            oauth_file=None,
+            oauth_config=None,
+        ))
+
+    assert exc.value.status_code == 400
+    manager.connect_server.assert_not_called()
+
+
 def test_add_server_still_defaults_empty_args_to_empty_list(monkeypatch):
     """No behavior change for the common case of an empty Args field."""
     add_server, manager = _add_server(monkeypatch)

--- a/tests/test_mcp_add_server_args_validation.py
+++ b/tests/test_mcp_add_server_args_validation.py
@@ -1,0 +1,107 @@
+"""Regression test for issue #6211: a malformed Args value on the "Add MCP
+Server" form must not be silently discarded into an empty argv.
+
+routes/mcp/mcp_routes.py's add_server() wrapped json.loads(args) in a bare
+except that fell back to `[]`, so a non-JSON Args value registered the
+server as "Connected" while forwarding no arguments to the spawned stdio
+subprocess at all, with no error surfaced anywhere.
+"""
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from routes.mcp import mcp_routes
+
+
+class _FakeSession:
+    """Stands in for core.database.SessionLocal(); add_server only adds+commits."""
+
+    def __init__(self):
+        self.added = []
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    def commit(self):
+        pass
+
+    def close(self):
+        pass
+
+
+def _add_server(monkeypatch):
+    """Register add_server on the shared module-level router and return the
+    freshly-added route's raw endpoint function, bypassing HTTP/Form parsing
+    (require_admin is the only other thing the function touches via `request`).
+    """
+    monkeypatch.setattr(mcp_routes, "require_admin", lambda request: None)
+    manager = MagicMock()
+    manager.connect_server = AsyncMock(return_value=True)
+    manager.get_server_status = MagicMock(return_value={"status": "connected", "tool_count": 1})
+    router = mcp_routes.setup_mcp_routes(manager)
+    # setup_mcp_routes appends new APIRoute objects to the shared router on
+    # every call, so take the LAST "add_server" route: the one just registered
+    # with our fake manager, not an earlier registration from importing app.py.
+    route = [r for r in router.routes if getattr(r, "name", None) == "add_server"][-1]
+    return route.endpoint, manager
+
+
+def test_add_server_rejects_malformed_args_instead_of_defaulting(monkeypatch):
+    add_server, manager = _add_server(monkeypatch)
+    monkeypatch.setattr(mcp_routes, "SessionLocal", lambda: (_ for _ in ()).throw(
+        AssertionError("must not reach the DB when args is rejected")))
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(add_server(
+            request=None,
+            name="filesystem",
+            transport="stdio",
+            command="mcp-server-filesystem",
+            args="/app/data/jarvis-files",  # the exact value from issue #6211
+            env="{}",
+        ))
+
+    assert exc.value.status_code == 400
+    manager.connect_server.assert_not_called()
+
+
+def test_add_server_still_accepts_valid_json_args(monkeypatch):
+    add_server, manager = _add_server(monkeypatch)
+    fake_session = _FakeSession()
+    monkeypatch.setattr(mcp_routes, "SessionLocal", lambda: fake_session)
+
+    result = asyncio.run(add_server(
+        request=None,
+        name="filesystem",
+        transport="stdio",
+        command="mcp-server-filesystem",
+        args=json.dumps(["/app/data/jarvis-files"]),
+        env="{}",
+    ))
+
+    assert result["connected"] is True
+    manager.connect_server.assert_awaited_once()
+    assert manager.connect_server.call_args.kwargs["args"] == ["/app/data/jarvis-files"]
+    assert fake_session.added[0].args == json.dumps(["/app/data/jarvis-files"])
+
+
+def test_add_server_still_defaults_empty_args_to_empty_list(monkeypatch):
+    """No behavior change for the common case of an empty Args field."""
+    add_server, manager = _add_server(monkeypatch)
+    fake_session = _FakeSession()
+    monkeypatch.setattr(mcp_routes, "SessionLocal", lambda: fake_session)
+
+    result = asyncio.run(add_server(
+        request=None,
+        name="no-args-server",
+        transport="stdio",
+        command="some-command",
+        args="",
+        env="{}",
+    ))
+
+    assert result["connected"] is True
+    assert manager.connect_server.call_args.kwargs["args"] == []

--- a/tests/test_mcp_add_server_args_validation.py
+++ b/tests/test_mcp_add_server_args_validation.py
@@ -36,6 +36,12 @@ def _add_server(monkeypatch):
     """Register add_server on the shared module-level router and return the
     freshly-added route's raw endpoint function, bypassing HTTP/Form parsing
     (require_admin is the only other thing the function touches via `request`).
+
+    Callers must pass every Form(...) parameter add_server reads past the args
+    check (url, oauth_file, oauth_config): calling the endpoint directly skips
+    FastAPI's dependency resolution, so an omitted one arrives as the Form
+    marker object itself rather than its declared default, and later code
+    (e.g. `if oauth_file:`) reads that marker as truthy.
     """
     monkeypatch.setattr(mcp_routes, "require_admin", lambda request: None)
     manager = MagicMock()
@@ -62,6 +68,9 @@ def test_add_server_rejects_malformed_args_instead_of_defaulting(monkeypatch):
             command="mcp-server-filesystem",
             args="/app/data/jarvis-files",  # the exact value from issue #6211
             env="{}",
+            url=None,
+            oauth_file=None,
+            oauth_config=None,
         ))
 
     assert exc.value.status_code == 400
@@ -80,6 +89,9 @@ def test_add_server_still_accepts_valid_json_args(monkeypatch):
         command="mcp-server-filesystem",
         args=json.dumps(["/app/data/jarvis-files"]),
         env="{}",
+        url=None,
+        oauth_file=None,
+        oauth_config=None,
     ))
 
     assert result["connected"] is True
@@ -101,6 +113,9 @@ def test_add_server_still_defaults_empty_args_to_empty_list(monkeypatch):
         command="some-command",
         args="",
         env="{}",
+        url=None,
+        oauth_file=None,
+        oauth_config=None,
     ))
 
     assert result["connected"] is True


### PR DESCRIPTION
## Summary

The Add MCP Server form's Args field silently discarded any value that was not valid JSON. `routes/mcp/mcp_routes.py`'s `add_server()` wrapped `json.loads(args)` in a bare `except json.JSONDecodeError: parsed_args = []`, and the browser's own parse attempt in `static/js/settings.js` had the identical shape (`catch (_) {}` keeping `args` at `'[]'`). A user who typed a plain path or space-separated argument list into a field labeled "Args" got no error at either layer: the server saved and connected with an empty argv, so `list_allowed_directories` (or any tool depending on the configured arguments) came back empty even though the integration showed "Connected". This matches the exact input and symptom from #6211.

Fix: the backend now raises `HTTPException(400, ...)` on an unparseable Args value instead of defaulting it, and the frontend shows an inline message and aborts the save instead of silently submitting `'[]'`. The `Env` field's existing silent-fallback behaviour is unchanged, since it wasn't part of the reported issue, and this keeps the PR to one concern.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #6211

## Type of Change

- [x] Bug fix (non-breaking, fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls); this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above, no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Backend: `python -m pytest tests/test_mcp_add_server_args_validation.py -v`, three new tests. Malformed Args now returns 400 and never reaches `connect_server`/the DB (fails on unmodified `dev`, passes on this branch); valid JSON Args still forwards correctly; an empty Args field still defaults to `[]` (no regression).
2. Full suite: `python -m pytest -q`, 5507 passed, 301 skipped, 7 pre-existing failures unrelated to this change (docs-image checks and a git/node-dependent test that cannot run in a container without `git`/`node`; identical failure set on unmodified `dev` in the same container).
3. End-to-end: ran the real app (`uvicorn app:app`, `LOCALHOST_BYPASS=true`) and drove the Settings modal's Integrations tab, Add MCP Server form, through a headless browser with the exact value from the issue (`Args: /app/data/jarvis-files`). Before the fix, Save reported "Saved" with no indication the Args field had been dropped. After the fix, Save is rejected inline with "Args must be valid JSON, e.g. [\"-y\", \"pkg\"]" and nothing is persisted.

Not verified: the actual stdio subprocess argv forwarding for a *valid* Args value end-to-end (no `mcp-server-filesystem` binary in the container), only the parsing/validation boundary this issue is about. `_connect_stdio` forwarding a given `args` list into `StdioServerParameters` is unchanged by this diff.

## Visual / UI changes, REQUIRED if you touched anything that renders

- [x] **Screenshot or short clip** of the change in the running app, attached below.
- [x] **Style match**: no new CSS variables, colors, fonts, or component patterns; the error message reuses the existing `#uf-mcp-msg` status line the form already uses for `Failed (${r.status})`.
- [x] **No new component patterns.**
- [x] **I am not an LLM agent submitting a bulk PR.** (#6211 was filed by a third party, not by me.)

### Screenshots / clips

Before (unmodified `dev`): entering the issue's exact Args value silently saves with no error.

![before: silent Saved with malformed Args](https://raw.githubusercontent.com/AmirF194/odysseus/pr-6211-assets/before-fix.png)

After (this branch): the same input is rejected inline before it reaches the server.

![after: inline validation error](https://raw.githubusercontent.com/AmirF194/odysseus/pr-6211-assets/after-fix.png)
