### PR TITLE
fix(docker): install libnuma1 so sgl_kernel can load

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libglib2.0-0t64 \
     libxcb1 \
     libmagic1 \
+    libnuma1 \
     && rm -rf /var/lib/apt/lists/*
 
 # libgl1/libglib2.0-0t64/libxcb1 are runtime shared libs (libGL.so.1,
@@ -51,6 +52,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # absent the import can block or raise, so keeping it image-only avoids
 # regressing pip/venv installs on hosts without libmagic. Debian always has the
 # lib here, so the import is instant and detection actually works.
+#
+# libnuma1 provides libnuma.so.1, which sgl_kernel's prebuilt CUDA
+# extension (sgl_kernel/sm*/common_ops.abi3.so) links against. Cookbook
+# installs SGLang from PyPI, so no package manager pulls this in; without
+# it every SGLang serve dies at import with "libnuma.so.1: cannot open
+# shared object file", surfaced as the misleading "[sgl_kernel] CRITICAL:
+# Could not load any common_ops library!".
 
 # Docker CLI (client only — daemon stays on the host via the
 # /var/run/docker.sock mount). The Debian `docker.io` package ships


### PR DESCRIPTION
## Problem

`sgl_kernel`'s prebuilt CUDA extension (`sgl_kernel/sm*/common_ops.abi3.so`)
links against `libnuma.so.1`. The slim base image doesn't carry it and no
pip dependency pulls it in, so every Cookbook SGLang serve dies at import:

```
ImportError: libnuma.so.1: cannot open shared object file
[sgl_kernel] CRITICAL: Could not load any common_ops library!
```

The second line is the one users see. It points at a broken `sgl_kernel`
install rather than a missing system library, so the obvious next step is
reinstalling sglang — which doesn't help.

## Fix

Add `libnuma1` to the apt list (~30KB), documented next to the existing
`libgl1` / `libmagic1` notes that cover the same class of problem.

## Verification

SGLang serves cleanly on a freshly recreated container.
