### PR TITLE
fix(compare): preserve explicit chat mode

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -1027,7 +1027,7 @@ def setup_chat_routes(
         auto_escalated = False
         _tool_intent = _classify_tool_intent(message) if isinstance(message, str) else None
         _workspace_agent_intent = False
-        if chat_mode == "chat" and _tool_intent and _tool_intent.needs_tools:
+        if chat_mode == "chat" and not compare_mode and _tool_intent and _tool_intent.needs_tools:
             chat_mode = "agent"
             auto_escalated = True
             _workspace_agent_intent = _tool_intent.category in {"shell", "workspace"}
@@ -1038,11 +1038,11 @@ def setup_chat_routes(
                 _tool_intent.category,
                 _tool_intent.reason,
             )
-        elif chat_mode == "chat" and _search_enabled:
+        elif chat_mode == "chat" and not compare_mode and _search_enabled:
             chat_mode = "agent"
             auto_escalated = True
             logger.info("chat→agent auto-escalation: search enabled")
-        elif chat_mode == "chat" and _explicit_web_intent:
+        elif chat_mode == "chat" and not compare_mode and _explicit_web_intent:
             chat_mode = "agent"
             auto_escalated = True
             logger.info("chat→agent auto-escalation: explicit web intent")
@@ -1229,6 +1229,7 @@ def setup_chat_routes(
                 raise HTTPException(400, "Selected model endpoint is not configured")
             if (
                 chat_mode == "chat"
+                and not compare_mode
                 and isinstance(message, str)
                 and (not _tool_intent or not _tool_intent.needs_tools)
                 and _is_contextual_web_followup(message, sess)
@@ -1244,7 +1245,7 @@ def setup_chat_routes(
                 )
             if isinstance(message, str) and _is_contextual_browser_followup(message, sess):
                 _explicit_browser_intent = True
-                if chat_mode == "chat":
+                if chat_mode == "chat" and not compare_mode:
                     chat_mode = "agent"
                     auto_escalated = True
                     _workspace_agent_intent = False
@@ -1253,11 +1254,12 @@ def setup_chat_routes(
                 _auto_workspace, _ = _resolve_workspace_from_message_path(request, message)
                 if _auto_workspace:
                     workspace = _auto_workspace
-                    chat_mode = "agent"
-                    auto_escalated = True
-                    _workspace_agent_intent = True
-                    allow_bash = "true"
-                    logger.info("chat→agent auto-escalation: explicit path workspace=%s", workspace)
+                    if not (compare_mode and chat_mode == "chat"):
+                        chat_mode = "agent"
+                        auto_escalated = True
+                        _workspace_agent_intent = True
+                        allow_bash = "true"
+                        logger.info("chat→agent auto-escalation: explicit path workspace=%s", workspace)
         except SessionNotFoundError as e:
             raise HTTPException(404, str(e))
         except (ValueError, ValidationError):

--- a/tests/test_chat_route_tool_policy.py
+++ b/tests/test_chat_route_tool_policy.py
@@ -127,6 +127,74 @@ def test_workspace_auto_escalation_keeps_shell_tools():
     assert "if auto_escalated and not _workspace_agent_intent:" in source
 
 
+def test_compare_chat_preserves_explicit_mode_during_tool_intent_routing():
+    """Compare Chat must not be auto-promoted to Agent by prompt-derived tool intent."""
+    source = _CHAT_ROUTES.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    chat_stream_func = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "chat_stream":
+            chat_stream_func = node
+            break
+
+    assert chat_stream_func is not None, "chat_stream function not found"
+
+    escalation_if = None
+    for node in ast.walk(chat_stream_func):
+        if not isinstance(node, ast.If):
+            continue
+
+        condition = ast.get_source_segment(source, node.test) or ""
+        if (
+            'chat_mode == "chat"' in condition
+            and "_tool_intent" in condition
+            and "needs_tools" in condition
+        ):
+            body = "\n".join(
+                ast.get_source_segment(source, stmt) or ""
+                for stmt in node.body
+            )
+            if 'chat_mode = "agent"' in body:
+                escalation_if = node
+                break
+
+    assert escalation_if is not None, "tool-intent Chat→Agent escalation branch not found"
+
+    condition = ast.get_source_segment(source, escalation_if.test) or ""
+    assert "not compare_mode" in condition, (
+        "Compare Chat must preserve its explicitly selected mode instead of "
+        "being auto-promoted to Agent by prompt-derived tool intent"
+    )
+
+
+def test_compare_chat_blocks_other_automatic_agent_escalation_paths():
+    """Compare Chat must stay Chat across search, web, follow-up, and workspace heuristics."""
+    source = _CHAT_ROUTES.read_text(encoding="utf-8")
+
+    assert 'elif chat_mode == "chat" and not compare_mode and _search_enabled:' in source
+    assert 'elif chat_mode == "chat" and not compare_mode and _explicit_web_intent:' in source
+
+    assert (
+        'chat_mode == "chat"\n'
+        '                and not compare_mode\n'
+        '                and isinstance(message, str)\n'
+        '                and (not _tool_intent or not _tool_intent.needs_tools)\n'
+        '                and _is_contextual_web_followup(message, sess)'
+    ) in source
+
+    assert (
+        'if isinstance(message, str) and _is_contextual_browser_followup(message, sess):\n'
+        '                _explicit_browser_intent = True\n'
+        '                if chat_mode == "chat" and not compare_mode:'
+    ) in source
+
+    assert (
+        'if _auto_workspace:\n'
+        '                    workspace = _auto_workspace\n'
+        '                    if not (compare_mode and chat_mode == "chat"):'
+    ) in source
+
 # ── Functional tests of the disabled-tools logic ───────────────
 
 


### PR DESCRIPTION
## Summary

Preserve the explicitly selected Compare Chat mode instead of allowing prompt-derived tool, search, web, browser-follow-up, or workspace heuristics to automatically promote the request to Agent.

I originally noticed this because some Compare responses were stopping at exactly 128 tokens, and reasoning models could sometimes end with the fallback `Hey.` instead of producing a final answer. Tracing the request showed that Compare Chat could be silently routed into Agent mode, where a fresh-session low-signal path applies the 128-token limit.

One reproducible case was the phrase `on its own line`, which could be interpreted as workspace intent and trigger the promotion. This change makes the user's explicit Compare mode take precedence over those automatic escalation heuristics, while preserving explicit Compare Agent behavior.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #6056

Related: #6104 takes a broader approach by generally removing prompt-derived Chat to Agent promotion in Chat. This PR intentionally keeps the existing regular Chat behavior and only prevents automatic promotion when Compare explicitly selected Chat, keeping the change focused on #6056.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.
- [ ] I did not run the app/runtime validation and stated that gap in **How to Test**. Leave this unchecked when the app-run box above is checked.

## How to Test

1. Run the relevant routing tests:

   `python -m pytest tests/test_chat_route_tool_policy.py tests/test_action_intents.py tests/test_compare_stop_disconnect_poll.py tests/test_foreground_model_routing.py -q`

   The relevant local test set passes with 152 tests.

2. Start Odysseus from this branch and open a fresh **Compare → Chat** comparison. Send:

   `You have three jugs of capacities 7, 5, and 3 liters. The 7-liter jug starts full; the others empty. Using only pouring (no markings), produce the shortest sequence of pours that leaves exactly 2 liters in the 3-liter jug. Output each step as pour A → B on its own line. Then state the total number of pours on a final line.`

   Confirm that the request remains in Chat mode and does not enter a `chat→agent auto-escalation` / Agent low-signal path.

   Before this fix, `on its own line` could be classified as workspace intent, promoting Compare Chat to Agent. In my original reproduction this resulted in all Compare responses being limited to 128 tokens, with some reasoning models reaching the `Hey.` fallback when no final content was produced within that limit.

3. Start another fresh **Compare → Chat** comparison with:

   `What is the latest AI news today?`

   Confirm that the explicit web-intent heuristic also does not promote the Compare Chat request to Agent.

4. Explicit **Compare → Agent** behavior should remain unchanged. Workspace detection can still resolve a workspace while in Compare Agent; the change only prevents automatic promotion when Compare explicitly selected Chat.

Additional local validation:

- `152 passed` across the relevant routing/test set
- `python -m py_compile routes/chat_routes.py` passes
- `git diff --check` passes
- Verified the original Compare Chat reproduction end-to-end in the running app
- Verified the explicit web-intent case end-to-end in the running app

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable — this PR only changes backend routing logic and regression tests. No UI or rendering files were modified.

### Screenshots / clips

Not applicable.
