### PR TITLE
fix(ui): keep auto-scroll pinned to the bottom during streaming (#5611)

### DIFF
--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -1567,7 +1567,6 @@ import { loadPanel } from './panels.js';
     try {
       // Re-enable auto-scroll when user sends a message
       uiModule.setAutoScroll(true);
-      uiModule.scrollHistoryInstant();
       // Clear completed dot now that user is interacting
       if (sessionModule.clearStreamComplete) sessionModule.clearStreamComplete(sessionModule.getCurrentSessionId());
 
@@ -1613,6 +1612,8 @@ import { loadPanel } from './panels.js';
       if (!skipBubble) {
         _userMsgEl = addMessage('user', userDisplay, null, _pendingAttachInfo ? { attachments: _pendingAttachInfo } : null);
       }
+      // Scroll to the user message now that it's in the DOM
+      uiModule.scrollHistoryInstant();
       _sendPerf.mark('user_bubble_visible');
       messageInput.value = approvalForSend ? (approvalForSend.draft || '') : '';
       messageInput.style.height = '';

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -488,17 +488,19 @@ function _smoothScrollStep() {
   const current = box.scrollTop;
   const diff = target - current;
 
-  // If content grew substantially since we started (tool output, images),
-  // skip to bottom — don't mistake this for a user scroll-up.
+  // If we're far from the bottom and content has grown, the lag is from
+  // new content, not a user scroll-up. Snap to bottom so the lerp doesn't
+  // fall irrecoverably behind (especially when many small tool results
+  // accumulate faster than the 0.2-factor lerp can keep up).
   const contentGrew = target - _lastTargetHeight;
-  if (diff > 300 && contentGrew > 200) {
+  if (diff > 300 && contentGrew > 20) {
     box.scrollTop = target;
     _lastTargetHeight = target;
     _scrollRafId = requestAnimationFrame(_smoothScrollStep);
     return;
   }
 
-  // If user scrolled up significantly, don't force them down
+  // If user scrolled up with no meaningful new content, respect that.
   if (diff > 300) {
     _scrollRafId = null;
     return;
@@ -508,6 +510,13 @@ function _smoothScrollStep() {
     box.scrollTop = target;
     _lastTargetHeight = target;
     _scrollRafId = null;
+    // Content may have arrived during the final lerp frame (e.g. last
+    // tool output in a chain). If the true bottom is now lower, restart.
+    const finalTarget = box.scrollHeight - box.clientHeight;
+    if (finalTarget > target + 1) {
+      _lastTargetHeight = finalTarget;
+      _scrollRafId = requestAnimationFrame(_smoothScrollStep);
+    }
     return;
   }
 

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -454,6 +454,7 @@ export function showError(msg) {
  * Throttled during streaming so it doesn't fight user scrolling.
  */
 let _scrollThrottleTimer = null;
+let _lastTargetHeight = 0;
 export function scrollHistory() {
   if (!autoScrollEnabled) return;
   if (!_scrollBox) {
@@ -462,6 +463,7 @@ export function scrollHistory() {
   // Throttle: only start a new scroll animation every 500ms
   if (_scrollThrottleTimer) return;
   _scrollThrottleTimer = setTimeout(() => { _scrollThrottleTimer = null; }, 500);
+  _lastTargetHeight = _scrollBox.scrollHeight - _scrollBox.clientHeight;
   if (!_scrollRafId) {
     _scrollRafId = requestAnimationFrame(_smoothScrollStep);
   }
@@ -477,6 +479,16 @@ function _smoothScrollStep() {
   const current = box.scrollTop;
   const diff = target - current;
 
+  // If content grew substantially since we started (tool output, images),
+  // skip to bottom — don't mistake this for a user scroll-up.
+  const contentGrew = target - _lastTargetHeight;
+  if (diff > 300 && contentGrew > 200) {
+    box.scrollTop = target;
+    _lastTargetHeight = target;
+    _scrollRafId = requestAnimationFrame(_smoothScrollStep);
+    return;
+  }
+
   // If user scrolled up significantly, don't force them down
   if (diff > 300) {
     _scrollRafId = null;
@@ -485,6 +497,7 @@ function _smoothScrollStep() {
 
   if (diff <= 1) {
     box.scrollTop = target;
+    _lastTargetHeight = target;
     _scrollRafId = null;
     return;
   }
@@ -492,6 +505,7 @@ function _smoothScrollStep() {
   // Lerp: gentle catch-up
   const factor = window.innerWidth <= 768 ? 0.4 : 0.2;
   box.scrollTop = current + diff * factor;
+  _lastTargetHeight = target;
   _scrollRafId = requestAnimationFrame(_smoothScrollStep);
 }
 

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -460,8 +460,17 @@ export function scrollHistory() {
   if (!_scrollBox) {
     _scrollBox = document.getElementById('chat-history');
   }
-  // Throttle: only start a new scroll animation every 500ms
-  if (_scrollThrottleTimer) return;
+  // If the smooth-scroll loop is still running, it picks up new content
+  // height on the next frame — nothing to do.
+  if (_scrollRafId) return;
+  // Throttle restarts to avoid animation jitter, but bypass if new
+  // content appeared since we last looked (e.g. next tool in a chain).
+  if (_scrollThrottleTimer) {
+    const target = _scrollBox.scrollHeight - _scrollBox.clientHeight;
+    if (target <= _lastTargetHeight) return;
+    clearTimeout(_scrollThrottleTimer);
+    _scrollThrottleTimer = null;
+  }
   _scrollThrottleTimer = setTimeout(() => { _scrollThrottleTimer = null; }, 500);
   _lastTargetHeight = _scrollBox.scrollHeight - _scrollBox.clientHeight;
   if (!_scrollRafId) {


### PR DESCRIPTION
## Summary

The chat transcript's auto-follow lost its pinned state in four distinct cases during streaming. Each case is one commit (4 commits, 2 files, +37/-4, `static/js/chat.js` and `static/js/ui.js`):

1. **On message send (the reported bug)** - `scrollHistoryInstant()` ran *before* the user bubble was added to the DOM, so the instant scroll-to-bottom targeted a height that did not include the bubble, and the view stayed at the previous bottom. It is now called right after `addMessage('user', ...)`.
2. **Single large tool output** - when one tool result grew the transcript by more than 300 px between frames, `_smoothScrollStep` interpreted that lag as the user scrolling up and aborted auto-follow permanently. The lag is now checked against real content growth (>20 px since the last frame): if content grew, it snaps to the bottom and keeps running instead of aborting.
3. **New content between tool calls** - while the 500 ms restart throttle was set, incoming `scrollHistory()` calls were dropped, so once the lerp loop had converged, new content left auto-follow stopped. If the target height grew since the last check, the throttle is now bypassed and the loop restarted.
4. **Many small results in parallel (15+ tool results)** - per-frame growth (~80 px tool headers) never crossed the content-growth check, so the 0.2-factor lerp fell irrecoverably behind and the viewport sat ~300 px above the bottom. The content-growth threshold is set to 20 px, and a post-finish re-check restarts the loop if content arrived during the final lerp frame.

Resubmission of #5972 (closed by the author, same 4 commits, no review recorded). Scope vs #6094/#6096 (transcript-following tracker): this PR only makes the 500 ms restart throttle and the 300 px abort boundary in `ui.js` content-growth-aware, plus the DOM-order fix in `chat.js`. It does not restructure scrolling into a shared controller and does not touch the 400 ms activity timer, the scroll-event state rewrite in `app.js`, or the transcript/composer padding alignment - those remain with the tracker.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #5611

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate. (#5611 is the bug; #5972 is the author's earlier closed attempt at this same fix; #6094/#6096 are the broader tracker this does not supersede.)
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in. (2 files, +37/-4, all auto-scroll code)
- [x] I actually ran the app (`uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough. (This instance runs from this checkout; all four fixes were developed and verified in live sessions, and a running-app clip is attached to #5972.)
- [ ] I did not run the app/runtime validation and stated that gap in **How to Test**. Leave this unchecked when the app-run box above is checked.

## How to Test

1. `uvicorn app:app` (or `docker compose up`), open a chat with a scrollable transcript, stay at the bottom.
2. Send a message → the transcript jumps instantly to the new user bubble (previously the view stayed at the previous bottom — the bug reported in #5611).
3. Ask the agent for a task that produces many tool results (e.g. "list every subdirectory of this repo, one per command") → auto-follow stays pinned to the bottom through all tool output, with no permanent stop ~300 px above the bottom.
4. Scroll up mid-stream → auto-follow correctly aborts and does not snap back down (user scroll-up is still respected).

## Visual / UI changes

No rendering changes — this changes scroll behaviour only (when the viewport follows the bottom). No CSS, DOM structure, or styling is touched, so the requirements below are n/a.

- [x] **Screenshot or short clip** of the change in the running app
- [x] **Style match**: n/a — no styling touched, existing scroll code only.
- [x] **No new component patterns.** n/a.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips


https://github.com/user-attachments/assets/9aabdc58-2df5-4b18-b3b7-e4ebce176835

