### PR TITLE
chore(docker): raise /dev/shm to 8GB for GPU serving

### DIFF
--- a/docker-compose.gpu-amd.yml
+++ b/docker-compose.gpu-amd.yml
@@ -12,6 +12,13 @@
 # host's numeric render group id when needed. See docker/gpu.amd.yml for details.
 services:
   odysseus:
+    # Docker's default /dev/shm is 64MB. SGLang and vLLM pass tensors
+    # between their tokenizer/scheduler/detokenizer processes through
+    # shared memory and both document raising it (vLLM's own docs pass
+    # --shm-size=8g); multimodal models add image/video buffers on top.
+    # Overrunning it kills a worker with SIGBUS, which surfaces only as an
+    # opaque "scheduler died during initialization (exit code: -7)".
+    shm_size: "8gb"
     build: .
     ports:
       - "${APP_BIND:-127.0.0.1}:${APP_PORT:-7000}:7000"

--- a/docker-compose.gpu-nvidia.yml
+++ b/docker-compose.gpu-nvidia.yml
@@ -11,6 +11,13 @@
 # for setup details.
 services:
   odysseus:
+    # Docker's default /dev/shm is 64MB. SGLang and vLLM pass tensors
+    # between their tokenizer/scheduler/detokenizer processes through
+    # shared memory and both document raising it (vLLM's own docs pass
+    # --shm-size=8g); multimodal models add image/video buffers on top.
+    # Overrunning it kills a worker with SIGBUS, which surfaces only as an
+    # opaque "scheduler died during initialization (exit code: -7)".
+    shm_size: "8gb"
     build: .
     ports:
       - "${APP_BIND:-127.0.0.1}:${APP_PORT:-7000}:7000"

--- a/docker/gpu.amd.yml
+++ b/docker/gpu.amd.yml
@@ -11,6 +11,13 @@
 # via Cookbook -> Dependencies (or pip) before serving GPU models.
 services:
   odysseus:
+    # Docker's default /dev/shm is 64MB. SGLang and vLLM pass tensors
+    # between their tokenizer/scheduler/detokenizer processes through
+    # shared memory and both document raising it (vLLM's own docs pass
+    # --shm-size=8g); multimodal models add image/video buffers on top.
+    # Overrunning it kills a worker with SIGBUS, which surfaces only as an
+    # opaque "scheduler died during initialization (exit code: -7)".
+    shm_size: "8gb"
     devices:
       - /dev/kfd
       - /dev/dri

--- a/docker/gpu.nvidia.yml
+++ b/docker/gpu.nvidia.yml
@@ -22,6 +22,13 @@
 # Cookbook -> Dependencies (or pip) before serving GPU models.
 services:
   odysseus:
+    # Docker's default /dev/shm is 64MB. SGLang and vLLM pass tensors
+    # between their tokenizer/scheduler/detokenizer processes through
+    # shared memory and both document raising it (vLLM's own docs pass
+    # --shm-size=8g); multimodal models add image/video buffers on top.
+    # Overrunning it kills a worker with SIGBUS, which surfaces only as an
+    # opaque "scheduler died during initialization (exit code: -7)".
+    shm_size: "8gb"
     environment:
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=compute,utility


### PR DESCRIPTION
## Problem

Docker's default `/dev/shm` is 64MB. SGLang and vLLM pass tensors between
their tokenizer, scheduler and detokenizer processes through shared memory,
and both document raising it — vLLM's own docs pass `--shm-size=8g`.
Multimodal models add image/video buffers on top.

Overrunning it kills a worker with SIGBUS, which surfaces only as an opaque
`scheduler died during initialization (exit code: -7)` — nothing points at
shared memory.

## Fix

`shm_size: "8gb"` on the `odysseus` service in both GPU overlays and both
standalone GPU compose files.

The second commit is the half the first one missed: the AMD overlay
(`docker/gpu.amd.yml`) did not get the setting, only the NVIDIA one did.
Since `docker-compose.gpu-amd.yml` inlines the overlay and *did* get it,
that broke the standalone-equals-base-plus-overlay invariant and
`test_amd_standalone_equals_base_plus_overlay` fails without it. AMD users
driving the stack through `COMPOSE_FILE` overlays were also still getting
the 64MB default.

## Verification

`tests/test_gpu_compose_standalone.py`: 12 passed. The AMD test fails on
the first commit alone and passes with the second.

Note this is hardening from the vLLM/SGLang docs plus the repo's own drift
test — I have not reproduced a SIGBUS on 64MB myself.
