### PR TITLE
fix(chat): deny trigger_research when the turn has no web access

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -65,6 +65,7 @@ from src.tool_policy import (
     WEB_TOOL_NAMES,
     build_effective_tool_policy,
     is_web_search_explicitly_denied,
+    tools_denied_without_web,
     web_search_enabled_for_turn,
 )
 from src.tool_approvals import tool_approval_store
@@ -1451,7 +1452,7 @@ def setup_chat_routes(
             disabled_tools.add("bash")
         _explicit_web_intent = _explicit_web_intent or bool(_tool_intent and _tool_intent.category == "web")
         if is_web_search_explicitly_denied(allow_web_search) or not _search_enabled:
-            disabled_tools.update(WEB_TOOL_NAMES)
+            disabled_tools.update(tools_denied_without_web(research_requested=do_research))
         if _explicit_web_intent:
             # A direct lookup/search request should not drift into personal
             # tools or shell fallbacks. It can only use web_search/web_fetch

--- a/src/tool_policy.py
+++ b/src/tool_policy.py
@@ -19,6 +19,21 @@ GUIDE_ONLY_DIRECTIVE = (
 WEB_TOOL_NAMES = frozenset({"web_search", "web_fetch"})
 
 
+def tools_denied_without_web(*, research_requested: bool) -> frozenset[str]:
+    """Tool names to deny on a turn that did not enable web access.
+
+    trigger_research reaches the public internet through the same search backend
+    as web_search, only with a much larger crawl behind it, so leaving it callable
+    makes the composer's web toggle advisory. A user who asked for Deep Research
+    has opted in explicitly — and routes/chat_routes.py gates that request on this
+    very tool name, so denying it there would turn the feature off instead.
+    """
+
+    if research_requested:
+        return WEB_TOOL_NAMES
+    return WEB_TOOL_NAMES | {"trigger_research"}
+
+
 def tool_toggle_enabled(value: object) -> bool:
     """Return true only for explicit true-like tool toggle values."""
 

--- a/tests/test_research_web_toggle.py
+++ b/tests/test_research_web_toggle.py
@@ -1,0 +1,57 @@
+"""Issue #5527 — "web search off" must also close the deep-research route.
+
+With the composer's web toggle off, web_search/web_fetch are denied for the turn
+but trigger_research was not, so "search online for X" still reached the internet
+— through a multi-round research job that crawls far more than the single search
+the user had just switched off.
+
+The carve-out matters as much as the denial: routes/chat_routes.py gates the
+user's own Deep Research request on `tool_policy.blocks("trigger_research")`, so
+denying that name unconditionally would silently break the Deep Research toggle
+(which forces chat mode, where no web toggle is ever sent).
+"""
+
+from pathlib import Path
+
+from src.tool_policy import (
+    WEB_TOOL_NAMES,
+    build_effective_tool_policy,
+    tools_denied_without_web,
+)
+
+_CHAT_ROUTES = Path(__file__).resolve().parent.parent / "routes" / "chat_routes.py"
+
+
+def test_agent_cannot_start_research_when_web_is_denied():
+    denied = tools_denied_without_web(research_requested=False)
+    assert "trigger_research" in denied
+    assert WEB_TOOL_NAMES <= denied
+
+
+def test_explicit_deep_research_request_still_runs_with_web_denied():
+    """The Deep Research toggle is its own opt-in; the turn it sends never
+    carries a web toggle, so denying research here would disable the feature."""
+    assert "trigger_research" not in tools_denied_without_web(research_requested=True)
+
+
+def test_reading_saved_research_is_never_denied():
+    """manage_research is Library CRUD over already-stored reports — no web."""
+    for requested in (True, False):
+        assert "manage_research" not in tools_denied_without_web(research_requested=requested)
+
+
+def test_denied_names_reach_the_gate_the_research_path_reads():
+    """chat_routes derives research_blocked_by_policy from exactly this call."""
+    policy = build_effective_tool_policy(
+        disabled_tools=tools_denied_without_web(research_requested=False),
+        last_user_message="search online for beans",
+    )
+    assert policy.blocks("trigger_research")
+    assert not policy.blocks("manage_research")
+
+
+def test_chat_route_applies_the_rule_on_the_web_denied_branch():
+    source = _CHAT_ROUTES.read_text(encoding="utf-8")
+    assert "tools_denied_without_web(research_requested=do_research)" in source, (
+        "the web-denied branch must deny research too, or the toggle is advisory"
+    )


### PR DESCRIPTION
## Summary

Turning web access off denies `web_search` and `web_fetch`, but still lets the agent call `trigger_research` and start a job that accesses the internet. Research now joins the denied tools for that turn unless the user explicitly requested Deep Research.

The explicit request needs that exception because both chat routes check the same tool policy, and the Deep Research toggle uses chat mode without sending a web toggle. Denying research unconditionally would disable the user's request too.

The denied set is computed separately from `WEB_TOOL_NAMES`, which also controls web intent, forced tool selection and pending approvals. `manage_research` remains available for reading saved reports.

## Linked Issue

Fixes #5527

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the change works end-to-end.

## How to Test

1. In agent mode with web off, ask for research. `trigger_research` should be absent from the outgoing tools.
2. Turn web on and repeat. Research should be available.
3. Turn web off and use the Deep Research toggle. The explicit research flow should still start.

## Validation

All three cases were checked against a running app with a stub OpenAI-compatible server. With web off, both web search and research were absent from the tools array. With web on, both were present. With explicit Deep Research and web off, the stream entered research mode and reached its clarifying questions while the lightweight web tools stayed absent.

Five regressions cover denied research, the explicit request, saved-report access, the effective policy and the route applying it. The full suite passed with 5,821 tests and 3 skips.

#6104 changes the same route block. Whichever lands second needs a small rebase: keep `tools_denied_without_web(...)` on the remaining `disabled_tools.update` call and retain both import additions. The merge check found two mechanical hunks; the behaviours don't otherwise interact.

## Visual / UI changes

Backend only (`routes/chat_routes.py` and `src/tool_policy.py`); no UI changes.

Claude Code assisted with the implementation and tests.
