### PR TITLE
fix(security): deny generated-image access when ownership verification fails

### DIFF
--- a/app.py
+++ b/app.py
@@ -534,6 +534,7 @@ async def serve_generated_image(filename: str, request: Request):
         raise
     except Exception as _e:
         logger.warning("Image ownership verification failed for %r", filename, exc_info=_e)
+        raise HTTPException(status_code=503, detail="Ownership verification unavailable")
     ext = filename.rsplit('.', 1)[-1].lower()
     mime = {
         "png": "image/png", "jpg": "image/jpeg", "jpeg": "image/jpeg",


### PR DESCRIPTION
## Summary

`serve_generated_image` catches all exceptions during ownership verification and falls through to serve the file anyway. If the database is down or corrupted, the ownership check is bypassed — any authenticated user can download any generated image by guessing the 12-hex content-hash filename. Raise HTTP 503 instead of falling through so the endpoint fails closed when verification is impossible.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #6267

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run `python -m py_compile app.py` — should pass with no output
2. Normal image serving (DB healthy) is unaffected because the exception is not raised
3. To verify the fix: corrupt `data/odysseus.db` and request a generated image — should return 503 instead of serving the file
4. Runtime validation: Started Odysseus locally with auth enabled, created admin user, placed test image in `data/generated_images/`, inserted gallery row. Normal request returned 200. Mocked `SessionLocal` to raise `ConnectionError` — endpoint returned 503 with "Ownership verification unavailable". After restore, endpoint returned 200 again.