### PR TITLE
fix(discovery): cache a successful but empty Tailscale lookup

### DIFF
--- a/src/model_discovery.py
+++ b/src/model_discovery.py
@@ -38,7 +38,10 @@ def discover_tailscale_hosts() -> List[str]:
     global _hosts_cache, _hosts_cache_time
 
     now = time.time()
-    if _hosts_cache and (now - _hosts_cache_time) < _HOSTS_CACHE_TTL:
+    # Gate on the timestamp, not the list: a successful query that found no
+    # eligible peers is a real answer, and testing the list's truthiness made
+    # that case re-run `tailscale status` (up to a 5s timeout) on every call.
+    if _hosts_cache_time and (now - _hosts_cache_time) < _HOSTS_CACHE_TTL:
         return list(_hosts_cache)
 
     hosts = []

--- a/tests/test_tailscale_discovery_cache.py
+++ b/tests/test_tailscale_discovery_cache.py
@@ -1,0 +1,69 @@
+"""A successful Tailscale query with no eligible hosts is still cached knowledge.
+
+`discover_tailscale_hosts` gated its cache on the host list being non-empty, so a
+valid "nothing to see here" answer looked identical to a cold cache and every
+caller paid for another `tailscale status --json` (up to a 5s timeout). Failures
+stay uncached so a peer coming online is still picked up promptly.
+"""
+
+import pytest
+
+from src import model_discovery
+
+
+class _Result:
+    def __init__(self, returncode, stdout):
+        self.returncode = returncode
+        self.stdout = stdout
+
+
+@pytest.fixture
+def tailscale(monkeypatch):
+    """Count `tailscale status` invocations and start from a cold cache."""
+    calls = []
+
+    def _record(result):
+        def _run(*_args, **_kwargs):
+            calls.append(1)
+            if isinstance(result, Exception):
+                raise result
+            return result
+        monkeypatch.setattr(model_discovery.subprocess, "run", _run)
+        return calls
+
+    monkeypatch.setattr(model_discovery, "_hosts_cache", [])
+    monkeypatch.setattr(model_discovery, "_hosts_cache_time", 0)
+    return _record
+
+
+def test_empty_but_successful_discovery_is_only_run_once(tailscale):
+    calls = tailscale(_Result(0, '{"Self":{},"Peer":{}}'))
+
+    assert model_discovery.discover_tailscale_hosts() == []
+    assert model_discovery.discover_tailscale_hosts() == []
+    assert len(calls) == 1
+
+
+def test_nonempty_discovery_is_still_cached(tailscale):
+    calls = tailscale(_Result(0, '{"Self":{"TailscaleIPs":["100.1.1.1"]},"Peer":{}}'))
+
+    assert model_discovery.discover_tailscale_hosts() == ["100.1.1.1"]
+    assert model_discovery.discover_tailscale_hosts() == ["100.1.1.1"]
+    assert len(calls) == 1
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        _Result(1, ""),                       # tailscale installed but logged out
+        _Result(0, "not json"),               # unparseable output
+        FileNotFoundError("tailscale"),       # not installed
+    ],
+    ids=["nonzero_exit", "bad_json", "not_installed"],
+)
+def test_failures_stay_retryable(tailscale, result):
+    calls = tailscale(result)
+
+    assert model_discovery.discover_tailscale_hosts() == []
+    assert model_discovery.discover_tailscale_hosts() == []
+    assert len(calls) == 2


### PR DESCRIPTION
Small one, found while reading the discovery path for something else.

## Summary

`discover_tailscale_hosts()` caches its result for 60s, but gates the cache on the host list rather than on whether a lookup actually happened:

```python
if _hosts_cache and (now - _hosts_cache_time) < _HOSTS_CACHE_TTL:
    return list(_hosts_cache)
```

An empty list is falsy, so "queried fine, nothing eligible" is indistinguishable from a cold cache and re-runs `tailscale status --json` on every call. That subprocess is spawned with `timeout=5`.

Stubbing the subprocess and calling twice inside the TTL:

```text
valid but empty result:  2 calls -> 2 invocations   (re-runs every time)
non-empty result:        2 calls -> 1 invocation    (cached, as intended)
```

`_get_hosts()` calls it on every discovery pass, so nothing else absorbs the repeat.

## What this changes

Gate on `_hosts_cache_time` instead of `_hosts_cache`. The timestamp is only assigned after a successful parse, so this is a one-word change that also draws the line in the right place:

- a successful lookup is cached whether or not it found anything;
- `tailscale` missing (`FileNotFoundError`), a non-zero exit (installed but logged out), unparseable output, and the 5s timeout all leave the timestamp unset and stay retryable.

I deliberately did not cache the failures. Caching "not installed" for 60s would be harmless, but caching a transient failure would delay picking up a peer that just came online, and that seemed like the wrong trade for a discovery path.

**On severity, so this isn't oversold:** a genuinely empty-but-successful topology needs Tailscale up with no self IPv4, which is uncommon — normally `Self` supplies an address and the cache already works. The failure paths are the more frequent source of repeated work and this fix intentionally leaves them retryable. So it's a correctness fix on the cache's own contract rather than a speedup you'd notice on a normal install.

## Linked Issue

Fixes #6220

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the change works end-to-end.

## How to Test

Stub the subprocess so the lookup succeeds with nothing eligible, reset the cache, and call twice:

```python
from src import model_discovery as md

class Empty:
    returncode = 0
    stdout = '{"Self":{},"Peer":{}}'

calls = []
md.subprocess.run = lambda *a, **k: (calls.append(1), Empty())[1]
md._hosts_cache, md._hosts_cache_time = [], 0

md.discover_tailscale_hosts(); md.discover_tailscale_hosts()
print(len(calls))     # dev: 2   with this PR: 1
```

Swap in `'{"Self":{"TailscaleIPs":["100.1.1.1"]},"Peer":{}}'` as a control — that case caches on `dev` already and still does here.

## Validation

Added 5 regression tests, one per outcome the function can produce: empty-but-successful (cached once), non-empty (still cached once), and the three failure modes — not installed, non-zero exit, unparseable output — each asserted to remain retryable rather than cached. Only the empty-but-successful case fails on current `dev`; the other four are there so the fix can't quietly turn into "cache everything".

Full suite:

```text
5814 passed, 3 skipped
```

Also ran the app to confirm startup discovery still behaves normally on a machine with no Tailscale installed, which is the `FileNotFoundError` path.

## Visual / UI changes

Not applicable — backend only (`src/model_discovery.py`). Nothing under `static/`.

Claude Code assisted with the implementation and validation. I reviewed the change and am submitting it myself.
