### PR TITLE
fix(tools): add the native function schema for generate_image

### DIFF
--- a/src/tool_schemas.py
+++ b/src/tool_schemas.py
@@ -26,6 +26,9 @@ _REQUIRED_NATIVE_TOOL_ARGS = {
     "write_file": ("path",),
     "edit_file": ("path",),
     "apply_patch": ("patch_text", "patchText", "patch"),
+    # Without this, a prompt-less call falls through to the line parser in
+    # tool_execution and the whole JSON blob becomes the image prompt.
+    "generate_image": ("prompt",),
 }
 
 # ---------------------------------------------------------------------------
@@ -1027,6 +1030,23 @@ FUNCTION_TOOL_SCHEMAS = [
                     "filter": {"type": "string", "description": "For action=endpoints: substring to filter paths/summaries (e.g. 'cookbook', 'gallery')"}
                 },
                 "required": ["action"]
+            }
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "generate_image",
+            "description": "Generate an image from a text prompt. Art, illustrations, photos.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "prompt": {"type": "string", "description": "Image description prompt"},
+                    "model": {"type": "string", "description": "Model name (auto-detects if omitted)"},
+                    "size": {"type": "string", "description": "Image size (default 1024x1024)"},
+                    "quality": {"type": "string", "description": "Quality: low, medium, high, auto (default medium)"},
+                },
+                "required": ["prompt"]
             }
         }
     },

--- a/tests/test_generate_image_native_schema.py
+++ b/tests/test_generate_image_native_schema.py
@@ -1,0 +1,61 @@
+"""Issue #5520 — generate_image had no native function schema.
+
+The tool exists in the fenced-block prompt, the executor, and the image_gen MCP
+server, but not in FUNCTION_TOOL_SCHEMAS. API models (native function calling)
+are only sent schemas from that list, so they could never call it and improvised
+malformed text calls instead.
+"""
+
+import json
+
+
+def _schemas():
+    import src.agent_tools  # noqa: F401  (tool_schemas <-> agent_tools import cycle)
+    from src.tool_schemas import FUNCTION_TOOL_SCHEMAS
+
+    return {s["function"]["name"]: s["function"] for s in FUNCTION_TOOL_SCHEMAS}
+
+
+def _convert(arguments):
+    import src.agent_tools  # noqa: F401
+    from src.tool_schemas import function_call_to_tool_block
+
+    return function_call_to_tool_block("generate_image", json.dumps(arguments))
+
+
+def test_generate_image_is_offered_to_native_function_calling_models():
+    schemas = _schemas()
+    assert "generate_image" in schemas, (
+        "generate_image has no native schema, so it is filtered out of the tools "
+        "sent to API models even when the selector picks it"
+    )
+    assert schemas["generate_image"]["parameters"]["required"] == ["prompt"]
+
+
+def test_native_call_reaches_the_executor_with_its_arguments_intact():
+    from src.tool_execution import _build_mcp_args
+
+    args = {"prompt": "a cat riding a bicycle", "model": "gpt-image-1",
+            "size": "1024x1024", "quality": "high"}
+    block = _convert(args)
+    assert block is not None and block.tool_type == "generate_image"
+    assert _build_mcp_args("generate_image", block.content) == args
+
+
+def test_call_without_a_prompt_is_rejected_instead_of_drawing_its_own_arguments():
+    """No prompt key means the line parser takes the whole JSON blob as the prompt,
+    so the model gets an image of its own arguments."""
+    assert _convert({"size": "512x512"}) is None
+    assert _convert({}) is None
+    assert _convert({"prompt": "   "}) is None
+
+
+def test_advertised_parameters_are_the_ones_the_image_server_accepts():
+    """Anything the schema advertises but the executor drops is a silent no-op."""
+    from mcp_servers.image_gen_server import list_tools
+    import asyncio
+
+    server_schema = asyncio.run(list_tools())[0].inputSchema
+    assert set(_schemas()["generate_image"]["parameters"]["properties"]) == set(
+        server_schema["properties"]
+    )


### PR DESCRIPTION
## Summary

The tool selector picks `generate_image`, but native API models never receive it because it's missing from `FUNCTION_TOOL_SCHEMAS`. The compact prompt still lists it as available, so the prompt and tools array disagree.

The schema now matches the image server: `prompt` is required, with optional `model`, `size` and `quality`. Calls without a usable prompt are rejected before the executor can mistake the JSON arguments for an image prompt. The existing generic converter already handles valid calls, so it needs no extra branch.

The existing image permission, disabled-tool, plan-mode and approval checks still apply.

## Linked Issue

Fixes #5520

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the change works end-to-end.

## How to Test

1. Register an endpoint with `supports_tools=true`.
2. In agent mode, ask for an image on the second turn; the first turn can skip tool selection.
3. Check that `generate_image` appears in both `relevant_tools` and the outgoing `tool_names`.
4. Emit a native call and check that its arguments reach the approval gate unchanged. A call with no usable prompt should be rejected.

## Validation

A running instance with a stub OpenAI-compatible server showed `generate_image` in the outgoing tools after the change. A native call retained its prompt and size and stopped at the approval gate before execution.

Four regressions cover schema availability, argument round-tripping, missing prompts and parity with the image server's schema. Three fail on the original code; the round-trip case already passes because the converter works. The full suite passed with 5,820 tests and 3 skips.

## Visual / UI changes

Backend only (`src/tool_schemas.py`); no UI changes.

Claude Code assisted with the implementation and tests.
