### PR TITLE
fix(pwa): let the service worker control the app root

### DIFF
--- a/app.py
+++ b/app.py
@@ -503,6 +503,12 @@ class _RevalidatingStatic(StaticFiles):
         resp = await super().get_response(path, scope)
         if path.endswith((".js", ".css", ".html")):
             resp.headers["Cache-Control"] = "no-cache"
+        if path == "sw.js":
+            # The worker is served from /static/ but has to control the app at
+            # /. Without this header the browser caps its scope at the script's
+            # own directory and silently registers a worker that controls
+            # nothing (index.html asks for scope "/" and would be rejected).
+            resp.headers["Service-Worker-Allowed"] = "/"
         return resp
 
 

--- a/static/index.html
+++ b/static/index.html
@@ -2586,6 +2586,6 @@
 <script type="module" src="/static/app.js?v=20260815toolapproval4"></script>  <!-- app.js must be LAST -->
   <script type="module" src="/static/js/init.js?v=20260715freshroot3"></script>
 <script type="module" src="/static/js/a11y.js"></script>
-<script nonce="{{CSP_NONCE}}">if('serviceWorker' in navigator){navigator.serviceWorker.register('/static/sw.js').catch(()=>{});}</script>
+<script nonce="{{CSP_NONCE}}">if('serviceWorker' in navigator){navigator.serviceWorker.register('/static/sw.js',{scope:'/'}).catch(()=>{});}</script>
 </body>
 </html>

--- a/tests/test_service_worker_scope.py
+++ b/tests/test_service_worker_scope.py
@@ -1,0 +1,52 @@
+"""The service worker has to control the app at /, not just /static/.
+
+static/sw.js precaches "/" and handles navigations to "/", but it is served from
+/static/, and a worker's scope defaults to its own directory. Controlling / needs
+both halves: the response must allow the wider scope and the registration must
+ask for it. Either one alone leaves a worker that installs, fills its cache, and
+controls nothing.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_registration_asks_for_root_scope():
+    html = (ROOT / "static" / "index.html").read_text(encoding="utf-8")
+    assert "navigator.serviceWorker.register('/static/sw.js',{scope:'/'})" in html
+
+
+def test_only_the_worker_response_widens_its_scope(tmp_path):
+    """Serving the header on every static file would let any of them claim /."""
+    probe = textwrap.dedent(
+        """
+        import json
+        from starlette.testclient import TestClient
+        import app
+
+        with TestClient(app.app) as client:
+            out = {
+                p: client.get(p).headers.get("Service-Worker-Allowed")
+                for p in ("/static/sw.js", "/static/app.js")
+            }
+        print("RESULT=" + json.dumps(out, sort_keys=True))
+        """
+    )
+    env = {**os.environ, "ODYSSEUS_DATA_DIR": str(tmp_path), "AUTH_ENABLED": "false"}
+    result = subprocess.run(
+        [sys.executable, "-c", probe], cwd=ROOT, env=env,
+        capture_output=True, text=True, timeout=180, check=False,
+    )
+    assert result.returncode == 0, result.stderr[-2000:]
+    line = next((l for l in result.stdout.splitlines() if l.startswith("RESULT=")), None)
+    assert line is not None, result.stdout[-2000:]
+
+    headers = json.loads(line.removeprefix("RESULT="))
+    assert headers["/static/sw.js"] == "/"
+    assert headers["/static/app.js"] is None


### PR DESCRIPTION
## Summary

The service worker registers successfully under `/static/`, but the app lives at `/`. That means the page is never controlled, even though the worker downloads its cache and has a handler for the app root.

Registration now asks for scope `/`, and the response for `/static/sw.js` includes `Service-Worker-Allowed: /`. The header is limited to that file. Keeping the existing URL also keeps its auth exemption and cache headers.

This makes the app shell cache-first for the first time. JavaScript and CSS remain network-first. Offline reload can now load the shell, but API requests still need a connection. The hardcoded registration URL still doesn't support an ASGI `root_path`; that needs a separate fix.

## Linked Issue

Fixes #6219

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the change works end-to-end.

## How to Test

1. Open the running app in a fresh browser profile.
2. Wait for registration and reload once.
3. Check `navigator.serviceWorker.controller` and the scopes returned by `navigator.serviceWorker.getRegistrations()`. The controller should be set and the scope should end at `/`.
4. Set DevTools Network to Offline and reload. The app shell should load from cache.

## Validation

A clean browser profile on the original code registered scope `/static/`, had no controller and failed offline reload with `ERR_INTERNET_DISCONNECTED`. With this change, it registered scope `/`, had a controller and returned HTTP 200 for the offline reload.

Two regressions check the requested scope and the headers served by the running app, including that `/static/app.js` does not receive the wider-scope header. Both fail on the original code. The full suite passed with 5,811 tests and 3 skips.

## Visual / UI changes

The app's appearance stays the same.

- [x] **Screenshot or short clip** of the change in the running app, attached below.
- [x] **Style match**: no CSS, colors, fonts, spacing, or markup touched.
- [x] **No new component patterns.**

### Screenshots / clips

Offline reload on this branch. The shell loads from cache; the session API request fails because the network is disabled.

![offline reload works](https://raw.githubusercontent.com/VykosMolt/odysseus/pr-assets/sw_offline_after.png)

Claude Code assisted with the implementation and tests.
