### PR TITLE
fix(models): stop discarding codex-named chat models during discovery

### DIFF
--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -604,8 +604,11 @@ _NON_CHAT_PREFIXES = (
     "snowflake/arctic-embed", "nvidia/nv-embed", "embed",
 )
 _NON_CHAT_CONTAINS = (
-    "-realtime", "-transcribe", "-tts", "-codex",
-    "codex-", "content-safety", "-safety", "-reward", "nvclip",
+    # "codex" is a chat family name (gpt-5.x-codex, and gateway routes named
+    # after it), not a completions-only marker: the legacy completions models
+    # are code-davinci-002 / code-cushman-001, which contain no "codex". See #6218.
+    "-realtime", "-transcribe", "-tts",
+    "content-safety", "-safety", "-reward", "nvclip",
     "kosmos", "fuyu", "deplot", "vila", "neva",
     "gliner", "riva", "-parse", "-embedqa", "-nemoretriever",
     "topic-control", "calibration",

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -433,6 +433,40 @@ class TestIsChatModel:
         # model id; it must not crash on .lower() (treated as chat-capable).
         assert _is_chat_model(bad) is True
 
+    @pytest.mark.parametrize("model_id", [
+        "gpt-5.1-codex", "gpt-5.2-codex", "gpt-5.3-codex-spark",
+        "oc/gpt-5.2-codex", "opencode/gpt-5.3-codex",
+        "codex-reliable-coding", "codex/codex-auto-review",
+    ])
+    def test_codex_family_is_chat(self, model_id):
+        # #6218: "codex" names a chat family, not a completions-only model.
+        # ChatGPT Subscription serves only these, and gateways expose routes
+        # named after it, so the substring must not disqualify a model.
+        assert _is_chat_model(model_id) is True
+
+
+# ── _probe_endpoint: codex-named chat models (#6218) ──
+
+def test_probe_keeps_codex_named_models(monkeypatch):
+    """Codex-named models reach cached_models; real non-chat ones still don't."""
+    monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url, raising=False)
+    monkeypatch.setattr(model_routes, "_normalize_base", lambda url: url.rstrip("/"))
+    served = [
+        "gpt-5.1",
+        "codex-reliable-coding",
+        "oc/gpt-5.2-codex",
+        "text-embedding-3-small",
+    ]
+
+    def fake_get(url, headers=None, timeout=None, verify=None, **kwargs):
+        return httpx.Response(200, json={"data": [{"id": m} for m in served]},
+                              request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(model_routes.httpx, "get", fake_get)
+    result = _probe_endpoint("https://gateway.example/v1", "key")
+
+    assert result == ["gpt-5.1", "codex-reliable-coding", "oc/gpt-5.2-codex"]
+
 
 # ── _classify_endpoint ──
 
@@ -1188,7 +1222,8 @@ def test_reprobe_chatgpt_subscription_does_not_hide_models(monkeypatch):
     monkeypatch.setattr(model_routes, "require_admin", lambda request: None)
     monkeypatch.setattr(model_routes, "_normalize_base", lambda url: url.rstrip("/"))
     monkeypatch.setattr(model_routes, "_probe_endpoint", lambda *a, **k: ["gpt-5.1-codex", "gpt-5.1"])
-    monkeypatch.setattr(model_routes, "_is_chat_model", lambda m: True)
+    # The real _is_chat_model runs here on purpose (#6218): this provider serves
+    # codex-named models, so a filter that drops them would silently halve the list.
     # Any completion probe would be a bug for this provider.
     monkeypatch.setattr(
         model_routes.httpx, "post",


### PR DESCRIPTION
## Summary

`_is_chat_model` rejected any model id containing `-codex` or `codex-`, two unanchored substrings in `_NON_CHAT_CONTAINS`. `_probe_endpoint` applies that filter to every OpenAI-compatible model list before the result is written to `cached_models`, so matching models were discarded at discovery time: they never reach `hidden_models`, nothing is logged on that path, and there is no way to bring them back from the UI. That is why the reporter saw 827 of 850 models with no error, and why renaming a gateway route from `codex-reliable-coding` to `reliable-coding` made it appear immediately.

The substrings do not match what they look like they were meant to catch. OpenAI's completions-only Codex models are `code-davinci-002` and `code-cushman-001`, and both already pass the filter today, so the entries never excluded a completions model. The only ids they match are modern codex-family chat models, which Odysseus supports elsewhere: `src/model_discovery.py` lists `gpt-5.2-codex` as an OpenAI chat model, and the ChatGPT Subscription integration reads its model list from the Codex backend and routes it through `/responses`. On a ChatGPT Subscription endpoint the filter removes most of what the provider serves.

This removes the two entries. Every other exclusion is untouched, so embedding, realtime, tts, image and the NVIDIA catalog entries are still filtered.

One test change is worth calling out: `test_reprobe_chatgpt_subscription_does_not_hide_models` probes `["gpt-5.1-codex", "gpt-5.1"]` and had to monkeypatch `_is_chat_model` to `True` to do it. That patch is removed so the test runs the real filter, which turns it into a regression guard — it fails on `dev` and passes here.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #6218

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end.
- [ ] I did not run the app/runtime validation and stated that gap in **How to Test**.

## How to Test

Unit level, on `dev` first to see it fail:

```
python -m pytest tests/test_model_routes.py -k "codex" -q
```

Nine assertions fail on `dev` and pass on this branch.

End to end against the running app:

1. Serve an OpenAI-compatible model list locally:

   ```python
   import json
   from http.server import BaseHTTPRequestHandler, HTTPServer
   MODELS = ["gpt-5.1", "codex-reliable-coding", "oc/gpt-5.2-codex", "text-embedding-3-small"]
   class H(BaseHTTPRequestHandler):
       def do_GET(self):
           body = json.dumps({"object": "list", "data": [{"id": m} for m in MODELS]}).encode()
           self.send_response(200); self.send_header("Content-Type", "application/json")
           self.send_header("Content-Length", str(len(body))); self.end_headers(); self.wfile.write(body)
   HTTPServer(("127.0.0.1", 9911), H).serve_forever()
   ```

2. Start the app: `AUTH_ENABLED=false python -m uvicorn app:app --port 8765`
3. Register the endpoint:

   ```
   curl -X POST http://127.0.0.1:8765/api/model-endpoints \
     -F name=codex-gateway -F base_url=http://127.0.0.1:9911/v1 \
     -F require_models=true -F endpoint_kind=api
   ```

On `dev`:

```json
"models":["gpt-5.1"]
```

On this branch:

```json
"models":["gpt-5.1","codex-reliable-coding","oc/gpt-5.2-codex"]
```

`text-embedding-3-small` is still excluded in both, which is the check that the rest of the filter still works. `GET /api/model-endpoints/<id>/models?refresh=true` shows the same three models in the picker, none of them hidden.

Full suite was run on this branch and on clean `dev` on the same machine; the failing-test sets are identical, so this introduces no regressions.

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI files were touched. The change is two entries in a model-id filter list in `routes/model_routes.py`, plus tests.
