### PR TITLE
fix(chat): don't abort healthy streams during prefill (#6231)

### DIFF
--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -2004,6 +2004,7 @@ import { loadPanel } from './panels.js';
         query: streamQuery,
         startedAt: Date.now(),
         lastActivity: Date.now(),
+        firstOutputAt: null, // Set when the first data event arrives — guards tab-recovery during prefill
         // Resolve the mutable closure at call time: live-thinking helpers are
         // installed after the stream entry is registered.
         cancelViewWork: () => _cancelLiveThinkingWork(),
@@ -2744,6 +2745,8 @@ import { loadPanel } from './panels.js';
         if (_firstVisibleOutputSeen) return;
         _firstVisibleOutputSeen = true;
         clearFirstTokenWaitTimers();
+        const _entry = _activeStreams.get(streamSessionId);
+        if (_entry) _entry.firstOutputAt = Date.now();
       };
 
       while (true) {
@@ -5424,6 +5427,14 @@ import { loadPanel } from './panels.js';
       if (document.visibilityState !== 'visible') return;
       const active = _getForegroundStreamState();
       if (!active) return;
+
+      // No first token yet → the model is still pre-filling. A slow local /
+      // multimodal model can legitimately spend minutes before its first chunk,
+      // and during that window the server sends nothing (no SSE heartbeat on the
+      // main prefill path), so "no activity" is expected — NOT evidence of a
+      // frozen stream. Don't abort it here; a genuinely dead prefill is handled
+      // by the response timeout ('timeout'), not tab-recovery.
+      if (!active.firstOutputAt) return;
 
       // Stream claims to be running — check if reader is actually alive
       const staleSince = Date.now() - (active.lastActivity || _lastReaderActivity);


### PR DESCRIPTION
## Summary

When a stream has not yet emitted its first token, the `visibilitychange` tab-recovery handler treats "no bytes received since the tab was hidden" as evidence of a frozen connection — but a slow local / multimodal model can legitimately spend minutes pre-filling (image + large agent prompt) before its first chunk, and the main prefill path sends no SSE heartbeat at all, so `lastActivity` stays frozen. Returning to the tab after 20s+ therefore aborted a perfectly healthy stream with "interrupted after the tab went inactive".

Fix: track `firstOutputAt` on the stream entry (set on the first data event) and skip tab-recovery until the stream has produced output:
- no first token yet → normal prefill silence, don't abort;
- had output then froze → recovery works exactly as before.
A genuinely dead prefill is still caught by the response timeout, not tab-recovery.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #6231 — reported there before filing this PR (no existing report existed: searched open **and** closed issues for the exact error string, 0 results). Repro steps in **How to Test** below mirror the issue's Steps to Reproduce.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate. (Searched the exact error string, `tab went inactive`, and `visibilitychange` PRs: #3821 pauses background *polling*, #5989/#5990 spinner — unrelated.)
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in. (1 file, +11 lines, 3 small hunks.)
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough. (Verified on the running instance: image + large prompt, tab switched away 25s+ mid-prefill, stream survives; frozen-stream regression path unchanged.)
- [ ] I did not run the app/runtime validation and stated that gap in **How to Test**. Leave this unchecked when the app-run box above is checked.

## How to Test

1. **Repro (without the fix):** send a prompt whose prefill takes >20s on a slow/local model — attach an image plus a large prompt. Immediately switch to another browser tab, wait 25s+, return. Before this PR: the stream is killed with "interrupted after the tab went inactive" even though the server is still happily pre-filling. With this PR: the stream continues.
2. **Regression (frozen streams still recover):** kill the backend mid-stream *after* the first token, switch tabs 20s+, return. The tab-recovery path fires exactly as before — the `firstOutputAt` guard only skips streams that never produced output.
3. `node --check static/js/chat.js` passes. (No unit test — this is frontend stream-state logic; the two behavioural paths above cover it.)

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [x] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile. — Behaviour-only change (stream lifecycle; no DOM/CSS/styling change). Per the template's `static/js` clause a clip is attached below showing the stream surviving a tab-away during prefill.
- [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips
I had a lot of trouble to say below 10Mb

https://github.com/user-attachments/assets/15005a6b-f387-4c5a-9d0c-527423d2598f



(clip of the tab-away-during-prefill repro attached before publishing)