### PR TITLE
fix(macos): add native menu bar launcher

### DIFF
--- a/build-macos-app.sh
+++ b/build-macos-app.sh
@@ -61,13 +61,24 @@ cat > "$APP/Contents/Info.plist" <<PLIST
     <key>CFBundleIconFile</key>        <string>odysseus</string>
     <key>LSMinimumSystemVersion</key>  <string>11.0</string>
     <key>NSHighResolutionCapable</key> <true/>
-    <key>LSUIElement</key>             <false/>
+    <key>LSUIElement</key>             <true/>
+    <key>NSDocumentsFolderUsageDescription</key>
+    <string>Odysseus needs access to its installation folder to start the local server.</string>
+    <key>NSDesktopFolderUsageDescription</key>
+    <string>Odysseus needs access to its installation folder to start the local server.</string>
+    <key>NSDownloadsFolderUsageDescription</key>
+    <string>Odysseus needs access to its installation folder to start the local server.</string>
 </dict>
 </plist>
 PLIST
 
-# ── Launcher executable (placeholders filled below) ──
-cat > "$APP/Contents/MacOS/$APP_NAME.tmpl" <<'LAUNCHER'
+# ── Launcher script (placeholders filled below) ──
+#
+# Keep this in Resources and start it from a native bundle executable. If the
+# CFBundleExecutable is itself a shell script, macOS attributes protected-folder
+# access to "sh" instead of Odysseus and cannot use this bundle's privacy usage
+# descriptions to present a useful consent prompt.
+cat > "$APP/Contents/Resources/$APP_NAME-launcher.tmpl" <<'LAUNCHER'
 #!/bin/bash
 # Odysseus.app — start the local server and open the UI in an app window.
 INSTALL_DIR="__INSTALL_DIR__"
@@ -80,6 +91,7 @@ export APP_PORT="$PORT"
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
 
 UVICORN="$INSTALL_DIR/venv/bin/uvicorn"
+PYVENV_CFG="$INSTALL_DIR/venv/pyvenv.cfg"
 LOG="$INSTALL_DIR/logs/odysseus-app.log"
 
 notify() { /usr/bin/osascript -e "display notification \"$1\" with title \"Odysseus\"" >/dev/null 2>&1; }
@@ -87,6 +99,24 @@ die_gui() {
   /usr/bin/osascript -e "display dialog \"$1\" with title \"Odysseus\" buttons {\"OK\"} default button 1 with icon stop" >/dev/null 2>&1
   exit 1
 }
+
+# A Finder-launched app is subject to macOS Files & Folders privacy controls.
+# Probe a file Python itself must read so a protected install location prompts
+# before startup, and turn a previous denial into an actionable error instead
+# of Python's opaque init_import_site/pyvenv.cfg traceback.
+if ! /bin/cat "$PYVENV_CFG" >/dev/null 2>&1; then
+  die_gui "macOS blocked the Odysseus shell launcher from reading:
+
+$PYVENV_CFG
+
+To allow access:
+1. Open System Settings → Privacy & Security → Files & Folders.
+2. Expand “Odysseus”.
+3. Turn on “Documents Folder”.
+4. Reopen Odysseus.
+
+There is no Add button in Files & Folders; apps appear there after requesting access."
+fi
 
 [ -x "$UVICORN" ] || die_gui "Odysseus isn't set up yet. Open Terminal and run:
 
@@ -113,7 +143,10 @@ open_ui() {
   /usr/bin/open "$URL"
 }
 
-mkdir -p "$INSTALL_DIR/logs"
+mkdir -p "$INSTALL_DIR/logs" || die_gui "Odysseus can't write to its logs folder:
+$INSTALL_DIR/logs
+
+Allow access in System Settings → Privacy & Security → Files & Folders, then reopen the app."
 
 # Already running? Just open the UI.
 if /usr/bin/curl -s -o /dev/null --max-time 2 "$URL"; then
@@ -151,9 +184,118 @@ wait "$SERVER_PID"
 LAUNCHER
 
 sed -e "s|__INSTALL_DIR__|$INSTALL_DIR|g" -e "s|__PORT__|$PORT|g" \
-    "$APP/Contents/MacOS/$APP_NAME.tmpl" > "$APP/Contents/MacOS/$APP_NAME"
-rm -f "$APP/Contents/MacOS/$APP_NAME.tmpl"
-chmod +x "$APP/Contents/MacOS/$APP_NAME"
+    "$APP/Contents/Resources/$APP_NAME-launcher.tmpl" > "$APP/Contents/Resources/$APP_NAME-launcher"
+rm -f "$APP/Contents/Resources/$APP_NAME-launcher.tmpl"
+chmod +x "$APP/Contents/Resources/$APP_NAME-launcher"
+
+# A native menu-bar parent gives TCC/Files & Folders the app's bundle identity.
+# It stays alive while the shell launcher runs; Exit Odysseus terminates the
+# shell, whose existing cleanup trap then stops the server.
+NATIVE_SRC="$(mktemp)"
+cat > "$NATIVE_SRC" <<'NATIVE_LAUNCHER'
+#import <Cocoa/Cocoa.h>
+
+@interface OdysseusDelegate : NSObject <NSApplicationDelegate>
+@property(nonatomic, strong) NSStatusItem *statusItem;
+@property(nonatomic, strong) NSTask *launcherTask;
+@end
+
+@implementation OdysseusDelegate
+
+- (void)applicationDidFinishLaunching:(NSNotification *)notification {
+    (void)notification;
+    [NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+    [[NSProcessInfo processInfo]
+        disableAutomaticTermination:@"Odysseus server is running"];
+    [[NSProcessInfo processInfo] disableSuddenTermination];
+
+    self.statusItem = [[NSStatusBar systemStatusBar]
+        statusItemWithLength:NSSquareStatusItemLength];
+    NSStatusBarButton *button = self.statusItem.button;
+    NSImage *icon = [NSImage imageNamed:NSImageNameApplicationIcon];
+    icon.size = NSMakeSize(18.0, 18.0);
+    button.image = icon;
+    button.toolTip = @"Odysseus is running";
+
+    NSMenu *menu = [[NSMenu alloc] init];
+    NSMenuItem *status = [[NSMenuItem alloc]
+        initWithTitle:@"Odysseus is running" action:nil keyEquivalent:@""];
+    status.enabled = NO;
+    [menu addItem:status];
+    [menu addItem:[NSMenuItem separatorItem]];
+    NSMenuItem *exitItem = [[NSMenuItem alloc]
+        initWithTitle:@"Exit Odysseus"
+               action:@selector(exitOdysseus:)
+        keyEquivalent:@"q"];
+    exitItem.target = self;
+    [menu addItem:exitItem];
+    self.statusItem.menu = menu;
+
+    NSString *launcher = [[[NSBundle mainBundle] resourcePath]
+        stringByAppendingPathComponent:@"Odysseus-launcher"];
+    self.launcherTask = [[NSTask alloc] init];
+    self.launcherTask.executableURL = [NSURL fileURLWithPath:@"/bin/bash"];
+    self.launcherTask.arguments = @[launcher];
+
+    __weak OdysseusDelegate *weakSelf = self;
+    self.launcherTask.terminationHandler = ^(NSTask *task) {
+        (void)task;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (weakSelf != nil) [NSApp terminate:nil];
+        });
+    };
+
+    NSError *error = nil;
+    if (![self.launcherTask launchAndReturnError:&error]) {
+        NSAlert *alert = [[NSAlert alloc] init];
+        alert.messageText = @"Odysseus could not start";
+        alert.informativeText = error.localizedDescription;
+        [alert runModal];
+        [NSApp terminate:nil];
+    }
+}
+
+- (void)exitOdysseus:(id)sender {
+    (void)sender;
+    [NSApp terminate:nil];
+}
+
+- (void)applicationWillTerminate:(NSNotification *)notification {
+    (void)notification;
+    if (self.launcherTask.running) {
+        [self.launcherTask terminate];
+        [self.launcherTask waitUntilExit];
+    }
+}
+
+- (NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication *)sender {
+    (void)sender;
+    return NSTerminateNow;
+}
+
+@end
+
+int main(int argc, const char *argv[]) {
+    (void)argc;
+    (void)argv;
+    @autoreleasepool {
+        NSApplication *application = [NSApplication sharedApplication];
+        static OdysseusDelegate *delegate;
+        delegate = [[OdysseusDelegate alloc] init];
+        application.delegate = delegate;
+        [application run];
+    }
+    return 0;
+}
+NATIVE_LAUNCHER
+xcrun clang -Os -Wall -Wextra -mmacosx-version-min=11.0 \
+    -fobjc-arc -framework Cocoa -x objective-c "$NATIVE_SRC" \
+    -o "$APP/Contents/MacOS/$APP_NAME"
+rm -f "$NATIVE_SRC"
+
+# Give Launch Services and TCC a code identity even for local, non-notarized
+# builds. Release distribution can replace this with a Developer ID signature.
+codesign --force --deep --sign - "$APP"
 
 # Refresh Finder's icon cache for the new bundle.
 touch "$APP"

--- a/build-macos-app.sh
+++ b/build-macos-app.sh
@@ -187,6 +187,7 @@ sed -e "s|__INSTALL_DIR__|$INSTALL_DIR|g" -e "s|__PORT__|$PORT|g" \
     "$APP/Contents/Resources/$APP_NAME-launcher.tmpl" > "$APP/Contents/Resources/$APP_NAME-launcher"
 rm -f "$APP/Contents/Resources/$APP_NAME-launcher.tmpl"
 chmod +x "$APP/Contents/Resources/$APP_NAME-launcher"
+printf '%s\n' "$INSTALL_DIR" > "$APP/Contents/Resources/install-dir"
 
 # A native menu-bar parent gives TCC/Files & Folders the app's bundle identity.
 # It stays alive while the shell launcher runs; Exit Odysseus terminates the
@@ -208,6 +209,34 @@ cat > "$NATIVE_SRC" <<'NATIVE_LAUNCHER'
     [[NSProcessInfo processInfo]
         disableAutomaticTermination:@"Odysseus server is running"];
     [[NSProcessInfo processInfo] disableSuddenTermination];
+
+    NSString *resources = [[NSBundle mainBundle] resourcePath];
+    NSString *installDirFile = [resources stringByAppendingPathComponent:@"install-dir"];
+    NSError *pathError = nil;
+    NSString *installDir = [NSString stringWithContentsOfFile:installDirFile
+                                                     encoding:NSUTF8StringEncoding
+                                                        error:&pathError];
+    installDir = [installDir stringByTrimmingCharactersInSet:
+        [NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    NSString *pyvenvConfig = [installDir stringByAppendingPathComponent:@"venv/pyvenv.cfg"];
+    NSError *accessError = nil;
+    NSData *configData = [NSData dataWithContentsOfFile:pyvenvConfig
+                                                options:NSDataReadingMappedIfSafe
+                                                  error:&accessError];
+    if (pathError != nil || installDir.length == 0 || configData == nil) {
+        [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+        [NSApp activateIgnoringOtherApps:YES];
+        NSAlert *alert = [[NSAlert alloc] init];
+        alert.messageText = @"Odysseus cannot access its Python environment";
+        alert.informativeText = [NSString stringWithFormat:
+            @"Odysseus needs permission to read %@. Open System Settings > "
+             "Privacy & Security > Files & Folders, enable Documents Folder "
+             "for Odysseus, then reopen the app.", pyvenvConfig];
+        [alert addButtonWithTitle:@"OK"];
+        [alert runModal];
+        [NSApp terminate:nil];
+        return;
+    }
 
     self.statusItem = [[NSStatusBar systemStatusBar]
         statusItemWithLength:NSSquareStatusItemLength];

--- a/build-macos-app.sh
+++ b/build-macos-app.sh
@@ -20,6 +20,16 @@ PORT="${ODYSSEUS_PORT:-7860}"
 DIST="$REPO_DIR/dist"
 APP="$DIST/$APP_NAME.app"
 
+# This app is a launcher for the checkout it was built from; it does not bundle
+# Python or project dependencies. Refuse to package a launcher that can never
+# start, instead of turning a missing venv into a misleading privacy prompt
+# after installation.
+if [ ! -f "$INSTALL_DIR/venv/pyvenv.cfg" ] || [ ! -x "$INSTALL_DIR/venv/bin/uvicorn" ]; then
+  echo "Error: Odysseus is not set up in $INSTALL_DIR." >&2
+  echo "Create the venv and install dependencies before building the macOS app." >&2
+  exit 1
+fi
+
 echo "Building $APP_NAME.app"
 echo "  install dir: $INSTALL_DIR"
 echo "  port:        $PORT"
@@ -223,15 +233,35 @@ cat > "$NATIVE_SRC" <<'NATIVE_LAUNCHER'
     NSData *configData = [NSData dataWithContentsOfFile:pyvenvConfig
                                                 options:NSDataReadingMappedIfSafe
                                                   error:&accessError];
-    if (pathError != nil || installDir.length == 0 || configData == nil) {
+    if (pathError != nil || installDir.length == 0) {
         [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
         [NSApp activateIgnoringOtherApps:YES];
         NSAlert *alert = [[NSAlert alloc] init];
-        alert.messageText = @"Odysseus cannot access its Python environment";
-        alert.informativeText = [NSString stringWithFormat:
-            @"Odysseus needs permission to read %@. Open System Settings > "
-             "Privacy & Security > Files & Folders, enable Documents Folder "
-             "for Odysseus, then reopen the app.", pyvenvConfig];
+        alert.messageText = @"Odysseus could not find its installation folder";
+        alert.informativeText = @"Rebuild Odysseus.app from the checkout you want it to run.";
+        [alert addButtonWithTitle:@"OK"];
+        [alert runModal];
+        [NSApp terminate:nil];
+        return;
+    }
+    if (configData == nil) {
+        [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+        [NSApp activateIgnoringOtherApps:YES];
+        NSAlert *alert = [[NSAlert alloc] init];
+        if ([accessError.domain isEqualToString:NSCocoaErrorDomain] &&
+            accessError.code == NSFileReadNoSuchFileError) {
+            alert.messageText = @"Odysseus is not set up in its build checkout";
+            alert.informativeText = [NSString stringWithFormat:
+                @"The Python environment does not exist at %@. Create the venv "
+                 "and install dependencies there, then rebuild Odysseus.app.",
+                 pyvenvConfig];
+        } else {
+            alert.messageText = @"Odysseus cannot access its Python environment";
+            alert.informativeText = [NSString stringWithFormat:
+                @"Odysseus needs permission to read %@. Open System Settings > "
+                 "Privacy & Security > Files & Folders, enable Documents Folder "
+                 "for Odysseus, then reopen the app.", pyvenvConfig];
+        }
         [alert addButtonWithTitle:@"OK"];
         [alert runModal];
         [NSApp terminate:nil];

--- a/tests/test_macos_app_bundle.py
+++ b/tests/test_macos_app_bundle.py
@@ -1,0 +1,70 @@
+"""Regression tests for the generated macOS launcher bundle."""
+
+from pathlib import Path
+import plistlib
+import re
+
+
+ROOT = Path(__file__).resolve().parent.parent
+BUILD_SCRIPT = ROOT / "build-macos-app.sh"
+
+
+def _build_script() -> str:
+    return BUILD_SCRIPT.read_text(encoding="utf-8")
+
+
+def _generated_info_plist() -> dict:
+    script = _build_script()
+    match = re.search(
+        r'cat > "\$APP/Contents/Info\.plist" <<PLIST\n(.*?)\nPLIST',
+        script,
+        re.DOTALL,
+    )
+    assert match, "could not find the Info.plist heredoc"
+    rendered = match.group(1).replace("$APP_NAME", "Odysseus")
+    return plistlib.loads(rendered.encode())
+
+
+def test_bundle_declares_protected_install_folder_access():
+    plist = _generated_info_plist()
+
+    for key in (
+        "NSDocumentsFolderUsageDescription",
+        "NSDesktopFolderUsageDescription",
+        "NSDownloadsFolderUsageDescription",
+    ):
+        assert plist.get(key), f"generated Info.plist is missing {key}"
+
+
+def test_launcher_checks_python_environment_access_before_starting_uvicorn():
+    script = _build_script()
+    probe = 'if ! /bin/cat "$PYVENV_CFG" >/dev/null 2>&1; then'
+    launch = '"$UVICORN" app:app'
+
+    assert probe in script
+    assert 'Expand “Odysseus”.' in script
+    assert "There is no Add button in Files & Folders" in script
+    assert script.index(probe) < script.index(launch)
+
+
+def test_bundle_uses_native_executable_for_macos_privacy_identity():
+    script = _build_script()
+
+    assert 'Contents/Resources/$APP_NAME-launcher' in script
+    assert 'xcrun clang' in script
+    assert '-o "$APP/Contents/MacOS/$APP_NAME"' in script
+    assert 'NSTask *launcherTask' in script
+    assert 'codesign --force --deep --sign - "$APP"' in script
+
+
+def test_native_launcher_has_menu_bar_status_and_exit_action():
+    script = _build_script()
+    plist = _generated_info_plist()
+
+    assert plist["LSUIElement"] is True
+    assert "NSStatusBar systemStatusBar" in script
+    assert '@"Odysseus is running"' in script
+    assert '@"Exit Odysseus"' in script
+    assert "[self.launcherTask terminate]" in script
+    assert "disableAutomaticTermination" in script
+    assert "static OdysseusDelegate *delegate" in script

--- a/tests/test_macos_app_bundle.py
+++ b/tests/test_macos_app_bundle.py
@@ -36,6 +36,15 @@ def test_bundle_declares_protected_install_folder_access():
         assert plist.get(key), f"generated Info.plist is missing {key}"
 
 
+def test_build_refuses_to_package_a_checkout_without_a_runnable_venv():
+    script = _build_script()
+    validation = 'if [ ! -f "$INSTALL_DIR/venv/pyvenv.cfg" ] || [ ! -x "$INSTALL_DIR/venv/bin/uvicorn" ]; then'
+
+    assert validation in script
+    assert "Create the venv and install dependencies before building" in script
+    assert script.index(validation) < script.index('rm -rf "$APP"')
+
+
 def test_launcher_checks_python_environment_access_before_starting_uvicorn():
     script = _build_script()
     probe = 'if ! /bin/cat "$PYVENV_CFG" >/dev/null 2>&1; then'
@@ -64,6 +73,8 @@ def test_native_launcher_triggers_protected_folder_consent_before_shell_child():
 
     assert 'Contents/Resources/install-dir' in script
     assert native_probe in script
+    assert "NSFileReadNoSuchFileError" in script
+    assert "The Python environment does not exist" in script
     assert "enable Documents Folder" in script
     assert script.index(native_probe) < script.index(child_launch)
 

--- a/tests/test_macos_app_bundle.py
+++ b/tests/test_macos_app_bundle.py
@@ -57,6 +57,17 @@ def test_bundle_uses_native_executable_for_macos_privacy_identity():
     assert 'codesign --force --deep --sign - "$APP"' in script
 
 
+def test_native_launcher_triggers_protected_folder_consent_before_shell_child():
+    script = _build_script()
+    native_probe = "NSData *configData = [NSData dataWithContentsOfFile:pyvenvConfig"
+    child_launch = "[self.launcherTask launchAndReturnError:&error]"
+
+    assert 'Contents/Resources/install-dir' in script
+    assert native_probe in script
+    assert "enable Documents Folder" in script
+    assert script.index(native_probe) < script.index(child_launch)
+
+
 def test_native_launcher_has_menu_bar_status_and_exit_action():
     script = _build_script()
     plist = _generated_info_plist()


### PR DESCRIPTION
## Summary

I ran into this while testing a DMG built from a checkout in `~/Documents`. The app failed before startup because macOS treated the launcher as `sh`, so Python could not read `venv/pyvenv.cfg` even though the Odysseus bundle had requested folder access.

This changes the generated app to use a small native AppKit launcher. macOS now recognizes the process as Odysseus, the existing shell launcher still handles server startup, and permission failures are reported before Python crashes. The launcher also adds a menu-bar icon that stays visible while Odysseus is running, with an **Exit Odysseus** item that shuts down Uvicorn cleanly.

## Target branch

- [x] `dev`

## Linked issue

Fixes #6247

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change

## What changed

- Added Documents, Desktop, and Downloads usage descriptions to the generated `Info.plist`.
- Moved the shell launcher into the app's Resources directory.
- Added a native, ad-hoc-signed AppKit executable that supervises the shell launcher.
- Added a native `pyvenv.cfg` read before the shell starts, which makes macOS show the folder-consent prompt for Odysseus itself.
- Made the build stop with a clear setup error when its checkout has no usable venv, instead of producing a DMG that can never launch.
- Distinguished a missing Python environment from a real macOS permission denial in the native dialog.
- Kept an early shell-side readability check with useful recovery instructions for previously denied access.
- Added a persistent menu-bar item and an **Exit Odysseus** action.
- Added focused regression tests for the generated bundle and launcher.

## How to test

1. Clone the repository somewhere beneath `~/Documents` and set it up from that checkout:

   ```bash
   python3 -m venv venv
   source venv/bin/activate
   pip install -r requirements.txt
   python setup.py
   ```

2. Run `./build-macos-app.sh`, open `dist/Odysseus.dmg`, and drag its `Odysseus.app` into Applications. If step 1 was skipped, confirm the build stops immediately instead of creating a broken DMG.
3. Reset the existing folder decision if necessary:

   ```bash
   tccutil reset SystemPolicyDocumentsFolder com.odysseus.launcher
   ```

4. Launch Odysseus and allow Documents access.
5. Confirm the site loads at `http://127.0.0.1:7860` and the menu-bar icon remains visible.
6. Click the icon and choose **Exit Odysseus**, then confirm the launcher and Uvicorn processes stop.

## Validation

I built the DMG on an Apple Silicon Mac, mounted it, copied its exact app payload into `/Applications`, reset the folder permission, and launched the installed copy. The native launcher prompted for access before starting its shell child, Uvicorn stayed active, and the app loaded successfully on port 7860. I also reproduced the misleading dialog from a checkout with no venv and confirmed the build now catches that mistake before packaging.

I also ran:

```text
bash -n build-macos-app.sh
focused tests in tests/test_macos_app_bundle.py
codesign --verify --deep --strict --verbose=2 dist/Odysseus.app
hdiutil verify dist/Odysseus.dmg
```

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`.
- [x] My changes are limited to the macOS launcher behavior described above.
- [x] I actually ran the app and verified the change works end-to-end.

## Menu-bar UI

The status item uses the existing Odysseus application icon and standard AppKit menu controls. This change does not alter the web interface.
