### PR TITLE
fix(llm): give reasoning models room in short-output utility calls

### DIFF
--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -14,6 +14,7 @@ from sqlalchemy.exc import IntegrityError
 from dateutil.rrule import rrulestr
 
 from core.database import SessionLocal, CalendarCal, CalendarDeletedEvent, CalendarEvent
+from src.constants import UTILITY_MAX_TOKENS, UTILITY_TIMEOUT
 from src.auth_helpers import effective_user, require_user
 from src.upload_limits import read_upload_limited, ICS_MAX_BYTES
 from src.upload_handler import reserve_upload_references
@@ -1695,8 +1696,8 @@ def setup_calendar_routes(upload_handler=None) -> APIRouter:
                 ],
                 headers=headers,
                 temperature=0.0,
-                max_tokens=512,
-                timeout=20,
+                max_tokens=UTILITY_MAX_TOKENS,
+                timeout=UTILITY_TIMEOUT,
             )
         except Exception as e:
             return {"ok": False, "error": f"LLM call failed: {e}"}

--- a/routes/document/document_routes.py
+++ b/routes/document/document_routes.py
@@ -11,7 +11,7 @@ from sqlalchemy import case, func, or_
 from core.database import SessionLocal, Document, DocumentVersion
 from core.database import Session as DbSession
 from src.auth_helpers import get_current_user, _auth_disabled
-from src.constants import MAIL_ATTACHMENTS_DIR
+from src.constants import MAIL_ATTACHMENTS_DIR, UTILITY_MAX_TOKENS, UTILITY_TIMEOUT
 from src.upload_handler import reserve_upload_references
 
 logger = logging.getLogger(__name__)
@@ -1016,9 +1016,9 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
                 [{"role": "system", "content": "You classify documents as junk or keep. Respond only with a JSON array."},
                  {"role": "user", "content": prompt}],
                 temperature=0.1,
-                max_tokens=200,
+                max_tokens=UTILITY_MAX_TOKENS,
                 headers=headers,
-                timeout=30,
+                timeout=UTILITY_TIMEOUT,
             )
 
             # Parse verdicts

--- a/routes/email_pollers.py
+++ b/routes/email_pollers.py
@@ -29,6 +29,7 @@ from datetime import datetime
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 
+from src.constants import UTILITY_MAX_TOKENS
 from src.task_endpoint import resolve_task_candidates, task_llm_call_async
 
 from routes.email_helpers import (
@@ -847,7 +848,7 @@ async def _auto_summarize_pass_single(days_back: int = 1, account_id: str | None
                             ],
                             fallback_url=url, fallback_model=model, fallback_headers=headers,
                             owner=account_owner or None,
-                            temperature=0.7, max_tokens=1024, timeout=90,
+                            temperature=0.7, max_tokens=UTILITY_MAX_TOKENS, timeout=90,
                         )
                         reply = _apply_email_style_mechanics(_extract_reply(reply or ""))
                         if reply:
@@ -1134,7 +1135,7 @@ async def _auto_summarize_pass_single(days_back: int = 1, account_id: str | None
                             messages=payload["messages"],
                             fallback_url=url, fallback_model=model, fallback_headers=headers,
                             owner=account_owner or None,
-                            temperature=0, max_tokens=200, timeout=60,
+                            temperature=0, max_tokens=UTILITY_MAX_TOKENS, timeout=60,
                         )
                         urg_raw = _strip_think(urg_raw or "")
                         urg_raw = re.sub(r"^```(?:json)?\s*|\s*```$", "", urg_raw, flags=re.MULTILINE).strip()
@@ -1265,7 +1266,7 @@ async def _auto_summarize_pass_single(days_back: int = 1, account_id: str | None
                             ],
                             fallback_url=url, fallback_model=model, fallback_headers=headers,
                             owner=account_owner or None,
-                            temperature=0.1, max_tokens=512, timeout=120,
+                            temperature=0.1, max_tokens=UTILITY_MAX_TOKENS, timeout=120,
                         )
                         raw_out = _strip_think((raw_out or "").strip())
                         raw_out = re.sub(r"^```(?:json)?\s*|\s*```$", "", raw_out, flags=re.MULTILINE).strip()

--- a/routes/email_routes.py
+++ b/routes/email_routes.py
@@ -38,7 +38,7 @@ from email.mime.multipart import MIMEMultipart
 
 from fastapi import APIRouter, Query, UploadFile, File, BackgroundTasks, HTTPException, Depends, Request
 from fastapi.responses import FileResponse, StreamingResponse
-from src.constants import DATA_DIR
+from src.constants import DATA_DIR, UTILITY_MAX_TOKENS, UTILITY_TIMEOUT
 
 from src.llm_core import llm_call_async
 from src.upload_limits import read_upload_limited, EMAIL_COMPOSE_UPLOAD_MAX_BYTES
@@ -5365,7 +5365,7 @@ def setup_email_routes():
                     _candidates,
                     messages=_messages,
                     temperature=0.7,
-                    max_tokens=1024 if fast_reply else 6144,
+                    max_tokens=UTILITY_MAX_TOKENS if fast_reply else 6144,
                     timeout=60 if fast_reply else 180,
                 )
             except Exception as e:
@@ -5399,8 +5399,8 @@ def setup_email_routes():
                             retry_messages,
                             headers=cand_headers,
                             temperature=0.3,
-                            max_tokens=1536 if fast_reply else 4096,
-                            timeout=45 if fast_reply else 120,
+                            max_tokens=UTILITY_MAX_TOKENS if fast_reply else 4096,
+                            timeout=UTILITY_TIMEOUT if fast_reply else 120,
                             max_retries=1,
                         )
                         retry_reply = _apply_email_style_mechanics(_extract_reply(raw_retry or ""))

--- a/routes/gallery/gallery_routes.py
+++ b/routes/gallery/gallery_routes.py
@@ -20,7 +20,7 @@ from src.upload_limits import (
     GALLERY_UPLOAD_MAX_BYTES,
     GALLERY_TRANSFORM_UPLOAD_MAX_BYTES,
 )
-from src.constants import GENERATED_IMAGES_DIR
+from src.constants import GENERATED_IMAGES_DIR, UTILITY_MAX_TOKENS
 from src.optional_deps import patch_realesrgan_torchvision_compat
 
 from routes.gallery.gallery_helpers import (
@@ -2298,7 +2298,7 @@ def setup_gallery_routes() -> APIRouter:
                             {"type": "image_url", "image_url": {"url": f"data:{mime};base64,{b64}"}},
                         ],
                     }],
-                    _tok_key: 200,
+                    _tok_key: UTILITY_MAX_TOKENS,
                     "temperature": 0.3,
                 }
                 # Reasoning models (o1/o3/o4/gpt-5) reject an explicit temperature.

--- a/routes/history/history_routes.py
+++ b/routes/history/history_routes.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, Request, HTTPException, Depends
 
 from core.models import ChatMessage
 from core.database import SessionLocal, ChatMessage as DbChatMessage, Session as DbSession
+from src.constants import UTILITY_MAX_TOKENS, UTILITY_TIMEOUT
 from src.auth_helpers import effective_user, require_chat_api_token_scope
 from src.topic_analyzer import analyze_topics
 from src.upload_handler import reserve_message_upload_references
@@ -763,8 +764,8 @@ def setup_history_routes(session_manager, upload_handler=None) -> APIRouter:
                     {"role": "system", "content": sys_prompt},
                     {"role": "user", "content": convo_text},
                 ],
-                temperature=0.2, max_tokens=1024,
-                headers=compact_headers, timeout=30,
+                temperature=0.2, max_tokens=UTILITY_MAX_TOKENS,
+                headers=compact_headers, timeout=UTILITY_TIMEOUT,
             )
             summary = normalize_compaction_summary(summary)
 

--- a/routes/memory/memory_routes.py
+++ b/routes/memory/memory_routes.py
@@ -23,6 +23,7 @@ def _strip_list_prefix(text: str) -> str:
 
 from services.memory import MemoryManager, MemoryStoreUnreadable
 from core.session_manager import SessionManager
+from src.constants import UTILITY_MAX_TOKENS
 from src.request_models import MemoryAddRequest
 from core.database import SessionLocal
 from src.llm_core import llm_call_async
@@ -267,7 +268,7 @@ def setup_memory_routes(memory_manager: MemoryManager, session_manager: SessionM
                 t_model,
                 messages,
                 temperature=0.2,
-                max_tokens=500,
+                max_tokens=UTILITY_MAX_TOKENS,
                 headers=t_headers,
             )
             try:

--- a/routes/note/note_routes.py
+++ b/routes/note/note_routes.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 from core.database import SessionLocal, Note
 from core.middleware import INTERNAL_TOOL_USER
 from src.auth_helpers import require_user
-from src.constants import DATA_DIR
+from src.constants import DATA_DIR, UTILITY_MAX_TOKENS, UTILITY_TIMEOUT
 from src.upload_handler import reserve_upload_references
 from sqlalchemy.orm.attributes import flag_modified
 
@@ -223,7 +223,7 @@ async def dispatch_reminder(
                         {"role": "system", "content": sys_prompt},
                         {"role": "user", "content": f"Title: {title}\n\n{note_body}".strip()},
                     ],
-                    temperature=0.7, max_tokens=200, headers=headers, timeout=30,
+                    temperature=0.7, max_tokens=UTILITY_MAX_TOKENS, headers=headers, timeout=UTILITY_TIMEOUT,
                 )
                 from src.text_helpers import strip_think as _strip_think
                 # prose=True strips untagged "The user wants me to…" chain-of-thought.

--- a/routes/preset_routes.py
+++ b/routes/preset_routes.py
@@ -8,6 +8,7 @@ from typing import Dict, Any, List
 from fastapi import APIRouter, HTTPException, Request, Depends
 from pydantic import BaseModel, Field
 
+from src.constants import UTILITY_MAX_TOKENS
 from src.request_models import PresetUpdateRequest
 from core.middleware import require_admin
 from src.auth_helpers import effective_user
@@ -104,7 +105,7 @@ def setup_preset_routes(preset_manager) -> APIRouter:
             model_spec = data.get("model") or ""
             user = effective_user(request)
             url, model, headers = await asyncio.to_thread(_resolve_model, model_spec, owner=user)
-            result = await llm_call_async(url, model, messages, temperature=0.8, max_tokens=500, headers=headers)
+            result = await llm_call_async(url, model, messages, temperature=0.8, max_tokens=UTILITY_MAX_TOKENS, headers=headers)
             return {"success": True, "prompt": result.strip()}
         except Exception as e:
             logger.error(f"Expand prompt failed: {e}")

--- a/routes/session_routes.py
+++ b/routes/session_routes.py
@@ -9,6 +9,7 @@ import logging
 
 from core.session_manager import SessionManager
 from core.models import ChatMessage
+from src.constants import UTILITY_MAX_TOKENS
 from src.request_models import SessionResponse
 from core.database import Session as DbSession, SessionLocal, Document, GalleryImage, utcnow_naive
 from src.auth_helpers import (
@@ -1053,7 +1054,7 @@ def setup_session_routes(
                 model,
                 [{"role": "system", "content": prompt}, {"role": "user", "content": convo_text}],
                 temperature=0.2,
-                max_tokens=1024,
+                max_tokens=UTILITY_MAX_TOKENS,
                 headers=headers,
                 timeout=60,
             )

--- a/src/constants.py
+++ b/src/constants.py
@@ -113,6 +113,26 @@ PASSWORD_MIN_LENGTH = 8
 DEFAULT_TEMPERATURE = 1.0
 DEFAULT_MAX_TOKENS = 0
 
+# Budget for the short-output utility calls that back titles, tags,
+# classifications and one-shot parses.
+#
+# Reasoning models (Qwen3, DeepSeek R1, QwQ, Minimax M2, ...) spend tokens
+# inside <think> before emitting a single visible character, and that
+# thinking is charged against max_tokens. A budget sized for the answer
+# alone is therefore consumed entirely by the reasoning: the response
+# comes back with finish_reason "length" and an empty content string.
+# Nothing raises, so the feature just silently does nothing.
+#
+# Measured against a local Qwen3.6-35B: a 3-6 word title left ~30 tokens
+# of visible output from a 1024 budget, and budgets of 200 and 512
+# returned the empty string. 4096 clears that with room to spare while
+# still capping a model that loops.
+UTILITY_MAX_TOKENS = 4096
+
+# Wall-clock room to match. A local reasoner filling the budget above
+# needs well past the 20-30s these call sites used to allow.
+UTILITY_TIMEOUT = 60
+
 
 def internal_api_base() -> str:
     """Base URL for in-process loopback calls to Odysseus's own API.


### PR DESCRIPTION
## Problem

Reasoning models (Qwen3, DeepSeek R1, QwQ, Minimax M2, ...) spend tokens
inside `<think>` before emitting a single visible character, and that
thinking is charged against `max_tokens`. A call whose budget is sized for
the answer alone is consumed entirely by the reasoning: the response comes
back with `finish_reason: "length"` and an empty `content` string.

Nothing raises on that path, so the feature simply does nothing. No photo
tags, no note synthesis, no calendar parse, no memory suggestions, no
expanded character prompt, no junk/keep verdicts.

Measured against a local Qwen3.6-35B served by llama.cpp, asking for a 3-6
word title:

| `max_tokens` | `finish_reason` | visible output |
|---|---|---|
| 200 | `length` | *(empty)* |
| 512 | `length` | *(empty)* |
| 1024 | `stop` | 32 chars |

1024 works only because ~990 tokens went to reasoning first, so it is
marginal rather than safe.

## Fix

Two call sites already carried this fix inline — `chat_helpers`' auto-name
(200 -> 4096, with a comment naming the symptom) and `chat_routes`' rewrite
(hardcoded 4096 -> 0). This lifts that rationale into `UTILITY_MAX_TOKENS`
/ `UTILITY_TIMEOUT` in `src/constants.py` and applies it to the thirteen
short-output call sites that were still sized for the answer alone.

The timeouts move with the budgets. 20-30s does not cover a local reasoner
filling 4096 tokens, so raising only `max_tokens` would have traded a
silent empty reply for a silent timeout.

Left deliberately unchanged: `document_routes`' VL page extraction and
`memory_routes`' document import, both at 2000. Those are real content
budgets rather than mis-sized ones, and when reasoning eats them they fail
loudly at `json.loads` instead of silently.

## Verification

Full suite on this branch: 5902 passed, 17 skipped, 1 failed —
`test_pr6020_browser_review_regressions.py::test_chat_runtime_stream_state_helpers_are_all_callable`,
which fails identically on a clean `dev` checkout and is unrelated to these
files.
