### PR TITLE
fix(vault): use atomic writes for vault config

### DIFF
--- a/routes/vault/vault_routes.py
+++ b/routes/vault/vault_routes.py
@@ -15,6 +15,7 @@ from datetime import datetime
 from fastapi import APIRouter, Request
 from pydantic import BaseModel
 
+from core.atomic_io import atomic_write_json
 from core.middleware import require_admin
 from core.platform_compat import IS_WINDOWS, safe_chmod, which_tool
 from src.constants import VAULT_FILE as _VAULT_FILE
@@ -70,8 +71,7 @@ def _load_config() -> dict:
 
 
 def _save_config(cfg: dict):
-    VAULT_FILE.parent.mkdir(parents=True, exist_ok=True)
-    VAULT_FILE.write_text(json.dumps(cfg, indent=2), encoding="utf-8")
+    atomic_write_json(str(VAULT_FILE), cfg, indent=2)
     # POSIX: restrict the BW_SESSION store to 0o600. Windows: no-op (profile dir
     # is ACL-restricted already).
     safe_chmod(str(VAULT_FILE), 0o600)

--- a/src/tools/vault.py
+++ b/src/tools/vault.py
@@ -8,6 +8,7 @@ and their helpers (_load_vault_config, _run_bw).
 import json
 from typing import Dict, Optional
 
+from core.atomic_io import atomic_write_json
 from src.constants import VAULT_FILE
 from src.tools._common import _parse_tool_args
 
@@ -179,7 +180,7 @@ async def do_vault_unlock(content: str, owner: Optional[str] = None) -> Dict:
     cfg["session"] = session
     from datetime import datetime as _dt
     cfg["unlocked_at"] = _dt.utcnow().isoformat()
-    p.write_text(json.dumps(cfg, indent=2), encoding="utf-8")
+    atomic_write_json(str(p), cfg, indent=2)
     try:
         import os as _os
         _os.chmod(str(p), 0o600)


### PR DESCRIPTION
## Summary

Replace non-atomic `write_text()` with `atomic_write_json()` from `core/atomic_io.py` in both vault config write paths. The previous `write_text()` truncates `vault.json` to 0 bytes before writing — a crash mid-write (Docker restart, OOM kill, power loss) permanently loses the Bitwarden session key, forcing re-authentication with the master password.

## Linked Issue

Addresses the non-atomic JSON write concern raised in #3803.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## What Changed

| File | Change |
|------|--------|
| `routes/vault/vault_routes.py` | Added `from core.atomic_io import atomic_write_json`; replaced `VAULT_FILE.write_text(...)` with `atomic_write_json(str(VAULT_FILE), cfg, indent=2)` |
| `src/tools/vault.py` | Added `from core.atomic_io import atomic_write_json`; replaced `p.write_text(...)` with `atomic_write_json(str(p), cfg, indent=2)` |

The `safe_chmod` / `os.chmod` calls after each write remain unchanged.

## How to Test

1. Run `python -m py_compile routes/vault/vault_routes.py` — should pass with no output
2. Run `python -m py_compile src/tools/vault.py` — should pass with no output
3. Confirm `core/atomic_io.py` is the same helper already used by 20+ other modules (auth, settings, integrations, prefs, etc.)
4. Runtime validation: Verified `atomic_write_json` writes valid JSON, overwrites correctly, leaves no temp files behind. Confirmed both `vault_routes.py` and `vault.py` import and call `atomic_write_json` instead of `write_text`. All 6 tests passed.

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end. Type-checks and unit tests are not enough.