### PR TITLE
fix(prefs): merge preference updates instead of republishing a snapshot

### DIFF
--- a/routes/backup_routes.py
+++ b/routes/backup_routes.py
@@ -207,10 +207,8 @@ def setup_backup_routes(memory_manager, preset_manager, skills_manager) -> APIRo
 
         # ── Preferences ──
         if "preferences" in body and isinstance(body["preferences"], dict):
-            from routes.prefs_routes import _load_for_user, _save_for_user
-            current = _load_for_user(user)
-            current.update(body["preferences"])
-            _save_for_user(user, current)
+            from routes.prefs_routes import _update_for_user
+            _update_for_user(user, body["preferences"])
             imported.append("preferences")
 
         if not imported:

--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -821,11 +821,8 @@ def setup_calendar_routes(upload_handler=None) -> APIRouter:
         return _load_caldav_accounts(owner)
 
     def _save_caldav_accounts(owner: str, accounts: list) -> None:
-        from routes.prefs_routes import _load_for_user, _save_for_user
-        prefs = _load_for_user(owner) or {}
-        prefs["caldav_accounts"] = accounts
-        prefs.pop("caldav", None)
-        _save_for_user(owner, prefs)
+        from routes.prefs_routes import _update_for_user
+        _update_for_user(owner, {"caldav_accounts": accounts}, remove=("caldav",))
 
     # ── CalDAV config routes (backward-compat single-account API) ────────────
 

--- a/routes/prefs_routes.py
+++ b/routes/prefs_routes.py
@@ -1,6 +1,7 @@
 """User preferences API — per-user key/value store backed by a JSON file."""
 import json
-from typing import Optional
+import threading
+from typing import Iterable, Optional
 from fastapi import APIRouter, Request
 from core.atomic_io import atomic_write_json
 from src.auth_helpers import get_current_user
@@ -11,6 +12,11 @@ _FOREGROUND_POLICY_KEYS = (
     "foreground_fallback_enabled",
     "foreground_model_fallbacks",
 )
+
+# Serializes the read-modify-write in _update_for_user against itself and
+# against a whole-map _save_for_user. Reentrant because _update_for_user
+# calls _save_for_user while already holding it.
+_PREFS_LOCK = threading.RLock()
 
 
 def _load():
@@ -28,7 +34,17 @@ def _save(prefs):
 
 
 def _load_for_user(user: Optional[str] = None) -> dict:
-    """Load preferences for a specific user."""
+    """Load preferences for a specific user.
+
+    Reads take the lock so they cannot observe a write in progress. That
+    matters on Windows, where os.replace onto a path another thread currently
+    holds open raises PermissionError rather than swapping the file silently.
+    """
+    with _PREFS_LOCK:
+        return _load_for_user_locked(user)
+
+
+def _load_for_user_locked(user: Optional[str] = None) -> dict:
     all_prefs = _load()
     users = all_prefs.get("_users")
     if isinstance(users, dict):
@@ -54,7 +70,16 @@ def _load_for_user(user: Optional[str] = None) -> dict:
 
 
 def _save_for_user(user: Optional[str], prefs: dict):
-    """Save preferences for a specific user."""
+    """Replace a user's stored preferences with `prefs`.
+
+    This publishes the caller's map wholesale. Prefer _update_for_user when
+    you only mean to change some of the keys.
+    """
+    with _PREFS_LOCK:
+        _save_for_user_locked(user, prefs)
+
+
+def _save_for_user_locked(user: Optional[str], prefs: dict):
     all_prefs = _load()
     if user is None:
         # Auth disabled. If the store is already multi-user (e.g. auth was
@@ -100,6 +125,34 @@ def _save_for_user(user: Optional[str], prefs: dict):
     _save(all_prefs)
 
 
+def _update_for_user(
+    user: Optional[str],
+    patch: Optional[dict] = None,
+    *,
+    remove: Iterable[str] = (),
+) -> dict:
+    """Merge `patch` into a user's stored preferences and return the result.
+
+    Callers used to load a snapshot, change one key in it, and hand the whole
+    map back to _save_for_user. Two overlapping updates to different keys then
+    raced: the second save republished a snapshot taken before the first one
+    landed, so a write that had reported success disappeared. The file stayed
+    valid JSON and nothing was logged, which is what made it silent.
+
+    Re-reading and merging inside the lock means an update only ever publishes
+    its own keys against whatever is persisted at that moment, so independent
+    changes survive each other regardless of ordering.
+    """
+    with _PREFS_LOCK:
+        current = _load_for_user_locked(user)
+        for key in remove:
+            current.pop(key, None)
+        if patch:
+            current.update(patch)
+        _save_for_user_locked(user, current)
+        return current
+
+
 def setup_prefs_routes():
     router = APIRouter(prefix="/api/prefs", tags=["preferences"])
 
@@ -117,9 +170,7 @@ def setup_prefs_routes():
     @router.put("/{key}")
     async def set_pref(request: Request, key: str, body: dict):
         user = get_current_user(request)
-        prefs = _load_for_user(user)
-        prefs[key] = body.get("value")
-        _save_for_user(user, prefs)
-        return {"key": key, "value": prefs[key]}
+        prefs = _update_for_user(user, {key: body.get("value")})
+        return {"key": key, "value": prefs.get(key)}
 
     return router

--- a/routes/task/task_routes.py
+++ b/routes/task/task_routes.py
@@ -20,7 +20,7 @@ from src.task_action_policy import (
     owner_has_admin_task_privileges,
 )
 from src.task_scheduler import compute_next_run, HOUSEKEEPING_DEFAULTS
-from routes.prefs_routes import _load_for_user, _save_for_user
+from routes.prefs_routes import _load_for_user, _update_for_user
 
 logger = logging.getLogger(__name__)
 
@@ -382,12 +382,11 @@ def setup_task_routes(task_scheduler) -> APIRouter:
     @router.post("/onboarding")
     async def update_tasks_onboarding(request: Request, body: dict):
         user = _owner(request)
-        prefs = _load_for_user(user) or {}
-        prefs["tasks_opened"] = True
         enable = bool(body.get("enabled"))
+        patch = {"tasks_opened": True}
         if enable:
-            prefs["tasks_enabled"] = True
-        _save_for_user(user, prefs)
+            patch["tasks_enabled"] = True
+        prefs = _update_for_user(user, patch)
         if user:
             await task_scheduler.ensure_defaults(user)
 

--- a/src/builtin_actions.py
+++ b/src/builtin_actions.py
@@ -3308,14 +3308,16 @@ async def action_cookbook_serve(
                 _settings["utility_model"] = selected_model
             _save_settings(_settings)
             if owner:
-                from routes.prefs_routes import _load_for_user, _save_for_user
+                from routes.prefs_routes import _load_for_user, _update_for_user
                 _prefs = _load_for_user(owner)
-                _prefs["default_endpoint_id"] = endpoint_id
-                _prefs["default_model"] = selected_model
+                _patch = {
+                    "default_endpoint_id": endpoint_id,
+                    "default_model": selected_model,
+                }
                 if not (_prefs.get("utility_endpoint_id") or "").strip():
-                    _prefs["utility_endpoint_id"] = endpoint_id
-                    _prefs["utility_model"] = selected_model
-                _save_for_user(owner, _prefs)
+                    _patch["utility_endpoint_id"] = endpoint_id
+                    _patch["utility_model"] = selected_model
+                _update_for_user(owner, _patch)
         except Exception as e:
             logger.warning(f"cookbook_serve: default endpoint update failed: {e}")
     # Register the new task in cookbook_state.json + stamp it with our

--- a/src/caldav_sync.py
+++ b/src/caldav_sync.py
@@ -583,7 +583,7 @@ def _load_caldav_accounts(owner: str) -> list:
     """Return the list of CalDAV accounts for *owner*, auto-migrating the legacy
     single-account ``caldav`` key to the new ``caldav_accounts`` list on first call.
 
-    The save step is best-effort: if ``_save_for_user`` is unavailable (e.g. in a
+    The save step is best-effort: if ``_update_for_user`` is unavailable (e.g. in a
     test with a minimal prefs mock) the migrated accounts are still returned; the
     next real call will just re-run the cheap migration again.
     """
@@ -603,11 +603,9 @@ def _load_caldav_accounts(owner: str) -> list:
             "username": legacy.get("username", ""),
             "password": legacy.get("password", ""),
         }]
-        prefs["caldav_accounts"] = accounts
-        prefs.pop("caldav", None)
         try:
-            from routes.prefs_routes import _save_for_user
-            _save_for_user(owner, prefs)
+            from routes.prefs_routes import _update_for_user
+            _update_for_user(owner, {"caldav_accounts": accounts}, remove=("caldav",))
         except (ImportError, AttributeError):
             pass  # best-effort; next call re-migrates from the still-present legacy key
         return accounts

--- a/tests/test_prefs_concurrent_updates.py
+++ b/tests/test_prefs_concurrent_updates.py
@@ -1,0 +1,265 @@
+"""Independent preference updates must not overwrite each other.
+
+Preference writers used to load a user's whole map, change a key in it, and
+hand the entire snapshot back to _save_for_user, which replaced that user's
+record wholesale. Anything another writer had committed in between was lost:
+both writes reported success, nothing was logged, and the file stayed valid
+JSON.
+
+The window is real because writers do not all run on the event loop.
+src/caldav_sync.py runs its work through asyncio.to_thread specifically so the
+loop stays free, so a sync worker can hold a stale snapshot across its network
+I/O while a request handler writes a preference.
+
+Locking only the write would not help, because the stale snapshot is taken
+before the lock is ever acquired. _update_for_user re-reads and merges inside
+the lock instead, so a writer only ever publishes its own keys.
+"""
+import asyncio
+import json
+import threading
+
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+import routes.prefs_routes as pr
+
+
+def _seed(tmp_path, monkeypatch, store):
+    f = tmp_path / "user_prefs.json"
+    f.write_text(json.dumps(store), encoding="utf-8")
+    monkeypatch.setattr(pr, "PREFS_FILE", str(f))
+    return f
+
+
+def _client_as(user):
+    """A TestClient for the real prefs router, authenticated as `user`."""
+    app = FastAPI()
+
+    @app.middleware("http")
+    async def _attach_user(request: Request, call_next):
+        request.state.current_user = user
+        return await call_next(request)
+
+    app.include_router(pr.setup_prefs_routes())
+    return TestClient(app)
+
+
+def test_background_writer_does_not_revert_a_concurrent_preference_change(
+    tmp_path, monkeypatch
+):
+    """The regression, in the shape production actually produces it.
+
+    A CalDAV worker reads preferences, spends time on the network, then writes
+    its accounts back. A preference change that lands inside that window must
+    survive it.
+
+    The window is opened deterministically rather than by timing: the worker's
+    read is held on a gate, and the gate is only released once the competing
+    write has either finished (old behaviour) or provably blocked on the lock
+    (new behaviour).
+    """
+    from src import caldav_sync
+
+    _seed(tmp_path, monkeypatch, {"_users": {"alice": {
+        "theme": "light",
+        "caldav": {"url": "https://dav.example.com", "username": "alice"},
+    }}})
+
+    gate = threading.Event()
+    holding = threading.Event()
+    real_load = pr._load
+    first = {"done": False}
+
+    def gated_load():
+        """Hold the CalDAV worker inside its read, once."""
+        if not first["done"] and threading.current_thread().name == "caldav":
+            first["done"] = True
+            data = real_load()
+            holding.set()
+            gate.wait(5)
+            return data
+        return real_load()
+
+    monkeypatch.setattr(pr, "_load", gated_load)
+
+    worker = threading.Thread(
+        target=caldav_sync._load_caldav_accounts, args=("alice",), name="caldav"
+    )
+    worker.start()
+    assert holding.wait(5), "CalDAV worker never reached its read"
+
+    client = _client_as("alice")
+    writer = threading.Thread(
+        target=lambda: client.put("/api/prefs/theme", json={"value": "dark"})
+    )
+    writer.start()
+    # Old behaviour: this write runs to completion inside the window. New
+    # behaviour: it blocks on the lock the worker holds, so the join times out.
+    writer.join(1.0)
+
+    gate.set()
+    worker.join(5)
+    writer.join(5)
+
+    stored = pr._load_for_user("alice")
+    assert stored.get("theme") == "dark", (
+        "the CalDAV worker republished a stale snapshot and reverted the "
+        f"preference change; stored theme is {stored.get('theme')!r}"
+    )
+    assert stored.get("caldav_accounts"), "the CalDAV migration did not persist"
+
+
+def test_concurrent_updates_keep_every_key(tmp_path, monkeypatch):
+    """Many writers, distinct keys, no losses regardless of interleaving."""
+    _seed(tmp_path, monkeypatch, {"_users": {"alice": {"theme": "dark"}}})
+
+    count = 24
+    start = threading.Barrier(count)
+    errors = []
+
+    def write(i):
+        start.wait()
+        try:
+            pr._update_for_user("alice", {f"k{i}": i})
+        except Exception as exc:
+            errors.append((i, repr(exc)))
+
+    threads = [threading.Thread(target=write, args=(i,)) for i in range(count)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == [], f"{len(errors)} preference writes failed: {errors[:3]}"
+    stored = pr._load_for_user("alice")
+    lost = [f"k{i}" for i in range(count) if stored.get(f"k{i}") != i]
+    assert lost == [], f"{len(lost)} of {count} writes were lost: {lost}"
+    assert stored["theme"] == "dark", "a pre-existing preference was dropped"
+
+
+def test_reads_and_writes_can_overlap_without_erroring(tmp_path, monkeypatch):
+    """A read must never catch a write mid-swap.
+
+    atomic_write_json replaces the file underneath readers. On Windows that
+    replace fails with PermissionError while another thread holds the path
+    open, so an unsynchronized reader turned a concurrent preference write
+    into a 500. Reads take the same lock, so the two cannot overlap.
+    """
+    _seed(tmp_path, monkeypatch, {"_users": {"alice": {"theme": "dark"}}})
+
+    workers = 12
+    start = threading.Barrier(workers * 2)
+    errors = []
+
+    def write(i):
+        start.wait()
+        try:
+            for _ in range(10):
+                pr._update_for_user("alice", {f"k{i}": i})
+        except Exception as exc:
+            errors.append(("write", repr(exc)))
+
+    def read(_i):
+        start.wait()
+        try:
+            for _ in range(10):
+                pr._load_for_user("alice")
+        except Exception as exc:
+            errors.append(("read", repr(exc)))
+
+    threads = [threading.Thread(target=write, args=(i,)) for i in range(workers)]
+    threads += [threading.Thread(target=read, args=(i,)) for i in range(workers)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == [], f"overlapping preference access raised: {errors[:3]}"
+
+
+def test_update_merges_into_the_currently_persisted_map(tmp_path, monkeypatch):
+    _seed(tmp_path, monkeypatch, {"_users": {"alice": {"theme": "dark"}}})
+
+    pr._update_for_user("alice", {"language": "fr"})
+    returned = pr._update_for_user("alice", {"sidebar": "collapsed"})
+
+    assert returned == {"theme": "dark", "language": "fr", "sidebar": "collapsed"}
+    assert pr._load_for_user("alice") == returned
+
+
+def test_update_removes_only_the_named_keys(tmp_path, monkeypatch):
+    _seed(tmp_path, monkeypatch, {
+        "_users": {"alice": {"theme": "dark", "caldav": {"url": "old"}}},
+    })
+
+    stored = pr._update_for_user(
+        "alice", {"caldav_accounts": [{"url": "new"}]}, remove=("caldav",)
+    )
+
+    assert "caldav" not in stored
+    assert stored["caldav_accounts"] == [{"url": "new"}]
+    assert stored["theme"] == "dark"
+
+
+def test_update_leaves_other_users_alone(tmp_path, monkeypatch):
+    _seed(tmp_path, monkeypatch, {"_users": {
+        "alice": {"theme": "dark"},
+        "bob": {"theme": "paper"},
+    }})
+
+    pr._update_for_user("alice", {"language": "fr"})
+
+    raw = pr._load()
+    assert raw["_users"]["bob"] == {"theme": "paper"}
+    assert raw["_users"]["alice"] == {"theme": "dark", "language": "fr"}
+
+
+def test_auth_disabled_update_keeps_root_consent_and_other_users(tmp_path, monkeypatch):
+    """The None path still honours the flat/root split for consent keys."""
+    _seed(tmp_path, monkeypatch, {
+        "_users": {"alice": {"theme": "light"}, "bob": {"theme": "paper"}},
+        "foreground_fallback_enabled": True,
+    })
+
+    pr._update_for_user(None, {"theme": "dark"})
+
+    raw = pr._load()
+    assert raw["_users"]["bob"] == {"theme": "paper"}
+    assert raw["_users"]["alice"]["theme"] == "dark"
+    assert raw["foreground_fallback_enabled"] is True
+    assert "foreground_fallback_enabled" not in raw["_users"]["alice"]
+
+
+def test_tasks_onboarding_route_persists_and_reports_the_flags(tmp_path, monkeypatch):
+    """The onboarding route is one of the converted callers and had no test.
+
+    It writes tasks_opened/tasks_enabled and then reports them back, so it
+    both patches preferences and reads its own result.
+    """
+    from types import SimpleNamespace
+
+    import routes.task.task_routes as task_routes
+
+    _seed(tmp_path, monkeypatch, {"_users": {"alice": {"theme": "dark"}}})
+
+    async def _ensure_defaults(_owner):
+        return None
+
+    router = task_routes.setup_task_routes(
+        SimpleNamespace(ensure_defaults=_ensure_defaults)
+    )
+    endpoint = None
+    for route in router.routes:
+        if getattr(route, "path", None) == "/api/tasks/onboarding" and "POST" in getattr(route, "methods", set()):
+            endpoint = route.endpoint
+    assert endpoint is not None, "POST /api/tasks/onboarding not registered"
+
+    request = SimpleNamespace(state=SimpleNamespace(current_user="alice"))
+    result = asyncio.run(endpoint(request, {"enabled": False}))
+
+    assert result["opened"] is True
+    assert result["enabled"] is False
+    stored = pr._load_for_user("alice")
+    assert stored["tasks_opened"] is True
+    assert stored["theme"] == "dark", "onboarding dropped an unrelated preference"


### PR DESCRIPTION
## Summary

Preference writers loaded a user's whole map, changed a key in it, and handed the entire snapshot back to `_save_for_user`, which replaced that user's record wholesale. Anything another writer had committed in between was lost. Both writes returned success, nothing was logged and the file stayed valid JSON, which is what made it silent.

The window is real because writers do not all run on the event loop. `src/caldav_sync.py:645` runs its work through `asyncio.to_thread` specifically so the loop stays free, so a sync worker holds a stale snapshot across its network I/O while a request handler writes a preference, and then reverts it.

This adds `_update_for_user(user, patch, remove=())`, which re-reads and merges inside a module lock so a writer only ever publishes its own keys, and moves every in-repo read-modify-write caller onto it: the prefs route, the CalDAV account save and its legacy migration, tasks onboarding, backup import and `cookbook_serve`. Locking only the write would not have been enough, because the stale snapshot is taken before the lock is acquired — I measured that too, see below.

Reads take the lock as well. `atomic_write_json` replaces the file underneath readers, and on Windows that replace fails with `PermissionError` while another thread holds the path open, so an unsynchronized reader turned a concurrent write into a 500.

`_save_for_user` stays as the wholesale-replace primitive that `_update_for_user` is built on, with a docstring saying which one to reach for.

Two notes on scope, both deliberate:

- A `threading.RLock` covers the process model as shipped. `uvicorn.run(...)` in `app.py` and `launcher.py` takes no `workers`, and the Dockerfile CMD has none, so there is one process. It would not survive `--workers N`, which needs a file lock or a revision check. That looked like scope you had kept out on purpose in #5596; happy to do it that way instead if you want it now.
- Two concurrent `PUT /api/prefs/{key}` calls were **not** losing data on dev. `set_pref` is `async def` with no await between its read and its write, so the loop cannot interleave two of them. I checked this against a running server before writing anything, and the issue's reproduction is at the helper level rather than the route level for the same reason. The trigger is a background thread writer, which is what the regression test models.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #6002

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/odysseus-dev/odysseus/issues) and [open PRs](https://github.com/odysseus-dev/odysseus/pulls) — this is not a duplicate. No open or closed PR references #6002; I commented on the issue to claim it before starting.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.
- [ ] I did not run the app/runtime validation and stated that gap in **How to Test**. Leave this unchecked when the app-run box above is checked.

## How to Test

1. Reproduce the loss on `dev`. This mirrors what `caldav_sync` does — read preferences, spend time on the network, write back — while a preference change lands in the window:

   ```python
   import asyncio, json, tempfile, os, time
   import routes.prefs_routes as p

   d = tempfile.mkdtemp(); f = os.path.join(d, "user_prefs.json")
   open(f, "w").write(json.dumps({"_users": {"alice": {"theme": "light"}}}))
   p.PREFS_FILE = f

   def caldav_worker():                      # asyncio.to_thread, as in caldav_sync
       prefs = p._load_for_user("alice")
       time.sleep(0.3)                       # talking to the CalDAV server
       prefs["caldav_accounts"] = [{"id": "x"}]
       p._save_for_user("alice", prefs)

   async def main():
       t = asyncio.create_task(asyncio.to_thread(caldav_worker))
       await asyncio.sleep(0.1)              # user hits Save mid-sync
       prefs = p._load_for_user("alice"); prefs["theme"] = "dark"
       p._save_for_user("alice", prefs)
       await t
       print(p._load_for_user("alice"))

   asyncio.run(main())
   ```

   On `dev` this prints `theme: 'light'` — the worker reverted the change. On this branch, with both writers going through `_update_for_user`, it prints `theme: 'dark'` and keeps `caldav_accounts`.

2. Run the new tests: `python -m pytest tests/test_prefs_concurrent_updates.py`. Eight tests. The first one, `test_background_writer_does_not_revert_a_concurrent_preference_change`, fails on `dev` with `stored theme is 'light'` and passes here; I ran it five times on each side to confirm it is not timing-dependent (it uses a gate, not a sleep).

3. Run the app and exercise the route: `uvicorn app:app --port 8791` with `AUTH_ENABLED=false`, then fire 20 concurrent `PUT /api/prefs/live_k{i}`. All return 200 and all 20 keys are present in `GET /api/prefs`.

4. Regression sweep: the CalDAV, calendar, task, backup, prefs and cookbook-serve test files are 262 passed with 3 pre-existing failures in `tests/test_calendar_css_url_escape_js.py`, which fail identically on clean `dev` (a Node-runner issue on this machine).

5. Full suite, both sides, Windows, `-m "not slow"`, same interpreter and `--basetemp`: `dev` is 182 failed / 5691 passed / 2 errors, this branch is 182 failed / 5699 passed / 2 errors. Normalized `FAILED`/`ERROR` name sets are identical (160 unique on each, set difference empty in both directions). The +8 passed are exactly the new tests. The 182 are pre-existing Windows environment failures, not something this branch touches.

One thing worth flagging: converting the tasks onboarding handler initially broke it, because `enable` and `prefs` are used further down that function and `if enable:` runs on every request. Nothing in the suite caught it — the endpoint had no test at all, though `static/js/tasks.js` calls it. Fixed, and there is now a test covering it.

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI change. The diff is `routes/`, `src/` and `tests/` only; no `static/`, template, HTML, CSS or SVG file is touched.

- [x] **I am not an LLM agent submitting a bulk PR.** Investigated with Claude Code, posted by the account owner, on an existing issue rather than as an unsolicited PR.
