### PR TITLE
fix(chat): show the specific upload rejection reason once (#6235)

### DIFF
--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -1661,7 +1661,8 @@ import { loadPanel } from './panels.js';
       if (_pendingAttachInfo && !ids.length && !(_pendingRegenAttachments && _pendingRegenAttachments.length)) {
         if (_userMsgEl && _userMsgEl.parentNode) _userMsgEl.remove();
         if (fileHandlerModule.wasLastUploadCancelled && !fileHandlerModule.wasLastUploadCancelled()) {
-          uiModule.showError && uiModule.showError('Upload failed. Attachment kept so you can retry.');
+          const _uploadErr = fileHandlerModule.getLastUploadError ? fileHandlerModule.getLastUploadError() : 'Upload failed';
+          uiModule.showError && uiModule.showError(_uploadErr + '. Attachment kept so you can retry.');
         }
         updateSubmitButton('idle', submitBtn);
         _releaseSendFlag();

--- a/static/js/fileHandler.js
+++ b/static/js/fileHandler.js
@@ -18,6 +18,7 @@ let _uploadSpinners = [];
 let _uploadAbortCtrl = null;
 let _uploading = false;
 let _lastUploadCancelled = false;
+let _lastUploadError = '';
 const _previewUrls = new WeakMap();
 
 const MAX_FILES = 10;
@@ -316,8 +317,12 @@ export async function uploadPending(opts = {}) {
       // "didn't even see them" (issue #1346). Show the server's reason and keep
       // pendingFiles so the strip re-renders for a retry (see finally below).
       let detail = '';
-      try { const e = await res.json(); detail = e.detail || e.error || ''; } catch (_) {}
-      _showToast('Upload failed' + (detail ? ': ' + detail : ` (HTTP ${res.status})`));
+      try {
+        const e = await res.json();
+        detail = (typeof e.detail === 'string') ? e.detail
+          : (e.detail && (e.detail.message || e.detail.error)) || e.error || '';
+      } catch (_) {}
+      _lastUploadError = detail ? ('Upload failed: ' + detail) : `Upload failed (HTTP ${res.status})`;
       return [];
     }
     const data = await res.json();
@@ -331,6 +336,7 @@ export async function uploadPending(opts = {}) {
     // callers that want it can grab it via getLastUploadedMeta(). Keep the
     // returned shape as `ids` for backward-compatibility with existing call sites.
     _lastUploadedMeta = uploaded;
+    _lastUploadError = '';
     return uploaded.map(x => x.id);
   } catch (e) {
     if (e && e.name === 'AbortError') {
@@ -338,7 +344,7 @@ export async function uploadPending(opts = {}) {
       _showToast('Upload cancelled');
       return [];
     }
-    _showToast('Upload failed: ' + (e?.message || 'network error'));
+    _lastUploadError = 'Upload failed: ' + (e?.message || 'network error');
     return [];
   } finally {
     clearTimeout(timeoutId);
@@ -453,6 +459,10 @@ export function wasLastUploadCancelled() {
   return _lastUploadCancelled;
 }
 
+export function getLastUploadError() {
+  return _lastUploadError;
+}
+
 export function cancelUpload() {
   _lastUploadCancelled = true;
   if (_uploadAbortCtrl && !_uploadAbortCtrl.signal.aborted) {
@@ -478,6 +488,7 @@ const fileHandlerModule = {
   isUploading,
   wasLastUploadCancelled,
   cancelUpload,
+  getLastUploadError,
 };
 
 export default fileHandlerModule;


### PR DESCRIPTION
## Summary

When a chat attachment upload is rejected by the server (e.g. over the 10 MB default cap, `ODYSSEUS_CHAT_UPLOAD_MAX_BYTES`), the user sees **two** error messages in **two different places** at once: the send path's generic `Upload failed. Attachment kept so you can retry.` toast (top-left, from `chat.js`) **and** the real reason `Upload failed: File size exceeds 10 MB limit` (bottom-center, from `fileHandler.js`'s own toast). The specific message never appears where the failure is surfaced, and the generic one never says *why* — or that the limit is configurable, which users assume is hardcoded.

Fix: `uploadPending()` no longer toasts on rejection; it stashes the server's reason in module state (`_lastUploadError`, same pattern as the existing `_lastUploadCancelled`), and the send path in `chat.js` shows it **once**, in the exact place the generic message used to be, keeping the retry hint. The parser also handles dict-shaped `detail` payloads (the `FILE_TOO_LARGE` path) so no `[object Object]` can reach the user, and the state is cleared on success so a later failed retry never inherits a stale message.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #6235

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate. (Searched `upload`, `attachment failed`, `file size`, `exceeds 10 MB` and the exact generic string — 0 reports of the split display. #4713 "File limit for uploads" is a request to *raise* the limits, not this display bug; called out in #6235.)
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in. (2 files, +16/−4, both `static/js/`)
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough. (Verified on a running uvicorn instance: over-limit upload now produces exactly one specific toast; raised-limit upload succeeds. Pre/post recording attached in the issue #6235 + clip below.)
- [ ] I did not run the app/runtime validation and stated that gap in **How to Test**. Leave this unchecked when the app-run box above is checked.

## How to Test

1. With the default 10 MB limit, attach a file larger than 10 MB (e.g. a 28 MB MP4) in a chat session and click Send.
2. **Before:** two toasts fire at once — top-left `Upload failed. Attachment kept so you can retry.` and bottom-center `Upload failed: File size exceeds 10 MB limit`. **After:** exactly one toast (top-left): `Upload failed: File size exceeds 10 MB limit. Attachment kept so you can retry.` — the attachment stays in the strip for retry, composer returns to idle.
3. Raise `ODYSSEUS_CHAT_UPLOAD_MAX_BYTES` in `.env`, restart, re-upload the same file → spinner completes, no error, attachment is attached.
4. Network-failure path (block the upload endpoint or cut the network mid-upload) → one specific message, no double toast.
5. `node --check static/js/chat.js static/js/fileHandler.js` — both pass.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [x] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if this affects mobile. (Clip of the fixed behavior — one toast instead of two — attached below; the pre/post comparison recording is also embedded in issue #6235.)
- [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units. (No styling touched — the message now flows through the existing `uiModule.showError` toast the generic message already used.)
  - Reuse existing button/input/card/border classes. Don't invent parallel styling. (Same.)
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text. (n/a)
  - Monospaced font (`Fira Code`) for primary UI text. Don't override. (n/a)
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded. (n/a)
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one. (Extends the existing toast path; no new widgets.)
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

https://github.com/user-attachments/assets/8f90d19c-80b4-4f74-b07e-6aecf62e7365

