### PR TITLE
fix(agent): preserve calendar tools for calendar-domain requests

### DIFF
--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -3977,6 +3977,10 @@ async def stream_agent_loop(
             )
             and not _active_document_relevant
             and not active_email
+            and not (
+                set(_intent.get("domains") or set())
+                & {"notes_calendar_tasks", "email", "contacts", "sessions", "integrations", "ui"}
+            )
         ):
             _relevant_tools = set(_WORKSPACE_TERMINUS_TOOLS)
             logger.info("[tool-rag] Workspace file/terminal request; using Odysseus Terminus toolset")


### PR DESCRIPTION
## Summary

Preserve personal-assistant tools when a request has already been classified into an explicit assistant domain such as notes_calendar_tasks. This prevents natural-language phrases like on Friday from being misclassified as local-computer requests and replacing the correctly retrieved manage_calendar tool with the Terminus toolset.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

<!-- Every PR should be linked to an issue.
     Use one of:  Fixes #NNN  |  Part of #NNN  |  Closes #NNN  -->

Fixes #6239

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.
- [ ] I did not run the app/runtime validation and stated that gap in **How to Test**. Leave this unchecked when the app-run box above is checked.

## How to Test

<!-- Step-by-step instructions a reviewer can follow to verify this works.
     Do not leave this empty — a PR without test steps will be sent back. -->

1. Configure a working calendar integration and start Odysseus in agent mode.
2. Ask: Use the calendar tool to list all events on Friday.
3. Before this fix, the logs show that the request is correctly classified as notes_calendar_tasks and manage_calendar is retrieved, but the local-computer heuristic subsequently replaces the selected tools with the Terminus toolset:
[agent-intent] ... domains=['notes_calendar_tasks'] ...
[tool-rag] Retrieved tools for query: [..., 'manage_calendar', ...]
[tool-rag] Workspace file/terminal request; using Odysseus Terminus toolset
4. With this fix applied, repeat the same request.
5. Verify that the Terminus-only override does not occur, manage_calendar remains available to the model, and Odysseus performs a live list_events calendar query.
6. Confirm the returned events match the actual calendar.

I tested this end-to-end using Docker Compose with Qwen3.8-27B through llama.cpp. Before the change the model reported that the calendar tool was unavailable. After the change the same request successfully performed a live calendar lookup.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

<!-- Drag and drop images or a screen recording here. Required for any UI/visual change. -->
