### PR TITLE
fix(ui): let Space reach the focused text field, not the hovered window

### DIFF
--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -142,7 +142,9 @@ function _closeHoveredWindow() {
 function _spaceIsBlocked(e, surface) {
   const target = _targetEl(e.target);
   if (!target) return false;
-  if (_isTextEditingTarget(target)) return !surface || surface.contains(target);
+  // Hover is not focus: Space belongs to the field the caret is in, not to
+  // whichever surface the pointer happens to rest on (#4856).
+  if (_isTextEditingTarget(target)) return true;
   const blocked = target.closest?.(SPACE_BLOCKED_SELECTOR);
   return !!(blocked && (!surface || surface.contains(blocked)));
 }

--- a/tests/test_space_hover_typing_js.py
+++ b/tests/test_space_hover_typing_js.py
@@ -1,0 +1,85 @@
+"""Issue #4856 — Space must reach the field you are typing in, not the card you hover.
+
+ui.js activates a hovered card / dock chip / window on Space. `_spaceIsBlocked`
+decided whether to leave the key alone, and for a text-editing target it only
+did so when that field lived *inside* the hovered surface. Typing in the chat
+composer while the pointer rested over an email tab therefore swallowed the
+space and closed the tab mid-sentence.
+
+The four declarations under test are pure once `closest`/`contains` exist, so
+they run against a hand-made target object instead of a DOM.
+"""
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_UI_JS = _REPO / "static" / "js" / "ui.js"
+_HAS_NODE = shutil.which("node") is not None
+
+_WANTED = (
+    r"const SPACE_BLOCKED_SELECTOR = \[[\s\S]*?\.join\(', '\);",
+    r"function _isTextEditingTarget\(target\) \{[\s\S]*?\n\}",
+    r"function _targetEl\(target\) \{[\s\S]*?\n\}",
+    r"function _spaceIsBlocked\(e, surface\) \{[\s\S]*?\n\}",
+)
+
+_HARNESS = """
+// A keydown target that answers closest() for its own tag, and a hovered
+// surface that either contains it or does not.
+function target(tag) {
+  return {
+    nodeType: 1,
+    closest(sel) {
+      return sel.split(',').map(s => s.trim()).includes(tag) ? this : null;
+    },
+  };
+}
+const surface = (holdsTarget) => ({ contains: () => holdsTarget });
+const blocked = (tag, holdsTarget) =>
+  _spaceIsBlocked({ target: target(tag) }, surface(holdsTarget));
+"""
+
+
+def _run(body: str):
+    source = _UI_JS.read_text(encoding="utf-8")
+    chunks = []
+    for pattern in _WANTED:
+        match = re.search(pattern, source)
+        assert match, f"ui.js no longer defines {pattern!r}"
+        chunks.append(match.group(0))
+    js = "\n".join(chunks) + _HARNESS + body
+    proc = subprocess.run(
+        ["node", "--input-type=module"],
+        input=js, capture_output=True, text=True, encoding="utf-8",
+        cwd=str(_REPO), timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout.strip())
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+@pytest.mark.parametrize("tag", ["input", "textarea", "select", '[contenteditable="true"]'])
+def test_typing_outside_the_hovered_surface_keeps_the_space(tag):
+    """The reported bug: composer focused, pointer over an unrelated window."""
+    assert _run(f'console.log(JSON.stringify(blocked({tag!r}, false)));') is True
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+@pytest.mark.parametrize("tag", ["input", "textarea", '[contenteditable="true"]'])
+def test_typing_inside_the_hovered_surface_still_keeps_the_space(tag):
+    assert _run(f'console.log(JSON.stringify(blocked({tag!r}, true)));') is True
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_hover_shortcut_still_fires_when_nothing_is_being_edited():
+    assert _run('console.log(JSON.stringify(blocked("div", false)));') is False
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_focused_button_inside_the_hovered_surface_still_wins():
+    assert _run('console.log(JSON.stringify(blocked("button", true)));') is True


### PR DESCRIPTION
I am back!! Been a while since I contributed here. Summer holidays, too much free time, got bored, and somehow that turned into spending like five hours digging through Odysseus today lol. Anywho, found a few things worth fixing. Starting with this one.

## Summary

Space can minimise a hovered window while you're typing in the composer. `_spaceIsBlocked()` only protects a text field if it happens to be inside that window. It now leaves Space alone whenever a text-editing control has focus, regardless of where the pointer is. The hover shortcut still works when no text field is focused.

## Linked Issue

Fixes #4856

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the change works end-to-end.

## How to Test

1. Open Calendar, Notes or an email window.
2. Click into the composer, then move the pointer over that window without clicking.
3. Type a message with spaces. The spaces should reach the composer and the window should stay open.
4. Move focus away from text fields and check that the hover-Space shortcut still works.

## Validation

The failure and fix were checked through the running app's DOM and event path. Nine regressions cover text controls, editable content, focus inside and outside the hovered surface, focused buttons and the existing shortcut. The outside-surface cases fail on the original code. The full suite passed with 5,818 tests and 3 skips.

@rudra496's diagnosis on #4856 identified the focus/hover mismatch. #5484 addressed it before being closed unmerged during the July cleanup; this fix was checked against the current code.

## Visual / UI changes

The change only affects key handling.

- [x] **Screenshot or short clip** of the change in the running app, attached below.
- [x] **Style match**: no CSS, colors, fonts, spacing, or markup touched.
- [x] **No new component patterns.**

### Screenshots / clips

Before: the space is missing from the composer and Calendar is minimised.

![before](https://raw.githubusercontent.com/VykosMolt/odysseus/pr-assets/space_before.png)

After: the space reaches the composer and Calendar stays open.

![after](https://raw.githubusercontent.com/VykosMolt/odysseus/pr-assets/space_after.png)

Claude Code assisted with the implementation and tests.
